### PR TITLE
fix: make ability provider bootstrap idempotent

### DIFF
--- a/inc/Abilities/AbilityRegistration.php
+++ b/inc/Abilities/AbilityRegistration.php
@@ -15,6 +15,13 @@ defined( 'ABSPATH' ) || exit;
 class AbilityRegistration {
 
 	/**
+	 * Registration callbacks claimed by their concrete provider and declaration.
+	 *
+	 * @var array<string, true>
+	 */
+	private static array $registration_owners = array();
+
+	/**
 	 * Tracks lazy full-runtime activation for ability execution callbacks.
 	 *
 	 * @var bool
@@ -27,6 +34,12 @@ class AbilityRegistration {
 	 * @param callable $register_callback Ability registration callback.
 	 */
 	public static function on_abilities_api_init( callable $register_callback ): void {
+		$owner = self::registration_owner( $register_callback );
+		if ( isset( self::$registration_owners[ $owner ] ) ) {
+			return;
+		}
+		self::$registration_owners[ $owner ] = true;
+
 		if ( doing_action( 'wp_abilities_api_init' ) ) {
 			$register_callback();
 			return;
@@ -52,6 +65,46 @@ class AbilityRegistration {
 		} finally {
 			array_pop( $wp_current_filter );
 		}
+	}
+
+	/**
+	 * Identify one provider registration callback across repeated construction.
+	 *
+	 * Concrete object classes keep inherited provider declarations distinct, while
+	 * the declaration location allows one provider to own multiple callbacks.
+	 *
+	 * @param callable $callback Ability registration callback.
+	 * @return string Stable request-local owner key.
+	 */
+	private static function registration_owner( callable $callback ): string {
+		if ( $callback instanceof \Closure ) {
+			$reflection = new \ReflectionFunction( $callback );
+			$bound      = $reflection->getClosureThis();
+			$scope      = $reflection->getClosureScopeClass();
+			$provider   = null !== $bound ? $bound::class : ( null !== $scope ? $scope->getName() : '' );
+
+			return implode(
+				':',
+				array(
+					$provider,
+					(string) $reflection->getFileName(),
+					(string) $reflection->getStartLine(),
+					(string) $reflection->getEndLine(),
+				)
+			);
+		}
+
+		if ( is_array( $callback ) ) {
+			$provider = is_object( $callback[0] ) ? $callback[0]::class : (string) $callback[0];
+
+			return $provider . '::' . (string) $callback[1];
+		}
+
+		if ( is_object( $callback ) ) {
+			return $callback::class . '::__invoke';
+		}
+
+		return (string) $callback;
 	}
 
 	/**

--- a/tests/ability-provider-bootstrap-idempotency-smoke.php
+++ b/tests/ability-provider-bootstrap-idempotency-smoke.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Regression smoke for idempotent ability provider bootstrap.
+ *
+ * Run with: php tests/ability-provider-bootstrap-idempotency-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+	if ( function_exists( 'wp_register_ability' ) ) {
+		require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+		require_once dirname( __DIR__ ) . '/inc/Abilities/AbilityCategories.php';
+		\DataMachine\Abilities\AbilityCategories::ensure_registered();
+
+		$notices = 0;
+		$watch   = static function ( string $function_name, string $message ) use ( &$notices ): void {
+			if ( 'WP_Abilities_Registry::register' === $function_name && str_contains( $message, 'datamachine/' ) ) {
+				++$notices;
+			}
+		};
+		add_action( 'doing_it_wrong_run', $watch, 10, 2 );
+
+		$bootstrap = static function (): void {
+			new \DataMachine\Abilities\Engine\ScheduleNextStepAbility();
+			new \DataMachine\Abilities\Taxonomy\ResolveTermAbility();
+		};
+
+		$bootstrap();
+		$bootstrap();
+		$abilities = array(
+			wp_get_ability( 'datamachine/resolve-term' ),
+			wp_get_ability( 'datamachine/schedule-next-step' ),
+		);
+		$bootstrap();
+		$bootstrap();
+		remove_action( 'doing_it_wrong_run', $watch, 10 );
+
+		if ( in_array( null, $abilities, true ) || 0 !== $notices ) {
+			fwrite( STDERR, "FAIL: repeated WordPress bootstrap duplicated or missed affected abilities\n" );
+			exit( 1 );
+		}
+
+		echo "PASS: WordPress ability provider bootstrap is idempotent\n";
+		return;
+	}
+
+	define( 'ABSPATH', __DIR__ );
+
+	$GLOBALS['datamachine_3066_state'] = (object) array(
+		'actions'       => array(),
+		'did'           => 0,
+		'doing'         => false,
+		'notices'       => 0,
+		'registrations' => array(),
+	);
+
+	if ( ! function_exists( 'add_action' ) ) {
+		function add_action( string $hook, callable $callback ): void {
+			$GLOBALS['datamachine_3066_state']->actions[ $hook ][] = $callback;
+		}
+	}
+
+	if ( ! function_exists( 'did_action' ) ) {
+		function did_action( string $hook ): int {
+			return 'wp_abilities_api_init' === $hook ? $GLOBALS['datamachine_3066_state']->did : 0;
+		}
+	}
+
+	if ( ! function_exists( 'doing_action' ) ) {
+		function doing_action( string $hook ): bool {
+			return 'wp_abilities_api_init' === $hook && $GLOBALS['datamachine_3066_state']->doing;
+		}
+	}
+
+	if ( ! function_exists( 'wp_register_ability' ) ) {
+		function wp_register_ability( string $name, array $args ): object {
+			unset( $args );
+			$state = $GLOBALS['datamachine_3066_state'];
+			if ( isset( $state->registrations[ $name ] ) ) {
+				++$state->notices;
+			}
+			$state->registrations[ $name ] = ( $state->registrations[ $name ] ?? 0 ) + 1;
+
+			return new \stdClass();
+		}
+	}
+
+	if ( ! function_exists( '__' ) ) {
+		function __( string $text, string $domain = 'default' ): string {
+			unset( $domain );
+			return $text;
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\Flows {
+	if ( ! class_exists( Flows::class ) ) {
+		class Flows {}
+	}
+}
+
+namespace DataMachine\Core\Database\Jobs {
+	if ( ! class_exists( Jobs::class ) ) {
+		class Jobs {}
+	}
+}
+
+namespace DataMachine\Core\Database\Pipelines {
+	if ( ! class_exists( Pipelines::class ) ) {
+		class Pipelines {}
+	}
+}
+
+namespace DataMachine\Core\Database\ProcessedItems {
+	if ( ! class_exists( ProcessedItems::class ) ) {
+		class ProcessedItems {}
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Abilities/AbilityRegistration.php';
+	require_once dirname( __DIR__ ) . '/inc/Abilities/Engine/EngineHelpers.php';
+	require_once dirname( __DIR__ ) . '/inc/Abilities/Engine/ScheduleNextStepAbility.php';
+	require_once dirname( __DIR__ ) . '/inc/Abilities/Taxonomy/ResolveTermAbility.php';
+
+	$bootstrap = static function (): void {
+		new \DataMachine\Abilities\Engine\ScheduleNextStepAbility();
+		new \DataMachine\Abilities\Taxonomy\ResolveTermAbility();
+	};
+
+	$bootstrap();
+	$bootstrap();
+
+	$state = $GLOBALS['datamachine_3066_state'];
+	if ( 2 !== count( $state->actions['wp_abilities_api_init'] ?? array() ) ) {
+		fwrite( STDERR, "FAIL: repeated bootstrap attached duplicate provider callbacks\n" );
+		exit( 1 );
+	}
+
+	$state->doing = true;
+	$state->did   = 1;
+	foreach ( $state->actions['wp_abilities_api_init'] as $callback ) {
+		$callback();
+	}
+	$state->doing = false;
+
+	$bootstrap();
+	$bootstrap();
+
+	foreach ( array( 'datamachine/resolve-term', 'datamachine/schedule-next-step' ) as $name ) {
+		if ( 1 !== ( $state->registrations[ $name ] ?? 0 ) ) {
+			fwrite( STDERR, "FAIL: {$name} did not register exactly once\n" );
+			exit( 1 );
+		}
+	}
+
+	if ( 0 !== $state->notices ) {
+		fwrite( STDERR, "FAIL: repeated bootstrap emitted duplicate-registration notices\n" );
+		exit( 1 );
+	}
+
+	echo "PASS: ability provider bootstrap is idempotent\n";
+}


### PR DESCRIPTION
## Summary
- claim ability registration callbacks once per concrete provider and declaration site in the shared Abilities API lifecycle helper
- preserve distinct inherited providers and providers with multiple declaration callbacks
- add standalone and real-WordPress regression coverage for repeated `resolve-term` and `schedule-next-step` bootstrap

## Root cause
Ability constructors submit fresh registration callbacks every time they are constructed. Operational paths construct `ScheduleNextStepAbility` to execute it, and repeated bootstrap/provider construction can do the same for `ResolveTermAbility`. After `wp_abilities_api_init` has fired, `AbilityRegistration::on_abilities_api_init()` immediately ran each fresh callback again, causing WordPress to reject the duplicate names through `WP_Abilities_Registry::register()` and emit `_doing_it_wrong` notices.

The fix belongs at the shared bootstrap seam because that helper owns lifecycle timing for all Data Machine ability providers. Making callback ownership idempotent there protects every provider consistently without adding registry lookups or defensive behavior to individual abilities.

## Test evidence
- `php tests/ability-provider-bootstrap-idempotency-smoke.php`
- focused ability boundary, lazy-runtime, resolve-term, and schedule-next-step smokes
- broader agent/image-template ability lifecycle smokes
- `composer lint`
- scoped Homeboy lint: PHPCS, ESLint, and PHPStan passed with no findings
- scoped Homeboy WordPress test: 1 passed, 0 failed
- scoped Homeboy PR audit: no introduced findings

No release or deploy was performed.

Fixes #3066