### PR TITLE
fix: preserve pathless batch recovery semantics

### DIFF
--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -44,7 +44,7 @@ use DataMachine\Core\PluginSettings;
 defined( 'ABSPATH' ) || exit;
 
 class BatchScheduler {
-	public const STORAGE_VERSION         = 2;
+	public const STORAGE_VERSION = 2;
 
 	/**
 	 * Parent completes after all child jobs complete.
@@ -432,7 +432,7 @@ class BatchScheduler {
 		$offset     = null === $expected_offset ? (int) ( $state['offset'] ?? 0 ) : $expected_offset;
 		$chunk_size = max( 1, (int) ( $parent_engine['batch_chunk_size'] ?? self::chunkSize( $context ) ) );
 		$lease      = (int) apply_filters( 'datamachine_batch_item_lease_seconds', BatchItems::DEFAULT_LEASE_SECONDS, $context );
-		$rows = $repository->claim_chunk(
+		$rows       = $repository->claim_chunk(
 			$parent_job_id,
 			$offset,
 			$chunk_size,

--- a/inc/Core/ActionScheduler/PathlessBatchRecovery.php
+++ b/inc/Core/ActionScheduler/PathlessBatchRecovery.php
@@ -103,8 +103,7 @@ class PathlessBatchRecovery {
 		$timeout_seconds = max( 1, $timeout_hours ) * HOUR_IN_SECONDS;
 		$now_gmt         = strtotime( current_time( 'mysql', true ) );
 		foreach ( $actions as $action ) {
-			$args = json_decode( (string) ( $action->args ?? '' ), true );
-			if ( $parent_job_id !== (int) ( $args['parent_job_id'] ?? 0 ) ) {
+			if ( self::extractParentJobId( (string) ( $action->args ?? '' ) ) !== $parent_job_id ) {
 				continue;
 			}
 			if ( 'pending' === (string) $action->status ) {
@@ -121,6 +120,34 @@ class PathlessBatchRecovery {
 		return false;
 	}
 
+	/** Extract a parent ID from keyed, nested, JSON, or serialized action args. */
+	private static function extractParentJobId( string $args ): int {
+		$decoded = json_decode( $args, true );
+		if ( is_array( $decoded ) ) {
+			if ( isset( $decoded['parent_job_id'] ) && is_numeric( $decoded['parent_job_id'] ) ) {
+				return (int) $decoded['parent_job_id'];
+			}
+			foreach ( $decoded as $value ) {
+				if ( is_array( $value ) && isset( $value['parent_job_id'] ) && is_numeric( $value['parent_job_id'] ) ) {
+					return (int) $value['parent_job_id'];
+				}
+			}
+		}
+
+		$unserialized = maybe_unserialize( $args );
+		if ( is_array( $unserialized ) ) {
+			if ( isset( $unserialized['parent_job_id'] ) && is_numeric( $unserialized['parent_job_id'] ) ) {
+				return (int) $unserialized['parent_job_id'];
+			}
+			foreach ( $unserialized as $value ) {
+				if ( is_array( $value ) && isset( $value['parent_job_id'] ) && is_numeric( $value['parent_job_id'] ) ) {
+					return (int) $value['parent_job_id'];
+				}
+			}
+		}
+		return 0;
+	}
+
 	/** Schedule a recovered chunk without scanning the scheduler table. */
 	private static function schedule( string $hook, int $parent_job_id, int $offset ): bool {
 		$args = array(
@@ -132,7 +159,15 @@ class PathlessBatchRecovery {
 				return true;
 			}
 		} catch ( \Throwable $exception ) {
-			do_action( 'datamachine_log', 'error', 'Pathless batch recovery scheduling failed', array( 'parent_job_id' => $parent_job_id, 'exception' => $exception->getMessage() ) );
+			do_action(
+				'datamachine_log',
+				'error',
+				'Pathless batch recovery scheduling failed',
+				array(
+					'parent_job_id' => $parent_job_id,
+					'exception'     => $exception->getMessage(),
+				)
+			);
 		}
 
 		$result = wp_schedule_single_event( time(), $hook, array( $parent_job_id, $offset ), true );

--- a/inc/Core/ActionScheduler/PathlessBatchRecovery.php
+++ b/inc/Core/ActionScheduler/PathlessBatchRecovery.php
@@ -9,6 +9,7 @@
 namespace DataMachine\Core\ActionScheduler;
 
 use DataMachine\Core\Database\BatchItems\BatchItems;
+use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\EngineData;
 
 defined( 'ABSPATH' ) || exit;
@@ -32,7 +33,7 @@ class PathlessBatchRecovery {
 		}
 
 		global $wpdb;
-		$jobs_table = $wpdb->prefix . 'datamachine_jobs';
+		$jobs_table = $wpdb->prefix . Jobs::TABLE_NAME;
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WordPress prefix.
 		$active_children = (int) $wpdb->get_var(
 			$wpdb->prepare( "SELECT COUNT(*) FROM {$jobs_table} WHERE parent_job_id = %d AND status IN ( %s, %s )", $parent_job_id, 'pending', 'processing' )
@@ -103,7 +104,7 @@ class PathlessBatchRecovery {
 		$timeout_seconds = max( 1, $timeout_hours ) * HOUR_IN_SECONDS;
 		$now_gmt         = strtotime( current_time( 'mysql', true ) );
 		foreach ( $actions as $action ) {
-			if ( self::extractParentJobId( (string) ( $action->args ?? '' ) ) !== $parent_job_id ) {
+			if ( $parent_job_id !== self::extractParentJobId( (string) ( $action->args ?? '' ) ) ) {
 				continue;
 			}
 			if ( 'pending' === (string) $action->status ) {

--- a/inc/Core/ActionScheduler/PathlessBatchRecovery.php
+++ b/inc/Core/ActionScheduler/PathlessBatchRecovery.php
@@ -104,7 +104,7 @@ class PathlessBatchRecovery {
 		$timeout_seconds = max( 1, $timeout_hours ) * HOUR_IN_SECONDS;
 		$now_gmt         = strtotime( current_time( 'mysql', true ) );
 		foreach ( $actions as $action ) {
-			if ( $parent_job_id !== self::extractParentJobId( (string) ( $action->args ?? '' ) ) ) {
+			if ( ! hash_equals( (string) $parent_job_id, (string) self::extractParentJobId( (string) ( $action->args ?? '' ) ) ) ) {
 				continue;
 			}
 			if ( 'pending' === (string) $action->status ) {
@@ -125,25 +125,24 @@ class PathlessBatchRecovery {
 	private static function extractParentJobId( string $args ): int {
 		$decoded = json_decode( $args, true );
 		if ( is_array( $decoded ) ) {
-			if ( isset( $decoded['parent_job_id'] ) && is_numeric( $decoded['parent_job_id'] ) ) {
-				return (int) $decoded['parent_job_id'];
-			}
-			foreach ( $decoded as $value ) {
-				if ( is_array( $value ) && isset( $value['parent_job_id'] ) && is_numeric( $value['parent_job_id'] ) ) {
-					return (int) $value['parent_job_id'];
-				}
+			$parent_job_id = self::extractParentJobIdFromArray( $decoded );
+			if ( 0 !== $parent_job_id ) {
+				return $parent_job_id;
 			}
 		}
 
 		$unserialized = maybe_unserialize( $args );
-		if ( is_array( $unserialized ) ) {
-			if ( isset( $unserialized['parent_job_id'] ) && is_numeric( $unserialized['parent_job_id'] ) ) {
-				return (int) $unserialized['parent_job_id'];
-			}
-			foreach ( $unserialized as $value ) {
-				if ( is_array( $value ) && isset( $value['parent_job_id'] ) && is_numeric( $value['parent_job_id'] ) ) {
-					return (int) $value['parent_job_id'];
-				}
+		return is_array( $unserialized ) ? self::extractParentJobIdFromArray( $unserialized ) : 0;
+	}
+
+	/** Extract a parent ID from keyed or one-level nested action arguments. */
+	private static function extractParentJobIdFromArray( array $args ): int {
+		if ( isset( $args['parent_job_id'] ) && is_numeric( $args['parent_job_id'] ) ) {
+			return (int) $args['parent_job_id'];
+		}
+		foreach ( $args as $value ) {
+			if ( is_array( $value ) && isset( $value['parent_job_id'] ) && is_numeric( $value['parent_job_id'] ) ) {
+				return (int) $value['parent_job_id'];
 			}
 		}
 		return 0;

--- a/inc/Core/ActionScheduler/ScopedDrainService.php
+++ b/inc/Core/ActionScheduler/ScopedDrainService.php
@@ -14,8 +14,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class ScopedDrainService {
 
-	private const GROUP = 'data-machine';
-	private const DISPATCH_EVIDENCE_LIMIT = 100;
+	private const GROUP                    = 'data-machine';
+	private const DISPATCH_EVIDENCE_LIMIT  = 100;
 	private const DISPATCH_STALE_THRESHOLD = 900;
 
 	public const HOOK_BATCH_CHUNK = 'datamachine_pipeline_batch_chunk';
@@ -42,13 +42,13 @@ class ScopedDrainService {
 		$terminal_callback      = is_callable( $options['terminal_status_callback'] ?? null ) ? $options['terminal_status_callback'] : null;
 		$terminal_state         = '';
 
-		$started_at    = microtime( true );
+		$started_at     = microtime( true );
 		$timeouts_reset = false;
-		$before_counts = $this->getStatusCounts( $hooks, $job_ids, $lane );
-		$batches       = 0;
-		$warnings      = 0;
-		$stop_reason   = 'empty';
-		$processed     = 0;
+		$before_counts  = $this->getStatusCounts( $hooks, $job_ids, $lane );
+		$batches        = 0;
+		$warnings       = 0;
+		$stop_reason    = 'empty';
+		$processed      = 0;
 
 		while ( $this->hasDuePendingAction( $hooks, $job_ids, $lane ) ) {
 			if ( null !== $terminal_callback ) {
@@ -90,11 +90,11 @@ class ScopedDrainService {
 				break;
 			}
 
-			$deadline_at   = 0.0;
+			$deadline_at = 0.0;
 			if ( $time_limit_ms > 0 ) {
 				$deadline_at = $started_at + max( 0, $time_limit_ms - $stop_before_timeout_ms ) / 1000;
 			}
-			$result = $this->runActionSchedulerBatch( $current_batch_size, $hooks, $job_ids, $deadline_at, $lane, $execution_context, ! $timeouts_reset );
+			$result         = $this->runActionSchedulerBatch( $current_batch_size, $hooks, $job_ids, $deadline_at, $lane, $execution_context, ! $timeouts_reset );
 			$timeouts_reset = true;
 			++$batches;
 
@@ -108,7 +108,7 @@ class ScopedDrainService {
 				break;
 			}
 
-			$progress     = (int) ( $result['actions_processed'] ?? 0 );
+			$progress   = (int) ( $result['actions_processed'] ?? 0 );
 			$processed += $progress;
 			if ( '' !== (string) $result['stop_reason'] ) {
 				$stop_reason = (string) $result['stop_reason'];
@@ -186,16 +186,16 @@ class ScopedDrainService {
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		if ( $group_id <= 0 ) {
 			return array(
-				'stale_due_sample_gmt'                   => null,
-				'in_progress_actions'                    => 0,
-				'in_progress_actions_capped'             => false,
-				'in_progress_attempt_sample_gmt'         => null,
-				'concurrency_deferred_actions'           => 0,
-				'concurrency_deferred_actions_capped'    => false,
+				'stale_due_sample_gmt'                => null,
+				'in_progress_actions'                 => 0,
+				'in_progress_actions_capped'          => false,
+				'in_progress_attempt_sample_gmt'      => null,
+				'concurrency_deferred_actions'        => 0,
+				'concurrency_deferred_actions_capped' => false,
 			);
 		}
 
-		$stale_values = array_merge(
+		$stale_values  = array_merge(
 			array( $actions_table ),
 			$hook_sql['values'],
 			array( $group_id, $stale_gmt )
@@ -208,7 +208,7 @@ class ScopedDrainService {
 
 		// Each read stops after the evidence needed for health classification; stale and claimed reads exclude future and historical rows.
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Dynamic hook scope is constructed from normalized placeholders and values.
-		$stale_row = $wpdb->get_row(
+		$stale_row       = $wpdb->get_row(
 			$wpdb->prepare(
 				'SELECT a.scheduled_date_gmt AS stale_due_sample_gmt
 				FROM %i a
@@ -234,7 +234,7 @@ class ScopedDrainService {
 			),
 			ARRAY_A
 		);
-		$deferred_row = $wpdb->get_row(
+		$deferred_row    = $wpdb->get_row(
 			$wpdb->prepare(
 				'SELECT COUNT(*) AS concurrency_deferred_actions
 				FROM (

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -226,6 +226,13 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$this->assertSame( 1, (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}actionscheduler_actions WHERE hook = %s AND args = %s AND status = 'pending'", PipelineBatchScheduler::BATCH_HOOK, wp_json_encode( array( 'parent_job_id' => $parent_id, 'offset' => 0 ) ) ) ) );
 	}
 
+	public function test_pathless_batch_recovery_preserves_nested_and_serialized_action_args(): void {
+		$extract = new \ReflectionMethod( PathlessBatchRecovery::class, 'extractParentJobId' );
+
+		$this->assertSame( 123, $extract->invoke( null, wp_json_encode( array( array( 'parent_job_id' => 123 ) ) ) ) );
+		$this->assertSame( 456, $extract->invoke( null, serialize( array( array( 'parent_job_id' => 456 ) ) ) ) );
+	}
+
 	/**
 	 * Regression for #2762: a concurrent RunMetrics write must not clobber
 	 * batch_state written by fan-out.

--- a/tests/flow-run-cli-drain-smoke.php
+++ b/tests/flow-run-cli-drain-smoke.php
@@ -80,7 +80,7 @@ assert_drain_contains( 'ensureCliMemoryLimit()', $drain_src, 'drain raises the C
 assert_drain_contains( "'memory_limit'", $service_src, 'drain reports memory-limit stop reason' );
 assert_drain_contains( "'return_code'       => empty( \$warnings ) ? 0 : 1", $service_src, 'drain surfaces runner failures through a result object' );
 assert_drain_contains( "'actions_processed' => \$processed", $service_src, 'drain reports lane-filtered actions processed by the current batch' );
-assert_drain_contains( "\$progress     = (int) ( \$result['actions_processed']", $service_src, 'drain judges lane progress from actions it processed, not unrelated lane deltas' );
+assert_drain_contains( "\$progress   = (int) ( \$result['actions_processed']", $service_src, 'drain judges lane progress from actions it processed, not unrelated lane deltas' );
 assert_drain_contains( "'remaining_pending'", $service_src, 'drain reports remaining pending actions' );
 assert_drain_contains( 'getDuePendingCount( $hooks, $job_ids, $lane )', $service_src, 'drain reports lane-scoped remaining pending actions' );
 assert_drain_contains( 'getPendingCount( $hooks, $job_ids, $lane )', $service_src, 'drain reports lane-scoped total pending actions' );

--- a/tests/recover-stuck-active-action-guard-smoke.php
+++ b/tests/recover-stuck-active-action-guard-smoke.php
@@ -48,7 +48,7 @@ echo "Case 4: batch parents guard chunk actions and active children\n";
 assert_recover_stuck_guard_smoke( 'active batch guard method exists', str_contains( $batch_source, 'public static function hasActiveWork' ) );
 assert_recover_stuck_guard_smoke( 'batch guard checks pipeline chunk actions', str_contains( $batch_source, 'datamachine_pipeline_batch_chunk' ) && str_contains( $batch_source, 'parent_job_id' ) );
 assert_recover_stuck_guard_smoke( 'batch guard checks active children', str_contains( $batch_source, 'WHERE parent_job_id = %d' ) && str_contains( $batch_source, 'status IN ( %s, %s )' ) );
-assert_recover_stuck_guard_smoke( 'batch guard confirms exact parent id', str_contains( $batch_source, '$parent_job_id !== (int) ( $args[\'parent_job_id\'] ?? 0 )' ) );
+assert_recover_stuck_guard_smoke( 'batch guard confirms exact parent id', str_contains( $batch_source, 'extractParentJobId' ) && str_contains( $batch_source, 'maybe_unserialize' ) );
 
 echo "\nRecover-stuck active action guard smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary
- preserve keyed, nested, JSON, and serialized Action Scheduler argument decoding when identifying an active batch parent
- use the canonical jobs-table constant in pathless recovery
- keep the final scheduler/drain formatting aligned with the repository's CI profile
- share nested argument extraction so recovery semantics remain consistent without audit duplication

## Context
Follow-up to #3063. The main liveness fix is landed in `v0.172.1`; these corrections were completed after its squash merge and are intentionally isolated here rather than rewriting the merged branch.

## Verification
- `homeboy review data-machine lint --changed-since origin/main`: pass, no findings
- `homeboy review audit ... --changed-since origin/main`: pass, no introduced findings
- focused pipeline batch PHPUnit suite: pass
- recovery active-action guard smoke: 15/15 pass
- batch v2 contract smoke: pass

## Safety
No queue limits, cleanup, release, deployment, or live database mutations are included. High-volume fan-out behavior remains unchanged.