### PR TITLE
fix: restore native Action Scheduler retention

### DIFF
--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -58,6 +58,7 @@ class SystemAgentServiceProvider {
 		$this->registerTaskHandlers();
 		$this->registerBuiltInSchedules();
 		$this->registerActionSchedulerHooks();
+		RetentionActionSchedulerTask::registerNativeRetention();
 		// Bootstrap immediately after AS initializes, then let AS's native daily
 		// recurring-ensure action repair schedules that are later interrupted.
 		add_action( 'action_scheduler_init', array( $this, 'manageRecurringTaskSchedules' ) );

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionActionSchedulerTask.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionActionSchedulerTask.php
@@ -7,6 +7,55 @@ defined( 'ABSPATH' ) || exit;
 use DataMachine\Engine\Tasks\TaskScheduler;
 
 class RetentionActionSchedulerTask extends RetentionTask {
+	private const NATIVE_CLEANUP_BATCH_SIZE = 250;
+	private const NATIVE_CLEANUP_BATCH_MAX  = 1000;
+
+	/**
+	 * Register Action Scheduler's native pre-claim retention backstop.
+	 *
+	 * Native cleanup runs before Action Scheduler stakes a queue claim, so it
+	 * remains available when claim failures prevent the richer Data Machine
+	 * recurrence from executing. The recurrence still owns per-hook windows,
+	 * failed actions, row ceilings, diagnostics, and catch-up scheduling.
+	 */
+	public static function registerNativeRetention(): void {
+		add_filter( 'action_scheduler_retention_period', array( self::class, 'filterNativeRetentionPeriod' ), PHP_INT_MAX );
+		add_filter( 'action_scheduler_cleanup_batch_size', array( self::class, 'filterNativeCleanupBatchSize' ), PHP_INT_MAX );
+	}
+
+	/**
+	 * Align Action Scheduler's native window with Data Machine's global policy.
+	 *
+	 * Preserve a shorter window supplied by another integration. Non-positive
+	 * values are replaced because Action Scheduler interprets zero as "now",
+	 * not as disabled retention.
+	 */
+	public static function filterNativeRetentionPeriod( $period ): int {
+		if ( ! self::retentionEnabledForCurrentBlog() ) {
+			return (int) $period;
+		}
+
+		$max_age = RetentionCleanup::actionSchedulerMaxAgeDays() * DAY_IN_SECONDS;
+		$period  = (int) $period;
+		return $period > 0 ? min( $period, $max_age ) : $max_age;
+	}
+
+	/**
+	 * Raise native cleanup throughput while retaining a per-phase safety ceiling.
+	 *
+	 * Action Scheduler applies this batch independently to each terminal status
+	 * and to timeout/failure maintenance. With its two default cleanup statuses,
+	 * the 250-row default permits at most 500 old-action deletions per runner.
+	 */
+	public static function filterNativeCleanupBatchSize( $batch_size ): int {
+		if ( ! self::retentionEnabledForCurrentBlog() ) {
+			return (int) $batch_size;
+		}
+
+		$configured = (int) apply_filters( 'datamachine_as_native_cleanup_batch_size', self::NATIVE_CLEANUP_BATCH_SIZE );
+		$configured = min( self::NATIVE_CLEANUP_BATCH_MAX, max( 20, $configured ) );
+		return min( self::NATIVE_CLEANUP_BATCH_MAX, max( (int) $batch_size, $configured ) );
+	}
 
 	public function getTaskType(): string {
 		return RetentionCleanup::TASK_AS_ACTIONS;
@@ -28,6 +77,13 @@ class RetentionActionSchedulerTask extends RetentionTask {
 		$this->maybeScheduleCatchUp( $result );
 
 		return $result;
+	}
+
+	private static function retentionEnabledForCurrentBlog(): bool {
+		$settings = get_option( 'datamachine_settings', array() );
+		return ! is_array( $settings ) || ! array_key_exists( 'retention_as_actions_enabled', $settings )
+			? true
+			: (bool) $settings['retention_as_actions_enabled'];
 	}
 
 	/**

--- a/tests/action-scheduler-native-retention-smoke.php
+++ b/tests/action-scheduler-native-retention-smoke.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Smoke coverage for Action Scheduler's native retention backstop (#2792).
+ *
+ * Run with: php tests/action-scheduler-native-retention-smoke.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Engine\Tasks {
+	class TaskScheduler {
+		public static function schedule( string $task_type, array $params ) {
+			return false;
+		}
+	}
+}
+
+namespace DataMachine\Engine\AI\System\Tasks\Retention {
+	abstract class RetentionTask {}
+
+	class RetentionCleanup {
+		public const TASK_AS_ACTIONS = 'retention_as_actions';
+
+		public static function actionSchedulerMaxAgeDays(): int {
+			return 7;
+		}
+
+		public static function cleanupActionSchedulerActions(): array {
+			return array( 'deleted' => 0 );
+		}
+	}
+}
+
+namespace {
+	use DataMachine\Engine\AI\System\Tasks\Retention\RetentionActionSchedulerTask;
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/../' );
+	}
+	if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+		define( 'DAY_IN_SECONDS', 86400 );
+	}
+
+	$GLOBALS['__as_retention_blog_id']  = 1;
+	$GLOBALS['__as_retention_filters']  = array();
+	$GLOBALS['__as_retention_options']  = array();
+	$GLOBALS['__as_registered_filters'] = array();
+
+	function add_filter( string $hook, callable $callback, int $priority = 10 ): void {
+		$GLOBALS['__as_registered_filters'][ $hook ] = array(
+			'callback' => $callback,
+			'priority' => $priority,
+		);
+	}
+
+	function apply_filters( string $hook, $value ) {
+		foreach ( $GLOBALS['__as_retention_filters'][ $hook ] ?? array() as $callback ) {
+			$value = $callback( $value );
+		}
+		return $value;
+	}
+
+	function get_option( string $name, $default = false ) {
+		$blog_id = $GLOBALS['__as_retention_blog_id'];
+		return $GLOBALS['__as_retention_options'][ $blog_id ][ $name ] ?? $default;
+	}
+
+	function do_action( ...$args ): void {}
+
+	$root     = dirname( __DIR__ );
+	$provider = file_get_contents( $root . '/inc/Engine/AI/System/SystemAgentServiceProvider.php' ) ?: '';
+	$task     = file_get_contents( $root . '/inc/Engine/AI/System/Tasks/Retention/RetentionActionSchedulerTask.php' ) ?: '';
+	$failed   = 0;
+	$total    = 0;
+
+	$assert = static function ( bool $condition, string $message ) use ( &$failed, &$total ): void {
+		++$total;
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+
+		++$failed;
+		echo "  [FAIL] {$message}\n";
+	};
+
+	echo "=== action-scheduler-native-retention-smoke ===\n";
+
+	require_once $root . '/inc/Engine/AI/System/Tasks/Retention/RetentionActionSchedulerTask.php';
+
+	$assert(
+		str_contains( $provider, 'RetentionActionSchedulerTask::registerNativeRetention();' ),
+		'provider registers the native retention backstop in each site context'
+	);
+
+	RetentionActionSchedulerTask::registerNativeRetention();
+	$period_filter = $GLOBALS['__as_registered_filters']['action_scheduler_retention_period'] ?? array();
+	$batch_filter  = $GLOBALS['__as_registered_filters']['action_scheduler_cleanup_batch_size'] ?? array();
+	$assert(
+		PHP_INT_MAX === ( $period_filter['priority'] ?? null )
+			&& PHP_INT_MAX === ( $batch_filter['priority'] ?? null ),
+		'native retention filters enforce final safety bounds'
+	);
+
+	$GLOBALS['__as_retention_blog_id'] = 7;
+	$assert(
+		7 * DAY_IN_SECONDS === RetentionActionSchedulerTask::filterNativeRetentionPeriod( 2678400 ),
+		'blog 7 shortens Action Scheduler native retention to seven days'
+	);
+	$assert(
+		DAY_IN_SECONDS === RetentionActionSchedulerTask::filterNativeRetentionPeriod( DAY_IN_SECONDS ),
+		'a shorter retention period from another integration is preserved'
+	);
+	$assert(
+		7 * DAY_IN_SECONDS === RetentionActionSchedulerTask::filterNativeRetentionPeriod( 0 ),
+		'non-positive retention is restored instead of being treated as disabled'
+	);
+	$assert(
+		250 === RetentionActionSchedulerTask::filterNativeCleanupBatchSize( 20 )
+			&& 1000 === RetentionActionSchedulerTask::filterNativeCleanupBatchSize( 5000 ),
+		'native cleanup throughput has a bounded 250-to-1000 row per-phase range'
+	);
+	$queue_cleaner = file_get_contents( $root . '/vendor/woocommerce/action-scheduler/classes/ActionScheduler_QueueCleaner.php' ) ?: '';
+	$assert(
+		str_contains( $queue_cleaner, 'foreach ( $statuses_to_purge as $status )' )
+			&& str_contains( $queue_cleaner, "apply_filters( 'action_scheduler_cleanup_batch_size'" ),
+		'test evidence pins Action Scheduler batch scope to each cleanup status and maintenance phase'
+	);
+
+	$GLOBALS['__as_retention_blog_id'] = 2;
+	$GLOBALS['__as_retention_options'][2]['datamachine_settings'] = array( 'retention_as_actions_enabled' => false );
+	$assert(
+		2678400 === RetentionActionSchedulerTask::filterNativeRetentionPeriod( 2678400 )
+			&& 20 === RetentionActionSchedulerTask::filterNativeCleanupBatchSize( 20 ),
+		'a site-scoped disabled setting leaves Action Scheduler defaults untouched'
+	);
+
+	$GLOBALS['__as_retention_blog_id'] = 1;
+	$assert(
+		7 * DAY_IN_SECONDS === RetentionActionSchedulerTask::filterNativeRetentionPeriod( 2678400 ),
+		'main-site settings do not leak from another multisite blog'
+	);
+	$assert(
+		str_contains( $task, '$result = RetentionCleanup::cleanupActionSchedulerActions();' )
+			&& str_contains( $task, '$this->maybeScheduleCatchUp( $result );' ),
+		'the full recurring cleanup and catch-up path remain unchanged'
+	);
+
+	if ( $failed > 0 ) {
+		echo "\naction-scheduler-native-retention-smoke failed: {$failed}/{$total} assertions failed.\n";
+		exit( 1 );
+	}
+
+	echo "\naction-scheduler-native-retention-smoke passed: {$total} assertions.\n";
+}

--- a/tests/action-scheduler-native-retention-smoke.php
+++ b/tests/action-scheduler-native-retention-smoke.php
@@ -46,26 +46,34 @@ namespace {
 	$GLOBALS['__as_retention_options']  = array();
 	$GLOBALS['__as_registered_filters'] = array();
 
-	function add_filter( string $hook, callable $callback, int $priority = 10 ): void {
-		$GLOBALS['__as_registered_filters'][ $hook ] = array(
-			'callback' => $callback,
-			'priority' => $priority,
-		);
-	}
-
-	function apply_filters( string $hook, $value ) {
-		foreach ( $GLOBALS['__as_retention_filters'][ $hook ] ?? array() as $callback ) {
-			$value = $callback( $value );
+	if ( ! function_exists( 'add_filter' ) ) {
+		function add_filter( string $hook, callable $callback, int $priority = 10 ): void {
+			$GLOBALS['__as_registered_filters'][ $hook ] = array(
+				'callback' => $callback,
+				'priority' => $priority,
+			);
 		}
-		return $value;
 	}
 
-	function get_option( string $name, $default = false ) {
-		$blog_id = $GLOBALS['__as_retention_blog_id'];
-		return $GLOBALS['__as_retention_options'][ $blog_id ][ $name ] ?? $default;
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook, $value ) {
+			foreach ( $GLOBALS['__as_retention_filters'][ $hook ] ?? array() as $callback ) {
+				$value = $callback( $value );
+			}
+			return $value;
+		}
 	}
 
-	function do_action( ...$args ): void {}
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $name, $default = false ) {
+			$blog_id = $GLOBALS['__as_retention_blog_id'];
+			return $GLOBALS['__as_retention_options'][ $blog_id ][ $name ] ?? $default;
+		}
+	}
+
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( ...$args ): void {}
+	}
 
 	$root     = dirname( __DIR__ );
 	$provider = file_get_contents( $root . '/inc/Engine/AI/System/SystemAgentServiceProvider.php' ) ?: '';
@@ -87,6 +95,8 @@ namespace {
 	echo "=== action-scheduler-native-retention-smoke ===\n";
 
 	require_once $root . '/inc/Engine/AI/System/Tasks/Retention/RetentionActionSchedulerTask.php';
+	$wp_runtime       = function_exists( 'has_filter' ) && function_exists( 'update_option' );
+	$original_settings = $wp_runtime ? get_option( 'datamachine_settings', null ) : null;
 
 	$assert(
 		str_contains( $provider, 'RetentionActionSchedulerTask::registerNativeRetention();' ),
@@ -94,11 +104,14 @@ namespace {
 	);
 
 	RetentionActionSchedulerTask::registerNativeRetention();
-	$period_filter = $GLOBALS['__as_registered_filters']['action_scheduler_retention_period'] ?? array();
-	$batch_filter  = $GLOBALS['__as_registered_filters']['action_scheduler_cleanup_batch_size'] ?? array();
+	$period_priority = $wp_runtime
+		? has_filter( 'action_scheduler_retention_period', array( RetentionActionSchedulerTask::class, 'filterNativeRetentionPeriod' ) )
+		: ( $GLOBALS['__as_registered_filters']['action_scheduler_retention_period']['priority'] ?? null );
+	$batch_priority  = $wp_runtime
+		? has_filter( 'action_scheduler_cleanup_batch_size', array( RetentionActionSchedulerTask::class, 'filterNativeCleanupBatchSize' ) )
+		: ( $GLOBALS['__as_registered_filters']['action_scheduler_cleanup_batch_size']['priority'] ?? null );
 	$assert(
-		PHP_INT_MAX === ( $period_filter['priority'] ?? null )
-			&& PHP_INT_MAX === ( $batch_filter['priority'] ?? null ),
+		PHP_INT_MAX === $period_priority && PHP_INT_MAX === $batch_priority,
 		'native retention filters enforce final safety bounds'
 	);
 
@@ -127,15 +140,23 @@ namespace {
 		'test evidence pins Action Scheduler batch scope to each cleanup status and maintenance phase'
 	);
 
-	$GLOBALS['__as_retention_blog_id'] = 2;
-	$GLOBALS['__as_retention_options'][2]['datamachine_settings'] = array( 'retention_as_actions_enabled' => false );
+	if ( $wp_runtime ) {
+		update_option( 'datamachine_settings', array( 'retention_as_actions_enabled' => false ) );
+	} else {
+		$GLOBALS['__as_retention_blog_id'] = 2;
+		$GLOBALS['__as_retention_options'][2]['datamachine_settings'] = array( 'retention_as_actions_enabled' => false );
+	}
 	$assert(
 		2678400 === RetentionActionSchedulerTask::filterNativeRetentionPeriod( 2678400 )
 			&& 20 === RetentionActionSchedulerTask::filterNativeCleanupBatchSize( 20 ),
 		'a site-scoped disabled setting leaves Action Scheduler defaults untouched'
 	);
 
-	$GLOBALS['__as_retention_blog_id'] = 1;
+	if ( $wp_runtime ) {
+		update_option( 'datamachine_settings', array( 'retention_as_actions_enabled' => true ) );
+	} else {
+		$GLOBALS['__as_retention_blog_id'] = 1;
+	}
 	$assert(
 		7 * DAY_IN_SECONDS === RetentionActionSchedulerTask::filterNativeRetentionPeriod( 2678400 ),
 		'main-site settings do not leak from another multisite blog'
@@ -145,6 +166,14 @@ namespace {
 			&& str_contains( $task, '$this->maybeScheduleCatchUp( $result );' ),
 		'the full recurring cleanup and catch-up path remain unchanged'
 	);
+
+	if ( $wp_runtime ) {
+		if ( null === $original_settings ) {
+			delete_option( 'datamachine_settings' );
+		} else {
+			update_option( 'datamachine_settings', $original_settings );
+		}
+	}
 
 	if ( $failed > 0 ) {
 		echo "\naction-scheduler-native-retention-smoke failed: {$failed}/{$total} assertions failed.\n";


### PR DESCRIPTION
## Summary

- align the Action Scheduler native cleaner with the existing seven-day Data Machine global retention policy
- raise native cleanup from 20 to 250 rows per status/maintenance phase, with a hard per-phase ceiling of 1,000
- preserve the full five-minute Data Machine recurrence for per-hook windows, failed rows, row ceilings, guardrails, and catch-up

## Root Cause

The original report that `action_scheduler_retention_period` was disabled was corrected by later production evidence: Action Scheduler resolves to its native 31-day default. The remaining gap was that Data Machine advertised a seven-day global policy but only enforced it through `datamachine_recurring_retention_as_actions`, itself an Action Scheduler action. On blog 7 that recurrence exists exactly once but became overdue when the bloated actions table caused claim failures. Native cleanup still ran before claims, but retained 31 days and deleted only 20 actions per status per runner, so it was not an effective backstop for the shorter Data Machine policy.

## Retention Behavior And Bounds

When `retention_as_actions_enabled` is enabled for the current blog:

- `action_scheduler_retention_period` becomes the shorter of the existing filtered period and the Data Machine global window, seven days by default.
- A non-positive period is normalized to seven days because Action Scheduler interprets zero as a cutoff of now, not disabled cleanup.
- `action_scheduler_cleanup_batch_size` defaults to 250 and is filterable through `datamachine_as_native_cleanup_batch_size`, clamped from 20 through 1,000.
- Action Scheduler applies that bound per status and maintenance phase. With its default `complete` and `canceled` cleanup statuses, the default permits at most 500 old-action deletions per runner. Its datastore deletion removes attached logs through the existing Action Scheduler primitive.
- A shorter period supplied by another integration is preserved.
- If Data Machine Action Scheduler retention is disabled on a blog, incoming Action Scheduler defaults remain untouched.

The existing Data Machine recurrence is unchanged. It continues every five minutes and adds behavior native cleanup does not provide: failed-action retention, one-hour high-volume hook windows, row ceilings, table guardrails, bounded SQL passes, and catch-up scheduling.

## Multisite Context

The filters run in the active Action Scheduler site context. Enablement reads the current blog `datamachine_settings` option directly rather than using the process-wide PluginSettings cache, so a switched multisite request cannot leak the setting from blog 1 into blog 7. Action Scheduler and the existing Data Machine cleanup both use the active blog `$wpdb->prefix`; no network loop or cross-blog deletion path is introduced.

## Tests

Passed:

- `composer lint`
- `php tests/action-scheduler-native-retention-smoke.php` (10 assertions)
- `php tests/recurring-scheduler-idempotency-smoke.php`
- `vendor/bin/phpunit --filter SystemAgentServiceProviderTest`
- PHP syntax checks for all changed PHP files
- `git diff --check`
- independent code review: no blocking findings

Known unrelated baseline failures:

- `php tests/retention-action-scheduler-batching-smoke.php`: 36/38 pass; two whitespace-sensitive source assertions are tracked in #2963.
- `php tests/retention-system-tasks-smoke.php`: 80/81 pass; stale file-retention assertion tracked in #3074.

## Post-Deploy Verification

Verification should remain read-only first:

1. Confirm blog 7 resolves `action_scheduler_retention_period` to 604800 seconds and `action_scheduler_cleanup_batch_size` to 250.
2. Confirm exactly one pending `datamachine_recurring_retention_as_actions` action and record whether its scheduled date is still overdue.
3. Run `wp --url=https://events.extrachill.com datamachine retention run --dry-run --format=json` under an operator-controlled timeout; review the actions/logs eligibility separately from other retention domains.
4. Recheck action/log row estimates, claim-failure rate, pending recurrence age, and queue throughput after native cleaner cycles.
5. Verify the claim-index readiness from #3070 separately; this PR does not apply that migration.

## Separately Gated Cleanup

This PR does not perform emergency cleanup. If post-deploy dry-run evidence still justifies an explicit cleanup, obtain operator approval and run only the existing bounded `wp datamachine retention run --yes` path during a maintenance window. Recheck queue health and disk headroom between passes. Raw deletes, table swaps, row purges, `OPTIMIZE TABLE`, and apply flags are not part of this PR and require separate approval.

No production data was mutated during investigation, implementation, or testing. No cleanup command with an apply flag was run.

Closes #2792