### PR TITLE
fix: preserve full materialized agent identity scope

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -814,6 +814,7 @@ function datamachine_activate_plugin( $network_wide = false ) {
  */
 function datamachine_create_network_agent_tables() {
 	\DataMachine\Core\Database\Agents\Agents::create_table();
+	\DataMachine\Core\Database\Agents\Agents::ensure_identity_scope_schema();
 	\DataMachine\Core\Database\Agents\Agents::ensure_site_scope_column();
 	\DataMachine\Core\Database\Agents\AgentAccess::create_table();
 	\DataMachine\Core\Database\Agents\AgentTokens::create_table();

--- a/inc/Abilities/File/ScaffoldAbilities.php
+++ b/inc/Abilities/File/ScaffoldAbilities.php
@@ -393,14 +393,8 @@ class ScaffoldAbilities {
 				return $dm->get_user_directory( $user_id );
 
 			case MemoryFileRegistry::LAYER_AGENT:
-				$agent_slug = $context['agent_slug'] ?? null;
-				if ( $agent_slug ) {
-					return $dm->get_agent_identity_directory( $agent_slug );
-				}
-				$agent_id = (int) ( $context['agent_id'] ?? 0 );
-				if ( $agent_id > 0 ) {
-					$slug = $dm->resolve_agent_slug( array( 'agent_id' => $agent_id ) );
-					return $dm->get_agent_identity_directory( $slug );
+				if ( ! empty( $context['agent_slug'] ) || (int) ( $context['agent_id'] ?? 0 ) > 0 ) {
+					return $dm->resolve_agent_directory( $context );
 				}
 				$user_id = (int) ( $context['user_id'] ?? 0 );
 				return $dm->get_agent_identity_directory_for_user( $user_id );

--- a/inc/Core/Database/Agents/Agents.php
+++ b/inc/Core/Database/Agents/Agents.php
@@ -55,18 +55,74 @@ class Agents extends BaseRepository {
 			agent_slug VARCHAR(200) NOT NULL,
 			agent_name VARCHAR(200) NOT NULL,
 			owner_id BIGINT(20) UNSIGNED NOT NULL,
+			instance_key VARCHAR(200) NOT NULL DEFAULT 'default',
 			site_scope BIGINT(20) UNSIGNED NULL DEFAULT NULL,
 			agent_config LONGTEXT NULL,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 			PRIMARY KEY (agent_id),
-			UNIQUE KEY agent_slug (agent_slug),
+			UNIQUE KEY agent_identity_scope (agent_slug, owner_id, instance_key),
 			KEY owner_id (owner_id),
 			KEY site_scope (site_scope)
 		) {$charset_collate};";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		dbDelta( $sql );
+	}
+
+	/**
+	 * Migrate legacy slug-only identity storage to the Agents API scope tuple.
+	 *
+	 * Existing rows become their owner's default materialized instance. The
+	 * explicit index repair is required because dbDelta does not drop obsolete
+	 * unique indexes from existing tables.
+	 */
+	public static function ensure_identity_scope_schema(): void {
+		global $wpdb;
+
+		$table_name = $wpdb->base_prefix . self::TABLE_NAME;
+		if ( ! BaseRepository::column_exists( $table_name, 'instance_key', $wpdb ) ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$wpdb->query( $wpdb->prepare( "ALTER TABLE %i ADD COLUMN instance_key VARCHAR(200) NOT NULL DEFAULT 'default'", $table_name ) );
+		}
+
+		if ( self::is_sqlite() ) {
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( 'DROP INDEX IF EXISTS agent_slug' );
+			$wpdb->query( $wpdb->prepare( 'CREATE UNIQUE INDEX IF NOT EXISTS agent_identity_scope ON %i (agent_slug, owner_id, instance_key)', $table_name ) );
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+			return;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$index_rows = $wpdb->get_results( $wpdb->prepare( 'SHOW INDEX FROM %i', $table_name ), ARRAY_A );
+		$indexes    = array();
+		foreach ( $index_rows as $index_row ) {
+			$name = (string) ( $index_row['Key_name'] ?? '' );
+			if ( '' === $name ) {
+				continue;
+			}
+			$indexes[ $name ]['unique'] = 0 === (int) ( $index_row['Non_unique'] ?? 1 );
+			$indexes[ $name ]['columns'][ (int) ( $index_row['Seq_in_index'] ?? 0 ) ] = (string) ( $index_row['Column_name'] ?? '' );
+		}
+
+		$has_identity_scope_index = false;
+		foreach ( $indexes as $name => $index ) {
+			ksort( $index['columns'] );
+			$columns = array_values( $index['columns'] );
+			if ( $index['unique'] && array( 'agent_slug' ) === $columns ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+				$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP INDEX %i', $table_name, $name ) );
+			}
+			if ( $index['unique'] && array( 'agent_slug', 'owner_id', 'instance_key' ) === $columns ) {
+				$has_identity_scope_index = true;
+			}
+		}
+
+		if ( ! $has_identity_scope_index ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD UNIQUE KEY %i (agent_slug, owner_id, instance_key)', $table_name, 'agent_identity_scope' ) );
+		}
 	}
 
 	/**
@@ -250,7 +306,7 @@ class Agents extends BaseRepository {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		$row = $this->wpdb->get_row(
 			$this->wpdb->prepare(
-				'SELECT * FROM %i WHERE agent_slug = %s LIMIT 1',
+				'SELECT * FROM %i WHERE agent_slug = %s ORDER BY agent_id ASC LIMIT 1',
 				$this->table_name,
 				$agent_slug
 			),
@@ -264,6 +320,29 @@ class Agents extends BaseRepository {
 
 		$row['agent_config'] = self::decode_agent_config( $row['agent_config'] ?? null );
 
+		return $row;
+	}
+
+	/** Resolve an agent by its complete normalized materialized identity scope. */
+	public function get_by_identity_scope( string $agent_slug, int $owner_id, string $instance_key = 'default' ): ?array {
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$row = $this->wpdb->get_row(
+			$this->wpdb->prepare(
+				'SELECT * FROM %i WHERE agent_slug = %s AND owner_id = %d AND instance_key = %s LIMIT 1',
+				$this->table_name,
+				$agent_slug,
+				$owner_id,
+				$instance_key
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( ! $row ) {
+			return null;
+		}
+
+		$row['agent_config'] = self::decode_agent_config( $row['agent_config'] ?? null );
 		return $row;
 	}
 
@@ -470,6 +549,48 @@ class Agents extends BaseRepository {
 		);
 
 		return (int) $this->wpdb->insert_id;
+	}
+
+	/**
+	 * Atomically materialize one complete identity scope.
+	 *
+	 * @return array{agent_id:int,created:bool}
+	 */
+	public function create_identity_if_missing( string $agent_slug, string $agent_name, int $owner_id, string $instance_key, array $agent_config = array() ): array {
+		$existing = $this->get_by_identity_scope( $agent_slug, $owner_id, $instance_key );
+		if ( $existing ) {
+			return array(
+				'agent_id' => (int) $existing['agent_id'],
+				'created'  => false,
+			);
+		}
+
+		// The composite unique key serializes concurrent materialization attempts.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$inserted = $this->wpdb->insert(
+			$this->table_name,
+			array(
+				'agent_slug'   => $agent_slug,
+				'agent_name'   => $agent_name,
+				'owner_id'     => $owner_id,
+				'instance_key' => $instance_key,
+				'agent_config' => wp_json_encode( AgentConfigFactory::normalize( $agent_config ) ),
+			),
+			array( '%s', '%s', '%d', '%s', '%s' )
+		);
+
+		if ( false !== $inserted && $this->wpdb->insert_id > 0 ) {
+			return array(
+				'agent_id' => (int) $this->wpdb->insert_id,
+				'created'  => true,
+			);
+		}
+
+		$existing = $this->get_by_identity_scope( $agent_slug, $owner_id, $instance_key );
+		return array(
+			'agent_id' => (int) ( $existing['agent_id'] ?? 0 ),
+			'created'  => false,
+		);
 	}
 
 	private static function decode_agent_config( mixed $value ): array {

--- a/inc/Core/Database/Agents/Agents.php
+++ b/inc/Core/Database/Agents/Agents.php
@@ -25,8 +25,8 @@ class Agents extends BaseRepository {
 	 */
 	const TABLE_NAME = 'datamachine_agents';
 
-	private const DEFAULT_INSTANCE_KEY = 'default';
-	private const IDENTITY_INDEX_NAME = 'agent_identity_scope_hash';
+	private const DEFAULT_INSTANCE_KEY       = 'default';
+	private const IDENTITY_INDEX_NAME        = 'agent_identity_scope_hash';
 	private const PROVISIONING_LEASE_SECONDS = 300;
 
 	/**
@@ -88,7 +88,7 @@ class Agents extends BaseRepository {
 	public static function ensure_identity_scope_schema(): void {
 		global $wpdb;
 
-		$table_name = $wpdb->base_prefix . self::TABLE_NAME;
+		$table_name         = $wpdb->base_prefix . self::TABLE_NAME;
 		$had_provisioned_at = BaseRepository::column_exists( $table_name, 'provisioned_at', $wpdb );
 		self::ensure_identity_column( $wpdb, $table_name, 'instance_key', 'LONGTEXT NULL' );
 		self::ensure_identity_column( $wpdb, $table_name, 'instance_key_hash', 'CHAR(64) NULL' );
@@ -165,13 +165,14 @@ class Agents extends BaseRepository {
 		if ( BaseRepository::column_exists( $table_name, $column, $wpdb ) ) {
 			return;
 		}
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Column and definition are private schema constants, while the table identifier is prepared.
 		self::query_or_throw( $wpdb, $wpdb->prepare( "ALTER TABLE %i ADD COLUMN {$column} {$definition}", $table_name ), "add agent identity column {$column}" );
 	}
 
 	private static function query_or_throw( \wpdb $wpdb, string $sql, string $operation ): void {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
 		if ( false === $wpdb->query( $sql ) ) {
-			throw new \RuntimeException( sprintf( 'Failed to %s: %s', $operation, (string) $wpdb->last_error ) );
+			throw new \RuntimeException( sprintf( 'Failed to %s: %s', esc_html( $operation ), esc_html( (string) $wpdb->last_error ) ) );
 		}
 	}
 
@@ -184,7 +185,7 @@ class Agents extends BaseRepository {
 			foreach ( $index_rows as $index_row ) {
 				$name = (string) ( $index_row['name'] ?? '' );
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-				$column_rows = $wpdb->get_results( $wpdb->prepare( 'PRAGMA index_info(%i)', $name ), ARRAY_A );
+				$column_rows      = $wpdb->get_results( $wpdb->prepare( 'PRAGMA index_info(%i)', $name ), ARRAY_A );
 				$indexes[ $name ] = array(
 					'unique'  => 1 === (int) ( $index_row['unique'] ?? 0 ),
 					'columns' => array_values( array_map( static fn( array $column_row ): string => (string) ( $column_row['name'] ?? '' ), $column_rows ) ),
@@ -624,12 +625,12 @@ class Agents extends BaseRepository {
 		}
 
 		$data    = array(
-			'agent_slug'   => $agent_slug,
-			'agent_name'   => $agent_name,
-			'owner_id'     => $owner_id,
-			'instance_key' => self::DEFAULT_INSTANCE_KEY,
+			'agent_slug'        => $agent_slug,
+			'agent_name'        => $agent_name,
+			'owner_id'          => $owner_id,
+			'instance_key'      => self::DEFAULT_INSTANCE_KEY,
 			'instance_key_hash' => self::instance_key_hash( self::DEFAULT_INSTANCE_KEY ),
-			'agent_config' => wp_json_encode( AgentConfigFactory::normalize( $agent_config ) ),
+			'agent_config'      => wp_json_encode( AgentConfigFactory::normalize( $agent_config ) ),
 		);
 		$formats = array( '%s', '%s', '%d', '%s', '%s', '%s' );
 
@@ -666,17 +667,17 @@ class Agents extends BaseRepository {
 
 		// The composite unique key serializes concurrent materialization attempts.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-		$data = array(
-				'agent_slug'   => $agent_slug,
-				'agent_name'   => $agent_name,
-				'owner_id'     => $owner_id,
-				'instance_key' => $instance_key,
-				'instance_key_hash' => self::instance_key_hash( $instance_key ),
-				'provisioning_token' => '',
-				'provisioning_started_at' => null,
-				'provisioned_at' => null,
-				'agent_config' => wp_json_encode( AgentConfigFactory::normalize( $agent_config ) ),
-			);
+		$data     = array(
+			'agent_slug'              => $agent_slug,
+			'agent_name'              => $agent_name,
+			'owner_id'                => $owner_id,
+			'instance_key'            => $instance_key,
+			'instance_key_hash'       => self::instance_key_hash( $instance_key ),
+			'provisioning_token'      => '',
+			'provisioning_started_at' => null,
+			'provisioned_at'          => null,
+			'agent_config'            => wp_json_encode( AgentConfigFactory::normalize( $agent_config ) ),
+		);
 		$formats  = array( '%s', '%s', '%d', '%s', '%s', '%s', null, null, '%s' );
 		$inserted = $this->insert_identity_row( $data, $formats );
 
@@ -694,7 +695,10 @@ class Agents extends BaseRepository {
 		);
 	}
 
-	/** @param array<string,mixed> $data @param array<int,string|null> $formats */
+	/**
+	 * @param array<string,mixed>    $data    Identity row data.
+	 * @param array<int,string|null> $formats Identity row formats.
+	 */
 	protected function insert_identity_row( array $data, array $formats ): int|false {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		return $this->wpdb->insert( $this->table_name, $data, $formats );
@@ -703,6 +707,7 @@ class Agents extends BaseRepository {
 	public function claim_identity_provisioning( int $agent_id, string $token ): bool {
 		$now    = gmdate( 'Y-m-d H:i:s' );
 		$expiry = gmdate( 'Y-m-d H:i:s', time() - self::PROVISIONING_LEASE_SECONDS );
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- The complete conditional update is prepared immediately below.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->query(
 			$this->wpdb->prepare(
@@ -714,10 +719,12 @@ class Agents extends BaseRepository {
 				$expiry
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		return 1 === $updated;
 	}
 
 	public function complete_identity_provisioning( int $agent_id, string $token ): bool {
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- The complete conditional update is prepared immediately below.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->query(
 			$this->wpdb->prepare(
@@ -728,10 +735,12 @@ class Agents extends BaseRepository {
 				$token
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		return 1 === $updated;
 	}
 
 	public function release_identity_provisioning( int $agent_id, string $token ): void {
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- The complete conditional update is prepared immediately below.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$this->wpdb->query(
 			$this->wpdb->prepare(
@@ -741,6 +750,7 @@ class Agents extends BaseRepository {
 				$token
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 	}
 
 	private static function instance_key_hash( string $instance_key ): string {

--- a/inc/Core/Database/Agents/Agents.php
+++ b/inc/Core/Database/Agents/Agents.php
@@ -25,6 +25,10 @@ class Agents extends BaseRepository {
 	 */
 	const TABLE_NAME = 'datamachine_agents';
 
+	private const DEFAULT_INSTANCE_KEY = 'default';
+	private const IDENTITY_INDEX_NAME = 'agent_identity_scope_hash';
+	private const PROVISIONING_LEASE_SECONDS = 300;
+
 	/**
 	 * Use network-level prefix so agents are shared across the multisite network.
 	 *
@@ -55,13 +59,17 @@ class Agents extends BaseRepository {
 			agent_slug VARCHAR(200) NOT NULL,
 			agent_name VARCHAR(200) NOT NULL,
 			owner_id BIGINT(20) UNSIGNED NOT NULL,
-			instance_key VARCHAR(200) NOT NULL DEFAULT 'default',
+			instance_key LONGTEXT NOT NULL,
+			instance_key_hash CHAR(64) NOT NULL,
+			provisioning_token CHAR(64) NOT NULL DEFAULT '',
+			provisioning_started_at DATETIME NULL DEFAULT NULL,
+			provisioned_at DATETIME NULL DEFAULT CURRENT_TIMESTAMP,
 			site_scope BIGINT(20) UNSIGNED NULL DEFAULT NULL,
 			agent_config LONGTEXT NULL,
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 			PRIMARY KEY (agent_id),
-			UNIQUE KEY agent_identity_scope (agent_slug, owner_id, instance_key),
+			UNIQUE KEY agent_identity_scope_hash (agent_slug, owner_id, instance_key_hash),
 			KEY owner_id (owner_id),
 			KEY site_scope (site_scope)
 		) {$charset_collate};";
@@ -73,30 +81,120 @@ class Agents extends BaseRepository {
 	/**
 	 * Migrate legacy slug-only identity storage to the Agents API scope tuple.
 	 *
-	 * Existing rows become their owner's default materialized instance. The
-	 * explicit index repair is required because dbDelta does not drop obsolete
-	 * unique indexes from existing tables.
+	 * Existing rows become their owner's default materialized instance. Full
+	 * instance keys remain lossless in LONGTEXT while a fixed-width SHA-256
+	 * digest provides portable MySQL/SQLite uniqueness.
 	 */
 	public static function ensure_identity_scope_schema(): void {
 		global $wpdb;
 
 		$table_name = $wpdb->base_prefix . self::TABLE_NAME;
-		if ( ! BaseRepository::column_exists( $table_name, 'instance_key', $wpdb ) ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-			$wpdb->query( $wpdb->prepare( "ALTER TABLE %i ADD COLUMN instance_key VARCHAR(200) NOT NULL DEFAULT 'default'", $table_name ) );
+		$had_provisioned_at = BaseRepository::column_exists( $table_name, 'provisioned_at', $wpdb );
+		self::ensure_identity_column( $wpdb, $table_name, 'instance_key', 'LONGTEXT NULL' );
+		self::ensure_identity_column( $wpdb, $table_name, 'instance_key_hash', 'CHAR(64) NULL' );
+		self::ensure_identity_column( $wpdb, $table_name, 'provisioning_token', "CHAR(64) NOT NULL DEFAULT ''" );
+		self::ensure_identity_column( $wpdb, $table_name, 'provisioning_started_at', 'DATETIME NULL DEFAULT NULL' );
+		// SQLite rejects non-constant defaults when ALTER TABLE adds a column.
+		self::ensure_identity_column( $wpdb, $table_name, 'provisioned_at', 'DATETIME NULL DEFAULT NULL' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		self::query_or_throw(
+			$wpdb,
+			$wpdb->prepare( 'UPDATE %i SET instance_key = %s WHERE instance_key IS NULL OR instance_key = %s', $table_name, self::DEFAULT_INSTANCE_KEY, '' ),
+			'backfill legacy agent instance keys'
+		);
+		if ( ! $had_provisioned_at ) {
+			self::query_or_throw(
+				$wpdb,
+				$wpdb->prepare( 'UPDATE %i SET provisioned_at = %s WHERE provisioned_at IS NULL', $table_name, gmdate( 'Y-m-d H:i:s' ) ),
+				'backfill legacy agent provisioning state'
+			);
 		}
 
-		if ( self::is_sqlite() ) {
-			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
-			$wpdb->query( 'DROP INDEX IF EXISTS agent_slug' );
-			$wpdb->query( $wpdb->prepare( 'CREATE UNIQUE INDEX IF NOT EXISTS agent_identity_scope ON %i (agent_slug, owner_id, instance_key)', $table_name ) );
-			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+		// Hash in PHP so SQLite and MySQL persist byte-for-byte equivalent digests.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results( $wpdb->prepare( 'SELECT agent_id, instance_key, instance_key_hash FROM %i', $table_name ), ARRAY_A );
+		foreach ( $rows as $row ) {
+			$instance_key = (string) ( $row['instance_key'] ?? self::DEFAULT_INSTANCE_KEY );
+			$digest       = self::instance_key_hash( $instance_key );
+			if ( hash_equals( $digest, (string) ( $row['instance_key_hash'] ?? '' ) ) ) {
+				continue;
+			}
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			if ( false === $wpdb->update( $table_name, array( 'instance_key_hash' => $digest ), array( 'agent_id' => (int) $row['agent_id'] ), array( '%s' ), array( '%d' ) ) ) {
+				throw new \RuntimeException( 'Failed to backfill agent identity scope digest.' );
+			}
+		}
+
+		if ( ! self::is_sqlite() ) {
+			self::query_or_throw( $wpdb, $wpdb->prepare( 'ALTER TABLE %i MODIFY instance_key LONGTEXT NOT NULL', $table_name ), 'make agent instance keys non-null' );
+			self::query_or_throw( $wpdb, $wpdb->prepare( 'ALTER TABLE %i MODIFY instance_key_hash CHAR(64) NOT NULL', $table_name ), 'make agent instance digests non-null' );
+		}
+
+		$indexes = self::get_identity_indexes( $wpdb, $table_name );
+		if ( ! self::has_unique_index( $indexes, array( 'agent_slug', 'owner_id', 'instance_key_hash' ) ) ) {
+			$sql = self::is_sqlite()
+				? $wpdb->prepare( 'CREATE UNIQUE INDEX %i ON %i (agent_slug, owner_id, instance_key_hash)', self::IDENTITY_INDEX_NAME, $table_name )
+				: $wpdb->prepare( 'ALTER TABLE %i ADD UNIQUE KEY %i (agent_slug, owner_id, instance_key_hash)', $table_name, self::IDENTITY_INDEX_NAME );
+			self::query_or_throw( $wpdb, $sql, 'create agent identity scope index' );
+		}
+
+		$indexes = self::get_identity_indexes( $wpdb, $table_name );
+		if ( ! self::has_unique_index( $indexes, array( 'agent_slug', 'owner_id', 'instance_key_hash' ) ) ) {
+			throw new \RuntimeException( 'Agent identity scope index verification failed.' );
+		}
+
+		// Only remove obsolete uniqueness after the digest-backed replacement is verified.
+		foreach ( $indexes as $name => $index ) {
+			if ( ! $index['unique'] || ! in_array( $index['columns'], array( array( 'agent_slug' ), array( 'agent_slug', 'owner_id', 'instance_key' ) ), true ) ) {
+				continue;
+			}
+			$sql = self::is_sqlite()
+				? $wpdb->prepare( 'DROP INDEX %i', $name )
+				: $wpdb->prepare( 'ALTER TABLE %i DROP INDEX %i', $table_name, $name );
+			self::query_or_throw( $wpdb, $sql, 'remove obsolete agent identity index' );
+		}
+
+		$indexes = self::get_identity_indexes( $wpdb, $table_name );
+		if ( ! self::has_unique_index( $indexes, array( 'agent_slug', 'owner_id', 'instance_key_hash' ) ) || self::has_unique_index( $indexes, array( 'agent_slug' ) ) ) {
+			throw new \RuntimeException( 'Agent identity schema migration did not reach a valid final state.' );
+		}
+	}
+
+	private static function ensure_identity_column( \wpdb $wpdb, string $table_name, string $column, string $definition ): void {
+		if ( BaseRepository::column_exists( $table_name, $column, $wpdb ) ) {
 			return;
+		}
+		self::query_or_throw( $wpdb, $wpdb->prepare( "ALTER TABLE %i ADD COLUMN {$column} {$definition}", $table_name ), "add agent identity column {$column}" );
+	}
+
+	private static function query_or_throw( \wpdb $wpdb, string $sql, string $operation ): void {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+		if ( false === $wpdb->query( $sql ) ) {
+			throw new \RuntimeException( sprintf( 'Failed to %s: %s', $operation, (string) $wpdb->last_error ) );
+		}
+	}
+
+	/** @return array<string,array{unique:bool,columns:string[]}> */
+	private static function get_identity_indexes( \wpdb $wpdb, string $table_name ): array {
+		$indexes = array();
+		if ( self::is_sqlite() ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$index_rows = $wpdb->get_results( $wpdb->prepare( 'PRAGMA index_list(%i)', $table_name ), ARRAY_A );
+			foreach ( $index_rows as $index_row ) {
+				$name = (string) ( $index_row['name'] ?? '' );
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$column_rows = $wpdb->get_results( $wpdb->prepare( 'PRAGMA index_info(%i)', $name ), ARRAY_A );
+				$indexes[ $name ] = array(
+					'unique'  => 1 === (int) ( $index_row['unique'] ?? 0 ),
+					'columns' => array_values( array_map( static fn( array $column_row ): string => (string) ( $column_row['name'] ?? '' ), $column_rows ) ),
+				);
+			}
+			return $indexes;
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$index_rows = $wpdb->get_results( $wpdb->prepare( 'SHOW INDEX FROM %i', $table_name ), ARRAY_A );
-		$indexes    = array();
 		foreach ( $index_rows as $index_row ) {
 			$name = (string) ( $index_row['Key_name'] ?? '' );
 			if ( '' === $name ) {
@@ -105,24 +203,20 @@ class Agents extends BaseRepository {
 			$indexes[ $name ]['unique'] = 0 === (int) ( $index_row['Non_unique'] ?? 1 );
 			$indexes[ $name ]['columns'][ (int) ( $index_row['Seq_in_index'] ?? 0 ) ] = (string) ( $index_row['Column_name'] ?? '' );
 		}
-
-		$has_identity_scope_index = false;
-		foreach ( $indexes as $name => $index ) {
+		foreach ( $indexes as &$index ) {
 			ksort( $index['columns'] );
-			$columns = array_values( $index['columns'] );
-			if ( $index['unique'] && array( 'agent_slug' ) === $columns ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-				$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP INDEX %i', $table_name, $name ) );
-			}
-			if ( $index['unique'] && array( 'agent_slug', 'owner_id', 'instance_key' ) === $columns ) {
-				$has_identity_scope_index = true;
-			}
+			$index['columns'] = array_values( $index['columns'] );
 		}
+		return $indexes;
+	}
 
-		if ( ! $has_identity_scope_index ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD UNIQUE KEY %i (agent_slug, owner_id, instance_key)', $table_name, 'agent_identity_scope' ) );
+	private static function has_unique_index( array $indexes, array $columns ): bool {
+		foreach ( $indexes as $index ) {
+			if ( $index['unique'] && $columns === $index['columns'] ) {
+				return true;
+			}
 		}
+		return false;
 	}
 
 	/**
@@ -328,11 +422,11 @@ class Agents extends BaseRepository {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		$row = $this->wpdb->get_row(
 			$this->wpdb->prepare(
-				'SELECT * FROM %i WHERE agent_slug = %s AND owner_id = %d AND instance_key = %s LIMIT 1',
+				'SELECT * FROM %i WHERE agent_slug = %s AND owner_id = %d AND instance_key_hash = %s LIMIT 1',
 				$this->table_name,
 				$agent_slug,
 				$owner_id,
-				$instance_key
+				self::instance_key_hash( $instance_key )
 			),
 			ARRAY_A
 		);
@@ -340,6 +434,9 @@ class Agents extends BaseRepository {
 
 		if ( ! $row ) {
 			return null;
+		}
+		if ( ! hash_equals( $instance_key, (string) ( $row['instance_key'] ?? '' ) ) ) {
+			throw new \UnexpectedValueException( 'Agent identity scope digest conflicts with persisted instance key.' );
 		}
 
 		$row['agent_config'] = self::decode_agent_config( $row['agent_config'] ?? null );
@@ -530,9 +627,11 @@ class Agents extends BaseRepository {
 			'agent_slug'   => $agent_slug,
 			'agent_name'   => $agent_name,
 			'owner_id'     => $owner_id,
+			'instance_key' => self::DEFAULT_INSTANCE_KEY,
+			'instance_key_hash' => self::instance_key_hash( self::DEFAULT_INSTANCE_KEY ),
 			'agent_config' => wp_json_encode( AgentConfigFactory::normalize( $agent_config ) ),
 		);
-		$formats = array( '%s', '%s', '%d', '%s' );
+		$formats = array( '%s', '%s', '%d', '%s', '%s', '%s' );
 
 		// Only write site_scope when the caller is intentional about it. The
 		// `false` sentinel leaves the column to its DB default (NULL = network-wide).
@@ -567,17 +666,19 @@ class Agents extends BaseRepository {
 
 		// The composite unique key serializes concurrent materialization attempts.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-		$inserted = $this->wpdb->insert(
-			$this->table_name,
-			array(
+		$data = array(
 				'agent_slug'   => $agent_slug,
 				'agent_name'   => $agent_name,
 				'owner_id'     => $owner_id,
 				'instance_key' => $instance_key,
+				'instance_key_hash' => self::instance_key_hash( $instance_key ),
+				'provisioning_token' => '',
+				'provisioning_started_at' => null,
+				'provisioned_at' => null,
 				'agent_config' => wp_json_encode( AgentConfigFactory::normalize( $agent_config ) ),
-			),
-			array( '%s', '%s', '%d', '%s', '%s' )
-		);
+			);
+		$formats  = array( '%s', '%s', '%d', '%s', '%s', '%s', null, null, '%s' );
+		$inserted = $this->insert_identity_row( $data, $formats );
 
 		if ( false !== $inserted && $this->wpdb->insert_id > 0 ) {
 			return array(
@@ -591,6 +692,59 @@ class Agents extends BaseRepository {
 			'agent_id' => (int) ( $existing['agent_id'] ?? 0 ),
 			'created'  => false,
 		);
+	}
+
+	/** @param array<string,mixed> $data @param array<int,string|null> $formats */
+	protected function insert_identity_row( array $data, array $formats ): int|false {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		return $this->wpdb->insert( $this->table_name, $data, $formats );
+	}
+
+	public function claim_identity_provisioning( int $agent_id, string $token ): bool {
+		$now    = gmdate( 'Y-m-d H:i:s' );
+		$expiry = gmdate( 'Y-m-d H:i:s', time() - self::PROVISIONING_LEASE_SECONDS );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $this->wpdb->query(
+			$this->wpdb->prepare(
+				"UPDATE %i SET provisioning_token = %s, provisioning_started_at = %s WHERE agent_id = %d AND provisioned_at IS NULL AND (provisioning_token = '' OR provisioning_token IS NULL OR provisioning_started_at IS NULL OR provisioning_started_at < %s)",
+				$this->table_name,
+				$token,
+				$now,
+				$agent_id,
+				$expiry
+			)
+		);
+		return 1 === $updated;
+	}
+
+	public function complete_identity_provisioning( int $agent_id, string $token ): bool {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $this->wpdb->query(
+			$this->wpdb->prepare(
+				"UPDATE %i SET provisioned_at = %s, provisioning_token = '', provisioning_started_at = NULL WHERE agent_id = %d AND provisioning_token = %s AND provisioned_at IS NULL",
+				$this->table_name,
+				gmdate( 'Y-m-d H:i:s' ),
+				$agent_id,
+				$token
+			)
+		);
+		return 1 === $updated;
+	}
+
+	public function release_identity_provisioning( int $agent_id, string $token ): void {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$this->wpdb->query(
+			$this->wpdb->prepare(
+				"UPDATE %i SET provisioning_token = '', provisioning_started_at = NULL WHERE agent_id = %d AND provisioning_token = %s AND provisioned_at IS NULL",
+				$this->table_name,
+				$agent_id,
+				$token
+			)
+		);
+	}
+
+	private static function instance_key_hash( string $instance_key ): string {
+		return hash( 'sha256', $instance_key );
 	}
 
 	private static function decode_agent_config( mixed $value ): array {

--- a/inc/Core/FilesRepository/DirectoryManager.php
+++ b/inc/Core/FilesRepository/DirectoryManager.php
@@ -360,6 +360,23 @@ class DirectoryManager {
 	 * @return string Full path to agent identity directory.
 	 */
 	public function resolve_agent_directory( array $context ): string {
+		$agent_id = (int) ( $context['agent_id'] ?? 0 );
+		if ( $agent_id > 0 && class_exists( '\\DataMachine\\Core\\Database\\Agents\\Agents' ) ) {
+			$agents_repo = new \DataMachine\Core\Database\Agents\Agents();
+			$agent       = $agents_repo->get_agent( $agent_id );
+			if ( is_array( $agent ) && ! empty( $agent['agent_slug'] ) ) {
+				$slug      = sanitize_title( (string) $agent['agent_slug'] );
+				$canonical = $agents_repo->get_by_slug( $slug );
+				$is_legacy = 'default' === (string) ( $agent['instance_key'] ?? 'default' )
+					&& (int) ( $canonical['agent_id'] ?? 0 ) === $agent_id;
+				if ( ! $is_legacy ) {
+					$scope_key = sprintf( '%s:%d:%s', $slug, (int) ( $agent['owner_id'] ?? 0 ), (string) ( $agent['instance_key'] ?? 'default' ) );
+					$slug     .= '--' . substr( hash( 'sha256', $scope_key ), 0, 16 );
+				}
+				return $this->get_agent_identity_directory( $slug );
+			}
+		}
+
 		return $this->get_agent_identity_directory( $this->resolve_agent_slug( $context ) );
 	}
 

--- a/inc/Core/Identity/AgentIdentityStoreAdapter.php
+++ b/inc/Core/Identity/AgentIdentityStoreAdapter.php
@@ -56,7 +56,8 @@ class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
 
 	/** @inheritDoc */
 	public function resolve( WP_Agent_Identity_Scope $scope ): ?WP_Agent_Materialized_Identity {
-		$row = $this->agents_repository->get_by_slug( $scope->normalize()->agent_slug );
+		$scope = $scope->normalize();
+		$row   = $this->agents_repository->get_by_identity_scope( $scope->agent_slug, $scope->owner_user_id, $scope->instance_key );
 		return is_array( $row ) ? $this->identity_from_row( $row, $scope ) : null;
 	}
 
@@ -69,7 +70,7 @@ class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
 	/** @inheritDoc */
 	public function materialize( WP_Agent_Identity_Scope $scope, array $default_config = array(), array $meta = array() ): WP_Agent_Materialized_Identity {
 		$scope    = $scope->normalize();
-		$existing = $this->agents_repository->get_by_slug( $scope->agent_slug );
+		$existing = $this->agents_repository->get_by_identity_scope( $scope->agent_slug, $scope->owner_user_id, $scope->instance_key );
 		if ( is_array( $existing ) ) {
 			return $this->identity_from_row( $existing, $scope );
 		}
@@ -83,12 +84,14 @@ class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
 			);
 		}
 
-		$agent_id = $this->agents_repository->create_if_missing(
+		$creation = $this->agents_repository->create_identity_if_missing(
 			$scope->agent_slug,
 			$this->label_from_meta( $meta, $scope->agent_slug ),
 			$scope->owner_user_id,
+			$scope->instance_key,
 			$default_config
 		);
+		$agent_id = $creation['agent_id'];
 
 		if ( $agent_id <= 0 ) {
 			throw new \RuntimeException(
@@ -103,19 +106,36 @@ class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
 				'agent_slug'   => $scope->agent_slug,
 				'agent_name'   => $this->label_from_meta( $meta, $scope->agent_slug ),
 				'owner_id'     => $scope->owner_user_id,
+				'instance_key' => $scope->instance_key,
 				'agent_config' => $default_config,
 			);
 		}
 
-		$this->after_created( $agent_id, $scope, $meta );
+		if ( $creation['created'] ) {
+			$this->after_created( $agent_id, $scope, $meta );
+		}
 
 		return $this->identity_from_row( $row, $scope, $meta );
 	}
 
 	/** @inheritDoc */
 	public function update( WP_Agent_Materialized_Identity $identity ): WP_Agent_Materialized_Identity {
-		$this->agents_repository->update_agent( $identity->id, array( 'agent_config' => $identity->config ) );
-		return $this->get( $identity->id ) ?? $identity;
+		$row = $this->agents_repository->get_agent( $identity->id );
+		if ( ! is_array( $row ) ) {
+			throw new \InvalidArgumentException( sprintf( 'Cannot update unknown materialized agent identity %d.', esc_html( (string) $identity->id ) ) );
+		}
+
+		$this->identity_from_row( $row, $identity->scope );
+		if ( ! $this->agents_repository->update_agent( $identity->id, array( 'agent_config' => $identity->config ) ) ) {
+			throw new \RuntimeException( sprintf( 'Failed to update materialized agent identity %d.', esc_html( (string) $identity->id ) ) );
+		}
+
+		$updated = $this->get( $identity->id );
+		if ( null === $updated ) {
+			throw new \RuntimeException( sprintf( 'Materialized agent identity %d disappeared after update.', esc_html( (string) $identity->id ) ) );
+		}
+
+		return $updated;
 	}
 
 	/** @inheritDoc */
@@ -138,7 +158,7 @@ class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
 
 		if ( class_exists( DirectoryManager::class ) ) {
 			$dir_mgr   = new DirectoryManager();
-			$agent_dir = $dir_mgr->get_agent_identity_directory( $scope->agent_slug );
+			$agent_dir = $dir_mgr->resolve_agent_directory( array( 'agent_id' => $agent_id ) );
 			$dir_mgr->ensure_directory_exists( $agent_dir );
 		}
 
@@ -146,14 +166,16 @@ class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
 		if ( $scaffold ) {
 			$scaffold->execute(
 				array(
-					'layer'      => 'agent',
-					'agent_slug' => $scope->agent_slug,
-					'agent_id'   => $agent_id,
+					'layer'         => 'agent',
+					'agent_slug'    => $scope->agent_slug,
+					'agent_id'      => $agent_id,
+					'owner_user_id' => $scope->owner_user_id,
+					'instance_key'  => $scope->instance_key,
 				)
 			);
 		}
 
-		do_action( 'datamachine_registered_agent_reconciled', $agent_id, $scope->agent_slug, $meta['datamachine_definition'] ?? $meta );
+		do_action( 'datamachine_registered_agent_reconciled', $agent_id, $scope->agent_slug, $meta['datamachine_definition'] ?? $meta, $scope );
 	}
 
 	/**
@@ -164,20 +186,26 @@ class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
 	 * @param array<string,mixed>          $meta  Additional metadata.
 	 */
 	private function identity_from_row( array $row, ?WP_Agent_Identity_Scope $scope = null, array $meta = array() ): WP_Agent_Materialized_Identity {
-		$scope ??= new WP_Agent_Identity_Scope(
+		$persisted_scope = new WP_Agent_Identity_Scope(
 			(string) ( $row['agent_slug'] ?? '' ),
-			(int) ( $row['owner_id'] ?? 0 )
+			(int) ( $row['owner_id'] ?? 0 ),
+			(string) ( $row['instance_key'] ?? 'default' )
 		);
+		$persisted_scope = $persisted_scope->normalize();
+		if ( null !== $scope && $persisted_scope->key() !== $scope->normalize()->key() ) {
+			throw new \UnexpectedValueException( sprintf( 'Persisted identity %d does not match requested scope.', (int) ( $row['agent_id'] ?? 0 ) ) );
+		}
 
 		return new WP_Agent_Materialized_Identity(
 			(int) ( $row['agent_id'] ?? 0 ),
-			$scope->normalize(),
+			$persisted_scope,
 			is_array( $row['agent_config'] ?? null ) ? $row['agent_config'] : array(),
 			array_merge(
 				$meta,
 				array(
-					'datamachine_agent_id' => (int) ( $row['agent_id'] ?? 0 ),
-					'datamachine_owner_id' => (int) ( $row['owner_id'] ?? 0 ),
+					'datamachine_agent_id'     => (int) ( $row['agent_id'] ?? 0 ),
+					'datamachine_owner_id'     => (int) ( $row['owner_id'] ?? 0 ),
+					'datamachine_instance_key' => (string) ( $row['instance_key'] ?? 'default' ),
 				)
 			),
 			$this->timestamp_from_row( $row, 'created_at' ),

--- a/inc/Core/Identity/AgentIdentityStoreAdapter.php
+++ b/inc/Core/Identity/AgentIdentityStoreAdapter.php
@@ -193,13 +193,13 @@ class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
 			if ( is_array( $current ) && $this->is_provisioned( $current ) ) {
 				return $this->identity_from_row( $current, $scope, $meta );
 			}
-			throw new \RuntimeException( sprintf( 'Materialized agent identity %d is currently provisioning; retry.', $agent_id ) );
+			throw new \RuntimeException( sprintf( 'Materialized agent identity %d is currently provisioning; retry.', esc_html( (string) $agent_id ) ) );
 		}
 
 		try {
 			$this->provision_identity( $agent_id, $scope, $meta );
 			if ( ! $this->agents_repository->complete_identity_provisioning( $agent_id, $token ) ) {
-				throw new \RuntimeException( sprintf( 'Failed to mark materialized agent identity %d provisioned.', $agent_id ) );
+				throw new \RuntimeException( sprintf( 'Failed to mark materialized agent identity %d provisioned.', esc_html( (string) $agent_id ) ) );
 			}
 		} catch ( \Throwable $throwable ) {
 			$this->agents_repository->release_identity_provisioning( $agent_id, $token );
@@ -208,7 +208,7 @@ class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
 
 		$current = $this->agents_repository->get_agent( $agent_id );
 		if ( ! is_array( $current ) || ! $this->is_provisioned( $current ) ) {
-			throw new \RuntimeException( sprintf( 'Materialized agent identity %d provisioning state was not persisted.', $agent_id ) );
+			throw new \RuntimeException( sprintf( 'Materialized agent identity %d provisioning state was not persisted.', esc_html( (string) $agent_id ) ) );
 		}
 		return $this->identity_from_row( $current, $scope, $meta );
 	}

--- a/inc/Core/Identity/AgentIdentityStoreAdapter.php
+++ b/inc/Core/Identity/AgentIdentityStoreAdapter.php
@@ -58,13 +58,13 @@ class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
 	public function resolve( WP_Agent_Identity_Scope $scope ): ?WP_Agent_Materialized_Identity {
 		$scope = $scope->normalize();
 		$row   = $this->agents_repository->get_by_identity_scope( $scope->agent_slug, $scope->owner_user_id, $scope->instance_key );
-		return is_array( $row ) ? $this->identity_from_row( $row, $scope ) : null;
+		return is_array( $row ) && $this->is_provisioned( $row ) ? $this->identity_from_row( $row, $scope ) : null;
 	}
 
 	/** @inheritDoc */
 	public function get( int $identity_id ): ?WP_Agent_Materialized_Identity {
 		$row = $this->agents_repository->get_agent( $identity_id );
-		return is_array( $row ) ? $this->identity_from_row( $row ) : null;
+		return is_array( $row ) && $this->is_provisioned( $row ) ? $this->identity_from_row( $row ) : null;
 	}
 
 	/** @inheritDoc */
@@ -72,7 +72,7 @@ class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
 		$scope    = $scope->normalize();
 		$existing = $this->agents_repository->get_by_identity_scope( $scope->agent_slug, $scope->owner_user_id, $scope->instance_key );
 		if ( is_array( $existing ) ) {
-			return $this->identity_from_row( $existing, $scope );
+			return $this->provision( $existing, $scope, $meta );
 		}
 
 		// Only materialize identities that correspond to a registered agent
@@ -111,11 +111,7 @@ class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
 			);
 		}
 
-		if ( $creation['created'] ) {
-			$this->after_created( $agent_id, $scope, $meta );
-		}
-
-		return $this->identity_from_row( $row, $scope, $meta );
+		return $this->provision( $row, $scope, $meta );
 	}
 
 	/** @inheritDoc */
@@ -151,20 +147,22 @@ class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
 	 * @param WP_Agent_Identity_Scope $scope    Normalized identity scope.
 	 * @param array<string,mixed>     $meta     Materialization metadata.
 	 */
-	private function after_created( int $agent_id, WP_Agent_Identity_Scope $scope, array $meta ): void {
-		if ( class_exists( AgentAccess::class ) ) {
-			( new AgentAccess() )->bootstrap_owner_access( $agent_id, $scope->owner_user_id );
+	protected function provision_identity( int $agent_id, WP_Agent_Identity_Scope $scope, array $meta ): void {
+		if ( class_exists( AgentAccess::class ) && $scope->owner_user_id > 0 && ! ( new AgentAccess() )->bootstrap_owner_access( $agent_id, $scope->owner_user_id ) ) {
+			throw new \RuntimeException( 'Failed to provision materialized agent owner access.' );
 		}
 
 		if ( class_exists( DirectoryManager::class ) ) {
 			$dir_mgr   = new DirectoryManager();
 			$agent_dir = $dir_mgr->resolve_agent_directory( array( 'agent_id' => $agent_id ) );
-			$dir_mgr->ensure_directory_exists( $agent_dir );
+			if ( ! $dir_mgr->ensure_directory_exists( $agent_dir ) ) {
+				throw new \RuntimeException( 'Failed to provision materialized agent directory.' );
+			}
 		}
 
 		$scaffold = ScaffoldAbilities::get_ability();
 		if ( $scaffold ) {
-			$scaffold->execute(
+			$result = $scaffold->execute(
 				array(
 					'layer'         => 'agent',
 					'agent_slug'    => $scope->agent_slug,
@@ -173,9 +171,51 @@ class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
 					'instance_key'  => $scope->instance_key,
 				)
 			);
+			if ( is_array( $result ) && empty( $result['success'] ) ) {
+				throw new \RuntimeException( 'Failed to provision materialized agent scaffold.' );
+			}
 		}
 
 		do_action( 'datamachine_registered_agent_reconciled', $agent_id, $scope->agent_slug, $meta['datamachine_definition'] ?? $meta, $scope );
+	}
+
+	/** @param array<string,mixed> $row */
+	private function provision( array $row, WP_Agent_Identity_Scope $scope, array $meta ): WP_Agent_Materialized_Identity {
+		$this->identity_from_row( $row, $scope );
+		if ( $this->is_provisioned( $row ) ) {
+			return $this->identity_from_row( $row, $scope, $meta );
+		}
+
+		$agent_id = (int) ( $row['agent_id'] ?? 0 );
+		$token    = hash( 'sha256', wp_generate_uuid4() . ':' . $agent_id );
+		if ( ! $this->agents_repository->claim_identity_provisioning( $agent_id, $token ) ) {
+			$current = $this->agents_repository->get_agent( $agent_id );
+			if ( is_array( $current ) && $this->is_provisioned( $current ) ) {
+				return $this->identity_from_row( $current, $scope, $meta );
+			}
+			throw new \RuntimeException( sprintf( 'Materialized agent identity %d is currently provisioning; retry.', $agent_id ) );
+		}
+
+		try {
+			$this->provision_identity( $agent_id, $scope, $meta );
+			if ( ! $this->agents_repository->complete_identity_provisioning( $agent_id, $token ) ) {
+				throw new \RuntimeException( sprintf( 'Failed to mark materialized agent identity %d provisioned.', $agent_id ) );
+			}
+		} catch ( \Throwable $throwable ) {
+			$this->agents_repository->release_identity_provisioning( $agent_id, $token );
+			throw $throwable;
+		}
+
+		$current = $this->agents_repository->get_agent( $agent_id );
+		if ( ! is_array( $current ) || ! $this->is_provisioned( $current ) ) {
+			throw new \RuntimeException( sprintf( 'Materialized agent identity %d provisioning state was not persisted.', $agent_id ) );
+		}
+		return $this->identity_from_row( $current, $scope, $meta );
+	}
+
+	/** @param array<string,mixed> $row */
+	private function is_provisioned( array $row ): bool {
+		return is_scalar( $row['provisioned_at'] ?? null ) && '' !== (string) $row['provisioned_at'];
 	}
 
 	/**

--- a/tests/Unit/Core/Identity/AgentIdentityStoreAdapterTest.php
+++ b/tests/Unit/Core/Identity/AgentIdentityStoreAdapterTest.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Materialized agent identity scope regression tests.
+ *
+ * @package DataMachine\Tests\Unit\Core\Identity
+ */
+
+namespace DataMachine\Tests\Unit\Core\Identity;
+
+use AgentsAPI\Core\Identity\WP_Agent_Identity_Scope;
+use AgentsAPI\Core\Identity\WP_Agent_Materialized_Identity;
+use DataMachine\Core\Database\Agents\AgentAccess;
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Core\Identity\AgentIdentityStoreAdapter;
+use WP_UnitTestCase;
+
+class AgentIdentityStoreAdapterTest extends WP_UnitTestCase {
+
+	private Agents $repository;
+	private AgentIdentityStoreAdapter $store;
+	private int $owner_a;
+	private int $owner_b;
+	private array $registered = array();
+
+	public function set_up(): void {
+		parent::set_up();
+		Agents::ensure_identity_scope_schema();
+		global $wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->base_prefix}datamachine_agent_access" );
+		$wpdb->query( "DELETE FROM {$wpdb->base_prefix}datamachine_agents" );
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$this->repository = new Agents();
+		$this->store      = new AgentIdentityStoreAdapter( $this->repository );
+		$this->owner_a    = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->owner_b    = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->owner_a );
+	}
+
+	public function tear_down(): void {
+		global $wpdb;
+		foreach ( $this->registered as $slug ) {
+			\WP_Agents_Registry::get_instance()->unregister( $slug );
+		}
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->base_prefix}datamachine_agent_access" );
+		$wpdb->query( "DELETE FROM {$wpdb->base_prefix}datamachine_agents" );
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		parent::tear_down();
+	}
+
+	public function test_same_slug_with_different_owners_materializes_distinct_identities(): void {
+		$this->register_agent( 'owner-scoped-agent' );
+		$first  = $this->store->materialize( new WP_Agent_Identity_Scope( 'owner-scoped-agent', $this->owner_a ) );
+		$second = $this->store->materialize( new WP_Agent_Identity_Scope( 'owner-scoped-agent', $this->owner_b ) );
+
+		$this->assertNotSame( $first->id, $second->id );
+		$this->assertSame( $this->owner_a, $this->store->get( $first->id )->scope->owner_user_id );
+		$this->assertSame( $this->owner_b, $this->store->get( $second->id )->scope->owner_user_id );
+	}
+
+	public function test_same_slug_and_owner_with_different_instance_keys_do_not_collide(): void {
+		$this->register_agent( 'instance-scoped-agent' );
+		$first  = $this->store->materialize( new WP_Agent_Identity_Scope( 'instance-scoped-agent', $this->owner_a, 'workspace:first' ) );
+		$second = $this->store->materialize( new WP_Agent_Identity_Scope( 'instance-scoped-agent', $this->owner_a, 'workspace:second' ) );
+
+		$this->assertNotSame( $first->id, $second->id );
+		$this->assertSame( 'workspace:first', $this->store->get( $first->id )->scope->instance_key );
+		$this->assertSame( 'workspace:second', $this->store->get( $second->id )->scope->instance_key );
+		$directories = new DirectoryManager();
+		$this->assertNotSame(
+			$directories->resolve_agent_directory( array( 'agent_id' => $first->id ) ),
+			$directories->resolve_agent_directory( array( 'agent_id' => $second->id ) )
+		);
+	}
+
+	public function test_legacy_default_row_resolves_with_preserved_access_and_directory(): void {
+		$agent_id = $this->repository->create_if_missing( 'legacy-default-agent', 'Legacy Default Agent', $this->owner_a );
+		( new AgentAccess() )->bootstrap_owner_access( $agent_id, $this->owner_a );
+
+		$identity = $this->store->resolve( new WP_Agent_Identity_Scope( 'legacy-default-agent', $this->owner_a ) );
+
+		$this->assertNotNull( $identity );
+		$this->assertSame( 'default', $identity->scope->instance_key );
+		$this->assertTrue( ( new AgentAccess() )->user_can_access( $agent_id, $this->owner_a, 'admin' ) );
+		$this->assertStringEndsWith( '/agents/legacy-default-agent', ( new DirectoryManager() )->resolve_agent_directory( array( 'agent_id' => $agent_id ) ) );
+	}
+
+	public function test_mismatched_stale_scope_fails_closed_on_resolve_and_update(): void {
+		$agent_id = $this->repository->create_identity_if_missing( 'stale-scope-agent', 'Stale Scope Agent', $this->owner_a, 'stored', array( 'value' => 'stored' ) )['agent_id'];
+		$this->assertNull( $this->store->resolve( new WP_Agent_Identity_Scope( 'stale-scope-agent', $this->owner_a, 'requested' ) ) );
+
+		$stale = new WP_Agent_Materialized_Identity(
+			$agent_id,
+			new WP_Agent_Identity_Scope( 'stale-scope-agent', $this->owner_a, 'requested' ),
+			array( 'value' => 'changed' )
+		);
+		try {
+			$this->store->update( $stale );
+			$this->fail( 'A contradictory scope must not update persisted identity state.' );
+		} catch ( \UnexpectedValueException $exception ) {
+			$this->assertStringContainsString( 'does not match requested scope', $exception->getMessage() );
+		}
+		$this->assertSame( 'stored', $this->repository->get_agent( $agent_id )['agent_config']['value'] );
+	}
+
+	public function test_concurrent_materialization_retries_are_idempotent(): void {
+		$this->register_agent( 'concurrent-agent' );
+		$scope = new WP_Agent_Identity_Scope( 'concurrent-agent', $this->owner_a, 'shared-instance' );
+
+		$first  = $this->store->materialize( $scope );
+		$second = ( new AgentIdentityStoreAdapter( new Agents() ) )->materialize( $scope );
+
+		$this->assertSame( $first->id, $second->id );
+		$this->assertCount( 1, array_filter( $this->repository->get_all(), static fn( array $row ): bool => 'concurrent-agent' === $row['agent_slug'] ) );
+	}
+
+	public function test_schema_migration_preserves_legacy_rows_and_replaces_slug_unique_key(): void {
+		global $wpdb;
+		$table = $wpdb->base_prefix . Agents::TABLE_NAME;
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP INDEX %i', $table, 'agent_identity_scope' ) );
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP COLUMN instance_key', $table ) );
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD UNIQUE KEY %i (agent_slug)', $table, 'agent_slug' ) );
+		$wpdb->insert(
+			$table,
+			array( 'agent_slug' => 'pre-migration-agent', 'agent_name' => 'Pre Migration Agent', 'owner_id' => $this->owner_a, 'agent_config' => '{}' ),
+			array( '%s', '%s', '%d', '%s' )
+		);
+		$agent_id = (int) $wpdb->insert_id;
+		( new AgentAccess() )->bootstrap_owner_access( $agent_id, $this->owner_a );
+
+		Agents::ensure_identity_scope_schema();
+		$row     = ( new Agents() )->get_agent( $agent_id );
+		$indexes = $wpdb->get_results( $wpdb->prepare( 'SHOW INDEX FROM %i', $table ), ARRAY_A );
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		$this->assertSame( 'default', $row['instance_key'] );
+		$this->assertTrue( ( new AgentAccess() )->user_can_access( $agent_id, $this->owner_a, 'admin' ) );
+		$this->assertNotEmpty( array_filter( $indexes, static fn( array $index ): bool => 'agent_identity_scope' === $index['Key_name'] ) );
+		$this->assertEmpty( array_filter( $indexes, static fn( array $index ): bool => 'agent_slug' === $index['Key_name'] && 0 === (int) $index['Non_unique'] ) );
+	}
+
+	private function register_agent( string $slug ): void {
+		\WP_Agents_Registry::get_instance()->register( $slug, array( 'label' => $slug ) );
+		$this->registered[] = $slug;
+	}
+}

--- a/tests/Unit/Core/Identity/AgentIdentityStoreAdapterTest.php
+++ b/tests/Unit/Core/Identity/AgentIdentityStoreAdapterTest.php
@@ -15,6 +15,43 @@ use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Core\Identity\AgentIdentityStoreAdapter;
 use WP_UnitTestCase;
 
+class FailingProvisionAdapter extends AgentIdentityStoreAdapter {
+	public bool $failed = false;
+
+	protected function provision_identity( int $agent_id, WP_Agent_Identity_Scope $scope, array $meta ): void {
+		unset( $agent_id, $scope, $meta );
+		$this->failed = true;
+		throw new \RuntimeException( 'Injected provisioning failure.' );
+	}
+}
+
+class CountingProvisionAdapter extends AgentIdentityStoreAdapter {
+	public int $provision_count = 0;
+
+	protected function provision_identity( int $agent_id, WP_Agent_Identity_Scope $scope, array $meta ): void {
+		++$this->provision_count;
+		parent::provision_identity( $agent_id, $scope, $meta );
+	}
+}
+
+class DuplicateLoserAgents extends Agents {
+	public bool $duplicate_loser_exercised = false;
+
+	protected function insert_identity_row( array $data, array $formats ): int|false {
+		unset( $formats );
+		$this->duplicate_loser_exercised = true;
+		$config = json_decode( (string) $data['agent_config'], true );
+		( new Agents() )->create_identity_if_missing(
+			(string) $data['agent_slug'],
+			(string) $data['agent_name'],
+			(int) $data['owner_id'],
+			(string) $data['instance_key'],
+			is_array( $config ) ? $config : array()
+		);
+		return false;
+	}
+}
+
 class AgentIdentityStoreAdapterTest extends WP_UnitTestCase {
 
 	private Agents $repository;
@@ -75,6 +112,21 @@ class AgentIdentityStoreAdapterTest extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_long_instance_keys_with_shared_prefix_round_trip_without_collision(): void {
+		$this->register_agent( 'long-instance-agent' );
+		$prefix = str_repeat( 'shared-prefix-', 30 );
+		$key_a  = $prefix . 'first';
+		$key_b  = $prefix . 'second';
+
+		$first  = $this->store->materialize( new WP_Agent_Identity_Scope( 'long-instance-agent', $this->owner_a, $key_a ) );
+		$second = $this->store->materialize( new WP_Agent_Identity_Scope( 'long-instance-agent', $this->owner_a, $key_b ) );
+
+		$this->assertGreaterThan( 200, strlen( $key_a ) );
+		$this->assertNotSame( $first->id, $second->id );
+		$this->assertSame( $key_a, $this->store->get( $first->id )->scope->instance_key );
+		$this->assertSame( $key_b, $this->store->get( $second->id )->scope->instance_key );
+	}
+
 	public function test_legacy_default_row_resolves_with_preserved_access_and_directory(): void {
 		$agent_id = $this->repository->create_if_missing( 'legacy-default-agent', 'Legacy Default Agent', $this->owner_a );
 		( new AgentAccess() )->bootstrap_owner_access( $agent_id, $this->owner_a );
@@ -105,14 +157,39 @@ class AgentIdentityStoreAdapterTest extends WP_UnitTestCase {
 		$this->assertSame( 'stored', $this->repository->get_agent( $agent_id )['agent_config']['value'] );
 	}
 
-	public function test_concurrent_materialization_retries_are_idempotent(): void {
+	public function test_failed_provisioning_remains_incomplete_and_retryable(): void {
+		$this->register_agent( 'retry-provision-agent' );
+		$scope   = new WP_Agent_Identity_Scope( 'retry-provision-agent', $this->owner_a, 'recoverable' );
+		$failing = new FailingProvisionAdapter( $this->repository );
+
+		try {
+			$failing->materialize( $scope );
+			$this->fail( 'Injected provisioning failure must propagate.' );
+		} catch ( \RuntimeException $exception ) {
+			$this->assertSame( 'Injected provisioning failure.', $exception->getMessage() );
+		}
+		$this->assertTrue( $failing->failed );
+		$this->assertNull( $this->store->resolve( $scope ) );
+		$row = $this->repository->get_by_identity_scope( 'retry-provision-agent', $this->owner_a, 'recoverable' );
+		$this->assertSame( '', (string) $row['provisioning_token'] );
+		$this->assertEmpty( $row['provisioned_at'] );
+
+		$identity = $this->store->materialize( $scope );
+		$this->assertSame( $identity->id, $this->store->resolve( $scope )->id );
+		$this->assertNotEmpty( $this->repository->get_agent( $identity->id )['provisioned_at'] );
+	}
+
+	public function test_duplicate_key_loser_reconciles_pending_winner(): void {
 		$this->register_agent( 'concurrent-agent' );
-		$scope = new WP_Agent_Identity_Scope( 'concurrent-agent', $this->owner_a, 'shared-instance' );
+		$scope      = new WP_Agent_Identity_Scope( 'concurrent-agent', $this->owner_a, 'shared-instance' );
+		$repository = new DuplicateLoserAgents();
+		$adapter    = new CountingProvisionAdapter( $repository );
 
-		$first  = $this->store->materialize( $scope );
-		$second = ( new AgentIdentityStoreAdapter( new Agents() ) )->materialize( $scope );
+		$identity = $adapter->materialize( $scope );
 
-		$this->assertSame( $first->id, $second->id );
+		$this->assertTrue( $repository->duplicate_loser_exercised );
+		$this->assertSame( 1, $adapter->provision_count );
+		$this->assertSame( $identity->id, $this->store->resolve( $scope )->id );
 		$this->assertCount( 1, array_filter( $this->repository->get_all(), static fn( array $row ): bool => 'concurrent-agent' === $row['agent_slug'] ) );
 	}
 
@@ -121,9 +198,14 @@ class AgentIdentityStoreAdapterTest extends WP_UnitTestCase {
 		$table = $wpdb->base_prefix . Agents::TABLE_NAME;
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP INDEX %i', $table, 'agent_identity_scope' ) );
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP INDEX %i', $table, 'agent_identity_scope_hash' ) );
 		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP COLUMN instance_key', $table ) );
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP COLUMN instance_key_hash', $table ) );
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP COLUMN provisioning_token', $table ) );
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP COLUMN provisioning_started_at', $table ) );
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP COLUMN provisioned_at', $table ) );
 		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD UNIQUE KEY %i (agent_slug)', $table, 'agent_slug' ) );
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ADD KEY %i (owner_id)', $table, 'agent_identity_scope_hash' ) );
 		$wpdb->insert(
 			$table,
 			array( 'agent_slug' => 'pre-migration-agent', 'agent_name' => 'Pre Migration Agent', 'owner_id' => $this->owner_a, 'agent_config' => '{}' ),
@@ -132,14 +214,26 @@ class AgentIdentityStoreAdapterTest extends WP_UnitTestCase {
 		$agent_id = (int) $wpdb->insert_id;
 		( new AgentAccess() )->bootstrap_owner_access( $agent_id, $this->owner_a );
 
+		try {
+			Agents::ensure_identity_scope_schema();
+			$this->fail( 'A conflicting replacement index must fail the migration.' );
+		} catch ( \RuntimeException $exception ) {
+			$this->assertStringContainsString( 'create agent identity scope index', $exception->getMessage() );
+		}
+		$failed_indexes = $wpdb->get_results( $wpdb->prepare( 'SHOW INDEX FROM %i', $table ), ARRAY_A );
+		$this->assertNotEmpty( array_filter( $failed_indexes, static fn( array $index ): bool => 'agent_slug' === $index['Key_name'] && 0 === (int) $index['Non_unique'] ) );
+
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP INDEX %i', $table, 'agent_identity_scope_hash' ) );
 		Agents::ensure_identity_scope_schema();
 		$row     = ( new Agents() )->get_agent( $agent_id );
 		$indexes = $wpdb->get_results( $wpdb->prepare( 'SHOW INDEX FROM %i', $table ), ARRAY_A );
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		$this->assertSame( 'default', $row['instance_key'] );
+		$this->assertSame( hash( 'sha256', 'default' ), $row['instance_key_hash'] );
+		$this->assertNotEmpty( $row['provisioned_at'] );
 		$this->assertTrue( ( new AgentAccess() )->user_can_access( $agent_id, $this->owner_a, 'admin' ) );
-		$this->assertNotEmpty( array_filter( $indexes, static fn( array $index ): bool => 'agent_identity_scope' === $index['Key_name'] ) );
+		$this->assertNotEmpty( array_filter( $indexes, static fn( array $index ): bool => 'agent_identity_scope_hash' === $index['Key_name'] ) );
 		$this->assertEmpty( array_filter( $indexes, static fn( array $index ): bool => 'agent_slug' === $index['Key_name'] && 0 === (int) $index['Non_unique'] ) );
 	}
 

--- a/tests/agent-registry-materializer-smoke.php
+++ b/tests/agent-registry-materializer-smoke.php
@@ -63,6 +63,12 @@ namespace {
 		}
 	}
 
+	if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+		function wp_generate_uuid4(): string {
+			return '00000000-0000-4000-8000-000000000001';
+		}
+	}
+
 	if ( ! function_exists( 'add_action' ) ) {
 		function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
 			unset( $accepted_args );
@@ -126,9 +132,39 @@ namespace DataMachine\Core\Database\Agents {
 				'owner_id'     => $owner_id,
 				'instance_key' => $instance_key,
 				'agent_config' => $agent_config,
+				'provisioned_at' => null,
 			);
 
 			return array( 'agent_id' => $agent_id, 'created' => true );
+		}
+
+		public function claim_identity_provisioning( int $agent_id, string $token ): bool {
+			foreach ( self::$rows as &$row ) {
+				if ( (int) $row['agent_id'] === $agent_id && empty( $row['provisioned_at'] ) && empty( $row['provisioning_token'] ) ) {
+					$row['provisioning_token'] = $token;
+					return true;
+				}
+			}
+			return false;
+		}
+
+		public function complete_identity_provisioning( int $agent_id, string $token ): bool {
+			foreach ( self::$rows as &$row ) {
+				if ( (int) $row['agent_id'] === $agent_id && $token === ( $row['provisioning_token'] ?? '' ) ) {
+					$row['provisioned_at']     = '2026-07-28 00:00:00';
+					$row['provisioning_token'] = '';
+					return true;
+				}
+			}
+			return false;
+		}
+
+		public function release_identity_provisioning( int $agent_id, string $token ): void {
+			foreach ( self::$rows as &$row ) {
+				if ( (int) $row['agent_id'] === $agent_id && $token === ( $row['provisioning_token'] ?? '' ) ) {
+					$row['provisioning_token'] = '';
+				}
+			}
 		}
 
 		public function update_agent( int $agent_id, array $data ): bool {
@@ -186,8 +222,9 @@ namespace DataMachine\Core\FilesRepository {
 			return '/agents/unknown';
 		}
 
-		public function ensure_directory_exists( string $path ): void {
+		public function ensure_directory_exists( string $path ): bool {
 			self::$ensured[] = $path;
+			return true;
 		}
 	}
 }

--- a/tests/agent-registry-materializer-smoke.php
+++ b/tests/agent-registry-materializer-smoke.php
@@ -83,7 +83,16 @@ namespace DataMachine\Core\Database\Agents {
 		public static array $rows = array();
 
 		public function get_by_slug( string $agent_slug ): ?array {
-			return self::$rows[ $agent_slug ] ?? null;
+			foreach ( self::$rows as $row ) {
+				if ( $agent_slug === ( $row['agent_slug'] ?? '' ) ) {
+					return $row;
+				}
+			}
+			return null;
+		}
+
+		public function get_by_identity_scope( string $agent_slug, int $owner_id, string $instance_key = 'default' ): ?array {
+			return self::$rows[ "{$agent_slug}:{$owner_id}:{$instance_key}" ] ?? null;
 		}
 
 		public function get_agent( int $agent_id ): ?array {
@@ -97,20 +106,29 @@ namespace DataMachine\Core\Database\Agents {
 		}
 
 		public function create_if_missing( string $agent_slug, string $agent_name, int $owner_id, array $agent_config = array() ): int {
-			if ( isset( self::$rows[ $agent_slug ] ) ) {
-				return (int) self::$rows[ $agent_slug ]['agent_id'];
+			$existing = $this->get_by_slug( $agent_slug );
+			if ( $existing ) {
+				return (int) $existing['agent_id'];
 			}
+			return $this->create_identity_if_missing( $agent_slug, $agent_name, $owner_id, 'default', $agent_config )['agent_id'];
+		}
 
+		public function create_identity_if_missing( string $agent_slug, string $agent_name, int $owner_id, string $instance_key, array $agent_config = array() ): array {
+			$key = "{$agent_slug}:{$owner_id}:{$instance_key}";
+			if ( isset( self::$rows[ $key ] ) ) {
+				return array( 'agent_id' => (int) self::$rows[ $key ]['agent_id'], 'created' => false );
+			}
 			$agent_id = count( self::$rows ) + 100;
-			self::$rows[ $agent_slug ] = array(
+			self::$rows[ $key ] = array(
 				'agent_id'     => $agent_id,
 				'agent_slug'   => $agent_slug,
 				'agent_name'   => $agent_name,
 				'owner_id'     => $owner_id,
+				'instance_key' => $instance_key,
 				'agent_config' => $agent_config,
 			);
 
-			return $agent_id;
+			return array( 'agent_id' => $agent_id, 'created' => true );
 		}
 
 		public function update_agent( int $agent_id, array $data ): bool {
@@ -157,6 +175,15 @@ namespace DataMachine\Core\FilesRepository {
 
 		public function get_agent_identity_directory( string $slug ): string {
 			return '/agents/' . $slug;
+		}
+
+		public function resolve_agent_directory( array $context ): string {
+			foreach ( \DataMachine\Core\Database\Agents\Agents::$rows as $row ) {
+				if ( (int) $row['agent_id'] === (int) ( $context['agent_id'] ?? 0 ) ) {
+					return $this->get_agent_identity_directory( $row['agent_slug'] );
+				}
+			}
+			return '/agents/unknown';
 		}
 
 		public function ensure_directory_exists( string $path ): void {
@@ -309,11 +336,11 @@ namespace {
 	do_action( 'init' );
 	$summary = AgentRegistry::reconcile();
 	assert_agent_materializer_equals( array( 'created' => array( 'example-agent' ), 'existing' => array(), 'skipped' => array() ), $summary, 'created summary matches pre-split registry behavior', $failures, $passes );
-	assert_agent_materializer_equals( 7, Agents::$rows['example-agent']['owner_id'] ?? 0, 'owner resolver controls created row owner', $failures, $passes );
-	assert_agent_materializer_equals( array( 'default_provider' => 'openai' ), Agents::$rows['example-agent']['agent_config'] ?? array(), 'default config persists on creation', $failures, $passes );
+	assert_agent_materializer_equals( 7, Agents::$rows['example-agent:7:default']['owner_id'] ?? 0, 'owner resolver controls created row owner', $failures, $passes );
+	assert_agent_materializer_equals( array( 'default_provider' => 'openai' ), Agents::$rows['example-agent:7:default']['agent_config'] ?? array(), 'default config persists on creation', $failures, $passes );
 	assert_agent_materializer_equals( array( array( 'agent_id' => 100, 'owner_id' => 7 ) ), AgentAccess::$bootstrapped, 'owner access is bootstrapped', $failures, $passes );
 	assert_agent_materializer_equals( array( '/agents/example-agent' ), DirectoryManager::$ensured, 'agent directory is ensured', $failures, $passes );
-	assert_agent_materializer_equals( array( array( 'layer' => 'agent', 'agent_slug' => 'example-agent', 'agent_id' => 100 ) ), ScaffoldAbilities::$ability->calls, 'agent scaffold ability is executed', $failures, $passes );
+	assert_agent_materializer_equals( array( array( 'layer' => 'agent', 'agent_slug' => 'example-agent', 'agent_id' => 100, 'owner_user_id' => 7, 'instance_key' => 'default' ) ), ScaffoldAbilities::$ability->calls, 'agent scaffold ability is executed', $failures, $passes );
 	assert_agent_materializer_equals( 'example-agent', $GLOBALS['__agent_materializer_actions']['datamachine_registered_agent_reconciled'][0][1] ?? '', 'reconciled action still fires with slug', $failures, $passes );
 
 	echo "\n[3] existing rows are adopted and mutable fields stay DB-owned:\n";


### PR DESCRIPTION
## Summary
- persist full normalized materialized identity scopes without truncating valid long instance keys
- recover and retry provisioning after failures or duplicate-key races instead of treating incomplete rows as ready
- migrate legacy uniqueness only after a digest-backed replacement index is created and verified

## Migration And Compatibility
- stores the complete normalized `instance_key` as `LONGTEXT`
- stores SHA-256 `instance_key_hash` and uniquely indexes `(agent_slug, owner_id, instance_key_hash)` on MySQL and SQLite
- verifies the digest hit against the full persisted key and fails closed on contradictory storage
- adds leased provisioning state (`provisioning_token`, `provisioning_started_at`, `provisioned_at`)
- backfills legacy rows as default, already-provisioned identities without changing IDs or access grants
- creates and verifies replacement uniqueness before dropping obsolete slug/full-key indexes; DDL failures throw so deferred migration remains retryable
- retains deterministic oldest-row behavior for legacy slug-only APIs and legacy default directories

## Provisioning Invariants
- incomplete rows are not returned by `resolve()` or `get()`
- owner access, directory creation, scaffold, and reconciliation failures propagate and release the provisioning claim
- stale claims expire; retries can reclaim and complete provisioning
- duplicate-key losers re-read and reconcile the winner's pending row
- `delete()` remains the pre-existing explicit no-op because Data Machine deletion lifecycle is owned by its higher-level agent deletion ability; this PR does not broaden deletion semantics

## Tests
- regression coverage in `AgentIdentityStoreAdapterTest` for >200-byte shared-prefix keys, provisioning failure/retry, duplicate-key loser reconciliation, legacy migration, and replacement-index failure/retry
- `php tests/agent-registry-materializer-smoke.php` (passed, 23 assertions)
- `php tests/agent-prune-resurrection-smoke.php` (passed, 5 assertions)
- `php tests/prefix-policy-audit.php` (passed, 11 assertions)
- PHP syntax checks for corrected implementation and regression class (passed)
- `git diff --check` (passed)
- `homeboy review lint --placement local --changed-only` (passed, PHPCS and PHPStan)
- `homeboy review audit --placement local --changed-since origin/main` (passed)
- `homeboy review test --placement local --skip-lint -- --filter=AgentIdentityStoreAdapterTest` (pre-existing harness blocker: exits 1 before structured test counts)
- `homeboy review test --placement local --skip-lint` (same pre-existing harness blocker)

Closes #3025