### PR TITLE
Install capabilities and settings defaults without an activation hook

### DIFF
--- a/inc/migrations/runtime.php
+++ b/inc/migrations/runtime.php
@@ -98,12 +98,53 @@ function datamachine_maybe_run_deferred_migrations(): void {
 		return;
 	}
 
-	// Mismatch: a deploy bumped the constant past the persisted option.
+	// Mismatch: a deploy bumped the constant past the persisted option, or the
+	// activation hook never fired for this install at all.
 	datamachine_run_schema_migrations();
+	datamachine_run_deferred_site_setup();
 	if ( function_exists( 'datamachine_mark_flow_schedule_reconciliation' ) ) {
 		datamachine_mark_flow_schedule_reconciliation();
 	}
 	update_option( 'datamachine_db_version', DATAMACHINE_VERSION, true );
+}
+
+/**
+ * Run the non-schema activation work that a deploy or a never-activated install
+ * would otherwise skip.
+ *
+ * `datamachine_run_schema_migrations()` already covers every table, so an
+ * install that was deployed in place rather than activated ends up with a
+ * complete database and an incomplete site: no `datamachine_*` capabilities on
+ * any role, and no seeded settings. That is a confusing half-working state —
+ * the data is right and every capability check fails.
+ *
+ * Three ways an install reaches it:
+ *
+ * - deploy-in-place, where files are updated and activation is never toggled
+ * - a test harness that loads the plugin without activating it
+ * - a must-use plugin, for which `register_activation_hook` never fires at all
+ *
+ * Both calls below are idempotent by construction. `add_cap()` is a no-op for a
+ * capability the role already has, and `datamachine_activate_defaults_for_site()`
+ * uses `add_option()`, which will not overwrite an operator's existing settings.
+ * That matters because this runs on every version bump, not only once.
+ *
+ * Deliberately NOT included: `ComposableFileGenerator::regenerate_all()`. It is
+ * expensive and activation-only by design, and the composable files have their
+ * own invalidation path. Adding it here would put a full regeneration on the
+ * first request after every deploy.
+ *
+ * @since 0.171.4
+ * @return void
+ */
+function datamachine_run_deferred_site_setup(): void {
+	if ( function_exists( 'datamachine_register_capabilities' ) ) {
+		datamachine_register_capabilities();
+	}
+
+	if ( function_exists( 'datamachine_activate_defaults_for_site' ) ) {
+		datamachine_activate_defaults_for_site();
+	}
 }
 
 // Run deferred migrations early in plugins_loaded (priority 5) so that

--- a/tests/migration-runtime-smoke.php
+++ b/tests/migration-runtime-smoke.php
@@ -130,6 +130,29 @@ if ( ! class_exists( '\DataMachine\Core\Database\BaseRepository' ) ) {
 	);
 }
 
+// #3047: capabilities and settings defaults only ever ran from the activation
+// hook, so an install deployed in place — or loaded as a must-use plugin, where
+// register_activation_hook never fires — ended up with a fully migrated
+// database and no datamachine_* capability on any role.
+if ( ! function_exists( 'datamachine_register_capabilities' ) ) {
+	function datamachine_register_capabilities(): void {
+		$GLOBALS['__test_site_setup_calls'][] = 'capabilities';
+	}
+}
+
+if ( ! function_exists( 'datamachine_activate_defaults_for_site' ) ) {
+	function datamachine_activate_defaults_for_site(): void {
+		$GLOBALS['__test_site_setup_calls'][] = 'defaults';
+		// Mirrors the real implementation: add_option, never update_option, so
+		// re-running on every version bump cannot clobber operator settings.
+		if ( ! isset( $GLOBALS['__test_options']['datamachine_settings'] ) ) {
+			$GLOBALS['__test_options']['datamachine_settings'] = array( 'seeded' => true );
+		}
+	}
+}
+
+$GLOBALS['__test_site_setup_calls'] = array();
+
 require_once dirname( __DIR__ ) . '/inc/migrations/runtime.php';
 
 echo "=== Current Schema Runtime Smoke ===\n";
@@ -151,6 +174,29 @@ $GLOBALS['__test_options']['datamachine_db_version'] = '0.1.0-stale';
 datamachine_maybe_run_deferred_migrations();
 assert_runtime( 'current schema ensures called when option lags', $schema_chain === $GLOBALS['__test_schema_calls'] );
 assert_runtime( 'option bumped to current DATAMACHINE_VERSION', DATAMACHINE_VERSION === $GLOBALS['__test_options']['datamachine_db_version'] );
