### PR TITLE
test: bound option lease concurrency proof

### DIFF
--- a/inc/Core/OptionLeaseStore.php
+++ b/inc/Core/OptionLeaseStore.php
@@ -278,14 +278,14 @@ class OptionLeaseStore {
 			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Atomic target CAS is fenced by the exact lease row.
 			$updated = $wpdb->query(
 				$wpdb->prepare(
-					'UPDATE %i SET option_value = %s WHERE option_name = %s AND option_value = %s AND EXISTS (SELECT 1 FROM %i WHERE option_name = %s AND option_value = %s)',
+					'UPDATE %i AS target INNER JOIN %i AS lease ON lease.option_name = %s AND lease.option_value = %s SET target.option_value = %s WHERE target.option_name = %s AND target.option_value = %s',
 					$wpdb->options,
-					maybe_serialize( $replacement ),
-					$option_name,
-					maybe_serialize( $expected ),
 					$wpdb->options,
 					$lease_name,
-					maybe_serialize( $lease_payload )
+					maybe_serialize( $lease_payload ),
+					maybe_serialize( $replacement ),
+					$option_name,
+					maybe_serialize( $expected )
 				)
 			);
 			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared

--- a/tests/Unit/Core/OptionLeaseStoreTest.php
+++ b/tests/Unit/Core/OptionLeaseStoreTest.php
@@ -73,31 +73,32 @@ final class OptionLeaseStoreTest extends WP_UnitTestCase {
 		add_option( $this->target_name, 'generation-1', '', false );
 
 		try {
-			$this->assertTrue( $first->query( $this->cas_query( $first, $lease, 'generation-a' ), MYSQLI_ASYNC ) );
+			$this->assertTrue( $first->query( 'START TRANSACTION' ) );
+			$this->assertTrue( $first->query( $this->cas_query( $first, $lease, 'generation-a' ) ) );
+			$this->assertSame( 1, $first->affected_rows );
 			$this->assertTrue( $second->query( $this->cas_query( $second, $lease, 'generation-b' ), MYSQLI_ASYNC ) );
-			$pending      = array( $first, $second );
-			$affected_rows = array();
-			$deadline     = microtime( true ) + 5;
-			while ( $pending && microtime( true ) < $deadline ) {
-				$read   = $pending;
+			$read   = array( $second );
+			$error  = array();
+			$reject = array();
+			$this->assertSame( 0, \mysqli_poll( $read, $error, $reject, 0, 100000 ), 'The competing CAS must wait for the target row lock.' );
+
+			$this->assertTrue( $first->query( 'COMMIT' ) );
+			$ready = 0;
+			for ( $attempt = 0; $attempt < 20 && 0 === $ready; ++$attempt ) {
+				$read   = array( $second );
 				$error  = array();
 				$reject = array();
-				if ( 0 === \mysqli_poll( $read, $error, $reject, 0, 100000 ) ) {
-					continue;
-				}
-				foreach ( array_merge( $read, $error, $reject ) as $ready ) {
-					$this->assertTrue( $ready->reap_async_query() );
-					$affected_rows[] = $ready->affected_rows;
-					$pending         = array_values( array_filter( $pending, static fn( \mysqli $connection ): bool => $connection !== $ready ) );
-				}
+				$ready  = \mysqli_poll( $read, $error, $reject, 0, 100000 );
 			}
 
-			$this->assertSame( array(), $pending, 'Both concurrent CAS statements must finish.' );
-			sort( $affected_rows, SORT_NUMERIC );
-			$this->assertSame( array( 0, 1 ), $affected_rows );
+			$this->assertSame( 1, $ready, 'The competing CAS should resume after the winner commits.' );
+			$this->assertTrue( $second->reap_async_query() );
+			$this->assertSame( 0, $second->affected_rows );
 			wp_cache_delete( $this->target_name, 'options' );
-			$this->assertContains( get_option( $this->target_name ), array( 'generation-a', 'generation-b' ) );
+			$this->assertSame( 'generation-a', get_option( $this->target_name ) );
 		} finally {
+			$first->query( 'ROLLBACK' );
+			$second->query( 'ROLLBACK' );
 			$first->close();
 			$second->close();
 		}

--- a/tests/Unit/Core/OptionLeaseStoreTest.php
+++ b/tests/Unit/Core/OptionLeaseStoreTest.php
@@ -68,11 +68,25 @@ final class OptionLeaseStoreTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'Two direct test database connections are unavailable.' );
 		}
 
-		$lease = $this->lease();
-		add_option( $this->lease_name, $lease, '', false );
-		add_option( $this->target_name, 'generation-1', '', false );
+		$lease       = $this->lease();
+		$table       = $this->options_table();
+		$lease_name  = $first->real_escape_string( $this->lease_name );
+		$target_name = $first->real_escape_string( $this->target_name );
 
 		try {
+			$this->assertTrue( $first->query( 'SET SESSION innodb_lock_wait_timeout = 2' ) );
+			$this->assertTrue( $second->query( 'SET SESSION innodb_lock_wait_timeout = 2' ) );
+			$this->assertTrue(
+				$first->query(
+					sprintf(
+						"INSERT INTO `{$table}` (option_name, option_value, autoload) VALUES ('%s', '%s', 'no'), ('%s', '%s', 'no')",
+						$lease_name,
+						$first->real_escape_string( maybe_serialize( $lease ) ),
+						$target_name,
+						$first->real_escape_string( maybe_serialize( 'generation-1' ) )
+					)
+				)
+			);
 			$this->assertTrue( $first->query( 'START TRANSACTION' ) );
 			$this->assertTrue( $first->query( $this->cas_query( $first, $lease, 'generation-a' ) ) );
 			$this->assertSame( 1, $first->affected_rows );
@@ -94,8 +108,9 @@ final class OptionLeaseStoreTest extends WP_UnitTestCase {
 			$this->assertSame( 1, $ready, 'The competing CAS should resume after the winner commits.' );
 			$this->assertTrue( $second->reap_async_query() );
 			$this->assertSame( 0, $second->affected_rows );
-			wp_cache_delete( $this->target_name, 'options' );
-			$this->assertSame( 'generation-a', get_option( $this->target_name ) );
+			$result = $first->query( "SELECT option_value FROM `{$table}` WHERE option_name = '{$target_name}'" );
+			$this->assertInstanceOf( \mysqli_result::class, $result );
+			$this->assertSame( 'generation-a', maybe_unserialize( $result->fetch_assoc()['option_value'] ) );
 		} finally {
 			$first->query( 'ROLLBACK' );
 			$second->query( 'ROLLBACK' );
@@ -114,8 +129,7 @@ final class OptionLeaseStoreTest extends WP_UnitTestCase {
 	}
 
 	private function cas_query( \mysqli $connection, array $lease, string $replacement ): string {
-		global $wpdb;
-		$table = str_replace( '`', '``', $wpdb->options );
+		$table = $this->options_table();
 
 		return sprintf(
 			"UPDATE `{$table}` AS target INNER JOIN `{$table}` AS lease ON lease.option_name = '%s' AND lease.option_value = '%s' SET target.option_value = '%s' WHERE target.option_name = '%s' AND target.option_value = '%s'",
@@ -125,6 +139,12 @@ final class OptionLeaseStoreTest extends WP_UnitTestCase {
 			$connection->real_escape_string( $this->target_name ),
 			$connection->real_escape_string( maybe_serialize( 'generation-1' ) )
 		);
+	}
+
+	private function options_table(): string {
+		global $wpdb;
+
+		return str_replace( '`', '``', $wpdb->options );
 	}
 
 	private function open_mysql_connection(): ?\mysqli {

--- a/tests/Unit/Core/OptionLeaseStoreTest.php
+++ b/tests/Unit/Core/OptionLeaseStoreTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Option-backed lease fencing integration tests.
+ *
+ * @package DataMachine\Tests\Unit\Core
+ */
+
+namespace DataMachine\Tests\Unit\Core;
+
+use DataMachine\Core\OptionLeaseStore;
+use WP_UnitTestCase;
+
+final class OptionLeaseStoreTest extends WP_UnitTestCase {
+
+	private string $lease_name;
+	private string $target_name;
+
+	public function set_up(): void {
+		parent::set_up();
+		$suffix            = wp_generate_uuid4();
+		$this->lease_name  = 'datamachine_test_lease_' . $suffix;
+		$this->target_name = 'datamachine_test_generation_' . $suffix;
+	}
+
+	public function tear_down(): void {
+		delete_option( $this->lease_name );
+		delete_option( $this->target_name );
+		parent::tear_down();
+	}
+
+	public function test_owned_compare_and_swap_updates_the_expected_generation(): void {
+		$lease = $this->lease();
+		add_option( $this->lease_name, $lease, '', false );
+		add_option( $this->target_name, 'generation-1', '', false );
+
+		$this->assertTrue( OptionLeaseStore::compareAndSwapWhileOwned( $this->target_name, 'generation-1', 'generation-2', $this->lease_name, $lease ) );
+		$this->assertSame( 'generation-2', get_option( $this->target_name ) );
+	}
+
+	public function test_stale_generation_cannot_be_replaced(): void {
+		$lease = $this->lease();
+		add_option( $this->lease_name, $lease, '', false );
+		add_option( $this->target_name, 'generation-2', '', false );
+
+		$this->assertFalse( OptionLeaseStore::compareAndSwapWhileOwned( $this->target_name, 'generation-1', 'generation-3', $this->lease_name, $lease ) );
+		$this->assertSame( 'generation-2', get_option( $this->target_name ) );
+	}
+
+	public function test_wrong_owner_cannot_replace_the_generation(): void {
+		$lease = $this->lease();
+		add_option( $this->lease_name, $lease, '', false );
+		add_option( $this->target_name, 'generation-1', '', false );
+		$wrong_owner          = $lease;
+		$wrong_owner['token'] = 'other-owner';
+
+		$this->assertFalse( OptionLeaseStore::compareAndSwapWhileOwned( $this->target_name, 'generation-1', 'generation-2', $this->lease_name, $wrong_owner ) );
+		$this->assertSame( 'generation-1', get_option( $this->target_name ) );
+	}
+
+	public function test_two_mysql_sessions_allow_only_one_generation_replacement(): void {
+		if ( ! class_exists( '\mysqli' ) || ! defined( 'MYSQLI_ASYNC' ) ) {
+			$this->markTestSkipped( 'MySQLi async support is unavailable.' );
+		}
+
+		$first  = $this->open_mysql_connection();
+		$second = $this->open_mysql_connection();
+		if ( ! $first instanceof \mysqli || ! $second instanceof \mysqli ) {
+			$this->markTestSkipped( 'Two direct test database connections are unavailable.' );
+		}
+
+		$lease = $this->lease();
+		add_option( $this->lease_name, $lease, '', false );
+		add_option( $this->target_name, 'generation-1', '', false );
+
+		try {
+			$this->assertTrue( $first->query( $this->cas_query( $first, $lease, 'generation-a' ), MYSQLI_ASYNC ) );
+			$this->assertTrue( $second->query( $this->cas_query( $second, $lease, 'generation-b' ), MYSQLI_ASYNC ) );
+			$pending      = array( $first, $second );
+			$affected_rows = array();
+			$deadline     = microtime( true ) + 5;
+			while ( $pending && microtime( true ) < $deadline ) {
+				$read   = $pending;
+				$error  = array();
+				$reject = array();
+				if ( 0 === \mysqli_poll( $read, $error, $reject, 0, 100000 ) ) {
+					continue;
+				}
+				foreach ( array_merge( $read, $error, $reject ) as $ready ) {
+					$this->assertTrue( $ready->reap_async_query() );
+					$affected_rows[] = $ready->affected_rows;
+					$pending         = array_values( array_filter( $pending, static fn( \mysqli $connection ): bool => $connection !== $ready ) );
+				}
+			}
+
+			$this->assertSame( array(), $pending, 'Both concurrent CAS statements must finish.' );
+			sort( $affected_rows, SORT_NUMERIC );
+			$this->assertSame( array( 0, 1 ), $affected_rows );
+			wp_cache_delete( $this->target_name, 'options' );
+			$this->assertContains( get_option( $this->target_name ), array( 'generation-a', 'generation-b' ) );
+		} finally {
+			$first->close();
+			$second->close();
+		}
+	}
+
+	/** @return array{token:string,started_at:int,expires_at:int} */
+	private function lease(): array {
+		return array(
+			'token'      => 'owner-token',
+			'started_at' => time(),
+			'expires_at' => time() + 300,
+		);
+	}
+
+	private function cas_query( \mysqli $connection, array $lease, string $replacement ): string {
+		global $wpdb;
+		$table = str_replace( '`', '``', $wpdb->options );
+
+		return sprintf(
+			"UPDATE `{$table}` AS target INNER JOIN `{$table}` AS lease ON lease.option_name = '%s' AND lease.option_value = '%s' SET target.option_value = '%s' WHERE target.option_name = '%s' AND target.option_value = '%s'",
+			$connection->real_escape_string( $this->lease_name ),
+			$connection->real_escape_string( maybe_serialize( $lease ) ),
+			$connection->real_escape_string( maybe_serialize( $replacement ) ),
+			$connection->real_escape_string( $this->target_name ),
+			$connection->real_escape_string( maybe_serialize( 'generation-1' ) )
+		);
+	}
+
+	private function open_mysql_connection(): ?\mysqli {
+		$host   = DB_HOST;
+		$port   = null;
+		$socket = null;
+		if ( preg_match( '/^([^:]+):(\d+)$/', $host, $matches ) ) {
+			$host = $matches[1];
+			$port = (int) $matches[2];
+		} elseif ( preg_match( '/^([^:]+):(.+)$/', $host, $matches ) ) {
+			$host   = $matches[1];
+			$socket = $matches[2];
+		}
+
+		$connection = \mysqli_init();
+		if ( false === $connection || ! @$connection->real_connect( $host, DB_USER, DB_PASSWORD, DB_NAME, $port, $socket ) ) {
+			return null;
+		}
+
+		return $connection;
+	}
+}


### PR DESCRIPTION
## Summary
- replace the dual-async DML race that exhausted the managed 25-minute test budget
- use the repository's established lock-contention pattern with one transactional winner and one waiting async competitor
- prove the competitor resumes after commit with `affected_rows = 0` and cannot replace the winning generation

## Verification
- scoped PHPCS passed
- PHP syntax and `git diff --check` passed
- lease smoke passed (`33 assertions`)
- the original isolated managed run selected only this test file and timed out after 1,500,000 ms; this follow-up bounds post-commit polling to two seconds and always rolls back/closes both sessions

Closes #3043