### PR TITLE
fix: gate Action Scheduler claim index migration

### DIFF
--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -353,6 +353,12 @@ wp datamachine system run daily_memory_generation
 # Generate a chat session title
 wp datamachine system title abc-123 --force
 
+# Inspect the current site's Action Scheduler claim index (dry-run by default)
+wp datamachine system action-scheduler-claim-index
+
+# Explicitly build and verify the index after preflight passes
+wp datamachine system action-scheduler-claim-index --apply
+
 # Manage system task prompts
 wp datamachine system prompts
 wp datamachine system prompt-get alt_text_generation system_prompt
@@ -361,6 +367,12 @@ wp datamachine system prompt-reset alt_text_generation system_prompt
 ```
 
 `system run` schedules a job through the system task contract; it does not execute the task inline in the CLI process. Process queued work with `wp datamachine worker run` or `wp datamachine drain`.
+
+`system action-scheduler-claim-index` checks for an index beginning with the exact default claim predicate/order columns: `(claim_id, status, priority, attempts, scheduled_date_gmt, action_id)`. It never builds the index during plugin bootstrap, activation, or deployment. The command reports the site-scoped table, current readiness, server/engine support, row and byte estimates, conservative disk requirements, and generated DDL. `--apply` uses `ALGORITHM=INPLACE, LOCK=NONE`, a bounded metadata-lock wait, an advisory migration lock, and post-DDL index verification; unsupported runtimes fail instead of falling back to copying or blocking DDL.
+
+For a remote `DB_HOST`, the web host cannot measure the database data/tmp filesystems. Establish free space on the database host and pass the byte count explicitly with `--available-disk-bytes=<bytes>`; the command still rejects values below its conservative estimate. The operation is safe to re-run: an already-ready index is a no-op, and an interrupted invocation can be inspected again to determine the physical result.
+
+This is a downstream operator path for an Action Scheduler schema gap, not a replacement schema owned by Data Machine. The upstream claim query and schema are maintained by WooCommerce Action Scheduler; upstream issues [#1104](https://github.com/woocommerce/action-scheduler/issues/1104), [#1250](https://github.com/woocommerce/action-scheduler/pull/1250), and [#1340](https://github.com/woocommerce/action-scheduler/pull/1340) document the same missing claim-order coverage. Once upstream ships an equivalent index, readiness detection accepts it under any name and the migration remains a no-op.
 
 ### datamachine batch
 

--- a/inc/Cli/Commands/SystemCommand.php
+++ b/inc/Cli/Commands/SystemCommand.php
@@ -14,6 +14,7 @@ use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Abilities\Engine\DrainJobAbility;
 use DataMachine\Abilities\SystemAbilities;
+use DataMachine\Core\ActionScheduler\ClaimIndexMigration;
 use DataMachine\Engine\Tasks\TaskRegistry;
 use DataMachine\Engine\AI\System\Tasks\SystemTask;
 
@@ -170,6 +171,99 @@ class SystemCommand extends BaseCommand {
 		}
 
 		WP_CLI::log( sprintf( 'Available check types: %s', implode( ', ', $result['available'] ) ) );
+	}
+
+	/**
+	 * Inspect or explicitly build the Action Scheduler claim-order index.
+	 *
+	 * This command is inspection-only unless --apply is supplied. The migration
+	 * fails closed unless online DDL and conservative database disk headroom are
+	 * established for the current site's Action Scheduler table.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--apply]
+	 * : Apply the generated online DDL after all preflight checks pass.
+	 *
+	 * [--available-disk-bytes=<bytes>]
+	 * : Operator-established free bytes on the database data/tmp filesystems.
+	 * Required when DB_HOST is remote and local disk headroom cannot be measured.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine system action-scheduler-claim-index
+	 *     wp datamachine system action-scheduler-claim-index --apply
+	 *     wp datamachine system action-scheduler-claim-index --available-disk-bytes=21474836480 --apply
+	 *
+	 * @subcommand action-scheduler-claim-index
+	 */
+	public function action_scheduler_claim_index( array $args, array $assoc_args ): void {
+		$format = $assoc_args['format'] ?? 'table';
+		$apply  = isset( $assoc_args['apply'] );
+		$disk   = null;
+
+		if ( isset( $assoc_args['available-disk-bytes'] ) ) {
+			$raw_disk = (string) $assoc_args['available-disk-bytes'];
+			if ( ! ctype_digit( $raw_disk ) || (int) $raw_disk < 1 ) {
+				WP_CLI::error( '--available-disk-bytes must be a positive integer.' );
+				return;
+			}
+			$disk = (int) $raw_disk;
+		}
+
+		$migration = new ClaimIndexMigration();
+		try {
+			$result = $apply ? $migration->apply( $disk ) : $migration->inspect( $disk );
+		} catch ( \RuntimeException $error ) {
+			WP_CLI::error( $error->getMessage() );
+			return;
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( (string) wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+		} else {
+			WP_CLI::log( sprintf( 'Table:          %s', $result['table'] ) );
+			WP_CLI::log( sprintf( 'Index:          %s', $result['matching_index'] ?? $result['index'] ) );
+			WP_CLI::log( sprintf( 'Expected:       %s', implode( ', ', $result['expected_columns'] ) ) );
+			WP_CLI::log( sprintf( 'Status:         %s', $result['status'] ?? 'unknown' ) );
+			if ( isset( $result['runtime'] ) ) {
+				WP_CLI::log( sprintf( 'Runtime:        %s %s / %s', $result['runtime']['vendor'], $result['runtime']['version'], $result['engine'] ) );
+			}
+			if ( isset( $result['rows_estimate'] ) ) {
+				WP_CLI::log( sprintf( 'Rows estimate:  %s', number_format_i18n( $result['rows_estimate'] ) ) );
+			}
+			if ( isset( $result['disk'] ) ) {
+				$free = null === $result['disk']['free_bytes'] ? 'unknown' : size_format( $result['disk']['free_bytes'], 2 );
+				WP_CLI::log( sprintf( 'Disk headroom:  %s available; %s required (%s)', $free, size_format( $result['disk']['required_bytes'], 2 ), $result['disk']['source'] ) );
+			}
+			if ( ! empty( $result['ddl'] ) && ! $result['ready'] ) {
+				WP_CLI::log( 'DDL:            ' . $result['ddl'] );
+			}
+			foreach ( $result['blockers'] ?? array() as $blocker ) {
+				WP_CLI::warning( $blocker );
+			}
+		}
+
+		if ( ! $result['success'] || ( $apply && ! $result['ready'] ) ) {
+			WP_CLI::error( 'Action Scheduler claim index migration is not ready to apply.' );
+			return;
+		}
+
+		if ( $result['ready'] ) {
+			WP_CLI::success( $result['applied'] ? 'Action Scheduler claim index created and verified.' : 'Action Scheduler claim index is ready.' );
+			return;
+		}
+
+		WP_CLI::log( 'Dry run only. Re-run with --apply to execute the displayed online DDL.' );
 	}
 
 	/**

--- a/inc/Core/ActionScheduler/ClaimIndexMigration.php
+++ b/inc/Core/ActionScheduler/ClaimIndexMigration.php
@@ -1,0 +1,391 @@
+<?php
+/**
+ * Operator-controlled Action Scheduler claim index migration.
+ *
+ * @package DataMachine\Core\ActionScheduler
+ */
+
+namespace DataMachine\Core\ActionScheduler;
+
+use DataMachine\Core\Database\BaseRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Inspects and explicitly installs the index required by the default claim order.
+ */
+class ClaimIndexMigration {
+
+	public const INDEX_NAME = 'claim_id_status_priority_attempts_scheduled_date_gmt';
+	public const REQUIRED_COLUMNS = array(
+		'claim_id',
+		'status',
+		'priority',
+		'attempts',
+		'scheduled_date_gmt',
+		'action_id',
+	);
+
+	private const MINIMUM_FREE_BYTES = 1073741824;
+	private const ESTIMATED_BYTES_PER_ROW = 512;
+	private const METADATA_LOCK_TIMEOUT = 10;
+
+	/** @var \wpdb */
+	private $wpdb;
+
+	private \Closure $disk_free_space;
+	private string $database_host;
+
+	/**
+	 * @param \wpdb|null    $wpdb            Database connection. Defaults to the WordPress global.
+	 * @param callable|null $disk_free_space Disk probe override for tests.
+	 * @param string|null   $database_host   Database host override for tests.
+	 */
+	public function __construct( ?\wpdb $wpdb = null, ?callable $disk_free_space = null, ?string $database_host = null ) {
+		if ( null === $wpdb ) {
+			global $wpdb;
+		}
+
+		$this->wpdb            = $wpdb;
+		$this->disk_free_space = \Closure::fromCallable(
+			$disk_free_space ?? static fn ( string $path ) => @disk_free_space( $path ) // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		);
+		$this->database_host   = $database_host ?? ( defined( 'DB_HOST' ) ? (string) DB_HOST : '' );
+	}
+
+	/**
+	 * Inspect readiness and every precondition needed for an online build.
+	 *
+	 * @param int|null $available_disk_bytes Operator-established database disk headroom for remote databases.
+	 * @return array<string,mixed>
+	 */
+	public function inspect( ?int $available_disk_bytes = null ): array {
+		$table = $this->wpdb->prefix . 'actionscheduler_actions';
+		$base  = array(
+			'success'          => false,
+			'table'            => $table,
+			'index'            => self::INDEX_NAME,
+			'expected_columns' => self::REQUIRED_COLUMNS,
+			'ready'            => false,
+			'can_apply'        => false,
+			'applied'          => false,
+			'blockers'         => array(),
+		);
+
+		if ( BaseRepository::is_sqlite() ) {
+			$base['status']     = 'unsupported';
+			$base['blockers'][] = 'SQLite does not support this MySQL/MariaDB online DDL migration.';
+			return $base;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$database = (string) $this->wpdb->get_var( 'SELECT DATABASE()' );
+		if ( '' === $database ) {
+			$base['status']     = 'inspection_failed';
+			$base['blockers'][] = 'Unable to determine the active database.';
+			return $base;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$table_info = $this->wpdb->get_row(
+			$this->wpdb->prepare(
+				'SELECT ENGINE, TABLE_ROWS, DATA_LENGTH, INDEX_LENGTH FROM information_schema.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s',
+				$database,
+				$table
+			),
+			ARRAY_A
+		);
+		if ( ! is_array( $table_info ) ) {
+			$base['status']     = 'inspection_failed';
+			$base['blockers'][] = 'The Action Scheduler actions table was not found.';
+			return $base;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$index_rows = $this->wpdb->get_results( $this->wpdb->prepare( 'SHOW INDEX FROM %i', $table ), ARRAY_A );
+		if ( ! is_array( $index_rows ) || '' !== (string) $this->wpdb->last_error ) {
+			$base['status']     = 'inspection_failed';
+			$base['blockers'][] = 'Unable to inspect Action Scheduler indexes.';
+			return $base;
+		}
+
+		$indexes        = self::normalizeIndexes( $index_rows );
+		$usable_indexes = self::normalizeUsableIndexes( $index_rows );
+		$matching_index = self::findCoveringIndex( $usable_indexes );
+		$ready          = null !== $matching_index;
+		$name_collision = isset( $indexes[ self::INDEX_NAME ] ) && null === self::findCoveringIndex( array( self::INDEX_NAME => $usable_indexes[ self::INDEX_NAME ] ?? array() ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$server = $this->wpdb->get_row( 'SELECT VERSION() AS version, @@version_comment AS version_comment, @@datadir AS datadir, @@tmpdir AS tmpdir', ARRAY_A );
+		$server = is_array( $server ) ? $server : array();
+		// SHOW VARIABLES is portable to releases predating @@innodb_tmpdir.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$innodb_tmpdir = $this->wpdb->get_row( "SHOW VARIABLES LIKE 'innodb_tmpdir'", ARRAY_A );
+		$server['innodb_tmpdir'] = is_array( $innodb_tmpdir ) ? (string) ( $innodb_tmpdir['Value'] ?? $innodb_tmpdir['value'] ?? '' ) : '';
+		$runtime = self::detectOnlineDdlSupport(
+			(string) ( $server['version'] ?? '' ),
+			(string) ( $server['version_comment'] ?? '' ),
+			(string) ( $table_info['ENGINE'] ?? '' )
+		);
+
+		$rows          = max( 0, (int) ( $table_info['TABLE_ROWS'] ?? 0 ) );
+		$data_bytes    = max( 0, (int) ( $table_info['DATA_LENGTH'] ?? 0 ) );
+		$index_bytes   = max( 0, (int) ( $table_info['INDEX_LENGTH'] ?? 0 ) );
+		$required_disk = self::MINIMUM_FREE_BYTES + max( $rows * self::ESTIMATED_BYTES_PER_ROW, (int) ceil( $data_bytes / 2 ) );
+		$disk          = $ready
+			? array(
+				'source'         => 'not_required',
+				'free_bytes'     => null,
+				'required_bytes' => $required_disk,
+				'sufficient'     => true,
+				'message'        => 'No index build is required.',
+			)
+			: $this->inspectDiskHeadroom( $server, $required_disk, $available_disk_bytes );
+
+		$ddl      = $this->buildDdl( $table );
+		$blockers = array();
+		if ( ! $ready && ! $runtime['supported'] ) {
+			$blockers[] = $runtime['reason'];
+		}
+		if ( ! $ready && ! $disk['sufficient'] ) {
+			$blockers[] = $disk['message'];
+		}
+		if ( ! $ready && $name_collision ) {
+			$blockers[] = sprintf( 'Index name %s already exists with a different definition; no automatic drop is permitted.', self::INDEX_NAME );
+		}
+
+		return array_merge(
+			$base,
+			array(
+				'success'          => true,
+				'status'           => $ready ? 'ready' : ( empty( $blockers ) ? 'migration_required' : 'blocked' ),
+				'database'         => $database,
+				'engine'           => strtoupper( (string) ( $table_info['ENGINE'] ?? '' ) ),
+				'rows_estimate'    => $rows,
+				'data_bytes'       => $data_bytes,
+				'index_bytes'      => $index_bytes,
+				'indexes'          => $indexes,
+				'usable_indexes'   => $usable_indexes,
+				'matching_index'   => $matching_index,
+				'name_collision'   => $name_collision,
+				'ready'            => $ready,
+				'runtime'          => $runtime,
+				'disk'             => $disk,
+				'ddl'              => $ddl,
+				'can_apply'        => ! $ready && empty( $blockers ),
+				'blockers'         => $blockers,
+			)
+		);
+	}
+
+	/**
+	 * Apply the preflighted DDL and verify the resulting physical index.
+	 *
+	 * @param int|null $available_disk_bytes Operator-established database disk headroom.
+	 * @return array<string,mixed>
+	 */
+	public function apply( ?int $available_disk_bytes = null ): array {
+		$inspection = $this->inspect( $available_disk_bytes );
+		if ( ! $inspection['success'] || $inspection['ready'] || ! $inspection['can_apply'] ) {
+			return $inspection;
+		}
+
+		$lock_name = 'datamachine-as-claim-index-' . substr( hash( 'sha256', $inspection['database'] . ':' . $inspection['table'] ), 0, 32 );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$lock = $this->wpdb->get_var( $this->wpdb->prepare( 'SELECT GET_LOCK(%s, 0)', $lock_name ) );
+		if ( '1' !== (string) $lock ) {
+			$inspection['status']     = 'blocked';
+			$inspection['can_apply']  = false;
+			$inspection['blockers'][] = 'Another claim-index migration is already running.';
+			return $inspection;
+		}
+
+		try {
+			// Fail quickly on a metadata-lock conflict rather than waiting behind live traffic indefinitely.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			if ( false === $this->wpdb->query( 'SET SESSION lock_wait_timeout = ' . self::METADATA_LOCK_TIMEOUT ) ) {
+				throw new \RuntimeException( 'Unable to set a bounded metadata lock timeout: ' . $this->wpdb->last_error );
+			}
+
+			// Explicit clauses prevent the server from silently falling back to a copying or blocking alter.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+			if ( false === $this->wpdb->query( $inspection['ddl'] ) ) {
+				throw new \RuntimeException( 'Online index creation failed: ' . $this->wpdb->last_error );
+			}
+		} finally {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$this->wpdb->get_var( $this->wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name ) );
+		}
+
+		$result            = $this->inspect( $available_disk_bytes );
+		$result['applied'] = true;
+		if ( ! $result['ready'] ) {
+			throw new \RuntimeException( 'Online DDL completed but the required claim index could not be verified.' );
+		}
+
+		return $result;
+	}
+
+	/** @return array<string,array<int,string>> */
+	public static function normalizeIndexes( array $rows ): array {
+		$indexes = array();
+		foreach ( $rows as $row ) {
+			$name     = (string) ( $row['Key_name'] ?? $row['key_name'] ?? '' );
+			$sequence = (int) ( $row['Seq_in_index'] ?? $row['seq_in_index'] ?? 0 );
+			$column   = (string) ( $row['Column_name'] ?? $row['column_name'] ?? '' );
+			if ( '' === $name || $sequence < 1 || '' === $column ) {
+				continue;
+			}
+			$indexes[ $name ][ $sequence ] = $column;
+		}
+
+		foreach ( $indexes as $name => $columns ) {
+			ksort( $columns );
+			$indexes[ $name ] = array_values( $columns );
+		}
+
+		return $indexes;
+	}
+
+	/**
+	 * Normalize only full-column, ascending, visible BTREE indexes usable by the claim query.
+	 *
+	 * @return array<string,array<int,string>>
+	 */
+	public static function normalizeUsableIndexes( array $rows ): array {
+		$invalid = array();
+		foreach ( $rows as $row ) {
+			$name       = (string) ( $row['Key_name'] ?? $row['key_name'] ?? '' );
+			$sequence   = (int) ( $row['Seq_in_index'] ?? $row['seq_in_index'] ?? 0 );
+			$sub_part   = $row['Sub_part'] ?? $row['sub_part'] ?? null;
+			$index_type = strtoupper( (string) ( $row['Index_type'] ?? $row['index_type'] ?? '' ) );
+			$collation  = strtoupper( (string) ( $row['Collation'] ?? $row['collation'] ?? '' ) );
+			$visible    = strtoupper( (string) ( $row['Visible'] ?? $row['visible'] ?? 'YES' ) );
+			$ignored    = strtoupper( (string) ( $row['Ignored'] ?? $row['ignored'] ?? 'NO' ) );
+			$expression = $row['Expression'] ?? $row['expression'] ?? null;
+			$required_prefix_part = $sequence >= 1 && $sequence <= count( self::REQUIRED_COLUMNS );
+			if ( '' === $name || ( $required_prefix_part && ( null !== $sub_part || 'BTREE' !== $index_type || 'A' !== $collation || 'NO' === $visible || 'YES' === $ignored || null !== $expression ) ) ) {
+				$invalid[ $name ] = true;
+			}
+		}
+
+		return array_diff_key( self::normalizeIndexes( $rows ), $invalid );
+	}
+
+	/** @param array<string,array<int,string>> $indexes */
+	public static function findCoveringIndex( array $indexes ): ?string {
+		foreach ( $indexes as $name => $columns ) {
+			if ( self::REQUIRED_COLUMNS === array_slice( $columns, 0, count( self::REQUIRED_COLUMNS ) ) ) {
+				return $name;
+			}
+		}
+		return null;
+	}
+
+	/** @return array{supported:bool,vendor:string,version:string,reason:string} */
+	public static function detectOnlineDdlSupport( string $version, string $comment, string $engine ): array {
+		$is_mariadb = str_contains( strtolower( $version . ' ' . $comment ), 'mariadb' );
+		$vendor     = $is_mariadb ? 'MariaDB' : 'MySQL';
+		if ( ! preg_match_all( '/\d+\.\d+\.\d+/', $version, $matches ) || empty( $matches[0] ) ) {
+			return array(
+				'supported' => false,
+				'vendor'    => $vendor,
+				'version'   => $version,
+				'reason'    => 'Unable to establish the database server version for online DDL.',
+			);
+		}
+
+		$normalized_version = $matches[0][0];
+		if ( $is_mariadb && '5.5.5' === $normalized_version && isset( $matches[0][1] ) ) {
+			// Older clients expose MariaDB's compatibility prefix before the real version.
+			$normalized_version = $matches[0][1];
+		}
+		$minimum_version    = $is_mariadb ? '10.0.0' : '5.6.0';
+		$supported          = 'INNODB' === strtoupper( $engine ) && version_compare( $normalized_version, $minimum_version, '>=' );
+		$reason             = $supported
+			? sprintf( '%s %s with InnoDB supports explicit ALGORITHM=INPLACE, LOCK=NONE secondary-index creation.', $vendor, $normalized_version )
+			: sprintf( 'Online DDL is not established for %s %s with table engine %s.', $vendor, $normalized_version, $engine ?: 'unknown' );
+
+		return array(
+			'supported' => $supported,
+			'vendor'    => $vendor,
+			'version'   => $normalized_version,
+			'reason'    => $reason,
+		);
+	}
+
+	private function buildDdl( string $table ): string {
+		$columns = implode( ', ', array_map( static fn ( string $column ): string => '`' . $column . '`', self::REQUIRED_COLUMNS ) );
+		return $this->wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+			"ALTER TABLE %i ADD INDEX %i ({$columns}), ALGORITHM=INPLACE, LOCK=NONE",
+			$table,
+			self::INDEX_NAME
+		);
+	}
+
+	/** @return array{source:string,free_bytes:int|null,required_bytes:int,sufficient:bool,message:string} */
+	private function inspectDiskHeadroom( array $server, int $required_bytes, ?int $available_disk_bytes ): array {
+		if ( null !== $available_disk_bytes ) {
+			$sufficient = $available_disk_bytes >= $required_bytes;
+			return array(
+				'source'         => 'operator',
+				'free_bytes'     => $available_disk_bytes,
+				'required_bytes' => $required_bytes,
+				'sufficient'     => $sufficient,
+				'message'        => $sufficient ? 'Operator-supplied database disk headroom is sufficient.' : 'Operator-supplied database disk headroom is insufficient.',
+			);
+		}
+
+		if ( ! self::isLocalDatabaseHost( $this->database_host ) ) {
+			return array(
+				'source'         => 'unavailable',
+				'free_bytes'     => null,
+				'required_bytes' => $required_bytes,
+				'sufficient'     => false,
+				'message'        => 'Database disk headroom cannot be measured for a remote DB_HOST; provide --available-disk-bytes.',
+			);
+		}
+
+		$temp_path = (string) ( $server['innodb_tmpdir'] ?? '' );
+		if ( '' === $temp_path ) {
+			$temp_path = (string) ( $server['tmpdir'] ?? '' );
+		}
+		$paths = array_filter( array_unique( array( (string) ( $server['datadir'] ?? '' ), $temp_path ) ) );
+		$free  = array();
+		foreach ( $paths as $path ) {
+			$bytes = ( $this->disk_free_space )( $path );
+			if ( false !== $bytes ) {
+				$free[] = (int) $bytes;
+			}
+		}
+
+		if ( count( $free ) !== count( $paths ) || empty( $free ) ) {
+			return array(
+				'source'         => 'unavailable',
+				'free_bytes'     => null,
+				'required_bytes' => $required_bytes,
+				'sufficient'     => false,
+				'message'        => 'Database data/tmp disk headroom could not be established; provide --available-disk-bytes.',
+			);
+		}
+
+		$available  = min( $free );
+		$sufficient = $available >= $required_bytes;
+		return array(
+			'source'         => 'local_database_filesystems',
+			'free_bytes'     => $available,
+			'required_bytes' => $required_bytes,
+			'sufficient'     => $sufficient,
+			'message'        => $sufficient ? 'Database data/tmp disk headroom is sufficient.' : 'Database data/tmp disk headroom is insufficient.',
+		);
+	}
+
+	public static function isLocalDatabaseHost( string $host ): bool {
+		$host = strtolower( trim( $host ) );
+		return '' === $host
+			|| str_starts_with( $host, '/' )
+			|| 1 === preg_match( '#^(?:localhost|127\.0\.0\.1)(?::(?:\d+|/.*))?$#', $host )
+			|| 1 === preg_match( '/^(?:\[::1\]|::1)(?::\d+)?$/', $host );
+	}
+}

--- a/tests/action-scheduler-claim-index-migration-smoke.php
+++ b/tests/action-scheduler-claim-index-migration-smoke.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * Regression coverage for the operator-controlled Action Scheduler claim index.
+ *
+ * Run with: php tests/action-scheduler-claim-index-migration-smoke.php
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
+if ( ! class_exists( 'wpdb' ) ) {
+	class wpdb {}
+}
+
+require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
+require_once __DIR__ . '/../inc/Core/ActionScheduler/ClaimIndexMigration.php';
+
+use DataMachine\Core\ActionScheduler\ClaimIndexMigration;
+
+class ClaimIndexMigrationSmokeWpdb extends wpdb {
+	public string $prefix = 'wp_7_';
+	public string $last_error = '';
+	public string $version = '10.11.8-MariaDB-ubu2204';
+	public string $version_comment = 'mariadb.org binary distribution';
+	public string $engine = 'InnoDB';
+	public array $indexes = array();
+	public array $queries = array();
+	public bool $fail_alter = false;
+	public bool $fail_index_inspection = false;
+
+	public function prepare( $query, ...$args ): string {
+		foreach ( $args as $argument ) {
+			if ( str_contains( $query, '%i' ) ) {
+				$query = preg_replace( '/%i/', '`' . str_replace( '`', '``', (string) $argument ) . '`', $query, 1 );
+			} elseif ( str_contains( $query, '%s' ) ) {
+				$query = preg_replace( '/%s/', "'" . addslashes( (string) $argument ) . "'", $query, 1 );
+			}
+		}
+		return $query;
+	}
+
+	public function get_var( $query ) {
+		if ( 'SELECT DATABASE()' === $query ) {
+			return 'wordpress';
+		}
+		if ( str_contains( $query, 'GET_LOCK' ) || str_contains( $query, 'RELEASE_LOCK' ) ) {
+			return '1';
+		}
+		return null;
+	}
+
+	public function get_row( $query, $output = null ) {
+		unset( $output );
+		if ( str_contains( $query, 'information_schema.TABLES' ) ) {
+			return array(
+				'ENGINE'       => $this->engine,
+				'TABLE_ROWS'   => 1000,
+				'DATA_LENGTH'  => 1048576,
+				'INDEX_LENGTH' => 524288,
+			);
+		}
+		if ( str_contains( $query, 'VERSION()' ) ) {
+			return array(
+				'version'         => $this->version,
+				'version_comment' => $this->version_comment,
+				'datadir'         => '/database',
+				'tmpdir'          => '/database-tmp',
+			);
+		}
+		if ( str_contains( $query, 'innodb_tmpdir' ) ) {
+			return array(
+				'Variable_name' => 'innodb_tmpdir',
+				'Value'         => '/innodb-tmp',
+			);
+		}
+		return null;
+	}
+
+	public function get_results( $query = null, $output = null ): array {
+		unset( $query, $output );
+		if ( $this->fail_index_inspection ) {
+			$this->last_error = 'simulated SHOW INDEX failure';
+			return array();
+		}
+		return $this->indexes;
+	}
+
+	public function query( $query ) {
+		$this->queries[] = $query;
+		if ( str_starts_with( $query, 'ALTER TABLE' ) ) {
+			if ( $this->fail_alter ) {
+				$this->last_error = 'simulated online DDL failure';
+				return false;
+			}
+			$this->indexes = claim_index_rows( ClaimIndexMigration::INDEX_NAME, ClaimIndexMigration::REQUIRED_COLUMNS );
+		}
+		return 1;
+	}
+}
+
+/** @return array<int,array<string,int|string>> */
+function claim_index_rows( string $name, array $columns ): array {
+	$rows = array();
+	foreach ( $columns as $offset => $column ) {
+		$rows[] = array(
+			'Key_name'     => $name,
+			'Seq_in_index' => $offset + 1,
+			'Column_name'  => $column,
+			'Sub_part'     => null,
+			'Index_type'   => 'BTREE',
+			'Collation'    => 'A',
+			'Visible'      => 'YES',
+			'Ignored'      => 'NO',
+			'Expression'   => null,
+		);
+	}
+	return $rows;
+}
+
+$failures = array();
+$assert   = static function ( bool $condition, string $label ) use ( &$failures ): void {
+	if ( ! $condition ) {
+		$failures[] = "FAIL: {$label}";
+	}
+};
+
+$required_rows = claim_index_rows( 'upstream_or_custom_name', ClaimIndexMigration::REQUIRED_COLUMNS );
+$indexes       = ClaimIndexMigration::normalizeUsableIndexes( array_reverse( $required_rows ) );
+$assert( 'upstream_or_custom_name' === ClaimIndexMigration::findCoveringIndex( $indexes ), 'detects exact ordered columns under any index name' );
+
+$wrong_columns    = ClaimIndexMigration::REQUIRED_COLUMNS;
+$wrong_columns[3] = 'scheduled_date_gmt';
+$wrong_columns[4] = 'attempts';
+$assert( null === ClaimIndexMigration::findCoveringIndex( ClaimIndexMigration::normalizeUsableIndexes( claim_index_rows( 'wrong_order', $wrong_columns ) ) ), 'rejects a wrong claim column order' );
+
+$prefix_rows                = $required_rows;
+$prefix_rows[1]['Sub_part'] = 10;
+$assert( null === ClaimIndexMigration::findCoveringIndex( ClaimIndexMigration::normalizeUsableIndexes( $prefix_rows ) ), 'rejects a prefix index' );
+$invisible_rows               = $required_rows;
+$invisible_rows[0]['Visible'] = 'NO';
+$assert( null === ClaimIndexMigration::findCoveringIndex( ClaimIndexMigration::normalizeUsableIndexes( $invisible_rows ) ), 'rejects an invisible index' );
+$ignored_rows               = $required_rows;
+$ignored_rows[0]['Ignored'] = 'YES';
+$assert( null === ClaimIndexMigration::findCoveringIndex( ClaimIndexMigration::normalizeUsableIndexes( $ignored_rows ) ), 'rejects a MariaDB ignored index' );
+$extended_rows   = $required_rows;
+$extended_rows[] = array(
+	'Key_name'     => 'upstream_or_custom_name',
+	'Seq_in_index' => 7,
+	'Column_name'  => 'hook',
+	'Sub_part'     => 20,
+	'Index_type'   => 'BTREE',
+	'Collation'    => 'A',
+	'Visible'      => 'YES',
+	'Ignored'      => 'NO',
+	'Expression'   => null,
+);
+$assert( 'upstream_or_custom_name' === ClaimIndexMigration::findCoveringIndex( ClaimIndexMigration::normalizeUsableIndexes( $extended_rows ) ), 'accepts harmless trailing index columns after the exact required prefix' );
+
+$mysql = ClaimIndexMigration::detectOnlineDdlSupport( '8.0.42', 'MySQL Community Server', 'InnoDB' );
+$maria = ClaimIndexMigration::detectOnlineDdlSupport( '5.5.5-10.11.8-MariaDB', 'MariaDB Server', 'InnoDB' );
+$old   = ClaimIndexMigration::detectOnlineDdlSupport( '5.5.62', 'MySQL Community Server', 'InnoDB' );
+$assert( $mysql['supported'], 'supports explicit online DDL on modern MySQL' );
+$assert( $maria['supported'] && '10.11.8' === $maria['version'], 'normalizes the MariaDB compatibility version prefix' );
+$assert( ! $old['supported'], 'fails closed on an unsupported MySQL runtime' );
+$assert( ClaimIndexMigration::isLocalDatabaseHost( 'localhost:3306' ), 'recognizes an exact loopback DB host with port' );
+$assert( ClaimIndexMigration::isLocalDatabaseHost( 'localhost:/run/mysqld/mysqld.sock' ), 'recognizes a local DB socket' );
+$assert( ! ClaimIndexMigration::isLocalDatabaseHost( 'localhost.example.com' ), 'does not treat a prefixed remote hostname as local' );
+
+$wpdb      = new ClaimIndexMigrationSmokeWpdb();
+$migration = new ClaimIndexMigration( $wpdb, static fn () => false, 'remote-db.example' );
+$dry_run   = $migration->inspect( 2 * 1024 * 1024 * 1024 );
+$assert( $dry_run['success'] && $dry_run['can_apply'] && ! $dry_run['ready'], 'dry run reports a migration-ready preflight' );
+$assert( array() === $wpdb->queries, 'dry run never executes a mutation' );
+$assert(
+	'ALTER TABLE `wp_7_actionscheduler_actions` ADD INDEX `claim_id_status_priority_attempts_scheduled_date_gmt` (`claim_id`, `status`, `priority`, `attempts`, `scheduled_date_gmt`, `action_id`), ALGORITHM=INPLACE, LOCK=NONE' === $dry_run['ddl'],
+	'generates fail-closed online DDL for the active site table'
+);
+
+$blocked = $migration->inspect();
+$assert( ! $blocked['can_apply'] && 'blocked' === $blocked['status'], 'remote database disk uncertainty blocks apply' );
+$assert( str_contains( implode( ' ', $blocked['blockers'] ), '--available-disk-bytes' ), 'blocked preflight explains the operator disk override' );
+
+$disk_paths      = array();
+$local_migration = new ClaimIndexMigration(
+	new ClaimIndexMigrationSmokeWpdb(),
+	static function ( string $path ) use ( &$disk_paths ): int {
+		$disk_paths[] = $path;
+		return 2 * 1024 * 1024 * 1024;
+	},
+	'localhost'
+);
+$local = $local_migration->inspect();
+$assert( $local['can_apply'], 'local database filesystems can establish sufficient disk headroom' );
+$assert( array( '/database', '/innodb-tmp' ) === $disk_paths, 'disk preflight checks datadir and innodb_tmpdir rather than the generic tmpdir' );
+
+$insufficient = $migration->inspect( 1024 );
+$assert( ! $insufficient['can_apply'] && ! $insufficient['disk']['sufficient'], 'insufficient operator-supplied disk fails closed' );
+
+$applied = $migration->apply( 2 * 1024 * 1024 * 1024 );
+$assert( $applied['ready'] && $applied['applied'], 'apply reinspects and verifies the physical index' );
+$assert( 2 === count( $wpdb->queries ), 'apply executes only the session timeout and online DDL mutations' );
+
+$ready_again = $migration->apply( 2 * 1024 * 1024 * 1024 );
+$assert( $ready_again['ready'] && ! $ready_again['applied'], 're-running apply is an idempotent no-op when ready' );
+$assert( 2 === count( $wpdb->queries ), 'idempotent apply does not execute DDL again' );
+
+$collision_wpdb          = new ClaimIndexMigrationSmokeWpdb();
+$collision_wpdb->indexes = claim_index_rows( ClaimIndexMigration::INDEX_NAME, array( 'claim_id', 'status', 'priority' ) );
+$collision               = ( new ClaimIndexMigration( $collision_wpdb, static fn () => false, 'remote-db.example' ) )->inspect( 2 * 1024 * 1024 * 1024 );
+$assert( $collision['name_collision'] && ! $collision['can_apply'], 'same-name malformed index is never dropped automatically' );
+
+$unsupported_wpdb          = new ClaimIndexMigrationSmokeWpdb();
+$unsupported_wpdb->version = '5.5.62';
+$unsupported               = ( new ClaimIndexMigration( $unsupported_wpdb, static fn () => false, 'remote-db.example' ) )->inspect( 2 * 1024 * 1024 * 1024 );
+$assert( ! $unsupported['runtime']['supported'] && ! $unsupported['can_apply'], 'unsupported runtime blocks apply even with disk headroom' );
+
+$failed_inspection_wpdb                        = new ClaimIndexMigrationSmokeWpdb();
+$failed_inspection_wpdb->fail_index_inspection = true;
+$failed_inspection                             = ( new ClaimIndexMigration( $failed_inspection_wpdb, static fn () => false, 'remote-db.example' ) )->inspect( 2 * 1024 * 1024 * 1024 );
+$assert( ! $failed_inspection['success'] && 'inspection_failed' === $failed_inspection['status'], 'SHOW INDEX database errors fail closed' );
+
+if ( $failures ) {
+	echo implode( "\n", $failures ) . "\n";
+	exit( 1 );
+}
+
+echo "Action Scheduler claim index migration smoke complete: all assertions passed.\n";


