### PR TITLE
test: follow centralized file retention counter

### DIFF
--- a/tests/retention-system-tasks-smoke.php
+++ b/tests/retention-system-tasks-smoke.php
@@ -131,8 +131,10 @@ assert_retention(
 );
 assert_retention(
 	'file dry-run counter includes old job directories',
-	str_contains( $sources['cleanup'], '$jobs_dir = "{$flow_dir}/jobs";' )
-		&& str_contains( $sources['cleanup'], '++$count;' )
+	str_contains( $sources['cleanup'], 'count_old_files( self::fileRetentionDays() )' )
+		&& str_contains( $sources['files'], '$jobs_dir = "{$flow_dir}/jobs";' )
+		&& str_contains( $sources['files'], 'if ( $count_job_dirs )' )
+		&& str_contains( $sources['files'], '++$matched_count;' )
 );
 assert_retention(
 	'job artifact retention has separate scope policy hook',


### PR DESCRIPTION
## Summary

- update the retention SystemTask smoke to follow the file dry-run count delegation into `FileCleanup`
- keep the assertion pinned to old repository job-directory counting without changing implementation behavior or expected counts
- preserve the separate scoped job-artifact retention contract

Closes #3074.

## Root Cause

PR #2707 centralized retention count primitives by moving the repository-file traversal from `RetentionCleanup::countOldFiles()` into `FileCleanup::count_old_files()`. The functional contract and its dedicated smoke moved with it, but `retention-system-tasks-smoke.php` kept searching `RetentionCleanup.php` for the old inline `$jobs_dir` traversal and `$count` increment. The assertion therefore failed on source location even though the dry-run behavior remained correct.

The later scoped job-artifact work from #2492 and #2497 is a separate retention domain under `datamachine-artifacts/jobs`. It did not remove legacy job data packets under `datamachine-files/.../jobs` from repository-file retention.

## Authoritative Contract

- `RetentionCleanup::countOldFiles()` delegates to `FileCleanup::count_old_files()` using `fileRetentionDays()`.
- Repository-file dry-run counts each old flow file and each non-empty job directory whose files are all old.
- `tests/file-cleanup-count-primitives-smoke.php` functionally pins that contract as `2`: one old flow file plus one all-old job directory.
- Scoped job artifacts remain independently counted and cleaned by `RetentionJobArtifactsTask` according to `JobArtifactSurfaces` policies.

## Assertion Semantics

Before: the smoke required the job-directory traversal and generic `$count` increment to remain inline in `RetentionCleanup.php`.

After: the smoke verifies the `RetentionCleanup` delegation and the authoritative `FileCleanup` traversal, including the job-directory path, the dry-run-only directory count guard, and the matched-count increment. The expected behavior and count are unchanged.

## Test Evidence

Passed:

- `php tests/retention-system-tasks-smoke.php` (81/81 assertions)
- `php tests/file-cleanup-count-primitives-smoke.php` (3/3 assertions)
- `php tests/job-artifact-surfaces-smoke.php` (15/15 assertions)
- `php tests/retention-engine-data-shedding-smoke.php` (24/24 assertions)
- `php tests/action-scheduler-native-retention-smoke.php` (10/10 assertions)
- `vendor/bin/phpcs tests/retention-system-tasks-smoke.php`
- `php -l tests/retention-system-tasks-smoke.php`
- `git diff --check`

## Unrelated Baseline Failures

- `php tests/retention-action-scheduler-batching-smoke.php` remains at 36/38 assertions. Its two failures are whitespace-sensitive source checks for the existing `datamachine_execute_step` defaults and are tracked separately in #2963.

No production files or data were modified. No release or deployment was performed.