### PR TITLE
fix: restore high-volume batch queue liveness

### DIFF
--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -16,6 +16,7 @@ use DataMachine\Core\ChildJobRecoveryPolicy;
 use DataMachine\Core\DirectJobEnqueuer;
 use DataMachine\Core\DirectOperationRecoveryPolicy;
 use DataMachine\Core\EngineData;
+use DataMachine\Core\ActionScheduler\BatchScheduler;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -541,6 +542,35 @@ class RecoverStuckJobsAbility {
 							'reason'  => 'Pending or in-progress scheduler work exists',
 						)
 					);
+					continue;
+				}
+
+				if ( BatchScheduler::STORAGE_VERSION === (int) ( $engine_data['batch_storage_version'] ?? 0 ) && empty( $engine_data['batch_state']['worklist_complete'] ) ) {
+					if ( $dry_run ) {
+						++$requeued;
+						$this->appendJobDetail( $jobs, $jobs_omitted, array(
+							'job_id'  => $job_id,
+							'flow_id' => $job_flow_id,
+							'status'  => 'would_requeue_pathless_batch',
+						) );
+						continue;
+					}
+					if ( ! $this->consumeTouchBudget( $attempted, $touched, $apply_limit ) ) {
+						$limit_reached = true;
+						break 2;
+					}
+					if ( BatchScheduler::recover( $job_id ) ) {
+						++$requeued;
+						++$mutations;
+						++$mutated;
+						$this->appendJobDetail( $jobs, $jobs_omitted, array(
+							'job_id'  => $job_id,
+							'flow_id' => $job_flow_id,
+							'status'  => 'requeued_pathless_batch',
+						) );
+					} else {
+						++$skipped;
+					}
 					continue;
 				}
 

--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -16,7 +16,7 @@ use DataMachine\Core\ChildJobRecoveryPolicy;
 use DataMachine\Core\DirectJobEnqueuer;
 use DataMachine\Core\DirectOperationRecoveryPolicy;
 use DataMachine\Core\EngineData;
-use DataMachine\Core\ActionScheduler\BatchScheduler;
+use DataMachine\Core\ActionScheduler\PathlessBatchRecovery;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -545,7 +545,7 @@ class RecoverStuckJobsAbility {
 					continue;
 				}
 