### PR DESCRIPTION
## Summary
- add a cheap physical readiness check for a visible, non-ignored, full-column BTREE index beginning with `(claim_id, status, priority, attempts, scheduled_date_gmt, action_id)`
- add a dry-run-by-default `wp datamachine system action-scheduler-claim-index` operator path with explicit `--apply`, site-scoped table/runtime/disk output, advisory locking, bounded metadata-lock wait, and post-DDL verification
- fail closed unless InnoDB online DDL support and conservative data/`innodb_tmpdir` disk headroom are established; never run the index build during bootstrap, activation, or deploy
- document operation, rerun behavior, remote database headroom input, and Action Scheduler's upstream ownership

## Safety
The apply path emits only:

```sql
ALTER TABLE <site-prefix>actionscheduler_actions
ADD INDEX claim_id_status_priority_attempts_scheduled_date_gmt
(claim_id, status, priority, attempts, scheduled_date_gmt, action_id),
ALGORITHM=INPLACE, LOCK=NONE
```

Explicit online clauses prevent silent fallback to copying/blocking DDL. A same-name malformed index is never dropped automatically. Existing equivalent indexes are accepted under any name, making this a no-op once upstream ships the correction. No production command or DDL was run while implementing this PR.

## Tests
- `php tests/action-scheduler-claim-index-migration-smoke.php`
- `php tests/system-health-scheduler-smoke.php`
- `php tests/action-scheduler-wpcli-compat-smoke.php`
- `composer run lint`
- `git diff --check`

