### PR TITLE
Satisfy the release lint baseline

### DIFF
--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -108,7 +108,7 @@ class AgentsChatHandler {
 		$agent_id = $identity ? $identity->agent_id : 0;
 
 		$calling_user_id = $this->resolveCallingUserId( $input );
-		$user_id = $this->resolveRuntimeUserId( $identity, (string) ( $input['agent'] ?? '' ), $input );
+		$user_id         = $this->resolveRuntimeUserId( $identity, (string) ( $input['agent'] ?? '' ), $input );
 		if ( $user_id <= 0 ) {
 			return new WP_Error( 'no_user', __( 'No user context available.', 'data-machine' ), array( 'status' => 400 ) );
 		}
@@ -153,7 +153,7 @@ class AgentsChatHandler {
 				'modes'                 => $modes,
 				'agent_id'              => $agent_id,
 				'agent_slug'            => $identity ? $identity->agent_slug : '',
-				'calling_user_id'        => $calling_user_id,
+				'calling_user_id'       => $calling_user_id,
 				'attachments'           => $input['attachments'] ?? array(),
 				'client_context'        => $client_context,
 				'tool_policy'           => is_array( $input['tool_policy'] ?? null ) ? $input['tool_policy'] : null,

--- a/inc/Abilities/Fetch/FetchRssAbility.php
+++ b/inc/Abilities/Fetch/FetchRssAbility.php
@@ -529,5 +529,4 @@ class FetchRssAbility {
 
 		return $item_timestamp >= $cutoff;
 	}
-
 }

--- a/inc/Abilities/Fetch/FetchWordPressApiAbility.php
+++ b/inc/Abilities/Fetch/FetchWordPressApiAbility.php
@@ -602,5 +602,4 @@ class FetchWordPressApiAbility {
 
 		return $item_timestamp >= $cutoff;
 	}
-
 }

--- a/inc/Abilities/Fetch/FetchWordPressMediaAbility.php
+++ b/inc/Abilities/Fetch/FetchWordPressMediaAbility.php
@@ -373,5 +373,4 @@ class FetchWordPressMediaAbility {
 
 		return $mime_patterns;
 	}
-
 }

--- a/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
+++ b/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
@@ -342,5 +342,4 @@ class QueryWordPressPostsAbility {
 
 		return array_merge( $defaults, $input );
 	}
