### PR TITLE
fix: make SQLite agent index migration idempotent

### DIFF
--- a/inc/Core/Database/Agents/Agents.php
+++ b/inc/Core/Database/Agents/Agents.php
@@ -179,21 +179,6 @@ class Agents extends BaseRepository {
 	/** @return array<string,array{unique:bool,columns:string[]}> */
 	private static function get_identity_indexes( \wpdb $wpdb, string $table_name ): array {
 		$indexes = array();
-		if ( self::is_sqlite() ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$index_rows = $wpdb->get_results( $wpdb->prepare( 'PRAGMA index_list(%i)', $table_name ), ARRAY_A );
-			foreach ( $index_rows as $index_row ) {
-				$name = (string) ( $index_row['name'] ?? '' );
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-				$column_rows      = $wpdb->get_results( $wpdb->prepare( 'PRAGMA index_info(%i)', $name ), ARRAY_A );
-				$indexes[ $name ] = array(
-					'unique'  => 1 === (int) ( $index_row['unique'] ?? 0 ),
-					'columns' => array_values( array_map( static fn( array $column_row ): string => (string) ( $column_row['name'] ?? '' ), $column_rows ) ),
-				);
-			}
-			return $indexes;
-		}
-
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$index_rows = $wpdb->get_results( $wpdb->prepare( 'SHOW INDEX FROM %i', $table_name ), ARRAY_A );
 		foreach ( $index_rows as $index_row ) {

--- a/tests/Unit/Core/Identity/AgentIdentityStoreAdapterTest.php
+++ b/tests/Unit/Core/Identity/AgentIdentityStoreAdapterTest.php
@@ -237,6 +237,24 @@ class AgentIdentityStoreAdapterTest extends WP_UnitTestCase {
 		$this->assertEmpty( array_filter( $indexes, static fn( array $index ): bool => 'agent_slug' === $index['Key_name'] && 0 === (int) $index['Non_unique'] ) );
 	}
 
+	public function test_schema_reconciliation_is_idempotent_with_existing_identity_index(): void {
+		global $wpdb;
+		$table = $wpdb->base_prefix . Agents::TABLE_NAME;
+
+		Agents::ensure_identity_scope_schema();
+		Agents::ensure_identity_scope_schema();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$indexes = $wpdb->get_results( $wpdb->prepare( 'SHOW INDEX FROM %i', $table ), ARRAY_A );
+		$identity_index = array_filter(
+			$indexes,
+			static fn( array $index ): bool => 'agent_identity_scope_hash' === $index['Key_name']
+		);
+
+		$this->assertCount( 3, $identity_index );
+		$this->assertSame( array( 'agent_slug', 'owner_id', 'instance_key_hash' ), array_column( $identity_index, 'Column_name' ) );
+	}
+
 	private function register_agent( string $slug ): void {
 		\WP_Agents_Registry::get_instance()->register( $slug, array( 'label' => $slug ) );
 		$this->registered[] = $slug;


### PR DESCRIPTION
## Summary
- inspect agent identity indexes through portable `SHOW INDEX` metadata on MySQL and SQLite
- make repeated identity schema reconciliation recognize the existing canonical index
- cover repeated reconciliation and exact index columns

Closes #3031

## Verification
- `git diff --check`
- `php -l inc/Core/Database/Agents/Agents.php`
- `php -l tests/Unit/Core/Identity/AgentIdentityStoreAdapterTest.php`
- Homeboy policy-routed lint/test commands were started but aborted before execution completed

## AI Assistance
OpenCode with `openai/gpt-5.6-sol` diagnosed the SQLite metadata mismatch, drafted the focused implementation and regression test, and ran the recorded verification. Chris Huber reviewed and directed the change.