The focused migration coverage includes exact/order/physical index detection, harmless trailing columns, generated DDL, dry-run and apply gating, local and remote disk checks, `innodb_tmpdir`, unsupported runtimes, failed inspection, name collisions, verification, and idempotency.

Two unrelated baseline smoke areas remain red on `origin/main`: `action-scheduler-group-registration-smoke.php` expects an older drain source pattern, and `retention-action-scheduler-batching-smoke.php` expects retired `execute_step` retention defaults. This PR does not touch those paths.

## Upstream Ownership
WooCommerce Action Scheduler owns the claim query and canonical schema. Existing upstream context is in woocommerce/action-scheduler#1104, #1250, and #1340. A separate upstream PR was not opened from this Data Machine-only worktree because it requires a proper Action Scheduler fork/worktree and upstream-specific schema tests; the exact follow-up patch is:

1. In `classes/schema/ActionScheduler_StoreSchema.php`, bump the store schema version from `8` to `9`.
2. Replace the schema declaration for `claim_id_status_priority_scheduled_date_gmt (claim_id, status, priority, scheduled_date_gmt)` with a newly named index such as `claim_id_status_priority_attempts_scheduled_date_gmt (claim_id, status, priority, attempts, scheduled_date_gmt, action_id)`. The new name is required so `dbDelta()` can add it on upgrades without colliding with the existing shorter definition.
3. Add schema tests asserting the exact ordered columns and an upgrade fixture proving schema version 8 receives the new index. Retain the old physical index on upgraded sites initially because `dbDelta()` does not safely remove it; new installs should declare only the complete index.
4. Include the #1340 benchmark and claim SQL (`claim_id/status` predicate plus `priority/attempts/scheduled_date_gmt/action_id` order) in the upstream PR rationale.

Fixes #3069