### PR TITLE
fix: register abilities after lazy runtime activation

### DIFF
--- a/inc/Abilities/AbilityRegistration.php
+++ b/inc/Abilities/AbilityRegistration.php
@@ -22,7 +22,7 @@ class AbilityRegistration {
 	private static bool $runtime_activated = false;
 
 	/**
-	 * Register now during wp_abilities_api_init, or hook before it fires.
+	 * Register on the Abilities API lifecycle, including after lazy initialization.
 	 *
 	 * @param callable $register_callback Ability registration callback.
 	 */
@@ -34,6 +34,23 @@ class AbilityRegistration {
 
 		if ( ! did_action( 'wp_abilities_api_init' ) ) {
 			add_action( 'wp_abilities_api_init', $register_callback );
+			return;
+		}
+
+		/*
+		 * Core's public registration helper only checks whether this lifecycle is
+		 * in the current hook stack. Run only the newly loaded callback in that
+		 * context instead of firing the one-shot action again, which would rerun
+		 * every existing registration callback and trigger duplicate notices.
+		 */
+		global $wp_current_filter;
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Match core's doing_action() context without replaying the global action.
+		$wp_current_filter[] = 'wp_abilities_api_init';
+		try {
+			$register_callback();
+		} finally {
+			array_pop( $wp_current_filter );
 		}
 	}
 

--- a/tests/ability-boundary-helpers-smoke.php
+++ b/tests/ability-boundary-helpers-smoke.php
@@ -9,8 +9,9 @@
 
 namespace DataMachine\Abilities {
 	function doing_action( $hook = '' ) {
-		global $datamachine_test_doing_action;
-		return 'wp_abilities_api_init' === $hook && $datamachine_test_doing_action;
+		global $datamachine_test_doing_action, $wp_current_filter;
+		return 'wp_abilities_api_init' === $hook
+			&& ( $datamachine_test_doing_action || in_array( $hook, $wp_current_filter, true ) );
 	}
 
 	function did_action( $hook = '' ) {
@@ -54,6 +55,7 @@ namespace {
 	$datamachine_test_did_action   = 0;
 	$datamachine_test_actions      = array();
 	$datamachine_test_abilities    = array();
+	$wp_current_filter             = array();
 
 	if ( ! function_exists( 'wp_get_ability' ) ) {
 		function wp_get_ability( string $name ) {
@@ -112,12 +114,14 @@ assert_ability_boundary( 'registration executes while wp_abilities_api_init is r
 $datamachine_test_doing_action = false;
 $datamachine_test_did_action   = 1;
 $before_hook_count             = count( $datamachine_test_actions['wp_abilities_api_init'] ?? array() );
+$called_during_late_context    = false;
 \DataMachine\Abilities\AbilityRegistration::on_abilities_api_init(
-	function () use ( &$called ) {
+	function () use ( &$called, &$called_during_late_context ) {
 		++$called;
+		$called_during_late_context = \DataMachine\Abilities\doing_action( 'wp_abilities_api_init' );
 	}
 );
-assert_ability_boundary( 'registration is a no-op after wp_abilities_api_init has fired', $before_hook_count === count( $datamachine_test_actions['wp_abilities_api_init'] ?? array() ) && 1 === $called );
+assert_ability_boundary( 'late registration executes without replaying wp_abilities_api_init', $before_hook_count === count( $datamachine_test_actions['wp_abilities_api_init'] ?? array() ) && 2 === $called && $called_during_late_context );
 
 $datamachine_test_abilities['datamachine/example'] = new Datamachine_Test_Ability();
 $result = \DataMachine\Cli\AbilityRunner::execute( 'datamachine/example', array( 'example' => true ) );

--- a/tests/lazy-runtime-ability-registration-smoke.php
+++ b/tests/lazy-runtime-ability-registration-smoke.php
@@ -10,6 +10,78 @@
 declare( strict_types = 1 );
 
 namespace {
+	if ( function_exists( 'wp_get_ability' ) ) {
+		require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+		require_once dirname( __DIR__ ) . '/inc/Abilities/AbilityRegistration.php';
+		require_once dirname( __DIR__ ) . '/inc/Abilities/AbilityCategories.php';
+		require_once dirname( __DIR__ ) . '/inc/Abilities/Content/UpsertPostAbility.php';
+		require_once dirname( __DIR__ ) . '/inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php';
+
+		$GLOBALS['datamachine_late_runtime_loads'] = 0;
+
+		if ( ! function_exists( 'datamachine_activate_full_runtime' ) ) {
+			function datamachine_activate_full_runtime( string $reason = '' ): void {
+				if ( 'ability:data-machine-events/upsert-event' !== $reason ) {
+					return;
+				}
+
+				++$GLOBALS['datamachine_late_runtime_loads'];
+				new \DataMachine\Abilities\DuplicateCheck\DuplicateCheckAbility();
+				new \DataMachine\Abilities\Content\UpsertPostAbility();
+			}
+		}
+
+		\DataMachine\Abilities\AbilityCategories::ensure_registered();
+		add_action(
+			'wp_abilities_api_init',
+			static function (): void {
+				wp_register_ability(
+					'data-machine-events/upsert-event',
+					array(
+						'label'               => 'Upsert Event',
+						'description'         => 'Test extension ability that activates Data Machine lazily.',
+						'category'            => 'datamachine-content',
+						'execute_callback'    => \DataMachine\Abilities\AbilityRegistration::runtime_callback(
+							static fn(): array => array( 'success' => true ),
+							'data-machine-events/upsert-event'
+						),
+						'permission_callback' => '__return_true',
+					)
+				);
+			}
+		);
+
+		$event_ability = wp_get_ability( 'data-machine-events/upsert-event' );
+		if ( ! $event_ability ) {
+			fwrite( STDERR, "FAIL: extension ability did not register before lazy activation\n" );
+			exit( 1 );
+		}
+
+		$event_ability->execute();
+		$ability_count = count( wp_get_abilities() );
+		$event_ability->execute();
+
+		$checks = array(
+			'late activation loads the full runtime once' => 1 === $GLOBALS['datamachine_late_runtime_loads'],
+			'late activation registers datamachine/check-duplicate' => null !== wp_get_ability( 'datamachine/check-duplicate' ),
+			'late activation registers datamachine/upsert-post' => null !== wp_get_ability( 'datamachine/upsert-post' ),
+			'late registration preserves category-first validation' => wp_has_ability_category( 'datamachine-agent' ) && wp_has_ability_category( 'datamachine-content' ),
+			'late registration does not duplicate existing abilities' => $ability_count === count( wp_get_abilities() ),
+			'late registration does not replay the one-shot lifecycle' => 1 === did_action( 'wp_abilities_api_init' ),
+		);
+
+		foreach ( $checks as $label => $passed ) {
+			if ( ! $passed ) {
+				fwrite( STDERR, "FAIL: {$label}\n" );
+				exit( 1 );
+			}
+			echo "ok - {$label}\n";
+		}
+
+		echo 'All ' . count( $checks ) . " WordPress lazy-runtime ability assertions passed.\n";
+		return;
+	}
+
 	define( 'ABSPATH', sys_get_temp_dir() . '/datamachine-lazy-runtime-abilities/' );
 
 	$GLOBALS['datamachine_test_state'] = (object) array(
@@ -73,19 +145,21 @@ namespace {
 
 	require_once dirname( __DIR__ ) . '/inc/Abilities/AbilityRegistration.php';
 
-	function datamachine_activate_full_runtime( string $reason = '' ): void {
-		$state = $GLOBALS['datamachine_test_state'];
-		++$state->full_runtime_loads;
+	if ( ! function_exists( 'datamachine_activate_full_runtime' ) ) {
+		function datamachine_activate_full_runtime( string $reason = '' ): void {
+			$state = $GLOBALS['datamachine_test_state'];
+			++$state->full_runtime_loads;
 
-		if ( 'ability:data-machine-events/upsert-event' !== $reason ) {
-			return;
+			if ( 'ability:data-machine-events/upsert-event' !== $reason ) {
+				return;
+			}
+
+			require_once dirname( __DIR__ ) . '/inc/Abilities/Content/UpsertPostAbility.php';
+			require_once dirname( __DIR__ ) . '/inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php';
+
+			new \DataMachine\Abilities\DuplicateCheck\DuplicateCheckAbility();
+			new \DataMachine\Abilities\Content\UpsertPostAbility();
 		}
-
-		require_once dirname( __DIR__ ) . '/inc/Abilities/Content/UpsertPostAbility.php';
-		require_once dirname( __DIR__ ) . '/inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php';
-
-		new \DataMachine\Abilities\DuplicateCheck\DuplicateCheckAbility();
-		new \DataMachine\Abilities\Content\UpsertPostAbility();
 	}
 
 	$assertions = 0;

--- a/tests/lazy-runtime-ability-registration-smoke.php
+++ b/tests/lazy-runtime-ability-registration-smoke.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Regression test for full-runtime ability registration after lazy activation.
+ *
+ * Run with: php tests/lazy-runtime-ability-registration-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare( strict_types = 1 );
+
+namespace {
+	define( 'ABSPATH', sys_get_temp_dir() . '/datamachine-lazy-runtime-abilities/' );
+
+	$GLOBALS['datamachine_test_state'] = (object) array(
+		'actions'                 => array(),
+		'categories'              => array( 'datamachine-agent', 'datamachine-content' ),
+		'did_abilities_init'      => 0,
+		'duplicate_registrations' => 0,
+		'full_runtime_loads'      => 0,
+		'registered'              => array(),
+		'rejected_registrations'  => 0,
+	);
+	$GLOBALS['wp_current_filter'] = array();
+
+	class WP_Ability {
+		public function __construct( public string $name, public array $args ) {}
+
+		public function execute( array $input = array() ): mixed {
+			return ( $this->args['execute_callback'] )( $input );
+		}
+	}
+
+	function __( string $text, string $domain = 'default' ): string {
+		unset( $domain );
+		return $text;
+	}
+
+	function add_action( string $hook, callable $callback ): void {
+		$GLOBALS['datamachine_test_state']->actions[ $hook ][] = $callback;
+	}
+
+	function add_filter( string $hook, callable $callback ): void {
+		add_action( $hook, $callback );
+	}
+
+	function doing_action( string $hook = '' ): bool {
+		return in_array( $hook, $GLOBALS['wp_current_filter'], true );
+	}
+
+	function did_action( string $hook ): int {
+		return 'wp_abilities_api_init' === $hook
+			? $GLOBALS['datamachine_test_state']->did_abilities_init
+			: 0;
+	}
+
+	function wp_register_ability( string $name, array $args ): ?WP_Ability {
+		$state = $GLOBALS['datamachine_test_state'];
+
+		if ( ! doing_action( 'wp_abilities_api_init' ) || ! in_array( $args['category'] ?? '', $state->categories, true ) ) {
+			++$state->rejected_registrations;
+			return null;
+		}
+
+		if ( isset( $state->registered[ $name ] ) ) {
+			++$state->duplicate_registrations;
+			return null;
+		}
+
+		$state->registered[ $name ] = new WP_Ability( $name, $args );
+		return $state->registered[ $name ];
+	}
+
+	require_once dirname( __DIR__ ) . '/inc/Abilities/AbilityRegistration.php';
+
+	function datamachine_activate_full_runtime( string $reason = '' ): void {
+		$state = $GLOBALS['datamachine_test_state'];
+		++$state->full_runtime_loads;
+
+		if ( 'ability:data-machine-events/upsert-event' !== $reason ) {
+			return;
+		}
+
+		require_once dirname( __DIR__ ) . '/inc/Abilities/Content/UpsertPostAbility.php';
+		require_once dirname( __DIR__ ) . '/inc/Abilities/DuplicateCheck/DuplicateCheckAbility.php';
+
+		new \DataMachine\Abilities\DuplicateCheck\DuplicateCheckAbility();
+		new \DataMachine\Abilities\Content\UpsertPostAbility();
+	}
+
+	$assertions = 0;
+	$assert     = static function ( string $label, bool $condition ) use ( &$assertions ): void {
+		++$assertions;
+		if ( ! $condition ) {
+			fwrite( STDERR, "FAIL: {$label}\n" );
+			exit( 1 );
+		}
+
+		echo "ok - {$label}\n";
+	};
+
+	// Reproduce the request: a lightweight extension ability exists before the
+	// one-shot lifecycle completes, then its execution opens Data Machine's full runtime.
+	$GLOBALS['wp_current_filter'][] = 'wp_abilities_api_init';
+	wp_register_ability(
+		'data-machine-events/upsert-event',
+		array(
+			'label'               => 'Upsert Event',
+			'description'         => 'Test extension ability that activates Data Machine lazily.',
+			'category'            => 'datamachine-content',
+			'execute_callback'    => \DataMachine\Abilities\AbilityRegistration::runtime_callback(
+				static fn(): array => array( 'success' => true ),
+				'data-machine-events/upsert-event'
+			),
+			'permission_callback' => '__return_true',
+		)
+	);
+	array_pop( $GLOBALS['wp_current_filter'] );
+	$GLOBALS['datamachine_test_state']->did_abilities_init = 1;
+
+	$event_ability = $GLOBALS['datamachine_test_state']->registered['data-machine-events/upsert-event'];
+	$event_ability->execute();
+	$event_ability->execute();
+
+	$registered = $GLOBALS['datamachine_test_state']->registered;
+	$assert( 'late activation loads the full runtime once', 1 === $GLOBALS['datamachine_test_state']->full_runtime_loads );
+	$assert( 'late activation registers datamachine/check-duplicate', isset( $registered['datamachine/check-duplicate'] ) );
+	$assert( 'late activation registers datamachine/upsert-post', isset( $registered['datamachine/upsert-post'] ) );
+	$assert( 'late registration preserves category-first validation', 0 === $GLOBALS['datamachine_test_state']->rejected_registrations );
+	$assert( 'late registration does not duplicate existing abilities', 0 === $GLOBALS['datamachine_test_state']->duplicate_registrations );
+	$assert( 'late registration does not replay the one-shot lifecycle', 1 === $GLOBALS['datamachine_test_state']->did_abilities_init );
+	$assert( 'late registration restores the WordPress hook stack', array() === $GLOBALS['wp_current_filter'] );
+
+	echo "All {$assertions} lazy-runtime ability assertions passed.\n";
+}

--- a/tests/lazy-runtime-ability-registration-smoke.php
+++ b/tests/lazy-runtime-ability-registration-smoke.php
@@ -80,7 +80,7 @@ namespace {
 
 		echo 'All ' . count( $checks ) . " WordPress lazy-runtime ability assertions passed.\n";
 		return;
-	}
+	} else {
 
 	define( 'ABSPATH', sys_get_temp_dir() . '/datamachine-lazy-runtime-abilities/' );
 
@@ -206,4 +206,5 @@ namespace {
 	$assert( 'late registration restores the WordPress hook stack', array() === $GLOBALS['wp_current_filter'] );
 
 	echo "All {$assertions} lazy-runtime ability assertions passed.\n";
+}
 }


### PR DESCRIPTION
## Summary

- register newly loaded full-runtime abilities when Data Machine is activated after the one-shot `wp_abilities_api_init` lifecycle
- execute only the late registration callback in WordPress's ability-registration context, avoiding a global lifecycle replay and duplicate registration
- add standalone and real-WordPress regression coverage for the DME lazy activation sequence and its required canonical abilities

## Root Cause

`AbilityRegistration::on_abilities_api_init()` handled only two states: execute immediately while `wp_abilities_api_init` was running, or hook a callback before it fired. Once the action had completed, the helper silently discarded registration callbacks from classes loaded by the full runtime.

WordPress core's public `wp_register_ability()` wrapper rejects registration unless `doing_action( 'wp_abilities_api_init' )` is true. The initialized registry can technically register later, but Data Machine's shared lifecycle callback currently owns complete registration closures rather than individual definitions. Replaying `wp_abilities_api_init` would rerun every existing callback and cause duplicate registrations. The fix therefore invokes only the newly loaded callback with the same current-hook context core uses, restoring that context in a `finally` block.

## Lifecycle Sequence

1. The request begins with Data Machine's full runtime gated off.
2. WordPress lazily initializes the abilities registry and completes `wp_abilities_api_init`.
3. DME executes its lightweight public `data-machine-events/upsert-event` ability.
4. The wrapped execution callback calls `datamachine_activate_full_runtime()`.
5. Full-runtime constructors instantiate `DuplicateCheckAbility` and `UpsertPostAbility` after the lifecycle action has already fired.
6. Their shared registration callbacks now run in a bounded registration context, making `datamachine/check-duplicate` and `datamachine/upsert-post` immediately available in the same request.

## Ownership

This belongs in Data Machine's shared `AbilityRegistration` lifecycle primitive. DME is only the consumer that exposed the lifecycle gap; adding DME retries or direct registrations would duplicate canonical Data Machine ability ownership and leave every other lazily loaded full-runtime ability vulnerable to the same failure.

## Tests

- `php tests/lazy-runtime-ability-registration-smoke.php`
- `php tests/ability-boundary-helpers-smoke.php`
- `php tests/agent-abilities-late-registration-smoke.php`
- `php tests/abilities-categories-load-order-smoke.php`
- `php tests/lightweight-ability-manifest-smoke.php`
- `php tests/prefix-policy-audit.php`
- changed-file PHPCS and PHPStan through `homeboy review lint` (passed, no findings)
- Homeboy real-WordPress helper smoke passed; the new Codebox smoke was not executed because WP Codebox timed out during `input.materialize` and was terminated by the 120-second harness limit (runs `04b6963a-3bc1-4e6b-a87f-8551f7cf6c5b` and `a5691c1b-9f27-44fb-9239-a1ba43404af9`)

Closes #3032