### PR TITLE
fix: use portable agent index removal

### DIFF
--- a/inc/Core/Database/Agents/Agents.php
+++ b/inc/Core/Database/Agents/Agents.php
@@ -149,9 +149,7 @@ class Agents extends BaseRepository {
 			if ( ! $index['unique'] || ! in_array( $index['columns'], array( array( 'agent_slug' ), array( 'agent_slug', 'owner_id', 'instance_key' ) ), true ) ) {
 				continue;
 			}
-			$sql = self::is_sqlite()
-				? $wpdb->prepare( 'DROP INDEX %i', $name )
-				: $wpdb->prepare( 'ALTER TABLE %i DROP INDEX %i', $table_name, $name );
+			$sql = $wpdb->prepare( 'ALTER TABLE %i DROP INDEX %i', $table_name, $name );
 			self::query_or_throw( $wpdb, $sql, 'remove obsolete agent identity index' );
 		}
 


### PR DESCRIPTION
## Summary
- remove obsolete agent identity indexes through the MySQL-compatible `ALTER TABLE ... DROP INDEX` contract on every supported database
- complete SQLite identity migration after the v0.170.7 live verification exposed bare `DROP INDEX` parsing failure

Closes #3031

## Verification
- `git diff --check`
- `php -l inc/Core/Database/Agents/Agents.php`
- live v0.170.7 runtime reproduced the exact remaining operation after portable index detection succeeded

## AI Assistance
OpenCode with `openai/gpt-5.6-sol` diagnosed the live SQLite follow-up, drafted the one-operation portability fix, and ran the recorded verification. Chris Huber directed immediate release and deployment.