+
+echo "\n[deferred:3] Non-schema site setup runs on the same gate (#3047)\n";
+$GLOBALS['__test_site_setup_calls']                  = array();
+$GLOBALS['__test_options']['datamachine_db_version'] = '0.1.0-stale';
+unset( $GLOBALS['__test_options']['datamachine_settings'] );
+datamachine_maybe_run_deferred_migrations();
+assert_runtime( 'capabilities registered without an activation hook', in_array( 'capabilities', $GLOBALS['__test_site_setup_calls'], true ) );
+assert_runtime( 'settings defaults seeded without an activation hook', in_array( 'defaults', $GLOBALS['__test_site_setup_calls'], true ) );
+assert_runtime( 'settings option now exists', isset( $GLOBALS['__test_options']['datamachine_settings'] ) );
+
+echo "\n[deferred:4] Matching option skips site setup too\n";
+$GLOBALS['__test_site_setup_calls']                  = array();
+$GLOBALS['__test_options']['datamachine_db_version'] = DATAMACHINE_VERSION;
+datamachine_maybe_run_deferred_migrations();
+assert_runtime( 'no site setup on the cheap path', array() === $GLOBALS['__test_site_setup_calls'] );
+
+echo "\n[deferred:5] Re-running never clobbers operator settings\n";
+// This path runs on EVERY version bump, not once, so it has to be idempotent
+// by construction rather than by luck.
+$GLOBALS['__test_options']['datamachine_settings']   = array( 'operator' => 'value' );
+$GLOBALS['__test_options']['datamachine_db_version'] = '0.1.0-stale';
+datamachine_maybe_run_deferred_migrations();
+assert_runtime( 'existing settings survive a later deploy', array( 'operator' => 'value' ) === $GLOBALS['__test_options']['datamachine_settings'] );
 
 echo "\n[identity-schema:1] Option/table mismatch installs and records schema\n";
 $GLOBALS['__test_identity_table_exists'] = false;


### PR DESCRIPTION
Closes #3047.

## What was actually broken

I filed this issue claiming schema and defaults both only install from `register_activation_hook`. That was half wrong, and the [correction is on the issue](https://github.com/Extra-Chill/data-machine/issues/3047) — worth reading before this diff, because it makes the change much smaller than the title suggests.

**Tables were already fine.** `datamachine_maybe_run_deferred_migrations()` has reconciled them on `plugins_loaded` priority 5 since 0.84.0, and `datamachine_ensure_all_tables()` covers the network-scoped agent tables too.

**Capabilities and settings defaults were not.** `datamachine_register_capabilities()` had exactly one call site — inside `datamachine_activate_for_site()` — and the settings defaults likewise only ran from the activation hook.

So an install deployed in place rather than activated reached a confusing half-working state:

- a complete, correctly migrated database
- **no `datamachine_*` capability on any role**, so every capability check fails
- `PluginSettings` reading `get_option( 'datamachine_settings', array() )` — an empty array rather than the seeded defaults, so `site_context_enabled` and `cleanup_job_data_on_failure` are silently absent instead of `true`

Capabilities is the one that bites: the data is right and the admin surface is dead.

## Three ways to reach it

- deploy-in-place, where files update and activation is never toggled
- a test harness that loads the plugin without activating it
- **a must-use plugin, for which `register_activation_hook` never fires at all**

The last is why this is a prerequisite for Extra-Chill/wp-coding-agents#323 (moving the agent runtime to `mu-plugins` so a site owner cannot deactivate their own assistant). Doing that move without this fix produces a site with tables and no capabilities, and no error to explain it.

## The change

`datamachine_run_deferred_site_setup()` on the existing version gate. No new hook, no new option, no new mechanism — it rides the gate that already exists.

Both calls are idempotent **by construction**, which matters because this runs on every version bump rather than once:

- `add_cap()` is a no-op for a capability the role already has
- the defaults use `add_option()`, which will not overwrite an operator's existing settings

## Deliberately excluded

`ComposableFileGenerator::regenerate_all()`. It is expensive and activation-only by design, and the composable files have their own invalidation path. Adding it here would put a full regeneration on the first request after every deploy — inheriting the activation-only decision by accident is exactly what this issue is about, so it is called out in the docblock rather than left implicit.

## Tests

`tests/migration-runtime-smoke.php` extends the existing stubbed option gate with three cases:

- setup runs when the persisted version lags — capabilities registered, defaults seeded, without any activation hook
- the cheap path (option matches constant) skips site setup as well as schema
- **a later deploy does not clobber operator settings** — the idempotency property, asserted rather than assumed

Verified non-vacuous: removing the `datamachine_run_deferred_site_setup()` call fails the suite (exit 1).

`tests/prefix-policy-audit.php`, `flow-schedule-reconciliation-deferred-smoke`, and `scaffold-ability-activation-smoke` all still pass.