### PR TITLE
fix: use portable agent index removal

### DIFF
--- a/inc/Core/Database/Agents/Agents.php
+++ b/inc/Core/Database/Agents/Agents.php
@@ -149,9 +149,7 @@ class Agents extends BaseRepository {
 			if ( ! $index['unique'] || ! in_array( $index['columns'], array( array( 'agent_slug' ), array( 'agent_slug', 'owner_id', 'instance_key' ) ), true ) ) {
 				continue;
 			}
-			$sql = self::is_sqlite()
-				? $wpdb->prepare( 'DROP INDEX %i', $name )
-				: $wpdb->prepare( 'ALTER TABLE %i DROP INDEX %i', $table_name, $name );
+			$sql = $wpdb->prepare( 'ALTER TABLE %i DROP INDEX %i', $table_name, $name );
 			self::query_or_throw( $wpdb, $sql, 'remove obsolete agent identity index' );
 		}
 

--- a/tests/Unit/Core/Identity/AgentIdentityStoreAdapterTest.php
+++ b/tests/Unit/Core/Identity/AgentIdentityStoreAdapterTest.php
@@ -225,6 +225,7 @@ class AgentIdentityStoreAdapterTest extends WP_UnitTestCase {
 
 		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP INDEX %i', $table, 'agent_identity_scope_hash' ) );
 		Agents::ensure_identity_scope_schema();
+		Agents::ensure_identity_scope_schema();
 		$row     = ( new Agents() )->get_agent( $agent_id );
 		$indexes = $wpdb->get_results( $wpdb->prepare( 'SHOW INDEX FROM %i', $table ), ARRAY_A );
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching


### PR DESCRIPTION
## Summary

- remove the remaining native SQLite `DROP INDEX` branch from agent identity reconciliation
- use WordPress database abstraction-compatible `ALTER TABLE ... DROP INDEX` on both backends
- run legacy identity schema reconciliation twice in the integration test to cover idempotency

Fixes #3037.

## Verification

- `vendor/bin/phpcs inc/Core/Database/Agents/Agents.php tests/Unit/Core/Identity/AgentIdentityStoreAdapterTest.php`
- PHP syntax checks for both changed files
- `php tests/prefix-policy-audit.php` (11 passed)
- Installed a package built from this commit into WordPress Studio; the real pending migration completed and advanced `datamachine_db_version` from `0.168.14` to `0.170.7`
- Verified Data Machine active and DMC targeted worktree resolution operational

## AI assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode reproduced the released migration failure in WordPress Studio, isolated the SQL dialect boundary, implemented the focused fix and test extension, built the verification package, and collected runtime evidence. Chris Huber reviewed and owns every line.