### PR TITLE
fix: avoid duplicate IMAP sent copies

### DIFF
--- a/inc/Abilities/Email/EmailAbilities.php
+++ b/inc/Abilities/Email/EmailAbilities.php
@@ -480,10 +480,12 @@ class EmailAbilities {
 			$headers[] = 'References: ' . $references;
 		}
 
+		$cc_list = array();
 		if ( ! empty( $input['cc'] ) ) {
-			$cc_list = array_map( 'trim', explode( ',', $input['cc'] ) );
-			foreach ( $cc_list as $cc ) {
+			$cc_candidates = array_map( 'trim', explode( ',', $input['cc'] ) );
+			foreach ( $cc_candidates as $cc ) {
 				if ( is_email( $cc ) ) {
+					$cc_list[] = $cc;
 					$headers[] = 'Cc: ' . $cc;
 				}
 			}
@@ -502,9 +504,9 @@ class EmailAbilities {
 		$sent = wp_mail( $to, $input['subject'], $input['body'], $headers );
 
 		if ( $sent ) {
-			// Save a copy to the IMAP Sent folder so the message appears in
-			// the user's email client (e.g. Gmail "Sent Mail" thread view).
-			$this->saveToSentFolder( $to, $input['subject'], $input['body'], $headers );
+			if ( ! $this->isConfiguredMailboxRecipient( $to, $cc_list ) ) {
+				$this->saveToSentFolder( $to, $input['subject'], $input['body'], $headers );
+			}
 
 			return array(
 				'success' => true,
@@ -1271,6 +1273,31 @@ class EmailAbilities {
 	private function getAuthProvider(): ?object {
 		$providers = apply_filters( 'datamachine_auth_providers', array() );
 		return $providers['email_imap'] ?? null;
+	}
+
+	/**
+	 * Check whether the configured mailbox will receive the sent message.
+	 *
+	 * @param array $to Valid To addresses.
+	 * @param array $cc Valid Cc addresses.
+	 */
+	private function isConfiguredMailboxRecipient( array $to, array $cc ): bool {
+		$auth = $this->getAuthProvider();
+		if ( ! $auth ) {
+			return false;
+		}
+
+		$mailbox = strtolower( trim( $auth->getUser() ) );
+		if ( ! is_email( $mailbox ) ) {
+			return false;
+		}
+
+		$recipients = array_map(
+			static fn ( string $address ): string => strtolower( trim( $address ) ),
+			array_merge( $to, $cc )
+		);
+
+		return in_array( $mailbox, $recipients, true );
 	}
 
 	/**

--- a/tests/email-reply-sent-copy-smoke.php
+++ b/tests/email-reply-sent-copy-smoke.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Pure-PHP smoke test for recipient-aware email reply Sent copies (#3045).
+ *
+ * Run with: php tests/email-reply-sent-copy-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$failed = 0;
+$total  = 0;
+
+function email_reply_assert( string $name, bool $condition ): void {
+	global $failed, $total;
+	++$total;
+
+	if ( $condition ) {
+		echo "  [PASS] {$name}\n";
+		return;
+	}
+
+	++$failed;
+	echo "  [FAIL] {$name}\n";
+}
+
+function apply_filters( string $hook, $value ) {
+	if ( 'datamachine_auth_providers' !== $hook ) {
+		return $value;
+	}
+
+	return array(
+		'email_imap' => new class() {
+			public function getUser(): string {
+				return ' Mailbox@Example.com ';
+			}
+		},
+	);
+}
+
+function is_email( $email ) {
+	return is_string( $email ) && false !== filter_var( $email, FILTER_VALIDATE_EMAIL ) ? $email : false;
+}
+
+require_once dirname( __DIR__ ) . '/inc/Abilities/Email/EmailAbilities.php';
+
+$reflection = new ReflectionClass( DataMachine\Abilities\Email\EmailAbilities::class );
+$ability    = $reflection->newInstanceWithoutConstructor();
+$method     = $reflection->getMethod( 'isConfiguredMailboxRecipient' );
+
+echo "\n[1] Configured mailbox recipient detection\n";
+email_reply_assert(
+	'Cc identity skips the synthetic Sent copy',
+	$method->invoke( $ability, array( 'person@example.net' ), array( 'mailbox@example.com' ) )
+);
+email_reply_assert(
+	'To identity skips the synthetic Sent copy',
+	$method->invoke( $ability, array( 'MAILBOX@EXAMPLE.COM' ), array() )
+);
+email_reply_assert(
+	'external-only recipients retain the synthetic Sent copy',
+	! $method->invoke( $ability, array( 'person@example.net' ), array( 'copy@example.org' ) )
+);
+
+if ( 0 === $failed ) {
+	echo "\n=== email-reply-sent-copy-smoke: all {$total} assertions passed ===\n";
+	exit( 0 );
+}
+
+echo "\n=== email-reply-sent-copy-smoke: {$failed} FAIL of {$total} ===\n";
+exit( 1 );


### PR DESCRIPTION
## Summary
- skip the synthetic IMAP Sent append when the configured mailbox is already a valid `To` or `Cc` recipient
- preserve the single `wp_mail()` send, threading headers, best-effort Sent append for external-only recipients, and existing failure behavior
- cover normalized mailbox identity matches in `To`, in `Cc`, and absent from recipients

## Root cause
`datamachine/email-reply` called `wp_mail()` once and then unconditionally appended a synthetic RFC822 copy to the configured IMAP Sent folder. When that same mailbox was a validated recipient, it received both the real SMTP delivery and the synthetic Sent copy, which could appear as duplicate outgoing messages in one thread.

## Production evidence
One invocation produced Inbox UID `94211` at `21:16:30` from the real Cc delivery and Sent UID `9901` at `21:16:31` from `imap_append()`, with the same subject and body. The external recipient received only one SMTP delivery.

## Mailbox behavior
Before: replies always produced a synthetic Sent append after successful delivery, including when the configured mailbox already received the message through `To` or `Cc`.

After: valid recipient addresses and the configured IMAP identity are trimmed and compared case-insensitively. A self-recipient match skips only the synthetic append; external-only messages retain the normal Sent copy.

## Test coverage
- configured IMAP identity in `Cc`
- configured IMAP identity in `To`
- configured IMAP identity absent from all recipients

## Commands run
- `php tests/email-reply-sent-copy-smoke.php`
- `php -l inc/Abilities/Email/EmailAbilities.php`
- `php -l tests/email-reply-sent-copy-smoke.php`
- `vendor/bin/phpcs inc/Abilities/Email/EmailAbilities.php tests/email-reply-sent-copy-smoke.php`
- `composer lint`
- `php tests/prefix-policy-audit.php`
- `git diff --check`
- `homeboy review test --path /var/lib/datamachine/workspace/data-machine@fix-3045-email-self-copy --placement local` (runner reported zero PHPUnit tests; this repository's focused coverage is the standalone smoke test above)

Closes #3045