### PR TITLE
fix: make bulk config dry runs non-mutating

### DIFF
--- a/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
+++ b/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
@@ -103,7 +103,10 @@ class ConfigureFlowStepsAbility {
 						'type'       => 'object',
 						'properties' => array(
 							'success'        => array( 'type' => 'boolean' ),
+							'valid'          => array( 'type' => 'boolean' ),
+							'mode'           => array( 'type' => 'string' ),
 							'pipeline_id'    => array( 'type' => 'integer' ),
+							'would_update'   => array( 'type' => 'array' ),
 							'updated_steps'  => array( 'type' => 'array' ),
 							'flows_updated'  => array( 'type' => 'integer' ),
 							'steps_modified' => array( 'type' => 'integer' ),
@@ -155,6 +158,7 @@ class ConfigureFlowStepsAbility {
 		$handler_config      = $input['handler_config'] ?? array();
 		$flow_configs        = $input['flow_configs'] ?? array();
 		$user_message        = $input['user_message'] ?? null;
+		$validate_only       = ! empty( $input['validate_only'] );
 
 		if ( ! is_numeric( $pipeline_id ) || (int) $pipeline_id <= 0 ) {
 			return array(
@@ -239,9 +243,9 @@ class ConfigureFlowStepsAbility {
 		$found_flow_ids    = array();
 		$pipeline_flow_ids = array_column( $flows, 'flow_id' );
 
-		$updated_details = array();
-		$errors          = array();
-		$skipped         = array();
+		$operations = array();
+		$errors     = array();
+		$skipped    = array();
 
 		foreach ( $flows as $flow ) {
 			$flow_id     = (int) $flow['flow_id'];
@@ -309,38 +313,21 @@ class ConfigureFlowStepsAbility {
 					}
 				}
 
-				$success = $this->updateHandler( $flow_step_id, $effective_handler_slug, $merged_config );
-				if ( ! $success ) {
-					$errors[] = array(
-						'flow_step_id' => $flow_step_id,
-						'flow_id'      => $flow_id,
-						'error'        => 'Failed to update handler',
-					);
-					continue;
-				}
-
-				if ( ! empty( $user_message ) ) {
-					$message_success = $this->updateUserMessage( $flow_step_id, $user_message );
-					if ( ! $message_success ) {
-						$errors[] = array(
-							'flow_step_id' => $flow_step_id,
-							'flow_id'      => $flow_id,
-							'error'        => 'Failed to update user message',
-						);
-						continue;
-					}
-				}
-
 				$detail = array(
 					'flow_id'      => $flow_id,
 					'flow_name'    => $flow_name,
+					'pipeline_id'  => $pipeline_id,
 					'flow_step_id' => $flow_step_id,
 					'handler_slug' => $effective_handler_slug,
 				);
 				if ( $is_switching ) {
 					$detail['switched_from'] = $existing_handler_slug;
 				}
-				$updated_details[] = $detail;
+				$operations[] = array(
+					'detail'         => $detail,
+					'handler_config' => $merged_config,
+					'user_message'   => $user_message,
+				);
 			}
 		}
 
@@ -374,6 +361,73 @@ class ConfigureFlowStepsAbility {
 			}
 		}
 
+		if ( ! empty( $errors ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Validation failed for ' . count( $errors ) . ' step(s).',
+				'errors'  => $errors,
+				'skipped' => $skipped,
+			);
+		}
+
+		if ( empty( $operations ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'No matching steps found for the specified criteria',
+				'skipped' => $skipped,
+			);
+		}
+
+		$would_update   = array_column( $operations, 'detail' );
+		$flows_updated  = count( array_unique( array_column( $would_update, 'flow_id' ) ) );
+		$steps_modified = count( $would_update );
+
+		if ( $validate_only ) {
+			$response = array(
+				'success'      => true,
+				'valid'        => true,
+				'mode'         => 'validate_only',
+				'pipeline_id'  => $pipeline_id,
+				'would_update' => $would_update,
+				'message'      => sprintf( 'Validation passed. Would configure %d step(s) across %d flow(s).', $steps_modified, $flows_updated ),
+			);
+
+			if ( ! empty( $skipped ) ) {
+				$response['skipped'] = $skipped;
+			}
+
+			return $response;
+		}
+
+		$updated_details = array();
+		$errors          = array();
+
+		foreach ( $operations as $operation ) {
+			$detail       = $operation['detail'];
+			$flow_step_id = $detail['flow_step_id'];
+			$flow_id      = $detail['flow_id'];
+
+			if ( ! $this->updateHandler( $flow_step_id, $detail['handler_slug'], $operation['handler_config'] ) ) {
+				$errors[] = array(
+					'flow_step_id' => $flow_step_id,
+					'flow_id'      => $flow_id,
+					'error'        => 'Failed to update handler',
+				);
+				continue;
+			}
+
+			if ( ! empty( $operation['user_message'] ) && ! $this->updateUserMessage( $flow_step_id, $operation['user_message'] ) ) {
+				$errors[] = array(
+					'flow_step_id' => $flow_step_id,
+					'flow_id'      => $flow_id,
+					'error'        => 'Failed to update user message',
+				);
+				continue;
+			}
+
+			$updated_details[] = $detail;
+		}
+
 		$flows_updated  = count( array_unique( array_column( $updated_details, 'flow_id' ) ) );
 		$steps_modified = count( $updated_details );
 
@@ -382,14 +436,6 @@ class ConfigureFlowStepsAbility {
 				'success' => false,
 				'error'   => 'No steps were updated. ' . count( $errors ) . ' error(s) occurred.',
 				'errors'  => $errors,
-				'skipped' => $skipped,
-			);
-		}
-
-		if ( 0 === $steps_modified ) {
-			return array(
-				'success' => false,
-				'error'   => 'No matching steps found for the specified criteria',
 				'skipped' => $skipped,
 			);
 		}
@@ -412,6 +458,7 @@ class ConfigureFlowStepsAbility {
 
 		$response = array(
 			'success'        => true,
+			'mode'           => 'execute',
 			'pipeline_id'    => $pipeline_id,
 			'flows_updated'  => $flows_updated,
 			'steps_modified' => $steps_modified,
@@ -748,32 +795,8 @@ class ConfigureFlowStepsAbility {
 			);
 		}
 
-		if ( $validate_only ) {
-			$would_update = array();
-			foreach ( $matching_flows as $match ) {
-				$flow         = $match['flow'];
-				$flow_step_id = $match['flow_step_id'];
-
-				$would_update[] = array(
-					'flow_id'      => $flow['flow_id'],
-					'flow_name'    => $flow['flow_name'] ?? '',
-					'pipeline_id'  => $flow['pipeline_id'] ?? null,
-					'flow_step_id' => $flow_step_id,
-					'handler_slug' => $target_handler_slug ?? $handler_slug,
-				);
-			}
-
-			return array(
-				'success'      => true,
-				'valid'        => true,
-				'mode'         => 'validate_only',
-				'would_update' => $would_update,
-				'message'      => sprintf( 'Validation passed. Would configure %d step(s) across %d flow(s).', count( $would_update ), count( array_unique( array_column( $would_update, 'flow_id' ) ) ) ),
-			);
-		}
-
-		$updated_details = array();
-		$errors          = array();
+		$operations = array();
+		$errors     = array();
 
 		foreach ( $matching_flows as $match ) {
 			$flow         = $match['flow'];
@@ -813,28 +836,6 @@ class ConfigureFlowStepsAbility {
 				}
 			}
 
-			$success = $this->updateHandler( $flow_step_id, $effective_handler_slug, $merged_config );
-			if ( ! $success ) {
-				$errors[] = array(
-					'flow_step_id' => $flow_step_id,
-					'flow_id'      => $flow_id,
-					'error'        => 'Failed to update handler',
-				);
-				continue;
-			}
-
-			if ( ! empty( $user_message ) ) {
-				$message_success = $this->updateUserMessage( $flow_step_id, $user_message );
-				if ( ! $message_success ) {
-					$errors[] = array(
-						'flow_step_id' => $flow_step_id,
-						'flow_id'      => $flow_id,
-						'error'        => 'Failed to update user message',
-					);
-					continue;
-				}
-			}
-
 			$detail = array(
 				'flow_id'      => $flow_id,
 				'flow_name'    => $flow_name,
@@ -845,6 +846,68 @@ class ConfigureFlowStepsAbility {
 			if ( $is_switching ) {
 				$detail['switched_from'] = $existing_handler_slug;
 			}
+			$operations[] = array(
+				'detail'         => $detail,
+				'handler_config' => $merged_config,
+				'user_message'   => $user_message,
+			);
+		}
+
+		if ( ! empty( $errors ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Validation failed for ' . count( $errors ) . ' step(s).',
+				'errors'  => $errors,
+			);
+		}
+
+		if ( empty( $operations ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'No matching steps found for the specified criteria',
+			);
+		}
+
+		$would_update   = array_column( $operations, 'detail' );
+		$flows_updated  = count( array_unique( array_column( $would_update, 'flow_id' ) ) );
+		$steps_modified = count( $would_update );
+
+		if ( $validate_only ) {
+			return array(
+				'success'      => true,
+				'valid'        => true,
+				'mode'         => 'validate_only',
+				'would_update' => $would_update,
+				'message'      => sprintf( 'Validation passed. Would configure %d step(s) across %d flow(s).', $steps_modified, $flows_updated ),
+			);
+		}
+
+		$updated_details = array();
+		$errors          = array();
+
+		foreach ( $operations as $operation ) {
+			$detail       = $operation['detail'];
+			$flow_step_id = $detail['flow_step_id'];
+			$flow_id      = $detail['flow_id'];
+
+			if ( ! $this->updateHandler( $flow_step_id, $detail['handler_slug'], $operation['handler_config'] ) ) {
+				$errors[] = array(
+					'flow_step_id' => $flow_step_id,
+					'flow_id'      => $flow_id,
+					'error'        => 'Failed to update handler',
+				);
+				continue;
+			}
+
+			if ( ! empty( $operation['user_message'] ) && ! $this->updateUserMessage( $flow_step_id, $operation['user_message'] ) ) {
+				$errors[] = array(
+					'flow_step_id' => $flow_step_id,
+					'flow_id'      => $flow_id,
+					'error'        => 'Failed to update user message',
+				);
+				continue;
+			}
+
 			$updated_details[] = $detail;
 		}
 
@@ -856,13 +919,6 @@ class ConfigureFlowStepsAbility {
 				'success' => false,
 				'error'   => 'No steps were updated. ' . count( $errors ) . ' error(s) occurred.',
 				'errors'  => $errors,
-			);
-		}
-
-		if ( 0 === $steps_modified ) {
-			return array(
-				'success' => false,
-				'error'   => 'No matching steps found for the specified criteria',
 			);
 		}
 
@@ -881,6 +937,7 @@ class ConfigureFlowStepsAbility {
 
 		$response = array(
 			'success'        => true,
+			'mode'           => 'execute',
 			'handler_slug'   => $handler_slug,
 			'global_scope'   => true,
 			'flows_updated'  => $flows_updated,

--- a/inc/Cli/Commands/Flows/BulkConfigCommand.php
+++ b/inc/Cli/Commands/Flows/BulkConfigCommand.php
@@ -168,13 +168,13 @@ class BulkConfigCommand extends BaseCommand {
 			'pipeline_id'    => $pipeline_id,
 			'handler_slug'   => $handler,
 			'handler_config' => $handler_config,
+			'validate_only'  => $dry_run,
 		);
 
 		if ( $step_type ) {
 			$input['step_type'] = $step_type;
 		}
 
-		// Pipeline mode doesn't have validate_only in the ability — we use the result to show preview.
 		$this->runAbility( $input, $dry_run, $format, "pipeline {$pipeline_id} (handler: {$handler})" );
 	}
 
@@ -198,13 +198,14 @@ class BulkConfigCommand extends BaseCommand {
 		$input = array(
 			'pipeline_id'    => $pipeline_id,
 			'handler_slug'   => $handler,
-			'handler_config' => $handler_config,
+			'handler_config' => array(),
 			'flow_configs'   => array(
 				array(
 					'flow_id'        => $flow_id,
 					'handler_config' => $handler_config,
 				),
 			),
+			'validate_only'  => $dry_run,
 		);
 
 		if ( $step_type ) {
@@ -232,21 +233,10 @@ class BulkConfigCommand extends BaseCommand {
 			return;
 		}
 
-		// Handle dry-run with validate_only result (global/cross-pipeline modes).
+		// Handle validation-only results for every scope.
 		if ( $dry_run && ! empty( $result['would_update'] ) ) {
 			$this->outputDryRunPreview( $result['would_update'] );
 			WP_CLI::success( $result['message'] ?? 'Dry run complete.' );
-			return;
-		}
-
-		// Handle dry-run for pipeline mode (no validate_only, so we show the actual result).
-		if ( $dry_run && ! empty( $result['success'] ) && ! empty( $result['updated_steps'] ) ) {
-			// Pipeline mode executed — but this was supposed to be dry-run.
-			// Show what was updated. Since pipeline mode doesn't support validate_only,
-			// we warn the user. However, to truly support dry-run for pipeline scope,
-			// we'd need to add validate_only support to the pipeline execution path.
-			$this->outputUpdatedSteps( $result );
-			WP_CLI::success( $result['message'] ?? 'Done.' );
 			return;
 		}
 

--- a/tests/Unit/Cli/Commands/Flows/BulkConfigCommandTest.php
+++ b/tests/Unit/Cli/Commands/Flows/BulkConfigCommandTest.php
@@ -27,6 +27,32 @@ class BulkConfigCommandTest extends WP_UnitTestCase {
 	private string $flow_step_id_1;
 	private string $flow_step_id_2;
 
+	private function createMutationSpyAbility(): ConfigureFlowStepsAbility {
+		return new class() extends ConfigureFlowStepsAbility {
+			public array $handler_updates = array();
+			public array $message_updates = array();
+
+			protected function updateHandler( string $flow_step_id, string $handler_slug = '', array $handler_settings = array() ): bool {
+				$this->handler_updates[] = array(
+					'flow_step_id'    => $flow_step_id,
+					'handler_slug'    => $handler_slug,
+					'handler_settings' => $handler_settings,
+				);
+
+				return true;
+			}
+
+			protected function updateUserMessage( string $flow_step_id, string $user_message ): bool {
+				$this->message_updates[] = array(
+					'flow_step_id' => $flow_step_id,
+					'user_message' => $user_message,
+				);
+
+				return true;
+			}
+		};
+	}
+
 	public function set_up(): void {
 		parent::set_up();
 
@@ -135,6 +161,52 @@ class BulkConfigCommandTest extends WP_UnitTestCase {
 		$this->assertSame( 10, $config_2['max_items'] );
 	}
 
+	public function test_pipeline_scope_dry_run_never_calls_mutation_methods(): void {
+		$ability = $this->createMutationSpyAbility();
+		$result  = $ability->execute( array(
+			'pipeline_id'    => $this->pipeline_id,
+			'handler_slug'   => 'rss',
+			'handler_config' => array( 'max_items' => 10 ),
+			'validate_only'  => true,
+		) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'validate_only', $result['mode'] );
+		$this->assertCount( 2, $result['would_update'] );
+		$this->assertSame( array(), $ability->handler_updates );
+		$this->assertSame( array(), $ability->message_updates );
+	}
+
+	public function test_pipeline_scope_apply_calls_mutation_once_per_validated_target(): void {
+		$ability = $this->createMutationSpyAbility();
+		$result  = $ability->execute( array(
+			'pipeline_id'    => $this->pipeline_id,
+			'handler_slug'   => 'rss',
+			'handler_config' => array( 'max_items' => 10 ),
+		) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'execute', $result['mode'] );
+		$this->assertSame( 2, $result['steps_modified'] );
+		$this->assertCount( 2, $ability->handler_updates );
+	}
+
+	public function test_pipeline_scope_invalid_patch_never_calls_mutation_methods(): void {
+		foreach ( array( false, true ) as $validate_only ) {
+			$ability = $this->createMutationSpyAbility();
+			$result  = $ability->execute( array(
+				'pipeline_id'    => $this->pipeline_id,
+				'handler_slug'   => 'rss',
+				'handler_config' => array( 'not_a_real_rss_field' => true ),
+				'validate_only'  => $validate_only,
+			) );
+
+			$this->assertFalse( $result['success'] );
+			$this->assertStringContainsString( 'Validation failed', $result['error'] );
+			$this->assertSame( array(), $ability->handler_updates );
+		}
+	}
+
 	public function test_pipeline_scope_preserves_existing_config(): void {
 		$ability = new ConfigureFlowStepsAbility();
 		$ability->execute( array(
@@ -163,7 +235,7 @@ class BulkConfigCommandTest extends WP_UnitTestCase {
 	}
 
 	public function test_global_scope_dry_run(): void {
-		$ability = new ConfigureFlowStepsAbility();
+		$ability = $this->createMutationSpyAbility();
 		$result  = $ability->execute( array(
 			'handler_slug'   => 'rss',
 			'global_scope'   => true,
@@ -175,11 +247,43 @@ class BulkConfigCommandTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['valid'] );
 		$this->assertSame( 'validate_only', $result['mode'] );
 		$this->assertCount( 2, $result['would_update'] );
+		$this->assertSame( array(), $ability->handler_updates );
 
 		// Verify nothing was actually changed.
 		$flow_1 = $this->flows->get_flow( $this->flow_id_1 );
 		$config = FlowStepConfig::getPrimaryHandlerConfig( $flow_1['flow_config'][ $this->flow_step_id_1 ] ?? array() );
 		$this->assertSame( 5, $config['max_items'] );
+	}
+
+	public function test_single_flow_selection_previews_and_applies_only_that_flow(): void {
+		$input = array(
+			'pipeline_id'    => $this->pipeline_id,
+			'handler_slug'   => 'rss',
+			'handler_config' => array(),
+			'flow_configs'   => array(
+				array(
+					'flow_id'        => $this->flow_id_2,
+					'handler_config' => array( 'max_items' => 25 ),
+				),
+			),
+		);
+
+		$preview_input                  = $input;
+		$preview_input['validate_only'] = true;
+		$preview_ability                = $this->createMutationSpyAbility();
+		$preview_result                 = $preview_ability->execute( $preview_input );
+
+		$this->assertTrue( $preview_result['success'] );
+		$this->assertCount( 1, $preview_result['would_update'] );
+		$this->assertSame( $this->flow_id_2, $preview_result['would_update'][0]['flow_id'] );
+		$this->assertSame( array(), $preview_ability->handler_updates );
+
+		$apply_ability = $this->createMutationSpyAbility();
+		$apply_result  = $apply_ability->execute( $input );
+
+		$this->assertTrue( $apply_result['success'] );
+		$this->assertCount( 1, $apply_ability->handler_updates );
+		$this->assertSame( $this->flow_step_id_2, $apply_ability->handler_updates[0]['flow_step_id'] );
 	}
 
 	public function test_global_scope_executes(): void {

--- a/tests/flow-config-cli-round-trip-smoke.php
+++ b/tests/flow-config-cli-round-trip-smoke.php
@@ -227,6 +227,15 @@ namespace DataMachine\Abilities\FlowStep {
 				'ability' => 'configure-flow-steps',
 				'input'   => $input,
 			);
+			if ( ! empty( $input['validate_only'] ) ) {
+				return array(
+					'success'      => true,
+					'valid'        => true,
+					'mode'         => 'validate_only',
+					'would_update' => array(),
+					'message'      => 'validated',
+				);
+			}
 			return array(
 				'success'       => true,
 				'updated_steps' => array(),
@@ -361,6 +370,49 @@ flow_config_cli_reset();
 	)
 );
 flow_config_cli_assert_same( $semantic, $GLOBALS['flow_config_cli_ability_calls'][0]['input']['handler_config'] ?? null, 'bulk-config decodes config exactly once' );
+
+flow_config_cli_reset();
+( new BulkConfigCommand() )->dispatch(
+	array(),
+	array(
+		'scope'   => 'global',
+		'handler' => 'fixture',
+		'config'  => $json,
+		'dry-run' => true,
+		'format'  => 'json',
+	)
+);
+flow_config_cli_assert_same( true, $GLOBALS['flow_config_cli_ability_calls'][0]['input']['validate_only'] ?? null, 'global dry-run uses validation-only ability mode' );
+
+flow_config_cli_reset();
+( new BulkConfigCommand() )->dispatch(
+	array(),
+	array(
+		'scope'       => 'pipeline',
+		'pipeline_id' => 7,
+		'handler'     => 'fixture',
+		'config'      => $json,
+		'dry-run'     => true,
+		'format'      => 'json',
+	)
+);
+flow_config_cli_assert_same( true, $GLOBALS['flow_config_cli_ability_calls'][0]['input']['validate_only'] ?? null, 'pipeline dry-run uses validation-only ability mode' );
+
+flow_config_cli_reset();
+( new BulkConfigCommand() )->dispatch(
+	array(),
+	array(
+		'scope'   => 'flow',
+		'flow_id' => 52,
+		'handler' => 'fixture',
+		'config'  => $json,
+		'dry-run' => true,
+		'format'  => 'json',
+	)
+);
+flow_config_cli_assert_same( true, $GLOBALS['flow_config_cli_ability_calls'][0]['input']['validate_only'] ?? null, 'flow dry-run uses validation-only ability mode' );
+flow_config_cli_assert_same( array(), $GLOBALS['flow_config_cli_ability_calls'][0]['input']['handler_config'] ?? null, 'flow scope does not apply shared config to sibling flows' );
+flow_config_cli_assert_same( $semantic, $GLOBALS['flow_config_cli_ability_calls'][0]['input']['flow_configs'][0]['handler_config'] ?? null, 'flow scope targets its selected flow config' );
 
 flow_config_cli_reset();
 $message = 'Process start/end from C:\\Temp with \\d+ items.';


### PR DESCRIPTION
## Summary
- route global, pipeline, and flow-scoped `bulk-config --dry-run` requests through the owning ability's `validate_only` mode
- separate target and patch validation from mutation so invalid patches and previews cannot call flow update helpers
- return explicit machine-readable `validate_only` and `execute` modes, and keep single-flow scope limited to its selected flow

## Root Cause
`BulkConfigCommand::executePipeline()` and `executeFlow()` did not pass `validate_only`. Pipeline requests therefore entered `ConfigureFlowStepsAbility`'s mutation loop, and the CLI treated the resulting `updated_steps` as preview output after the writes had already occurred. Global previews returned before validating the actual merged handler patch, so preview and apply did not share the same validation path.

## Invariant
Every dry-run scope now resolves the same targets and validates the same merged config patch as execute mode, but returns before `updateHandler()` or `updateUserMessage()` can run. Invalid patches and empty selections fail before mutation. Valid execute requests continue through the existing mutation helpers once per validated target.

## Output And Compatibility
- preview responses include `mode: validate_only`, `valid: true`, and `would_update`
- apply responses include `mode: execute` while retaining existing update counts and `updated_steps`
- table output continues to render `would_update`; JSON remains the complete ability response
- `--execute` remains the explicit write opt-in

## Test Evidence
- `php tests/flow-config-cli-round-trip-smoke.php` (23 passed, 0 failed)
- PHP syntax checks for all four changed PHP files
- `homeboy review lint --changed-only --summary` (PHPCS and PHPStan passed, no baseline drift)
- `homeboy review audit --profile pr --changed-since origin/main` (no introduced findings)
- `git diff --check`
- added PHPUnit mutation-spy regressions for dry-run, invalid patch, single-flow targeting, and apply call counts; the local Homeboy WordPress PHPUnit runner exited without output or structured counts, so these remain for CI execution

Closes #3019