### PR TITLE
feat: support definition-only agents

### DIFF
--- a/inc/Engine/Agents/AgentMaterializer.php
+++ b/inc/Engine/Agents/AgentMaterializer.php
@@ -35,19 +35,27 @@ class AgentMaterializer {
 	 * @return array{
 	 *     created: string[],
 	 *     existing: string[],
+	 *     definition_only: string[],
 	 *     skipped: string[],
 	 * }
 	 */
 	public static function reconcile( array $definitions ): array {
 		$summary = array(
-			'created'  => array(),
-			'existing' => array(),
-			'skipped'  => array(),
+			'created'         => array(),
+			'existing'        => array(),
+			'definition_only' => array(),
+			'skipped'         => array(),
 		);
 
 		$store = new AgentIdentityStoreAdapter();
 
 		foreach ( $definitions as $slug => $def ) {
+			$meta = is_array( $def['meta'] ?? null ) ? $def['meta'] : array();
+			if ( false === ( $meta['datamachine_default_materialization'] ?? true ) ) {
+				$summary['definition_only'][] = $slug;
+				continue;
+			}
+
 			$owner_id = self::resolve_owner( $def );
 			if ( $owner_id <= 0 ) {
 				$summary['skipped'][] = $slug;
@@ -70,7 +78,7 @@ class AgentMaterializer {
 				$scope,
 				$agent->get_default_config(),
 				array_merge(
-					is_array( $def['meta'] ?? null ) ? $def['meta'] : array(),
+					$meta,
 					array(
 						'label'                  => (string) ( $def['label'] ?? $slug ),
 						'datamachine_definition' => $def,

--- a/inc/Engine/Agents/AgentRegistry.php
+++ b/inc/Engine/Agents/AgentRegistry.php
@@ -66,6 +66,10 @@ class AgentRegistry {
 	 *                                    Defaults to `DirectoryManager::get_default_agent_user_id()`.
 	 *     @type array    $default_config Initial agent_config persisted on creation.
 	 *                                    Mutations thereafter go through the DB.
+	 *     @type array    $meta           Agents API metadata. Set
+	 *                                    `datamachine_default_materialization` to false
+	 *                                    to keep the definition registered without
+	 *                                    creating a default identity during reconciliation.
 	 * }
 	 * @return void
 	 */
@@ -139,6 +143,7 @@ class AgentRegistry {
 	 * @return array{
 	 *     created: string[],
 	 *     existing: string[],
+	 *     definition_only: string[],
 	 *     skipped: string[],
 	 * }
 	 */

--- a/tests/Unit/Core/Identity/AgentIdentityStoreAdapterTest.php
+++ b/tests/Unit/Core/Identity/AgentIdentityStoreAdapterTest.php
@@ -180,7 +180,7 @@ class AgentIdentityStoreAdapterTest extends WP_UnitTestCase {
 	}
 
 	public function test_duplicate_key_loser_reconciles_pending_winner(): void {
-		$this->register_agent( 'concurrent-agent' );
+		$this->register_agent( 'concurrent-agent', array( 'meta' => array( 'datamachine_default_materialization' => false ) ) );
 		$scope      = new WP_Agent_Identity_Scope( 'concurrent-agent', $this->owner_a, 'shared-instance' );
 		$repository = new DuplicateLoserAgents();
 		$adapter    = new CountingProvisionAdapter( $repository );
@@ -256,8 +256,8 @@ class AgentIdentityStoreAdapterTest extends WP_UnitTestCase {
 		$this->assertSame( array( 'agent_slug', 'owner_id', 'instance_key_hash' ), array_column( $identity_index, 'Column_name' ) );
 	}
 
-	private function register_agent( string $slug ): void {
-		\WP_Agents_Registry::get_instance()->register( $slug, array( 'label' => $slug ) );
+	private function register_agent( string $slug, array $args = array() ): void {
+		\WP_Agents_Registry::get_instance()->register( $slug, array_merge( array( 'label' => $slug ), $args ) );
 		$this->registered[] = $slug;
 	}
 }

--- a/tests/agent-registry-materializer-smoke.php
+++ b/tests/agent-registry-materializer-smoke.php
@@ -261,6 +261,7 @@ namespace {
 	use DataMachine\Core\Database\Agents\AgentAccess;
 	use DataMachine\Core\Database\Agents\Agents;
 	use DataMachine\Core\FilesRepository\DirectoryManager;
+	use DataMachine\Core\Identity\AgentIdentityStoreAdapter;
 	use DataMachine\Engine\Agents\AgentRegistry;
 
 	$failures = array();
@@ -372,7 +373,7 @@ namespace {
 	);
 	do_action( 'init' );
 	$summary = AgentRegistry::reconcile();
-	assert_agent_materializer_equals( array( 'created' => array( 'example-agent' ), 'existing' => array(), 'skipped' => array() ), $summary, 'created summary matches pre-split registry behavior', $failures, $passes );
+	assert_agent_materializer_equals( array( 'created' => array( 'example-agent' ), 'existing' => array(), 'definition_only' => array(), 'skipped' => array() ), $summary, 'created summary matches pre-split registry behavior', $failures, $passes );
 	assert_agent_materializer_equals( 7, Agents::$rows['example-agent:7:default']['owner_id'] ?? 0, 'owner resolver controls created row owner', $failures, $passes );
 	assert_agent_materializer_equals( array( 'default_provider' => 'openai' ), Agents::$rows['example-agent:7:default']['agent_config'] ?? array(), 'default config persists on creation', $failures, $passes );
 	assert_agent_materializer_equals( array( array( 'agent_id' => 100, 'owner_id' => 7 ) ), AgentAccess::$bootstrapped, 'owner access is bootstrapped', $failures, $passes );
@@ -382,11 +383,71 @@ namespace {
 
 	echo "\n[3] existing rows are adopted and mutable fields stay DB-owned:\n";
 	$summary = AgentRegistry::reconcile();
-	assert_agent_materializer_equals( array( 'created' => array(), 'existing' => array( 'example-agent' ), 'skipped' => array() ), $summary, 'second reconcile reports existing row', $failures, $passes );
+	assert_agent_materializer_equals( array( 'created' => array(), 'existing' => array( 'example-agent' ), 'definition_only' => array(), 'skipped' => array() ), $summary, 'second reconcile reports existing row', $failures, $passes );
 	assert_agent_materializer_equals( 1, count( AgentAccess::$bootstrapped ), 'existing row does not bootstrap access again', $failures, $passes );
 	assert_agent_materializer_equals( 1, count( ScaffoldAbilities::$ability->calls ), 'existing row does not scaffold again', $failures, $passes );
 
-	echo "\n[4] materializer owns Data Machine side-effect dependencies:\n";
+	echo "\n[4] definition-only registration skips default reconciliation but supports exact explicit scopes:\n";
+	reset_agent_materializer_smoke();
+	DirectoryManager::$default_user_id = 19;
+	add_action(
+		'wp_agents_api_init',
+		static function (): void {
+			wp_register_agent(
+				'definition-only-agent',
+				array(
+					'label'          => 'Definition Only Agent',
+					'default_config' => array( 'default_provider' => 'openai' ),
+					'meta'           => array( 'datamachine_default_materialization' => false ),
+				)
+			);
+		}
+	);
+	do_action( 'init' );
+	$summary = AgentRegistry::reconcile();
+	assert_agent_materializer_equals( array( 'created' => array(), 'existing' => array(), 'definition_only' => array( 'definition-only-agent' ), 'skipped' => array() ), $summary, 'definition-only summary exposes the opt-out', $failures, $passes );
+	assert_agent_materializer_equals( array(), Agents::$rows, 'definition-only reconciliation creates no default row', $failures, $passes );
+	assert_agent_materializer_equals( array(), AgentAccess::$bootstrapped, 'definition-only reconciliation grants no owner access', $failures, $passes );
+	assert_agent_materializer_equals( array(), DirectoryManager::$ensured, 'definition-only reconciliation creates no directory', $failures, $passes );
+	assert_agent_materializer_equals( array(), ScaffoldAbilities::$ability->calls, 'definition-only reconciliation runs no scaffold', $failures, $passes );
+
+	$identity = wp_materialize_agent_identity(
+		'definition-only-agent',
+		new AgentIdentityStoreAdapter(),
+		array(
+			'owner_user_id' => 23,
+			'instance_key'  => 'workspace:one',
+			'meta'          => array( 'label' => 'Explicit Agent' ),
+		)
+	);
+	$repeat = wp_materialize_agent_identity(
+		'definition-only-agent',
+		new AgentIdentityStoreAdapter(),
+		array(
+			'owner_user_id' => 23,
+			'instance_key'  => 'workspace:one',
+		)
+	);
+	assert_agent_materializer_equals( 23, $identity->scope->owner_user_id ?? 0, 'explicit materialization preserves exact owner scope', $failures, $passes );
+	assert_agent_materializer_equals( 'workspace:one', $identity->scope->instance_key ?? '', 'explicit materialization preserves exact instance scope', $failures, $passes );
+	assert_agent_materializer_equals( $identity->id ?? 0, $repeat->id ?? -1, 'explicit materialization is idempotent', $failures, $passes );
+	assert_agent_materializer_equals( 1, count( Agents::$rows ), 'explicit materialization creates only the requested identity', $failures, $passes );
+	assert_agent_materializer_equals( array( array( 'agent_id' => 100, 'owner_id' => 23 ) ), AgentAccess::$bootstrapped, 'explicit materialization provisions owner access', $failures, $passes );
+	assert_agent_materializer_equals( 1, count( ScaffoldAbilities::$ability->calls ), 'explicit materialization provisions one scaffold', $failures, $passes );
+
+	\WP_Agents_Registry::get_instance()->register(
+		'runtime-bundle-agent',
+		array(
+			'label'          => 'Runtime Bundle Agent',
+			'owner_resolver' => static fn() => 31,
+		)
+	);
+	$result = datamachine_reconcile_runtime_agent_bundle_import( array( 'success' => true, 'agent_slug' => 'runtime-bundle-agent' ) );
+	assert_agent_materializer_equals( 'runtime-bundle-agent', $result['agent_slug'] ?? '', 'runtime import result passes through reconciliation', $failures, $passes );
+	assert_agent_materializer_equals( 31, Agents::$rows['runtime-bundle-agent:31:default']['owner_id'] ?? 0, 'runtime bundle definitions retain default materialization', $failures, $passes );
+	assert_agent_materializer_equals( false, isset( Agents::$rows['definition-only-agent:19:default'] ), 'bundle reconciliation does not materialize definition-only defaults', $failures, $passes );
+
+	echo "\n[5] materializer owns Data Machine side-effect dependencies:\n";
 	$registration_source = (string) file_get_contents( AGENTS_API_PATH . 'src/Registry/register-agents.php' );
 	$registry_source     = (string) file_get_contents( __DIR__ . '/../inc/Engine/Agents/AgentRegistry.php' );
 	$materializer_source = (string) file_get_contents( __DIR__ . '/../inc/Engine/Agents/AgentMaterializer.php' );


### PR DESCRIPTION
## Summary

- allow registered agent definitions to opt out of Data Machine's automatic default reconciliation through `meta.datamachine_default_materialization=false`
- report opted-out definitions separately as `definition_only` without creating rows, access grants, directories, scaffolds, or reconciliation hooks
- preserve explicit, idempotent exact-scope materialization and all existing default reconciliation behavior

Closes #3034

## Existing Primitive Investigation

Agents API already separates declarative registration from host-owned materialization. `WP_Agent` preserves generic `meta`, `wp_materialize_agent_identity()` validates the registered definition and constructs an exact `WP_Agent_Identity_Scope`, and `WP_Agent_Identity_Store::materialize()` owns idempotent persistence. It does not expose a default-materialization policy field or filter; its registration docs explicitly leave that decision to hosts.

This PR therefore does not change the generic Agents API dependency or add a parallel materialization path. It adds only a Data Machine consumer-owned reconciliation policy in existing definition metadata.

## Contract

Definitions retain today's behavior by default. Only an explicit strict-false marker opts out:

```php
'meta' => array(
    'datamachine_default_materialization' => false,
),
```

Normal `AgentRegistry::reconcile()` reports that slug under `definition_only` before resolving a default owner or invoking the identity store. Explicit `wp_materialize_agent_identity()` calls continue through the registered Agents API definition and Data Machine identity store with the requested owner and instance key, including duplicate-key concurrency handling.

Runtime bundle/import reconciliation remains default-on for definitions without the marker and continues skipping marked definition-only defaults.

## Compatibility

- existing definitions and the default system agent remain default-materialized
- existing `created`, `existing`, and `skipped` outcomes retain their meaning
- reconciliation summaries add the `definition_only` outcome
- no `owner_resolver=0`, post-reconciliation deletion, product-specific behavior, or generic-layer vendor vocabulary is introduced

## Tests

- `php tests/agent-registry-materializer-smoke.php` passes all 37 assertions
- `php tests/runtime-agent-bundle-reconcile-smoke.php` passes
- `php tests/agent-prune-resurrection-smoke.php` passes
- `homeboy review lint data-machine --path . --placement local --changed-only --summary` passes
- `homeboy review audit data-machine --path . --placement local --profile pr --changed-since origin/main --json-summary` passes with no introduced findings
- configured Homeboy test selection identifies 129 tests but returns an unstructured zero-test failure; the focused direct tests above pass, and the runner defect is tracked in Extra-Chill/homeboy#10601