### PR TITLE
feat: expose run artifact read contract

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -361,6 +361,7 @@ function datamachine_run_datamachine_plugin() {
 	new \DataMachine\Abilities\FlowStep\ConfigureFlowStepsAbility();
 	new \DataMachine\Abilities\FlowStep\ValidateFlowStepsConfigAbility();
 	new \DataMachine\Abilities\Job\GetJobsAbility();
+	new \DataMachine\Abilities\Job\GetRunArtifactsAbility();
 	new \DataMachine\Abilities\Job\HydrateJobArtifactAbility();
 	new \DataMachine\Abilities\Job\DeleteJobsAbility();
 	new \DataMachine\Abilities\Job\ExecuteWorkflowAbility();

--- a/inc/Abilities/Job/GetRunArtifactsAbility.php
+++ b/inc/Abilities/Job/GetRunArtifactsAbility.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Get Run Artifacts Ability.
+ *
+ * @package DataMachine\Abilities\Job
+ */
+
+namespace DataMachine\Abilities\Job;
+
+use DataMachine\Core\JobArtifacts;
+use DataMachine\Engine\Bundle\BundleSchema;
+
+defined( 'ABSPATH' ) || exit;
+
+class GetRunArtifactsAbility {
+
+	use JobHelpers;
+
+	private const SCHEMA_VERSION = 1;
+
+	public function __construct() {
+		$this->initDatabases();
+		$this->registerAbility();
+	}
+
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'datamachine/get-run-artifacts',
+				array(
+					'label'               => __( 'Get Run Artifacts', 'data-machine' ),
+					'description'         => __( 'Retrieve the normalized public artifact payload and effective artifact egress policy captured for a job.', 'data-machine' ),
+					'category'            => 'datamachine-jobs',
+					'input_schema'        => array(
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'required'             => array( 'job_id' ),
+						'properties'           => array(
+							'job_id' => array(
+								'type'        => 'integer',
+								'minimum'     => 1,
+								'description' => __( 'Job identifier whose public run artifacts should be returned.', 'data-machine' ),
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'                    => array( 'type' => 'boolean' ),
+							'schema_version'             => array( 'type' => 'integer' ),
+							'job_id'                     => array( 'type' => 'integer' ),
+							'artifacts'                  => array( 'type' => 'object' ),
+							'run_artifact_egress_policy' => array( 'type' => 'object' ),
+							'policy_provenance'          => array(
+								'type'       => 'object',
+								'properties' => array(
+									'source'     => array(
+										'type' => 'string',
+										'enum' => array( 'job_snapshot', 'flow_snapshot', 'none' ),
+									),
+									'path'       => array( 'type' => 'string' ),
+									'normalized' => array( 'type' => 'boolean' ),
+								),
+							),
+							'error_code'                 => array( 'type' => 'string' ),
+							'error'                      => array( 'type' => 'string' ),
+							'status'                     => array( 'type' => 'integer' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					'permission_callback' => array( $this, 'checkPermission' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
+	}
+
+	/**
+	 * Retrieve a job's public run artifact contract.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input ): array {
+		$job_id = (int) ( $input['job_id'] ?? 0 );
+		if ( $job_id <= 0 ) {
+			return $this->error( 'invalid_job_id', 'job_id must be a positive integer.', 400 );
+		}
+
+		$job = $this->db_jobs->get_job( $job_id );
+		if ( ! is_array( $job ) ) {
+			return $this->error( 'job_not_found', sprintf( 'Job %d was not found.', $job_id ), 404 );
+		}
+
+		if ( ! $this->canAccessJob( $job ) ) {
+			return $this->jobAccessDenied();
+		}
+
+		$artifact_result = ( new JobArtifacts() )->get( $job_id );
+		if ( empty( $artifact_result['success'] ) || ! is_array( $artifact_result['artifacts'] ?? null ) ) {
+			return $this->error(
+				'artifacts_unavailable',
+				(string) ( $artifact_result['error'] ?? 'Run artifacts are unavailable.' ),
+				500
+			);
+		}
+
+		$policy = $this->effectivePolicy( $job['engine_data'] ?? null );
+
+		return array(
+			'success'                    => true,
+			'schema_version'             => self::SCHEMA_VERSION,
+			'job_id'                     => $job_id,
+			'artifacts'                  => $artifact_result['artifacts'],
+			'run_artifact_egress_policy' => $policy['policy'],
+			'policy_provenance'          => $policy['provenance'],
+		);
+	}
+
+	/**
+	 * Resolve the effective captured policy without exposing engine data.
+	 *
+	 * @param mixed $engine_data Stored engine data.
+	 * @return array{policy:array<string,array<string,mixed>>,provenance:array{source:string,path:string,normalized:bool}}
+	 */
+	private function effectivePolicy( mixed $engine_data ): array {
+		$engine_data = is_array( $engine_data ) ? $engine_data : array();
+		$candidates  = array(
+			array( 'job_snapshot', 'run_artifact_egress_policy', $engine_data['run_artifact_egress_policy'] ?? null ),
+			array( 'flow_snapshot', 'flow.run_artifacts', $engine_data['flow']['run_artifacts'] ?? null ),
+		);
+
+		foreach ( $candidates as list( $source, $path, $candidate ) ) {
+			if ( null === $candidate ) {
+				continue;
+			}
+
+			return array(
+				'policy'     => BundleSchema::normalize_run_artifact_egress_policy( $candidate ),
+				'provenance' => array(
+					'source'     => $source,
+					'path'       => $path,
+					'normalized' => true,
+				),
+			);
+		}
+
+		return array(
+			'policy'     => array(),
+			'provenance' => array(
+				'source'     => 'none',
+				'path'       => '',
+				'normalized' => true,
+			),
+		);
+	}
+
+	/** @return array{success:false,error_code:string,error:string,status:int} */
+	private function error( string $code, string $message, int $status ): array {
+		return array(
+			'success'    => false,
+			'error_code' => $code,
+			'error'      => $message,
+			'status'     => $status,
+		);
+	}
+}

--- a/tests/Unit/Abilities/Job/GetRunArtifactsAbilityTest.php
+++ b/tests/Unit/Abilities/Job/GetRunArtifactsAbilityTest.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Public run artifact read contract coverage.
+ *
+ * @package DataMachine\Tests\Unit\Abilities\Job
+ */
+
+namespace DataMachine\Tests\Unit\Abilities\Job;
+
+use DataMachine\Abilities\Job\GetRunArtifactsAbility;
+use DataMachine\Core\Database\Jobs\Jobs;
+use WP_UnitTestCase;
+
+class GetRunArtifactsAbilityTest extends WP_UnitTestCase {
+
+	private int $owner_id;
+	private int $other_user_id;
+	private Jobs $jobs;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		datamachine_register_capabilities();
+		$this->owner_id      = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->other_user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		get_user_by( 'id', $this->owner_id )->add_cap( 'datamachine_manage_flows' );
+		get_user_by( 'id', $this->other_user_id )->add_cap( 'datamachine_manage_flows' );
+		$this->jobs = new Jobs();
+	}
+
+	public function tear_down(): void {
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	public function test_contract_is_discoverable_as_a_public_ability(): void {
+		new GetRunArtifactsAbility();
+
+		$this->assertTrue( wp_has_ability( 'datamachine/get-run-artifacts' ) );
+	}
+
+	public function test_missing_run_has_explicit_error(): void {
+		wp_set_current_user( $this->owner_id );
+		$result = ( new GetRunArtifactsAbility() )->execute( array( 'job_id' => PHP_INT_MAX ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'job_not_found', $result['error_code'] );
+		$this->assertSame( 404, $result['status'] );
+	}
+
+	public function test_unauthorized_run_is_denied_before_artifact_projection(): void {
+		$job_id = $this->createJob();
+		wp_set_current_user( $this->other_user_id );
+
+		$result = ( new GetRunArtifactsAbility() )->execute( array( 'job_id' => $job_id ) );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'job_access_denied', $result['error_code'] );
+		$this->assertArrayNotHasKey( 'artifacts', $result );
+	}
+
+	public function test_valid_empty_artifacts_and_absent_policy_are_distinct_from_failure(): void {
+		$job_id = $this->createJob();
+		wp_set_current_user( $this->owner_id );
+
+		$result = ( new GetRunArtifactsAbility() )->execute( array( 'job_id' => $job_id ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 1, $result['schema_version'] );
+		$this->assertSame( $job_id, $result['job_id'] );
+		$this->assertIsArray( $result['artifacts'] );
+		$this->assertSame( array(), $result['artifacts']['daily_memory_artifacts'] );
+		$this->assertSame( array(), $result['run_artifact_egress_policy'] );
+		$this->assertSame(
+			array(
+				'source'     => 'none',
+				'path'       => '',
+				'normalized' => true,
+			),
+			$result['policy_provenance']
+		);
+	}
+
+	public function test_populated_artifacts_and_job_policy_are_normalized(): void {
+		$job_id = $this->createJob(
+			array(
+				'completion_assertions_required'  => array( 'tool_names' => array( 'build' ) ),
+				'completion_assertions_satisfied' => array( 'tool_names' => array( 'build' ) ),
+				'run_artifact_egress_policy'       => array(
+					'daily_memory' => array(
+						'egress'               => array( 'pr-body', 'invalid-target', 'bundle-file', 'pr-body' ),
+						'bundle_relative_path' => '/memory/agent/daily/{yyyy}/{mm}/{dd}.md',
+					),
+				),
+			)
+		);
+		wp_set_current_user( $this->owner_id );
+
+		$result = ( new GetRunArtifactsAbility() )->execute( array( 'job_id' => $job_id ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array( 'build' ), $result['artifacts']['required_tool_names'] );
+		$this->assertSame( array( 'build' ), $result['artifacts']['satisfied_tool_names'] );
+		$this->assertSame(
+			array(
+				'daily_memory' => array(
+					'egress'               => array( 'bundle-file', 'pr-body' ),
+					'bundle_relative_path' => 'memory/agent/daily/{yyyy}/{mm}/{dd}.md',
+				),
+			),
+			$result['run_artifact_egress_policy']
+		);
+		$this->assertSame( 'job_snapshot', $result['policy_provenance']['source'] );
+		$this->assertSame( 'run_artifact_egress_policy', $result['policy_provenance']['path'] );
+	}
+
+	public function test_malformed_legacy_policy_normalizes_to_empty_with_provenance(): void {
+		$job_id = $this->createJob(
+			array(
+				'flow' => array(
+					'run_artifacts' => 'legacy-invalid-value',
+				),
+			)
+		);
+		wp_set_current_user( $this->owner_id );
+
+		$result = ( new GetRunArtifactsAbility() )->execute( array( 'job_id' => $job_id ) );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array(), $result['run_artifact_egress_policy'] );
+		$this->assertSame(
+			array(
+				'source'     => 'flow_snapshot',
+				'path'       => 'flow.run_artifacts',
+				'normalized' => true,
+			),
+			$result['policy_provenance']
+		);
+	}
+
+	public function test_legacy_flow_policy_is_returned_with_provenance(): void {
+		$job_id = $this->createJob(
+			array(
+				'flow' => array(
+					'run_artifacts' => array(
+						'transcript_summary' => array( 'egress' => array( 'artifact' ) ),
+					),
+				),
+			)
+		);
+		wp_set_current_user( $this->owner_id );
+
+		$result = ( new GetRunArtifactsAbility() )->execute( array( 'job_id' => $job_id ) );
+
+		$this->assertSame(
+			array( 'transcript_summary' => array( 'egress' => array( 'artifact' ) ) ),
+			$result['run_artifact_egress_policy']
+		);
+		$this->assertSame( 'flow_snapshot', $result['policy_provenance']['source'] );
+	}
+
+	/**
+	 * @param array<string,mixed> $engine_data Engine data to store.
+	 */
+	private function createJob( array $engine_data = array() ): int {
+		$job_id = $this->jobs->create_job(
+			array(
+				'pipeline_id' => 'direct',
+				'flow_id'     => 'direct',
+				'user_id'     => $this->owner_id,
+				'source'      => 'direct',
+			)
+		);
+		$this->assertIsInt( $job_id );
+		if ( ! empty( $engine_data ) ) {
+			$this->assertTrue( $this->jobs->store_engine_data( $job_id, $engine_data ) );
+		}
+
+		return $job_id;
+	}
+}

--- a/tests/cleanup-cluster-smoke.php
+++ b/tests/cleanup-cluster-smoke.php
@@ -113,6 +113,7 @@ foreach ( array(
 	'FlowStep\\ConfigureFlowStepsAbility',
 	'FlowStep\\ValidateFlowStepsConfigAbility',
 	'Job\\GetJobsAbility',
+	'Job\\GetRunArtifactsAbility',
 	'Job\\HydrateJobArtifactAbility',
 	'Job\\DeleteJobsAbility',
 	'Job\\ExecuteWorkflowAbility',


### PR DESCRIPTION
## Summary
- add a discoverable `datamachine/get-run-artifacts` ability with a versioned, normalized response
- enforce existing job ownership before projecting public artifacts or effective egress policy
- report canonical, legacy, or absent policy provenance without exposing engine data or storage rows
- cover unavailable discovery, missing jobs, authorization, empty and populated artifacts, malformed legacy policy, and provenance

## Tests
- `homeboy review lint --changed-since origin/main` (PHPCS and PHPStan pass)
- `homeboy review audit --profile architecture --changed-since origin/main` (no introduced findings)
- `php tests/cleanup-cluster-smoke.php`
- `php tests/run-artifact-egress-policy-smoke.php`
- `php tests/prefix-policy-audit.php`

## Environment Notes
- The host WP Codebox test runner stopped before PHPUnit execution because its cached CLI module is missing. The focused WordPress integration suite is included for CI.
- Full-repository lint and audit were run and report existing baseline findings outside the touched scope; changed-scope gates are clean.

Closes #3057