-				if ( BatchScheduler::STORAGE_VERSION === (int) ( $engine_data['batch_storage_version'] ?? 0 ) && empty( $engine_data['batch_state']['worklist_complete'] ) ) {
+				if ( PathlessBatchRecovery::isRecoverable( $engine_data ) ) {
 					if ( $dry_run ) {
 						++$requeued;
 						$this->appendJobDetail( $jobs, $jobs_omitted, array(
@@ -559,7 +559,7 @@ class RecoverStuckJobsAbility {
 						$limit_reached = true;
 						break 2;
 					}
-					if ( BatchScheduler::recover( $job_id ) ) {
+					if ( PathlessBatchRecovery::recover( $job_id ) ) {
 						++$requeued;
 						++$mutations;
 						++$mutated;
@@ -1196,7 +1196,7 @@ class RecoverStuckJobsAbility {
 			return true;
 		}
 
-		if ( $this->hasActiveBatchWork( $job_id, $engine_data, $timeout_hours ) ) {
+		if ( PathlessBatchRecovery::hasActiveWork( $job_id, $engine_data, $timeout_hours ) ) {
 			return true;
 		}
 
@@ -1263,111 +1263,6 @@ class RecoverStuckJobsAbility {
 				if ( ( $now_gmt - $started_at ) < $timeout_seconds ) {
 					return true;
 				}
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Check whether a pipeline batch parent still has scheduled chunk or child work.
-	 *
-	 * Batch parents wait on `datamachine_pipeline_batch_chunk` actions and child jobs,
-	 * not `datamachine_execute_step` actions. Treat both as live work so recovery
-	 * does not fail a parent while fan-out is still queued or children are active.
-	 *
-	 * @param int                  $parent_job_id Parent job ID.
-	 * @param array<string, mixed> $engine_data Parent engine data.
-	 * @param int                  $timeout_hours Hours before in-progress actions are considered stale.
-	 * @return bool True when batch chunk or child work is still active.
-	 */
-	private function hasActiveBatchWork( int $parent_job_id, array $engine_data, int $timeout_hours ): bool {
-		if ( $parent_job_id <= 0 || empty( $engine_data['batch'] ) ) {
-			return false;
-		}
-
-		if ( $this->hasActiveActionForArg( 'datamachine_pipeline_batch_chunk', 'parent_job_id', $parent_job_id, $timeout_hours ) ) {
-			return true;
-		}
-
-		global $wpdb;
-		$jobs_table = $wpdb->prefix . 'datamachine_jobs';
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
-		$active_children = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT COUNT(*)
-				 FROM {$jobs_table}
-				 WHERE parent_job_id = %d
-				 AND status IN ( %s, %s )",
-				$parent_job_id,
-				'pending',
-				'processing'
-			)
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-
-		return $active_children > 0;
-	}
-
-	/**
-	 * Check for a pending or fresh in-progress Action Scheduler action by arg ID.
-	 *
-	 * @param string $hook Action hook.
-	 * @param string $arg_name Numeric argument name to match.
-	 * @param int    $arg_id Expected numeric argument value.
-	 * @param int    $timeout_hours Hours before in-progress actions are considered stale.
-	 * @return bool True when matching action is pending or freshly in-progress.
-	 */
-	private function hasActiveActionForArg( string $hook, string $arg_name, int $arg_id, int $timeout_hours ): bool {
-		global $wpdb;
-
-		if ( $arg_id <= 0 ) {
-			return false;
-		}
-
-		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
-		$like_arg_id   = '%"' . $wpdb->esc_like( $arg_name ) . '":' . $wpdb->esc_like( (string) $arg_id ) . '%';
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
-		$actions = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT action_id, args, status, scheduled_date_gmt, last_attempt_gmt
-				 FROM {$actions_table}
-				 WHERE hook = %s
-				 AND status IN ( %s, %s )
-				 AND args LIKE %s",
-				$hook,
-				'pending',
-				'in-progress',
-				$like_arg_id
-			)
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-
-		$timeout_seconds = max( 1, $timeout_hours ) * HOUR_IN_SECONDS;
-		$now_gmt         = strtotime( current_time( 'mysql', true ) );
-
-		foreach ( $actions as $action ) {
-			if ( $arg_id !== $this->extractActionArgInt( (string) ( $action->args ?? '' ), $arg_name ) ) {
-				continue;
-			}
-
-			if ( 'pending' === (string) $action->status ) {
-				return true;
-			}
-
-			$last_attempt = (string) ( $action->last_attempt_gmt ?? '' );
-			$scheduled    = (string) ( $action->scheduled_date_gmt ?? '' );
-			$reference    = $last_attempt && '0000-00-00 00:00:00' !== $last_attempt ? $last_attempt : $scheduled;
-			$started_at   = $reference ? strtotime( $reference ) : false;
-
-			if ( false === $started_at || false === $now_gmt ) {
-				return true;
-			}
-
-			if ( ( $now_gmt - $started_at ) < $timeout_seconds ) {
-				return true;
 			}
 		}
 

--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -45,7 +45,7 @@ defined( 'ABSPATH' ) || exit;
 
 class BatchScheduler {
 	public const STORAGE_VERSION         = 2;
-	private const INITIAL_RECOVERY_DELAY = 300;
+	private const RECOVERY_CLAIM_TTL = 300;
 
 	/**
 	 * Parent completes after all child jobs complete.
@@ -168,11 +168,6 @@ class BatchScheduler {
 		if ( 0 === $total ) {
 			return self::startResult( $parent_job_id, 0, $chunk_size );
 		}
-		// Establish a queue owner before any worklist or parent state commits.
-		if ( ! self::scheduleV2Chunk( $hook, $parent_job_id, 0, time() + self::INITIAL_RECOVERY_DELAY ) ) {
-			self::discardStartItems( $items, $cleanup_contexts, $parent_job_id, $context );
-			return self::startResult( $parent_job_id, $total, $chunk_size );
-		}
 		$checksums = array();
 		foreach ( $items as $item ) {
 			$encoded = wp_json_encode( $item );
@@ -262,6 +257,9 @@ class BatchScheduler {
 			}
 			return self::startResult( $parent_job_id, $total, $chunk_size );
 		}
+		if ( ! empty( $insert['existing'] ) ) {
+			return self::startResult( $parent_job_id, $total, $chunk_size, 0, true );
+		}
 
 		\DataMachine\Core\RunMetrics::start(
 			$parent_job_id,
@@ -328,13 +326,13 @@ class BatchScheduler {
 	}
 
 	/** Build the stable public start result. */
-	private static function startResult( int $parent_job_id, int $total, int $chunk_size, int $action_id = 0 ): array {
+	private static function startResult( int $parent_job_id, int $total, int $chunk_size, int $action_id = 0, ?bool $scheduled = null ): array {
 		return array(
 			'parent_job_id' => $parent_job_id,
 			'total'         => $total,
 			'chunk_size'    => $chunk_size,
 			'action_id'     => $action_id,
-			'scheduled'     => (bool) $action_id,
+			'scheduled'     => null === $scheduled ? (bool) $action_id : $scheduled,
 		);
 	}
 
@@ -389,7 +387,6 @@ class BatchScheduler {
 		$state = is_array( $parent_engine['batch_state'] ?? null ) ? $parent_engine['batch_state'] : null;
 		$total = (int) ( $parent_engine['batch_total'] ?? 0 );
 		if ( is_array( $state ) && ! empty( $state['worklist_complete'] ) ) {
-			self::scheduleFinalizeRetry( $parent_engine, $parent_job_id );
 			return self::chunkResult(
 				0,
 				(int) ( $parent_engine['batch_offset'] ?? $total ),
@@ -436,16 +433,13 @@ class BatchScheduler {
 		$offset     = null === $expected_offset ? (int) ( $state['offset'] ?? 0 ) : $expected_offset;
 		$chunk_size = max( 1, (int) ( $parent_engine['batch_chunk_size'] ?? self::chunkSize( $context ) ) );
 		$lease      = (int) apply_filters( 'datamachine_batch_item_lease_seconds', BatchItems::DEFAULT_LEASE_SECONDS, $context );
-		// The recovery owner must exist before rows cross the durable claim boundary.
-		if ( ! self::scheduleV2Chunk( (string) $state['hook'], $parent_job_id, $offset, time() + max( 1, $lease ) ) ) {
-			$discarded = self::discardV2Outstanding( $repository, $parent_job_id, $context );
-			$completed = $repository->count_completed( $parent_job_id );
-			if ( $discarded ) {
-				self::finishV2State( $parent_job_id, $completed, $offset, true, true );
-			}
-			return self::chunkResult( 0, $offset, $total, false, false, false, false, true );
-		}
-		$rows = $repository->claim_chunk( $parent_job_id, $offset, $chunk_size, $lease );
+		$rows = $repository->claim_chunk(
+			$parent_job_id,
+			$offset,
+			$chunk_size,
+			$lease,
+			static fn(): bool => self::scheduleV2Chunk( (string) $state['hook'], $parent_job_id, $offset, time() + max( 1, $lease ) )
+		);
 		if ( ! $rows ) {
 			$outstanding = $repository->first_outstanding_index( $parent_job_id );
 			if ( null === $outstanding ) {
@@ -587,6 +581,54 @@ class BatchScheduler {
 		}
 		$result = wp_schedule_single_event( $timestamp, $hook, $wp_args, true );
 		return ! is_wp_error( $result ) && true === $result;
+	}
+
+	/** Re-establish one scheduler path for a durable pathless v2 batch. */
+	public static function recover( int $parent_job_id ): bool {
+		$engine = EngineData::retrieve( $parent_job_id );
+		$state  = is_array( $engine['batch_state'] ?? null ) ? $engine['batch_state'] : array();
+		$hook   = (string) ( $state['hook'] ?? $engine['batch_hook'] ?? '' );
+		if ( self::STORAGE_VERSION !== (int) ( $engine['batch_storage_version'] ?? 0 ) || '' === $hook || ! empty( $state['worklist_complete'] ) ) {
+			return false;
+		}
+
+		$offset = ( new BatchItems() )->first_outstanding_index( $parent_job_id );
+		if ( null === $offset ) {
+			return false;
+		}
+
+		$token = bin2hex( random_bytes( 16 ) );
+		$claim = EngineData::mutate(
+			$parent_job_id,
+			static function ( array $current ) use ( $token ): ?array {
+				$owner      = is_array( $current['batch_recovery_owner'] ?? null ) ? $current['batch_recovery_owner'] : array();
+				$claimed_at = strtotime( (string) ( $owner['claimed_at'] ?? '' ) . ' UTC' );
+				if ( false !== $claimed_at && ( time() - $claimed_at ) < self::RECOVERY_CLAIM_TTL ) {
+					return null;
+				}
+				$current['batch_recovery_owner'] = array(
+					'token'      => $token,
+					'claimed_at' => current_time( 'mysql', true ),
+				);
+				return $current;
+			},
+			'batch_recovery_claim'
+		);
+		if ( empty( $claim['success'] ) || ! self::scheduleV2Chunk( $hook, $parent_job_id, $offset, time() ) ) {
+			return false;
+		}
+
+		EngineData::mutate(
+			$parent_job_id,
+			static function ( array $current ) use ( $token ): array {
+				if ( hash_equals( $token, (string) ( $current['batch_recovery_owner']['token'] ?? '' ) ) ) {
+					$current['batch_recovery_owner']['scheduled_at'] = current_time( 'mysql', true );
+				}
+				return $current;
+			},
+			'batch_recovery_scheduled'
+		);
+		return true;
 	}
 
 	private static function discardV2Outstanding( BatchItems $repository, int $parent_job_id, string $context ): bool {

--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -45,7 +45,6 @@ defined( 'ABSPATH' ) || exit;
 
 class BatchScheduler {
 	public const STORAGE_VERSION         = 2;
-	private const RECOVERY_CLAIM_TTL = 300;
 
 	/**
 	 * Parent completes after all child jobs complete.
@@ -581,54 +580,6 @@ class BatchScheduler {
 		}
 		$result = wp_schedule_single_event( $timestamp, $hook, $wp_args, true );
 		return ! is_wp_error( $result ) && true === $result;
-	}
-
-	/** Re-establish one scheduler path for a durable pathless v2 batch. */
-	public static function recover( int $parent_job_id ): bool {
-		$engine = EngineData::retrieve( $parent_job_id );
-		$state  = is_array( $engine['batch_state'] ?? null ) ? $engine['batch_state'] : array();
-		$hook   = (string) ( $state['hook'] ?? $engine['batch_hook'] ?? '' );
-		if ( self::STORAGE_VERSION !== (int) ( $engine['batch_storage_version'] ?? 0 ) || '' === $hook || ! empty( $state['worklist_complete'] ) ) {
-			return false;
-		}
-
-		$offset = ( new BatchItems() )->first_outstanding_index( $parent_job_id );
-		if ( null === $offset ) {
-			return false;
-		}
-
-		$token = bin2hex( random_bytes( 16 ) );
-		$claim = EngineData::mutate(
-			$parent_job_id,
-			static function ( array $current ) use ( $token ): ?array {
-				$owner      = is_array( $current['batch_recovery_owner'] ?? null ) ? $current['batch_recovery_owner'] : array();
-				$claimed_at = strtotime( (string) ( $owner['claimed_at'] ?? '' ) . ' UTC' );
-				if ( false !== $claimed_at && ( time() - $claimed_at ) < self::RECOVERY_CLAIM_TTL ) {
-					return null;
-				}
-				$current['batch_recovery_owner'] = array(
-					'token'      => $token,
-					'claimed_at' => current_time( 'mysql', true ),
-				);
-				return $current;
-			},
-			'batch_recovery_claim'
-		);
-		if ( empty( $claim['success'] ) || ! self::scheduleV2Chunk( $hook, $parent_job_id, $offset, time() ) ) {
-			return false;
-		}
-
-		EngineData::mutate(
-			$parent_job_id,
-			static function ( array $current ) use ( $token ): array {
-				if ( hash_equals( $token, (string) ( $current['batch_recovery_owner']['token'] ?? '' ) ) ) {
-					$current['batch_recovery_owner']['scheduled_at'] = current_time( 'mysql', true );
-				}
-				return $current;
-			},
-			'batch_recovery_scheduled'
-		);
-		return true;
 	}
 
 	private static function discardV2Outstanding( BatchItems $repository, int $parent_job_id, string $context ): bool {

--- a/inc/Core/ActionScheduler/PathlessBatchRecovery.php
+++ b/inc/Core/ActionScheduler/PathlessBatchRecovery.php
@@ -1,0 +1,141 @@
+<?php
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Recovery requires fresh scheduler and child-job evidence.
+/**
+ * Pathless pipeline batch recovery.
+ *
+ * @package DataMachine\Core\ActionScheduler
+ */
+
+namespace DataMachine\Core\ActionScheduler;
+
+use DataMachine\Core\Database\BatchItems\BatchItems;
+use DataMachine\Core\EngineData;
+
+defined( 'ABSPATH' ) || exit;
+
+class PathlessBatchRecovery {
+	private const CLAIM_TTL = 300;
+
+	/** Whether a v2 batch still has work that can be requeued. */
+	public static function isRecoverable( array $engine_data ): bool {
+		return BatchScheduler::STORAGE_VERSION === (int) ( $engine_data['batch_storage_version'] ?? 0 )
+			&& empty( $engine_data['batch_state']['worklist_complete'] );
+	}
+
+	/** Check whether a batch parent still has scheduled chunk or child work. */
+	public static function hasActiveWork( int $parent_job_id, array $engine_data, int $timeout_hours ): bool {
+		if ( $parent_job_id <= 0 || empty( $engine_data['batch'] ) ) {
+			return false;
+		}
+		if ( self::hasActiveAction( $parent_job_id, $timeout_hours ) ) {
+			return true;
+		}
+
+		global $wpdb;
+		$jobs_table = $wpdb->prefix . 'datamachine_jobs';
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WordPress prefix.
+		$active_children = (int) $wpdb->get_var(
+			$wpdb->prepare( "SELECT COUNT(*) FROM {$jobs_table} WHERE parent_job_id = %d AND status IN ( %s, %s )", $parent_job_id, 'pending', 'processing' )
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return $active_children > 0;
+	}
+
+	/** Re-establish one scheduler path for a durable pathless v2 batch. */
+	public static function recover( int $parent_job_id ): bool {
+		$engine = EngineData::retrieve( $parent_job_id );
+		$state  = is_array( $engine['batch_state'] ?? null ) ? $engine['batch_state'] : array();
+		$hook   = (string) ( $state['hook'] ?? $engine['batch_hook'] ?? '' );
+		if ( ! self::isRecoverable( $engine ) || '' === $hook ) {
+			return false;
+		}
+
+		$offset = ( new BatchItems() )->first_outstanding_index( $parent_job_id );
+		if ( null === $offset ) {
+			return false;
+		}
+
+		$token = bin2hex( random_bytes( 16 ) );
+		$claim = EngineData::mutate(
+			$parent_job_id,
+			static function ( array $current ) use ( $token ): ?array {
+				$owner      = is_array( $current['batch_recovery_owner'] ?? null ) ? $current['batch_recovery_owner'] : array();
+				$claimed_at = strtotime( (string) ( $owner['claimed_at'] ?? '' ) . ' UTC' );
+				if ( false !== $claimed_at && ( time() - $claimed_at ) < self::CLAIM_TTL ) {
+					return null;
+				}
+				$current['batch_recovery_owner'] = array(
+					'token'      => $token,
+					'claimed_at' => current_time( 'mysql', true ),
+				);
+				return $current;
+			},
+			'batch_recovery_claim'
+		);
+		if ( empty( $claim['success'] ) || ! self::schedule( $hook, $parent_job_id, $offset ) ) {
+			return false;
+		}
+
+		EngineData::mutate(
+			$parent_job_id,
+			static function ( array $current ) use ( $token ): array {
+				if ( hash_equals( $token, (string) ( $current['batch_recovery_owner']['token'] ?? '' ) ) ) {
+					$current['batch_recovery_owner']['scheduled_at'] = current_time( 'mysql', true );
+				}
+				return $current;
+			},
+			'batch_recovery_scheduled'
+		);
+		return true;
+	}
+
+	/** Check exact pending or fresh in-progress chunk actions for one parent. */
+	private static function hasActiveAction( int $parent_job_id, int $timeout_hours ): bool {
+		global $wpdb;
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$like_parent   = '%"parent_job_id":' . $wpdb->esc_like( (string) $parent_job_id ) . '%';
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WordPress prefix.
+		$actions = $wpdb->get_results(
+			$wpdb->prepare( "SELECT args, status, scheduled_date_gmt, last_attempt_gmt FROM {$actions_table} WHERE hook = %s AND status IN ( %s, %s ) AND args LIKE %s", 'datamachine_pipeline_batch_chunk', 'pending', 'in-progress', $like_parent )
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$timeout_seconds = max( 1, $timeout_hours ) * HOUR_IN_SECONDS;
+		$now_gmt         = strtotime( current_time( 'mysql', true ) );
+		foreach ( $actions as $action ) {
+			$args = json_decode( (string) ( $action->args ?? '' ), true );
+			if ( $parent_job_id !== (int) ( $args['parent_job_id'] ?? 0 ) ) {
+				continue;
+			}
+			if ( 'pending' === (string) $action->status ) {
+				return true;
+			}
+			$last_attempt = (string) ( $action->last_attempt_gmt ?? '' );
+			$scheduled    = (string) ( $action->scheduled_date_gmt ?? '' );
+			$reference    = $last_attempt && '0000-00-00 00:00:00' !== $last_attempt ? $last_attempt : $scheduled;
+			$started_at   = $reference ? strtotime( $reference ) : false;
+			if ( false === $started_at || false === $now_gmt || ( $now_gmt - $started_at ) < $timeout_seconds ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/** Schedule a recovered chunk without scanning the scheduler table. */
+	private static function schedule( string $hook, int $parent_job_id, int $offset ): bool {
+		$args = array(
+			'parent_job_id' => $parent_job_id,
+			'offset'        => $offset,
+		);
+		try {
+			if ( as_schedule_single_action( time(), $hook, $args, GroupRegistrar::GROUP ) ) {
+				return true;
+			}
+		} catch ( \Throwable $exception ) {
+			do_action( 'datamachine_log', 'error', 'Pathless batch recovery scheduling failed', array( 'parent_job_id' => $parent_job_id, 'exception' => $exception->getMessage() ) );
+		}
+
+		$result = wp_schedule_single_event( time(), $hook, array( $parent_job_id, $offset ), true );
+		return ! is_wp_error( $result ) && true === $result;
+	}
+}

--- a/inc/Core/ActionScheduler/ScopedDrainService.php
+++ b/inc/Core/ActionScheduler/ScopedDrainService.php
@@ -43,12 +43,14 @@ class ScopedDrainService {
 		$terminal_state         = '';
 
 		$started_at    = microtime( true );
+		$timeouts_reset = false;
 		$before_counts = $this->getStatusCounts( $hooks, $job_ids, $lane );
 		$batches       = 0;
 		$warnings      = 0;
 		$stop_reason   = 'empty';
+		$processed     = 0;
 
-		while ( $this->getDuePendingCount( $hooks, $job_ids, $lane ) > 0 ) {
+		while ( $this->hasDuePendingAction( $hooks, $job_ids, $lane ) ) {
 			if ( null !== $terminal_callback ) {
 				$terminal_state = (string) $terminal_callback();
 				if ( '' !== $terminal_state ) {
@@ -57,14 +59,13 @@ class ScopedDrainService {
 				}
 			}
 
-			$stats = $this->buildStats( $before_counts, $this->getStatusCounts( $hooks, $job_ids, $lane ), $batches, $warnings, $hooks, $job_ids, $stop_reason, $lane, $terminal_state );
 			// @phpstan-ignore-next-line
 			if ( $this->isMemorySoftLimitReached() ) {
 				$stop_reason = 'memory_limit';
 				break;
 			}
 
-			if ( $limit > 0 && (int) $stats['actions_processed'] >= $limit ) {
+			if ( $limit > 0 && $processed >= $limit ) {
 				$stop_reason = 'limit';
 				break;
 			}
@@ -82,20 +83,19 @@ class ScopedDrainService {
 
 			$current_batch_size = $batch_size;
 			if ( $limit > 0 ) {
-				$current_batch_size = min( $batch_size, $limit - (int) $stats['actions_processed'] );
+				$current_batch_size = min( $batch_size, $limit - $processed );
 			}
 			if ( $current_batch_size <= 0 ) {
 				$stop_reason = 'limit';
 				break;
 			}
 
-			$due_before    = $this->getDuePendingCount( $hooks, $job_ids, $lane );
-			$status_before = $this->getStatusCounts( $hooks, $job_ids, $lane );
 			$deadline_at   = 0.0;
 			if ( $time_limit_ms > 0 ) {
 				$deadline_at = $started_at + max( 0, $time_limit_ms - $stop_before_timeout_ms ) / 1000;
 			}
-			$result = $this->runActionSchedulerBatch( $current_batch_size, $hooks, $job_ids, $deadline_at, $lane, $execution_context );
+			$result = $this->runActionSchedulerBatch( $current_batch_size, $hooks, $job_ids, $deadline_at, $lane, $execution_context, ! $timeouts_reset );
+			$timeouts_reset = true;
 			++$batches;
 
 			if ( 0 !== (int) $result['return_code'] ) {
@@ -108,13 +108,13 @@ class ScopedDrainService {
 				break;
 			}
 
-			$status_after = $this->getStatusCounts( $hooks, $job_ids, $lane );
-			$progress     = (int) ( $result['actions_processed'] ?? $this->processedDelta( $status_before, $status_after ) );
+			$progress     = (int) ( $result['actions_processed'] ?? 0 );
+			$processed += $progress;
 			if ( '' !== (string) $result['stop_reason'] ) {
 				$stop_reason = (string) $result['stop_reason'];
 				break;
 			}
-			if ( 0 === $progress && $this->getDuePendingCount( $hooks, $job_ids, $lane ) >= $due_before ) {
+			if ( 0 === $progress ) {
 				++$warnings;
 				if ( null !== $warning_callback ) {
 					$warning_callback( 'Drain stopped because Action Scheduler made no observable progress.' );
@@ -338,7 +338,7 @@ class ScopedDrainService {
 	 * @param string        $execution_context Action Scheduler execution context.
 	 * @return array{return_code:int,stdout:string,stderr:string,stop_reason:string,actions_processed:int} Result data.
 	 */
-	private function runActionSchedulerBatch( int $batch_size, ?array $hooks = null, array $job_ids = array(), float $deadline_at = 0.0, string $lane = '', string $execution_context = 'Data Machine drain' ): array {
+	private function runActionSchedulerBatch( int $batch_size, ?array $hooks = null, array $job_ids = array(), float $deadline_at = 0.0, string $lane = '', string $execution_context = 'Data Machine drain', bool $reset_timeouts = true ): array {
 		$store       = \ActionScheduler_Store::instance();
 		$runner      = \ActionScheduler::runner();
 		$warnings    = array();
@@ -349,7 +349,9 @@ class ScopedDrainService {
 
 		try {
 			GroupRegistrar::ensureDataMachineGroup();
-			$this->runActionSchedulerTimeoutCleanup( $store );
+			if ( $reset_timeouts ) {
+				$this->runActionSchedulerTimeoutCleanup( $store );
+			}
 			$claim = $store->stake_claim( $claim_size, null, $hooks ?? array(), self::GROUP );
 		} catch ( \Throwable $throwable ) {
 			return array(
@@ -362,6 +364,7 @@ class ScopedDrainService {
 		}
 
 		try {
+			$claimed_action_ids = array_map( 'intval', $store->find_actions_by_claim_id( $claim->get_id() ) );
 			foreach ( $claim->get_actions() as $action_id ) {
 				if ( $deadline_at > 0 && microtime( true ) >= $deadline_at ) {
 					$stop_reason = 'timeout_margin';
@@ -379,7 +382,6 @@ class ScopedDrainService {
 					continue;
 				}
 
-				$claimed_action_ids = array_map( 'intval', $store->find_actions_by_claim_id( $claim->get_id() ) );
 				if ( ! in_array( $action_id, $claimed_action_ids, true ) ) {
 					$warnings[] = sprintf( 'Action Scheduler claim %d was lost during drain.', $claim->get_id() );
 					break;
@@ -914,6 +916,40 @@ class ScopedDrainService {
 	 */
 	private function getDuePendingCount( ?array $hooks = null, array $job_ids = array(), string $lane = '' ): int {
 		return $this->countActions( true, $hooks, $job_ids, $lane );
+	}
+
+	/** Check for due work without counting the queue. */
+	private function hasDuePendingAction( ?array $hooks = null, array $job_ids = array(), string $lane = '' ): bool {
+		if ( '' !== $lane ) {
+			return $this->getDuePendingCount( $hooks, $job_ids, $lane ) > 0;
+		}
+
+		global $wpdb;
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$groups_table  = $wpdb->prefix . 'actionscheduler_groups';
+		$hook_sql      = $this->hookWhereSql( $hooks, $job_ids );
+		$values        = array_merge(
+			array( $actions_table, $groups_table ),
+			$hook_sql['values'],
+			array( self::GROUP, gmdate( 'Y-m-d H:i:s' ) )
+		);
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Dynamic normalized scope is prepared with matching values.
+		$action_id = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT a.action_id
+				FROM %i a
+				INNER JOIN %i g ON g.group_id = a.group_id
+				WHERE ' . $hook_sql['sql'] . 'a.status = \'pending\'
+				AND g.slug = %s
+				AND a.scheduled_date_gmt <= %s
+				LIMIT 1',
+				$values
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		return null !== $action_id;
 	}
 
 	/**

--- a/inc/Core/Database/BatchItems/BatchItems.php
+++ b/inc/Core/Database/BatchItems/BatchItems.php
@@ -185,8 +185,14 @@ class BatchItems extends BaseRepository {
 		);
 	}
 
-	/** Atomically claim ready or expired rows in one chunk boundary. */
-	public function claim_chunk( int $batch_job_id, int $offset, int $limit, int $lease_seconds = self::DEFAULT_LEASE_SECONDS ): array {
+	/**
+	 * Atomically claim ready or expired rows in one chunk boundary.
+	 *
+	 * The optional owner callback runs after rows are locked and updated but
+	 * before commit. A false result rolls the claim back, allowing callers to
+	 * establish an external recovery path before the lease becomes durable.
+	 */
+	public function claim_chunk( int $batch_job_id, int $offset, int $limit, int $lease_seconds = self::DEFAULT_LEASE_SECONDS, ?callable $owner = null ): array {
 		if ( $batch_job_id <= 0 || $limit < 1 || false === $this->wpdb->query( 'START TRANSACTION' ) ) {
 			return array();
 		}
@@ -237,6 +243,11 @@ class BatchItems extends BaseRepository {
 			$row['lease_token']      = $token;
 			$row['lease_expires_at'] = $expires_at;
 			$claimed[]               = $this->decode_row( $row );
+		}
+
+		if ( $claimed && null !== $owner && ! $owner() ) {
+			$this->wpdb->query( 'ROLLBACK' );
+			return array();
 		}
 
 		if ( false === $this->wpdb->query( 'COMMIT' ) ) {

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -10,6 +10,7 @@ namespace DataMachine\Tests\Unit\Abilities\Engine;
 
 use DataMachine\Abilities\Engine\PipelineBatchScheduler;
 use DataMachine\Core\ActionScheduler\BatchScheduler;
+use DataMachine\Core\ActionScheduler\PathlessBatchRecovery;
 use DataMachine\Core\Database\BatchItems\BatchItems;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
@@ -220,8 +221,8 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$scheduler->fanOut( $parent_id, 'step_a', array( $this->make_data_packet( 'Event A' ) ), $this->make_engine_snapshot( $parent_id ) );
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}actionscheduler_actions WHERE hook = %s AND args = %s", PipelineBatchScheduler::BATCH_HOOK, wp_json_encode( array( 'parent_job_id' => $parent_id, 'offset' => 0 ) ) ) );
 
-		$this->assertTrue( BatchScheduler::recover( $parent_id ) );
-		$this->assertFalse( BatchScheduler::recover( $parent_id ) );
+		$this->assertTrue( PathlessBatchRecovery::recover( $parent_id ) );
+		$this->assertFalse( PathlessBatchRecovery::recover( $parent_id ) );
 		$this->assertSame( 1, (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}actionscheduler_actions WHERE hook = %s AND args = %s AND status = 'pending'", PipelineBatchScheduler::BATCH_HOOK, wp_json_encode( array( 'parent_job_id' => $parent_id, 'offset' => 0 ) ) ) ) );
 	}
 

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -186,6 +186,45 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$this->assertSame( 'first', $state['extra']['route'] );
 	}
 
+	public function test_exact_retry_adopts_one_existing_chunk_path(): void {
+		global $wpdb;
+		$parent_id = $this->create_parent_job();
+		$items     = array( $this->make_data_packet( 'Event A' ) );
+
+		$first = BatchScheduler::start( $parent_id, PipelineBatchScheduler::BATCH_HOOK, $items, array( 'next_flow_step_id' => 'step_a' ), 'pipeline', BatchScheduler::COMPLETION_STRATEGY_CHILDREN_COMPLETE );
+		$retry = BatchScheduler::start( $parent_id, PipelineBatchScheduler::BATCH_HOOK, $items, array( 'next_flow_step_id' => 'step_a' ), 'pipeline', BatchScheduler::COMPLETION_STRATEGY_CHILDREN_COMPLETE );
+
+		$this->assertTrue( $first['scheduled'] );
+		$this->assertTrue( $retry['scheduled'] );
+		$this->assertSame( 1, (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}actionscheduler_actions WHERE hook = %s AND args = %s AND status = 'pending'", PipelineBatchScheduler::BATCH_HOOK, wp_json_encode( array( 'parent_job_id' => $parent_id, 'offset' => 0 ) ) ) ) );
+	}
+
+	public function test_duplicate_completed_chunk_does_not_perpetuate_recovery_actions(): void {
+		global $wpdb;
+		$parent_id = $this->create_parent_job();
+		$scheduler = new PipelineBatchScheduler();
+		$scheduler->fanOut( $parent_id, 'step_a', array( $this->make_data_packet( 'Event A' ) ), $this->make_engine_snapshot( $parent_id ) );
+		$scheduler->processChunk( $parent_id, 0 );
+		$before = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}actionscheduler_actions WHERE hook = %s AND args = %s AND status = 'pending'", PipelineBatchScheduler::BATCH_HOOK, wp_json_encode( array( 'parent_job_id' => $parent_id, 'offset' => 0 ) ) ) );
+
+		$scheduler->processChunk( $parent_id, 0 );
+
+		$after = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}actionscheduler_actions WHERE hook = %s AND args = %s AND status = 'pending'", PipelineBatchScheduler::BATCH_HOOK, wp_json_encode( array( 'parent_job_id' => $parent_id, 'offset' => 0 ) ) ) );
+		$this->assertSame( $before, $after );
+	}
+
+	public function test_pathless_batch_recovery_is_idempotent_without_scheduler_scan(): void {
+		global $wpdb;
+		$parent_id = $this->create_parent_job();
+		$scheduler = new PipelineBatchScheduler();
+		$scheduler->fanOut( $parent_id, 'step_a', array( $this->make_data_packet( 'Event A' ) ), $this->make_engine_snapshot( $parent_id ) );
+		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}actionscheduler_actions WHERE hook = %s AND args = %s", PipelineBatchScheduler::BATCH_HOOK, wp_json_encode( array( 'parent_job_id' => $parent_id, 'offset' => 0 ) ) ) );
+
+		$this->assertTrue( BatchScheduler::recover( $parent_id ) );
+		$this->assertFalse( BatchScheduler::recover( $parent_id ) );
+		$this->assertSame( 1, (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}actionscheduler_actions WHERE hook = %s AND args = %s AND status = 'pending'", PipelineBatchScheduler::BATCH_HOOK, wp_json_encode( array( 'parent_job_id' => $parent_id, 'offset' => 0 ) ) ) ) );
+	}
+
 	/**
 	 * Regression for #2762: a concurrent RunMetrics write must not clobber
 	 * batch_state written by fan-out.

--- a/tests/Unit/Core/Database/BatchItemsTest.php
+++ b/tests/Unit/Core/Database/BatchItemsTest.php
@@ -83,6 +83,16 @@ class BatchItemsTest extends WP_UnitTestCase {
 		$this->assertNotSame( $first[0]['lease_token'], $second[0]['lease_token'] );
 	}
 
+	public function test_claim_owner_failure_rolls_back_the_lease(): void {
+		global $wpdb;
+		$this->assertTrue( $this->repository->insert_batch( $this->batch_job_id, array( array( 'id' => 1 ) ), array( array() ) )['success'] );
+
+		$claimed = $this->repository->claim_chunk( $this->batch_job_id, 0, 1, 60, static fn(): bool => false );
+
+		$this->assertSame( array(), $claimed );
+		$this->assertSame( BatchItems::STATE_READY, $wpdb->get_var( $wpdb->prepare( 'SELECT state FROM %i WHERE batch_job_id = %d AND item_index = 0', $this->repository->get_table_name(), $this->batch_job_id ) ) );
+	}
+
 	public function test_stale_token_is_fenced_and_release_supports_partial_retry(): void {
 		global $wpdb;
 		$this->assertTrue( $this->repository->insert_batch( $this->batch_job_id, array( array( 'id' => 1 ), array( 'id' => 2 ) ), array( array(), array() ) )['success'] );

--- a/tests/recover-stuck-active-action-guard-smoke.php
+++ b/tests/recover-stuck-active-action-guard-smoke.php
@@ -23,7 +23,8 @@ function assert_recover_stuck_guard_smoke( string $name, bool $condition, string
 	++$failed;
 }
 
-$source = file_get_contents( __DIR__ . '/../inc/Abilities/Job/RecoverStuckJobsAbility.php' ) ?: '';
+$source       = file_get_contents( __DIR__ . '/../inc/Abilities/Job/RecoverStuckJobsAbility.php' ) ?: '';
+$batch_source = file_get_contents( __DIR__ . '/../inc/Core/ActionScheduler/PathlessBatchRecovery.php' ) ?: '';
 $timeout_loop = strstr( $source, 'foreach ( $timed_out_jobs as $job )' ) ?: '';
 
 echo "Case 1: timed-out recovery skips jobs with active scheduler work\n";
@@ -44,10 +45,10 @@ assert_recover_stuck_guard_smoke( 'pending actions remain guarded unconditionall
 assert_recover_stuck_guard_smoke( 'old in-progress actions can fall through', str_contains( $source, '( $now_gmt - $started_at ) < $timeout_seconds' ) );
 
 echo "Case 4: batch parents guard chunk actions and active children\n";
-assert_recover_stuck_guard_smoke( 'active batch guard method exists', str_contains( $source, 'private function hasActiveBatchWork' ) );
-assert_recover_stuck_guard_smoke( 'batch guard checks pipeline chunk actions', str_contains( $source, 'datamachine_pipeline_batch_chunk' ) && str_contains( $source, 'parent_job_id' ) );
-assert_recover_stuck_guard_smoke( 'batch guard checks active children', str_contains( $source, 'WHERE parent_job_id = %d' ) && str_contains( $source, "status IN ( %s, %s )" ) );
-assert_recover_stuck_guard_smoke( 'generic action arg extractor supports parent ids', str_contains( $source, 'private function extractActionArgInt' ) && str_contains( $source, '$this->extractActionArgInt( (string) ( $action->args ?? \'\' ), $arg_name )' ) );
+assert_recover_stuck_guard_smoke( 'active batch guard method exists', str_contains( $batch_source, 'public static function hasActiveWork' ) );
+assert_recover_stuck_guard_smoke( 'batch guard checks pipeline chunk actions', str_contains( $batch_source, 'datamachine_pipeline_batch_chunk' ) && str_contains( $batch_source, 'parent_job_id' ) );
+assert_recover_stuck_guard_smoke( 'batch guard checks active children', str_contains( $batch_source, 'WHERE parent_job_id = %d' ) && str_contains( $batch_source, 'status IN ( %s, %s )' ) );
+assert_recover_stuck_guard_smoke( 'batch guard confirms exact parent id', str_contains( $batch_source, '$parent_job_id !== (int) ( $args[\'parent_job_id\'] ?? 0 )' ) );
 
 echo "\nRecover-stuck active action guard smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary
- make exact batch starts adopt the durable worklist owner instead of scheduling another initial/recovery chain
- create lease recovery actions only for rows actually claimed, inside the claim transaction, and make completed/stale chunk delivery a terminal no-op
- requeue pathless v2 batches through bounded engine-data CAS ownership and reduce repeated full-table work in scoped drains

## Root cause
`BatchScheduler::start()` scheduled a five-minute recovery action before the worklist and parent state were committed, then scheduled the immediate initial chunk after commit. Every v2 chunk also scheduled another recovery action before attempting its durable item claim. A stale or overlapping chunk therefore scheduled its successor even when it owned no rows, and a delivery after `worklist_complete` scheduled another finalization retry. At high volume those duplicate paths became self-perpetuating rather than a bounded reflection of legitimate calendar ingestion.

The drain path amplified the throughput loss by running full due counts and grouped status scans around every small claim batch, resetting global Action Scheduler timeouts for every batch, and re-reading the same claim membership once per action. On multi-million-row scheduler tables, those operations increased lock pressure and delayed forward progress.

## Why this remains scale-safe
- fan-out cardinality, chunk size, chunk delay, and ingestion behavior are unchanged
- exact overlapping starts adopt the existing durable worklist contract without an Action Scheduler existence scan
- a recovery action is now established only after rows are selected and before their lease transaction commits; non-owning duplicate deliveries cannot create another chain
- pathless recovery uses a short engine-data CAS lease and the indexed Data Machine batch worklist, not an unbounded scheduler-table scan
- unscoped drains use a `LIMIT 1` liveness probe between claims, take status snapshots only at the boundaries, reset timeouts once, and verify claim membership once per claim

## Tests
- `vendor/bin/phpunit tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php tests/Unit/Core/Database/BatchItemsTest.php`
- `vendor/bin/phpunit tests/Unit/Core/Database/JobLifecycleTransitionTest.php`
- `composer lint`
- `php tests/flow-run-cli-drain-smoke.php`
- `php tests/recover-stuck-active-action-guard-smoke.php`
- `php tests/batch-v2-contract-smoke.php`

## Live cleanup boundary
This change does not delete or mutate existing production scheduler history. After deployment, reconcile only explicitly identified stale/pathless parent jobs through the bounded `jobs recover-stuck` job scope, then cancel/delete obsolete `datamachine_pipeline_batch_chunk` actions only for terminal parents or exact superseded `(parent_job_id, offset)` paths in small operator-reviewed batches. Preserve pending actions for active parents and do not run an unscoped hook-wide deletion; allow normal Action Scheduler retention cleanup to remove completed history after forward progress is restored.

Fixes #3062