-
 }

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -46,7 +46,7 @@ class ExecuteWorkflowAbility {
 						'type'       => 'object',
 						'required'   => array( 'workflow' ),
 						'properties' => array(
-							'workflow'     => array(
+							'workflow'      => array(
 								'type'        => 'object',
 								'description' => __( 'Ephemeral workflow with steps array', 'data-machine' ),
 								'properties'  => array(
@@ -56,15 +56,15 @@ class ExecuteWorkflowAbility {
 									),
 								),
 							),
-							'timestamp'    => array(
+							'timestamp'     => array(
 								'type'        => array( 'integer', 'null' ),
 								'description' => __( 'Future Unix timestamp for delayed execution. Omit for immediate execution.', 'data-machine' ),
 							),
-							'initial_data' => array(
+							'initial_data'  => array(
 								'type'        => 'object',
 								'description' => __( 'Optional initial engine data to merge into the engine data alongside configs.', 'data-machine' ),
 							),
-							'dry_run'      => array(
+							'dry_run'       => array(
 								'type'        => 'boolean',
 								'default'     => false,
 								'description' => __( 'Preview execution without creating posts. Returns preview data instead of publishing.', 'data-machine' ),
@@ -130,10 +130,10 @@ class ExecuteWorkflowAbility {
 	 * @return array
 	 */
 	private function executeWithAuthority( array $input, bool $system_context ): array {
-		$workflow       = $input['workflow'] ?? null;
-		$timestamp      = $input['timestamp'] ?? null;
-		$initial_data   = is_array( $input['initial_data'] ?? null ) ? $input['initial_data'] : array();
-		$operation_key  = is_string( $input['operation_key'] ?? null ) ? trim( $input['operation_key'] ) : '';
+		$workflow      = $input['workflow'] ?? null;
+		$timestamp     = $input['timestamp'] ?? null;
+		$initial_data  = is_array( $input['initial_data'] ?? null ) ? $input['initial_data'] : array();
+		$operation_key = is_string( $input['operation_key'] ?? null ) ? trim( $input['operation_key'] ) : '';
 
 		// Validate workflow structure
 		$validation = WorkflowSpecValidator::validate( $workflow );
@@ -185,12 +185,12 @@ class ExecuteWorkflowAbility {
 			: 'Chat Workflow';
 
 		$create_args = array(
-			'pipeline_id'      => 'direct',
-			'flow_id'          => 'direct',
-			'source'           => $job_source,
-			'label'            => $job_label,
-			'user_id'          => $ownership['user_id'],
-			'operation_state'  => 'preparing',
+			'pipeline_id'       => 'direct',
+			'flow_id'           => 'direct',
+			'source'            => $job_source,
+			'label'             => $job_label,
+			'user_id'           => $ownership['user_id'],
+			'operation_state'   => 'preparing',
 			'operation_step_id' => $first_step_id,
 		);
 		if ( $ownership['agent_id'] > 0 ) {
@@ -228,9 +228,9 @@ class ExecuteWorkflowAbility {
 			$engine_data['dry_run_mode'] = true;
 		}
 
-		$request_fingerprint = $this->requestFingerprint( $engine_data, $timestamp );
+		$request_fingerprint                = $this->requestFingerprint( $engine_data, $timestamp );
 		$create_args['request_fingerprint'] = $request_fingerprint;
-		$engine_data['direct_request']       = array(
+		$engine_data['direct_request']      = array(
 			'operation_key'  => $operation_key,
 			'fingerprint'    => $request_fingerprint,
 			'execution_type' => $timestamp && is_numeric( $timestamp ) && (int) $timestamp > time() ? 'delayed' : 'immediate',
@@ -294,9 +294,9 @@ class ExecuteWorkflowAbility {
 		);
 		if ( empty( $enqueue['success'] ) ) {
 			return array(
-				'success'    => false,
-				'error'      => (string) ( $enqueue['error'] ?? 'enqueue_failed' ),
-				'retryable'  => ! empty( $enqueue['retryable'] ),
+				'success'       => false,
+				'error'         => (string) ( $enqueue['error'] ?? 'enqueue_failed' ),
+				'retryable'     => ! empty( $enqueue['retryable'] ),
 				'enqueue_state' => (string) ( $enqueue['state'] ?? 'enqueue_failed' ),
 			);
 		}
@@ -319,7 +319,7 @@ class ExecuteWorkflowAbility {
 		$agent_id        = max( 0, (int) ( $scope->acting_agent_id() ?? 0 ) );
 		$agent_slug      = '';
 
-		$caller_snapshot = is_array( $initial_data['job'] ?? null ) ? $initial_data['job'] : array();
+		$caller_snapshot  = is_array( $initial_data['job'] ?? null ) ? $initial_data['job'] : array();
 		$identity_context = array_filter(
 			$agent_id > 0
 				? array( 'agent_id' => $agent_id )

--- a/inc/Abilities/Job/GetJobsAbility.php
+++ b/inc/Abilities/Job/GetJobsAbility.php
@@ -142,21 +142,21 @@ class GetJobsAbility {
 	 * @return array Result with jobs list.
 	 */
 	public function execute( array $input ): array {
-		$job_id      = $input['job_id'] ?? null;
-		$flow_id     = $input['flow_id'] ?? null;
-		$pipeline_id = $input['pipeline_id'] ?? null;
-		$user_id     = $input['user_id'] ?? null;
-		$agent_id    = $input['agent_id'] ?? null;
-		$status      = $input['status'] ?? null;
-		$source      = $input['source'] ?? null;
-		$handler     = $input['handler'] ?? null;
-		$since       = $input['since'] ?? null;
-		$per_page    = (int) ( $input['per_page'] ?? self::DEFAULT_PER_PAGE );
-		$offset      = (int) ( $input['offset'] ?? 0 );
-		$orderby     = $input['orderby'] ?? 'j.job_id';
-		$order       = $input['order'] ?? 'DESC';
-		$fields      = $input['fields'] ?? null;
-		$metadata    = \DataMachine\Core\ExecutionQuery::normalize_metadata_filters( $input['metadata'] ?? array() );
+		$job_id          = $input['job_id'] ?? null;
+		$flow_id         = $input['flow_id'] ?? null;
+		$pipeline_id     = $input['pipeline_id'] ?? null;
+		$user_id         = $input['user_id'] ?? null;
+		$agent_id        = $input['agent_id'] ?? null;
+		$status          = $input['status'] ?? null;
+		$source          = $input['source'] ?? null;
+		$handler         = $input['handler'] ?? null;
+		$since           = $input['since'] ?? null;
+		$per_page        = (int) ( $input['per_page'] ?? self::DEFAULT_PER_PAGE );
+		$offset          = (int) ( $input['offset'] ?? 0 );
+		$orderby         = $input['orderby'] ?? 'j.job_id';
+		$order           = $input['order'] ?? 'DESC';
+		$fields          = $input['fields'] ?? null;
+		$metadata        = \DataMachine\Core\ExecutionQuery::normalize_metadata_filters( $input['metadata'] ?? array() );
 		$ownership_scope = $this->jobCollectionScope(
 			null !== $user_id ? (int) $user_id : null,
 			null !== $agent_id ? (int) $agent_id : null

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -82,7 +82,7 @@ class ChatOrchestrator {
 		if ( ! $workspace instanceof WP_Agent_Workspace_Scope ) {
 			return new WP_Error( 'invalid_transcript_workspace', __( 'A canonical transcript workspace is required.', 'data-machine' ), array( 'status' => 400 ) );
 		}
-		$transcript_owner     = ChatTranscriptOwner::resolve_for_request( $options, $user_id );
+		$transcript_owner = ChatTranscriptOwner::resolve_for_request( $options, $user_id );
 		if ( is_wp_error( $transcript_owner ) ) {
 			return $transcript_owner;
 		}
@@ -425,7 +425,7 @@ class ChatOrchestrator {
 			);
 		}
 
-		$metadata = $session['metadata'] ?? array();
+		$metadata        = $session['metadata'] ?? array();
 		$calling_user_id = null !== $calling_user_id
 			? max( 0, $calling_user_id )
 			: ( array_key_exists( 'calling_user_id', $metadata ) ? max( 0, (int) $metadata['calling_user_id'] ) : $user_id );
@@ -921,15 +921,15 @@ class ChatOrchestrator {
 			$client_context = $options['client_context'] ?? array();
 			$all_tools      = $resolver->resolve(
 				array(
-					'modes'          => $modes,
-					'agent_id'       => $agent_id,
-					'agent_slug'     => $agent_slug,
-					'user_id'        => $user_id,
+					'modes'           => $modes,
+					'agent_id'        => $agent_id,
+					'agent_slug'      => $agent_slug,
+					'user_id'         => $user_id,
 					'calling_user_id' => $calling_user_id,
-					'interactive'    => true,
-					'client_context' => is_array( $client_context ) ? $client_context : array(),
-					'tool_policy'    => is_array( $options['tool_policy'] ?? null ) ? $options['tool_policy'] : null,
-					'allow_only'     => is_array( $options['allow_only'] ?? null ) ? $options['allow_only'] : array(),
+					'interactive'     => true,
+					'client_context'  => is_array( $client_context ) ? $client_context : array(),
+					'tool_policy'     => is_array( $options['tool_policy'] ?? null ) ? $options['tool_policy'] : null,
+					'allow_only'      => is_array( $options['allow_only'] ?? null ) ? $options['allow_only'] : array(),
 				)
 			);
 

--- a/inc/Api/Execute.php
+++ b/inc/Api/Execute.php
@@ -40,32 +40,32 @@ class Execute {
 					return PermissionHelper::can( 'manage_flows' );
 				},
 				'args'                => array(
-					'flow_id'      => array(
+					'flow_id'       => array(
 						'type'        => 'integer',
 						'required'    => false,
 						'description' => 'Database flow ID to execute',
 					),
-					'workflow'     => array(
+					'workflow'      => array(
 						'type'        => 'object',
 						'required'    => false,
 						'description' => 'Ephemeral workflow structure',
 					),
-					'count'        => array(
+					'count'         => array(
 						'type'        => 'integer',
 						'required'    => false,
 						'description' => 'Number of times to run (1-10, database flow only)',
 					),
-					'timestamp'    => array(
+					'timestamp'     => array(
 						'type'        => 'integer',
 						'required'    => false,
 						'description' => 'Unix timestamp for delayed execution',
 					),
-					'initial_data' => array(
+					'initial_data'  => array(
 						'type'        => 'object',
 						'required'    => false,
 						'description' => 'Initial engine data to merge before workflow execution',
 					),
-					'dry_run'      => array(
+					'dry_run'       => array(
 						'type'        => 'boolean',
 						'required'    => false,
 						'default'     => false,
@@ -232,10 +232,10 @@ class Execute {
 	 * Handle ephemeral workflow execution via datamachine/execute-workflow.
 	 */
 	private static function handle_ephemeral_execution( $request ) {
-		$workflow     = $request->get_param( 'workflow' );
-		$timestamp    = $request->get_param( 'timestamp' );
-		$initial_data = $request->get_param( 'initial_data' );
-		$dry_run      = $request->get_param( 'dry_run' );
+		$workflow      = $request->get_param( 'workflow' );
+		$timestamp     = $request->get_param( 'timestamp' );
+		$initial_data  = $request->get_param( 'initial_data' );
+		$dry_run       = $request->get_param( 'dry_run' );
 		$operation_key = $request->get_param( 'operation_key' );
 
 		$ability = wp_get_ability( 'datamachine/execute-workflow' );
@@ -268,8 +268,8 @@ class Execute {
 		}
 
 		if ( ! ( $result['success'] ?? false ) ) {
-			$status = 400;
-			$error  = $result['error'] ?? __( 'Execution failed', 'data-machine' );
+			$status     = 400;
+			$error      = $result['error'] ?? __( 'Execution failed', 'data-machine' );
 			$error_data = array( 'status' => $status );
 
 			if ( false !== strpos( $error, 'not found' ) ) {
@@ -277,7 +277,7 @@ class Execute {
 			} elseif ( false !== strpos( $error, 'Failed to create' ) || false !== strpos( $error, 'not available' ) ) {
 				$status = 500;
 			} elseif ( ! empty( $result['retryable'] ) ) {
-				$status = 409;
+				$status                      = 409;
 				$error_data['retryable']     = true;
 				$error_data['enqueue_state'] = (string) ( $result['enqueue_state'] ?? 'enqueuing' );
 			}

--- a/inc/Cli/Commands/PendingActionsCommand.php
+++ b/inc/Cli/Commands/PendingActionsCommand.php
@@ -34,7 +34,12 @@ class PendingActionsCommand extends BaseCommand {
 		if ( '' === $action_id ) {
 			WP_CLI::error( 'action_id is required.' );
 		}
-		$result = \DataMachine\Engine\AI\Actions\ResolvePendingActionAbility::execute( array( 'action_id' => $action_id, 'decision' => $decision, 'resolver' => 'cli:' . get_current_user_id(), 'context' => array( 'resolution_transport' => 'cli' ) ) );
+		$result = \DataMachine\Engine\AI\Actions\ResolvePendingActionAbility::execute( array(
+			'action_id' => $action_id,
+			'decision'  => $decision,
+			'resolver'  => 'cli:' . get_current_user_id(),
+			'context'   => array( 'resolution_transport' => 'cli' ),
+		) );
 		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( (string) ( $result['error'] ?? 'Pending action could not be resolved.' ) );
 		}

--- a/inc/Cli/WorkerHealth.php
+++ b/inc/Cli/WorkerHealth.php
@@ -29,13 +29,13 @@ class WorkerHealth {
 			);
 		}
 
-		$due_count               = max( 0, (int) ( $evidence['due_count'] ?? 0 ) );
-		$deferred                = max( 0, (int) ( $evidence['concurrency_deferred_actions'] ?? 0 ) );
-		$stale_due_sample_age    = isset( $evidence['stale_due_sample_age_seconds'] ) ? max( 0, (int) $evidence['stale_due_sample_age_seconds'] ) : null;
-		$queue_trigger_state     = (string) ( $evidence['queue_trigger_state'] ?? 'unknown' );
-		$heartbeat_state         = (string) ( $evidence['worker_heartbeat_state'] ?? 'absent' );
-		$worker_claimed          = 'fresh' === $heartbeat_state;
-		$dispatcher_starved      = $due_count > 0
+		$due_count            = max( 0, (int) ( $evidence['due_count'] ?? 0 ) );
+		$deferred             = max( 0, (int) ( $evidence['concurrency_deferred_actions'] ?? 0 ) );
+		$stale_due_sample_age = isset( $evidence['stale_due_sample_age_seconds'] ) ? max( 0, (int) $evidence['stale_due_sample_age_seconds'] ) : null;
+		$queue_trigger_state  = (string) ( $evidence['queue_trigger_state'] ?? 'unknown' );
+		$heartbeat_state      = (string) ( $evidence['worker_heartbeat_state'] ?? 'absent' );
+		$worker_claimed       = 'fresh' === $heartbeat_state;
+		$dispatcher_starved   = $due_count > 0
 			&& ! $worker_claimed
 			&& null !== $stale_due_sample_age
 			&& $stale_due_sample_age > $stale_threshold_seconds

--- a/inc/Core/ActionScheduler/ScopedDrainService.php
+++ b/inc/Core/ActionScheduler/ScopedDrainService.php
@@ -14,8 +14,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class ScopedDrainService {
 
-	private const GROUP = 'data-machine';
-	private const DISPATCH_EVIDENCE_LIMIT = 100;
+	private const GROUP                    = 'data-machine';
+	private const DISPATCH_EVIDENCE_LIMIT  = 100;
 	private const DISPATCH_STALE_THRESHOLD = 900;
 
 	public const HOOK_BATCH_CHUNK = 'datamachine_pipeline_batch_chunk';
@@ -186,16 +186,16 @@ class ScopedDrainService {
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		if ( $group_id <= 0 ) {
 			return array(
-				'stale_due_sample_gmt'                   => null,
-				'in_progress_actions'                    => 0,
-				'in_progress_actions_capped'             => false,
-				'in_progress_attempt_sample_gmt'         => null,
-				'concurrency_deferred_actions'           => 0,
-				'concurrency_deferred_actions_capped'    => false,
+				'stale_due_sample_gmt'                => null,
+				'in_progress_actions'                 => 0,
+				'in_progress_actions_capped'          => false,
+				'in_progress_attempt_sample_gmt'      => null,
+				'concurrency_deferred_actions'        => 0,
+				'concurrency_deferred_actions_capped' => false,
 			);
 		}
 
-		$stale_values = array_merge(
+		$stale_values  = array_merge(
 			array( $actions_table ),
 			$hook_sql['values'],
 			array( $group_id, $stale_gmt )
@@ -208,7 +208,7 @@ class ScopedDrainService {
 
 		// Each read stops after the evidence needed for health classification; stale and claimed reads exclude future and historical rows.
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Dynamic hook scope is constructed from normalized placeholders and values.
-		$stale_row = $wpdb->get_row(
+		$stale_row       = $wpdb->get_row(
 			$wpdb->prepare(
 				'SELECT a.scheduled_date_gmt AS stale_due_sample_gmt
 				FROM %i a
@@ -234,7 +234,7 @@ class ScopedDrainService {
 			),
 			ARRAY_A
 		);
-		$deferred_row = $wpdb->get_row(
+		$deferred_row    = $wpdb->get_row(
 			$wpdb->prepare(
 				'SELECT COUNT(*) AS concurrency_deferred_actions
 				FROM (

--- a/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
@@ -63,10 +63,10 @@ abstract class FetchHandler {
 	 * @return DataPacket[] Array of DataPackets (empty on failure/no data).
 	 */
 	final public function get_fetch_data( int|string $pipeline_id, array $handler_config, ?string $job_id = null ): array {
-		$config  = $this->extractConfig( $handler_config );
-		$context = ExecutionContext::fromConfig( $handler_config, $job_id, $this->handler_type );
-		$stages  = $this->initialFetchDiagnostics( $config, $context );
-		$max_items = (int) ( $config['max_items'] ?? $this->getDefaultMaxItems() );
+		$config              = $this->extractConfig( $handler_config );
+		$context             = ExecutionContext::fromConfig( $handler_config, $job_id, $this->handler_type );
+		$stages              = $this->initialFetchDiagnostics( $config, $context );
+		$max_items           = (int) ( $config['max_items'] ?? $this->getDefaultMaxItems() );
 		$stages['max_items'] = max( 0, $max_items );
 
 		$result = $this->executeFetch( $config, $context );
@@ -80,7 +80,7 @@ abstract class FetchHandler {
 
 		// Normalize: if handler returned { items: [...] }, use that list.
 		// Otherwise treat the entire result as a single item.
-		$items = ( isset( $result['items'] ) && is_array( $result['items'] ) )
+		$items                         = ( isset( $result['items'] ) && is_array( $result['items'] ) )
 			? $result['items']
 			: array( $result );
 		$stages['source_materialized'] = count( $items );
@@ -97,7 +97,7 @@ abstract class FetchHandler {
 		// Set to 0 for unlimited.
 		if ( $max_items > 0 && count( $items ) > $max_items ) {
 			$stages['eligible_outside_max_items'] = count( $items ) - $max_items;
-			$items = array_slice( $items, 0, $max_items );
+			$items                                = array_slice( $items, 0, $max_items );
 		}
 		$stages['selected_after_max_items'] = count( $items );
 
@@ -167,17 +167,17 @@ abstract class FetchHandler {
 		$result         = array();
 
 		if ( is_array( $diagnostics ) ) {
-			$identifierless_items                        = count( $candidates ) - count( $identifiers );
-			$diagnostics['valid_items']                  = $valid_items;
-			$diagnostics['invalid_items']                = max( 0, (int) $diagnostics['source_materialized'] - $valid_items );
-			$diagnostics['identified_items']             = count( $identifiers );
-			$diagnostics['identifierless_items']         = $identifierless_items;
-			$diagnostics['unique_identifiers']           = (int) ( $counts['unique'] ?? 0 );
-			$diagnostics['duplicate_identifiers']        = (int) ( $counts['duplicates'] ?? 0 );
-			$diagnostics['eligible_before_max_items']    = (int) ( $counts['eligible'] ?? 0 ) + $identifierless_items;
-			$diagnostics['processed_skipped']            = (int) ( $counts['processed_skipped'] ?? 0 );
-			$diagnostics['reprocess_eligible']           = (int) ( $counts['processed_reprocess_eligible'] ?? 0 );
-			$diagnostics['actively_claimed']             = (int) ( $counts['actively_claimed'] ?? 0 );
+			$identifierless_items                     = count( $candidates ) - count( $identifiers );
+			$diagnostics['valid_items']               = $valid_items;
+			$diagnostics['invalid_items']             = max( 0, (int) $diagnostics['source_materialized'] - $valid_items );
+			$diagnostics['identified_items']          = count( $identifiers );
+			$diagnostics['identifierless_items']      = $identifierless_items;
+			$diagnostics['unique_identifiers']        = (int) ( $counts['unique'] ?? 0 );
+			$diagnostics['duplicate_identifiers']     = (int) ( $counts['duplicates'] ?? 0 );
+			$diagnostics['eligible_before_max_items'] = (int) ( $counts['eligible'] ?? 0 ) + $identifierless_items;
+			$diagnostics['processed_skipped']         = (int) ( $counts['processed_skipped'] ?? 0 );
+			$diagnostics['reprocess_eligible']        = (int) ( $counts['processed_reprocess_eligible'] ?? 0 );
+			$diagnostics['actively_claimed']          = (int) ( $counts['actively_claimed'] ?? 0 );
 		}
 
 		foreach ( $candidates as $candidate ) {
@@ -234,7 +234,7 @@ abstract class FetchHandler {
 			if ( is_array( $diagnostics ) ) {
 				++$diagnostics['claim_attempts'];
 			}
-			$is_duplicate                            = isset( $attempted_identifiers[ (string) $item_identifier ] );
+			$is_duplicate                                       = isset( $attempted_identifiers[ (string) $item_identifier ] );
 			$attempted_identifiers[ (string) $item_identifier ] = true;
 			$claim = $context->claimItemOwnership( (string) $context->getFlowStepId(), (string) $item_identifier );
 			if ( false === $claim ) {
@@ -268,29 +268,29 @@ abstract class FetchHandler {
 	 */
 	private function initialFetchDiagnostics( array $config, ExecutionContext $context ): array {
 		return array(
-			'schema_version'                 => 'datamachine.fetch_stages.v1',
-			'handler_type'                   => $this->handler_type,
-			'execution_mode'                 => $context->getMode(),
-			'config_hash'                    => $this->configHash( $config ),
-			'source_materialized'            => 0,
-			'valid_items'                    => 0,
-			'invalid_items'                  => 0,
-			'identified_items'               => 0,
-			'identifierless_items'            => 0,
-			'unique_identifiers'             => 0,
-			'duplicate_identifiers'          => 0,
-			'eligible_before_max_items'      => 0,
-			'processed_skipped'              => 0,
-			'reprocess_eligible'             => 0,
-			'actively_claimed'               => 0,
-			'max_items'                      => 0,
-			'eligible_outside_max_items'     => 0,
-			'selected_after_max_items'       => 0,
-			'claim_attempts'                 => 0,
-			'claims_acquired'                => 0,
-			'claim_conflicts'                => 0,
-			'duplicate_claim_conflicts'      => 0,
-			'final_packets'                  => 0,
+			'schema_version'             => 'datamachine.fetch_stages.v1',
+			'handler_type'               => $this->handler_type,
+			'execution_mode'             => $context->getMode(),
+			'config_hash'                => $this->configHash( $config ),
+			'source_materialized'        => 0,
+			'valid_items'                => 0,
+			'invalid_items'              => 0,
+			'identified_items'           => 0,
+			'identifierless_items'       => 0,
+			'unique_identifiers'         => 0,
+			'duplicate_identifiers'      => 0,
+			'eligible_before_max_items'  => 0,
+			'processed_skipped'          => 0,
+			'reprocess_eligible'         => 0,
+			'actively_claimed'           => 0,
+			'max_items'                  => 0,
+			'eligible_outside_max_items' => 0,
+			'selected_after_max_items'   => 0,
+			'claim_attempts'             => 0,
+			'claims_acquired'            => 0,
+			'claim_conflicts'            => 0,
+			'duplicate_claim_conflicts'  => 0,
+			'final_packets'              => 0,
 		);
 	}
 
@@ -344,7 +344,7 @@ abstract class FetchHandler {
 		}
 		--$remaining;
 
-		$segmented_key = preg_replace( '/([a-z0-9])([A-Z])/', '$1_$2', $key ) ?? $key;
+		$segmented_key  = preg_replace( '/([a-z0-9])([A-Z])/', '$1_$2', $key ) ?? $key;
 		$normalized_key = strtolower( str_replace( '-', '_', $segmented_key ) );
 		if ( '' !== $normalized_key && ( 'key' === $normalized_key || str_ends_with( $normalized_key, '_key' ) || preg_match( '/(?:^|_)(?:auth|authentication|authorization|oauth|api_?key|private_key|signing_key|secret_key|access_key|bearer|cookie|passwd|password|passphrase|pat|secret|tokens?|credentials?)(?:_|$)/', $normalized_key ) ) ) {
 			return '[redacted]';

--- a/inc/Engine/AI/Actions/ActionPolicyResolver.php
+++ b/inc/Engine/AI/Actions/ActionPolicyResolver.php
@@ -87,8 +87,8 @@ class ActionPolicyResolver {
 	 */
 	public function resolveForTool( array $context ): string {
 		$context['input'] = is_array( $context['input'] ?? null ) ? $context['input'] : array();
-		$context = $this->withAgentConfig( $context );
-		$policy  = $this->resolver->resolve_for_tool( $context );
+		$context          = $this->withAgentConfig( $context );
+		$policy           = $this->resolver->resolve_for_tool( $context );
 
 		return $this->applyDataMachineFilter( $policy, (string) ( $context['tool_name'] ?? '' ), (string) ( $context['mode'] ?? self::MODE_CHAT ), $context );
 	}

--- a/inc/Engine/AI/Actions/PendingActionAuthorizationReceipt.php
+++ b/inc/Engine/AI/Actions/PendingActionAuthorizationReceipt.php
@@ -11,28 +11,31 @@ defined( 'ABSPATH' ) || exit;
 
 final class PendingActionAuthorizationReceipt {
 
-	private const OPTION_SECRET = 'datamachine_pending_action_receipt_secret';
+	private const OPTION_SECRET              = 'datamachine_pending_action_receipt_secret';
 	private static ?string $transient_secret = null;
 
 	/** Issue a signed receipt from an atomically claimed action payload. */
 	public static function issue( array $action, string $resolver ): array {
 		$authorization = self::authorization( $action );
 		$claims        = array(
-			'action_id'    => (string) $action['action_id'],
-			'kind'         => (string) $action['kind'],
-			'operation'    => $authorization['operation'],
-			'target_digest'=> self::digest( $authorization['target'] ),
-			'input_digest' => self::digest( $action['apply_input'] ?? array() ),
-			'subject'      => (string) ( $action['agent'] ?? $action['creator'] ?? '' ),
-			'workspace'    => $action['workspace'] ?? null,
-			'resolver'     => $resolver,
-			'issued_at'    => time(),
-			'expires_at'   => (int) ( $action['expires_at'] ?? 0 ),
-			'nonce'        => (string) ( $action['receipt_nonce'] ?? '' ),
+			'action_id'     => (string) $action['action_id'],
+			'kind'          => (string) $action['kind'],
+			'operation'     => $authorization['operation'],
+			'target_digest' => self::digest( $authorization['target'] ),
+			'input_digest'  => self::digest( $action['apply_input'] ?? array() ),
+			'subject'       => (string) ( $action['agent'] ?? $action['creator'] ?? '' ),
+			'workspace'     => $action['workspace'] ?? null,
+			'resolver'      => $resolver,
+			'issued_at'     => time(),
+			'expires_at'    => (int) ( $action['expires_at'] ?? 0 ),
+			'nonce'         => (string) ( $action['receipt_nonce'] ?? '' ),
 		);
 
 		$encoded = self::base64url_encode( wp_json_encode( $claims ) );
-		return array( 'token' => $encoded . '.' . self::base64url_encode( hash_hmac( 'sha256', $encoded, self::secret(), true ) ), 'claims' => $claims );
+		return array(
+			'token'  => $encoded . '.' . self::base64url_encode( hash_hmac( 'sha256', $encoded, self::secret(), true ) ),
+			'claims' => $claims,
+		);
 	}
 
 	/**
@@ -105,6 +108,13 @@ final class PendingActionAuthorizationReceipt {
 		return $secret;
 	}
 
-	private static function base64url_encode( string $value ): string { return rtrim( strtr( base64_encode( $value ), '+/', '-_' ), '=' ); }
-	private static function base64url_decode( string $value ): string { return (string) base64_decode( strtr( $value, '-_', '+/' ) ); }
+	private static function base64url_encode( string $value ): string {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Base64url encodes the signed receipt for transport.
+		return rtrim( strtr( base64_encode( $value ), '+/', '-_' ), '=' );
+	}
+
+	private static function base64url_decode( string $value ): string {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decodes the transport-safe signed receipt.
+		return (string) base64_decode( strtr( $value, '-_', '+/' ) );
+	}
 }

--- a/inc/Engine/AI/Actions/PendingActionHelper.php
+++ b/inc/Engine/AI/Actions/PendingActionHelper.php
@@ -93,8 +93,8 @@ class PendingActionHelper {
 		$grants = apply_filters( 'datamachine_pending_action_resolver_grants', $grants, $args );
 		$grants = is_array( $grants ) ? array_values( array_filter( $grants, 'is_array' ) ) : array();
 
-		$datamachine_metadata    = isset( $metadata['datamachine'] ) && is_array( $metadata['datamachine'] ) ? $metadata['datamachine'] : array();
-		$metadata['datamachine'] = array_merge(
+		$datamachine_metadata                     = isset( $metadata['datamachine'] ) && is_array( $metadata['datamachine'] ) ? $metadata['datamachine'] : array();
+		$metadata['datamachine']                  = array_merge(
 			$datamachine_metadata,
 			array(
 				'agent_id'        => $agent_id,
@@ -104,7 +104,7 @@ class PendingActionHelper {
 				'resolve_with'    => 'resolve_pending_action',
 			)
 		);
-		$authorization = isset( $args['authorization'] ) && is_array( $args['authorization'] ) ? $args['authorization'] : array();
+		$authorization                            = isset( $args['authorization'] ) && is_array( $args['authorization'] ) ? $args['authorization'] : array();
 		$metadata['datamachine']['authorization'] = array(
 			'operation' => (string) ( $authorization['operation'] ?? $kind ),
 			'target'    => $authorization['target'] ?? $apply_input,

--- a/inc/Engine/AI/Actions/PendingActionStore.php
+++ b/inc/Engine/AI/Actions/PendingActionStore.php
@@ -200,17 +200,17 @@ class PendingActionStore {
 	public static function store( string $action_id, array $payload ): bool {
 		global $wpdb;
 
-		$workspace            = isset( $payload['workspace'] ) && is_array( $payload['workspace'] )
+		$workspace               = isset( $payload['workspace'] ) && is_array( $payload['workspace'] )
 			? \AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope::from_array( $payload['workspace'] )
 			: WordPressWorkspaceScope::current();
-		$payload['workspace'] = $workspace->to_array();
-		$context              = is_array( $payload['context'] ?? null ) ? $payload['context'] : array();
-		$context['wordpress'] = WordPressWorkspaceScope::metadata();
-		$payload['context']   = $context;
-		$metadata             = is_array( $payload['metadata'] ?? null ) ? $payload['metadata'] : array();
-		$datamachine          = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
-		$datamachine_context  = is_array( $datamachine['context'] ?? null ) ? $datamachine['context'] : array();
-		$datamachine['context'] = array_replace_recursive( $datamachine_context, $context );
+		$payload['workspace']    = $workspace->to_array();
+		$context                 = is_array( $payload['context'] ?? null ) ? $payload['context'] : array();
+		$context['wordpress']    = WordPressWorkspaceScope::metadata();
+		$payload['context']      = $context;
+		$metadata                = is_array( $payload['metadata'] ?? null ) ? $payload['metadata'] : array();
+		$datamachine             = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
+		$datamachine_context     = is_array( $datamachine['context'] ?? null ) ? $datamachine['context'] : array();
+		$datamachine['context']  = array_replace_recursive( $datamachine_context, $context );
 		$metadata['datamachine'] = $datamachine;
 		$payload['metadata']     = $metadata;
 
@@ -462,7 +462,7 @@ class PendingActionStore {
 			$payload['resolution_result']   = $result;
 			$payload['resolution_error']    = $error;
 			$payload['resolution_metadata'] = $metadata;
-			$completed = set_transient( self::TRANSIENT_PREFIX . $action_id, $payload, self::resolve_ttl( $payload ) );
+			$completed                      = set_transient( self::TRANSIENT_PREFIX . $action_id, $payload, self::resolve_ttl( $payload ) );
 			if ( $completed && in_array( $status, array( WP_Agent_Pending_Action_Status::ACCEPTED, WP_Agent_Pending_Action_Status::REJECTED ), true ) ) {
 				$action = self::action_from_payload( $payload );
 				if ( null !== $action ) {
@@ -473,7 +473,19 @@ class PendingActionStore {
 		}
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
-		$updated = $wpdb->update( self::get_table_name(), array( 'status' => $status, 'resolved_at' => current_time( 'mysql', true ), 'resolved_by' => get_current_user_id(), 'resolver' => self::nullable_string( $resolver ?? self::current_resolver() ), 'resolution_result' => self::encode_json( $result ), 'resolution_error' => $error, 'resolution_metadata' => self::encode_json( $metadata ) ), array( 'action_id' => $action_id, 'status' => 'applying', 'receipt_nonce' => $nonce ), array( '%s', '%s', '%d', '%s', '%s', '%s', '%s' ), array( '%s', '%s', '%s' ) );
+		$updated = $wpdb->update( self::get_table_name(), array(
+			'status'              => $status,
+			'resolved_at'         => current_time( 'mysql', true ),
+			'resolved_by'         => get_current_user_id(),
+			'resolver'            => self::nullable_string( $resolver ?? self::current_resolver() ),
+			'resolution_result'   => self::encode_json( $result ),
+			'resolution_error'    => $error,
+			'resolution_metadata' => self::encode_json( $metadata ),
+		), array(
+			'action_id'     => $action_id,
+			'status'        => 'applying',
+			'receipt_nonce' => $nonce,
+		), array( '%s', '%s', '%d', '%s', '%s', '%s', '%s' ), array( '%s', '%s', '%s' ) );
 		if ( 1 === $updated && in_array( $status, array( WP_Agent_Pending_Action_Status::ACCEPTED, WP_Agent_Pending_Action_Status::REJECTED ), true ) ) {
 			$action = self::get_action( $action_id, true );
 			if ( null !== $action ) {

--- a/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
+++ b/inc/Engine/AI/Actions/ResolvePendingActionAbility.php
@@ -258,7 +258,7 @@ class ResolvePendingActionAbility {
 			);
 		}
 
-		$origin_blog_id = self::originBlogIdFromInput( $input );
+		$origin_blog_id  = self::originBlogIdFromInput( $input );
 		$current_blog_id = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
 		if ( empty( $input['_origin_routed'] ) && $origin_blog_id > 0 && $origin_blog_id !== $current_blog_id ) {
 			return self::resolveAtOrigin( $input, $origin_blog_id );
@@ -420,7 +420,10 @@ class ResolvePendingActionAbility {
 			return self::claimed_elsewhere_response( $action_id, $kind );
 		}
 		$receipt          = PendingActionAuthorizationReceipt::issue( $claimed, $resolver );
-		$resolver_context = array_merge( $resolver_context, array( 'authorization_receipt' => $receipt, 'pending_action' => $claimed ) );
+		$resolver_context = array_merge( $resolver_context, array(
+			'authorization_receipt' => $receipt,
+			'pending_action'        => $claimed,
+		) );
 
 		// Accepted: invoke the apply handler with the stored input.
 		$result = self::applyHandler( $handler, $decision, $apply_input, $payload, $resolver_payload, $resolver_context, $pending_action, $receipt );
@@ -516,7 +519,7 @@ class ResolvePendingActionAbility {
 	private static function payloadMatchesOrigin( array $payload, int $origin_blog_id ): bool {
 		$context   = is_array( $payload['context'] ?? null ) ? $payload['context'] : array();
 		$wordpress = is_array( $context['wordpress'] ?? null ) ? $context['wordpress'] : array();
-		return $origin_blog_id === absint( $wordpress['blog_id'] ?? 0 );
+		return absint( $wordpress['blog_id'] ?? 0 ) === $origin_blog_id;
 	}
 
 	/**
@@ -574,7 +577,12 @@ class ResolvePendingActionAbility {
 	}
 
 	private static function claimed_elsewhere_response( string $action_id, string $kind ): array {
-		return array( 'success' => false, 'error' => 'Pending action has already been claimed or resolved.', 'action_id' => $action_id, 'kind' => $kind );
+		return array(
+			'success'   => false,
+			'error'     => 'Pending action has already been claimed or resolved.',
+			'action_id' => $action_id,
+			'kind'      => $kind,
+		);
 	}
 
 	/**

--- a/inc/Engine/Bundle/AgentConfigArtifactProjector.php
+++ b/inc/Engine/Bundle/AgentConfigArtifactProjector.php
@@ -172,7 +172,7 @@ final class AgentConfigArtifactProjector {
 			$tracking      = (string) ( $policy['tracking'] ?? 'include' );
 			$backup_egress = (string) ( $policy['backup_egress'] ?? 'include' );
 			$merge         = (string) ( $policy['merge'] ?? 'three_way' );
-			$entry    = array(
+			$entry         = array(
 				'tracking'      => in_array( $tracking, array( 'include', 'exclude' ), true ) ? $tracking : 'include',
 				'backup_egress' => in_array( $backup_egress, array( 'include', 'exclude' ), true ) ? $backup_egress : 'include',
 				'merge'         => in_array( $merge, array( 'three_way', 'preserve_local' ), true ) ? $merge : 'three_way',


### PR DESCRIPTION
## Summary
- apply the WordPress coding standards autofixes required by the release lint gate
- retain signed-receipt base64url transport with narrow, documented PHPCS suppressions
- fix the remaining Yoda comparison manually

## Verification
- Real Lab changed-file lint passed with PHPCS and PHPStan at zero findings: `runner-exec-review-homeboy-lab-a0505b82-054c-43bc-97eb-6bd9d0c7b243`
- Homeboy observation run: `2511a8ff-01ba-4bc7-bed9-764eb0dd336f`
- `git diff --check origin/main...HEAD`

## Release Context
The interrupted `v0.170.5` head-release recovery stops at `preflight.lint` on these findings. This patch clears that upstream gate so the next release can complete normally.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode helped inspect the release failure, apply and review the mechanical PHPCS corrections, and verify the real Lab gate. Chris Huber remains responsible for every line.