### PR TITLE
Redact HTTP request bodies in logs

### DIFF
--- a/inc/Core/HttpClient.php
+++ b/inc/Core/HttpClient.php
@@ -40,6 +40,7 @@ class HttpClient {
 	 *                        - headers: array - Additional headers to merge
 	 *                        - body: string|array - Request body (for POST/PUT/PATCH)
 	 *                        - timeout: int - Request timeout (default 120)
+	 *                        - limit_response_size: int - Maximum response body bytes (default unlimited)
 	 *                        - proxy_url: string - Optional per-request proxy URL (http, https, socks4, socks5, socks5h)
 	 *                        - auth: array - Optional standard auth config: {type: basic, username, password} or {type: bearer, token}
 	 *                        - auth_ref: string - Optional provider:account credential reference resolved through registered auth providers
@@ -203,7 +204,7 @@ class HttpClient {
 		$headers = array_merge( $default_headers, $options['headers'] ?? array() );
 		$headers = self::applyAuthentication( $headers, $options['auth'] ?? null );
 
-		$args = array(
+		$args                = array(
 			'timeout' => $timeout,
 			'headers' => $headers,
 		);

--- a/inc/Core/HttpClient.php
+++ b/inc/Core/HttpClient.php
@@ -377,6 +377,10 @@ class HttpClient {
 	 * Redact sensitive HTTP request data before log emission.
 	 */
 	private static function redactRequestArgsForLog( array $args ): array {
+		if ( array_key_exists( 'body', $args ) && null !== $args['body'] && '' !== $args['body'] && array() !== $args['body'] ) {
+			$args['body'] = '[redacted]';
+		}
+
 		if ( ! empty( $args['headers'] ) && is_array( $args['headers'] ) ) {
 			foreach ( $args['headers'] as $name => $value ) {
 				if ( in_array( strtolower( (string) $name ), array( 'authorization', 'proxy-authorization', 'cookie', 'set-cookie' ), true ) ) {

--- a/inc/Core/HttpClient.php
+++ b/inc/Core/HttpClient.php
@@ -207,6 +207,10 @@ class HttpClient {
 			'timeout' => $timeout,
 			'headers' => $headers,
 		);
+		$limit_response_size = max( 0, (int) ( $options['limit_response_size'] ?? 0 ) );
+		if ( $limit_response_size > 0 ) {
+			$args['limit_response_size'] = $limit_response_size;
+		}
 
 		if ( 'GET' !== $method ) {
 			$args['method'] = $method;

--- a/tests/http-client-proxy-auth-smoke.php
+++ b/tests/http-client-proxy-auth-smoke.php
@@ -202,6 +202,12 @@ $provider->save_config(
 $GLOBALS['datamachine_http_client_auth_providers'] = array(
 	HttpBasicAuthProvider::PROVIDER_SLUG => $provider,
 );
+if ( function_exists( 'add_filter' ) ) {
+	add_filter(
+		'datamachine_auth_providers',
+		static fn() => $GLOBALS['datamachine_http_client_auth_providers']
+	);
+}
 
 $resolved_options = http_client_private(
 	'resolveAuthRefOptions',

--- a/tests/http-client-proxy-auth-smoke.php
+++ b/tests/http-client-proxy-auth-smoke.php
@@ -226,6 +226,7 @@ $redacted = http_client_private(
 			'Cookie'              => 'wordpress_logged_in=hidden',
 			'X-Test'              => 'visible',
 		),
+		'body'    => '{"username":"chubes4","password":"top-secret"}',
 	)
 );
 
@@ -233,6 +234,7 @@ http_client_smoke_assert( 'Authorization is redacted', '[redacted]' === ( $redac
 http_client_smoke_assert( 'Proxy-Authorization is redacted', '[redacted]' === ( $redacted['headers']['Proxy-Authorization'] ?? null ) );
 http_client_smoke_assert( 'Cookie is redacted', '[redacted]' === ( $redacted['headers']['Cookie'] ?? null ) );
 http_client_smoke_assert( 'Non-sensitive header remains visible', 'visible' === ( $redacted['headers']['X-Test'] ?? null ) );
+http_client_smoke_assert( 'Request body is redacted', '[redacted]' === ( $redacted['body'] ?? null ) );
 
 echo "\n[4] Proxy scheme mapping\n";
 

--- a/tests/http-client-proxy-auth-smoke.php
+++ b/tests/http-client-proxy-auth-smoke.php
@@ -183,6 +183,11 @@ http_client_smoke_assert(
 	'Custom manual' === ( $manual_args['headers']['authorization'] ?? null )
 );
 
+$bounded_args = http_client_private( 'buildRequestArgs', 'GET', array( 'limit_response_size' => 1048576 ) );
+http_client_smoke_assert( 'response byte limit is forwarded to WordPress HTTP', 1048576 === ( $bounded_args['limit_response_size'] ?? null ) );
+$unbounded_args = http_client_private( 'buildRequestArgs', 'GET', array( 'limit_response_size' => 0 ) );
+http_client_smoke_assert( 'invalid response byte limit is omitted', ! isset( $unbounded_args['limit_response_size'] ) );
+
 echo "\n[2] Auth ref options\n";
 
 $provider = new HttpBasicAuthProvider();


### PR DESCRIPTION
## Summary
- redact every non-empty HTTP request body before transport-failure log emission
- forward an optional positive `limit_response_size` to the WordPress HTTP API
- preserve existing sensitive-header redaction and outbound request behavior
- cover credential-bearing JSON bodies and response-byte bounds

## Verification
- `php tests/http-client-proxy-auth-smoke.php`
- `php tests/http-client-error-response-contract-smoke.php`
- PHP lint
- `git diff --check`

Closes #3026
Closes #3028

## AI assistance
OpenAI `openai/gpt-5.6-sol` via OpenCode identified the logging and response-bound gaps, implemented the generic fixes, and ran focused verification. Chris Huber remains responsible for the submitted change.