### PR TITLE
fix: fence stale option lease takeover

### DIFF
--- a/inc/Core/OptionLeaseStore.php
+++ b/inc/Core/OptionLeaseStore.php
@@ -22,7 +22,7 @@ class OptionLeaseStore {
 	 * @param int                 $ttl                       Stale fallback TTL in seconds.
 	 * @param int|null            $now                       Current timestamp.
 	 * @param callable|null       $is_stale                  Optional extra stale predicate.
-	 * @param bool                $replace_stale_with_update Whether to update when stale delete/add races.
+	 * @param bool                $replace_stale_with_update Retained for compatibility; stale replacement is always atomic.
 	 * @return array{acquired:bool,status:string,payload:array<string,mixed>,option_name:string}
 	 */
 	public static function acquire(
@@ -35,6 +35,8 @@ class OptionLeaseStore {
 	): array {
 		$now      = $now ?? time();
 		$existing = self::snapshot( $option_name, $ttl, $now, $is_stale );
+		// Stale takeover no longer has a non-atomic mode; retain the argument for named-call compatibility.
+		unset( $replace_stale_with_update );
 
 		if ( 'held' === $existing['status'] ) {
 			return array(
@@ -45,8 +47,13 @@ class OptionLeaseStore {
 			);
 		}
 
-		if ( 'stale' === $existing['status'] ) {
-			delete_option( $option_name );
+		if ( 'stale' === $existing['status'] && self::replaceStale( $option_name, $existing['payload'], $payload ) ) {
+			return array(
+				'acquired'    => true,
+				'status'      => 'held',
+				'payload'     => $payload,
+				'option_name' => $option_name,
+			);
 		}
 
 		if ( add_option( $option_name, $payload, '', false ) ) {
@@ -58,21 +65,6 @@ class OptionLeaseStore {
 			);
 		}
 
-		if ( 'stale' === $existing['status'] && $replace_stale_with_update ) {
-			$after_delete = self::snapshot( $option_name, $ttl, $now, $is_stale );
-			if ( 'held' !== $after_delete['status'] && update_option( $option_name, $payload, false ) ) {
-				$current = get_option( $option_name, array() );
-				if ( is_array( $current ) && hash_equals( (string) ( $payload['token'] ?? '' ), (string) ( $current['token'] ?? '' ) ) ) {
-					return array(
-						'acquired'    => true,
-						'status'      => 'held',
-						'payload'     => $payload,
-						'option_name' => $option_name,
-					);
-				}
-			}
-		}
-
 		$current = self::snapshot( $option_name, $ttl, $now, $is_stale );
 
 		return array(
@@ -81,6 +73,43 @@ class OptionLeaseStore {
 			'payload'     => $current['payload'],
 			'option_name' => $option_name,
 		);
+	}
+
+	/**
+	 * Atomically replace one exact stale lease payload.
+	 *
+	 * @param array<string,mixed> $stale_payload Exact stale payload observed by the caller.
+	 * @param array<string,mixed> $replacement   New lease payload.
+	 */
+	private static function replaceStale( string $option_name, array $stale_payload, array $replacement ): bool {
+		global $wpdb;
+		if ( isset( $wpdb->options ) && method_exists( $wpdb, 'query' ) && method_exists( $wpdb, 'prepare' ) ) {
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Exact-value CAS is the stale takeover fencing primitive.
+			$updated = $wpdb->query(
+				$wpdb->prepare(
+					'UPDATE %i SET option_value = %s WHERE option_name = %s AND option_value = %s',
+					$wpdb->options,
+					maybe_serialize( $replacement ),
+					$option_name,
+					maybe_serialize( $stale_payload )
+				)
+			);
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+
+			if ( 1 !== $updated ) {
+				return false;
+			}
+
+			wp_cache_delete( $option_name, 'options' );
+			return true;
+		}
+
+		// Lightweight test runtimes may not provide wpdb; preserve exact-value semantics as closely as possible.
+		if ( get_option( $option_name, null ) !== $stale_payload || ! update_option( $option_name, $replacement, false ) ) {
+			return false;
+		}
+
+		return get_option( $option_name, null ) === $replacement;
 	}
 
 	/**

--- a/tests/Unit/Core/OptionLeaseStoreTest.php
+++ b/tests/Unit/Core/OptionLeaseStoreTest.php
@@ -57,6 +57,100 @@ final class OptionLeaseStoreTest extends WP_UnitTestCase {
 		$this->assertSame( 'generation-1', get_option( $this->target_name ) );
 	}
 
+	public function test_acquire_replaces_an_exact_stale_lease(): void {
+		$now   = time();
+		$stale = array(
+			'token'      => 'stale-owner',
+			'started_at' => $now - 600,
+			'expires_at' => $now - 300,
+		);
+		$fresh = array(
+			'token'      => 'fresh-owner',
+			'started_at' => $now,
+			'expires_at' => $now + 300,
+		);
+		add_option( $this->lease_name, $stale, '', false );
+
+		$result = OptionLeaseStore::acquire( $this->lease_name, $fresh, 300, $now );
+
+		$this->assertTrue( $result['acquired'] );
+		$this->assertSame( $fresh, get_option( $this->lease_name ) );
+	}
+
+	public function test_two_mysql_sessions_allow_only_one_stale_lease_takeover(): void {
+		if ( ! class_exists( '\mysqli' ) || ! defined( 'MYSQLI_ASYNC' ) ) {
+			$this->markTestSkipped( 'MySQLi async support is unavailable.' );
+		}
+
+		$first  = $this->open_mysql_connection();
+		$second = $this->open_mysql_connection();
+		if ( ! $first instanceof \mysqli || ! $second instanceof \mysqli ) {
+			$this->markTestSkipped( 'Two direct test database connections are unavailable.' );
+		}
+
+		$now   = time();
+		$stale = array(
+			'token'      => 'stale-owner',
+			'started_at' => $now - 600,
+			'expires_at' => $now - 300,
+		);
+		$winner = array(
+			'token'      => 'first-owner',
+			'started_at' => $now,
+			'expires_at' => $now + 300,
+		);
+		$loser = array(
+			'token'      => 'second-owner',
+			'started_at' => $now,
+			'expires_at' => $now + 300,
+		);
+		$table      = $this->options_table();
+		$lease_name = $first->real_escape_string( $this->lease_name );
+
+		try {
+			$this->assertTrue( $first->query( 'SET SESSION innodb_lock_wait_timeout = 2' ) );
+			$this->assertTrue( $second->query( 'SET SESSION innodb_lock_wait_timeout = 2' ) );
+			$this->assertTrue(
+				$first->query(
+					sprintf(
+						"INSERT INTO `{$table}` (option_name, option_value, autoload) VALUES ('%s', '%s', 'no')",
+						$lease_name,
+						$first->real_escape_string( maybe_serialize( $stale ) )
+					)
+				)
+			);
+			$this->assertTrue( $first->query( 'START TRANSACTION' ) );
+			$this->assertTrue( $first->query( $this->takeover_query( $first, $stale, $winner ) ) );
+			$this->assertSame( 1, $first->affected_rows );
+			$this->assertTrue( $second->query( $this->takeover_query( $second, $stale, $loser ), MYSQLI_ASYNC ) );
+			$read   = array( $second );
+			$error  = array();
+			$reject = array();
+			$this->assertSame( 0, \mysqli_poll( $read, $error, $reject, 0, 100000 ), 'The competing takeover must wait for the lease row lock.' );
+
+			$this->assertTrue( $first->query( 'COMMIT' ) );
+			$ready = 0;
+			for ( $attempt = 0; $attempt < 20 && 0 === $ready; ++$attempt ) {
+				$read   = array( $second );
+				$error  = array();
+				$reject = array();
+				$ready  = \mysqli_poll( $read, $error, $reject, 0, 100000 );
+			}
+
+			$this->assertSame( 1, $ready, 'The competing takeover should resume after the winner commits.' );
+			$this->assertTrue( $second->reap_async_query() );
+			$this->assertSame( 0, $second->affected_rows );
+			$result = $first->query( "SELECT option_value FROM `{$table}` WHERE option_name = '{$lease_name}'" );
+			$this->assertInstanceOf( \mysqli_result::class, $result );
+			$this->assertSame( $winner, maybe_unserialize( $result->fetch_assoc()['option_value'] ) );
+		} finally {
+			$first->query( 'ROLLBACK' );
+			$second->query( 'ROLLBACK' );
+			$first->close();
+			$second->close();
+		}
+	}
+
 	public function test_two_mysql_sessions_allow_only_one_generation_replacement(): void {
 		if ( ! class_exists( '\mysqli' ) || ! defined( 'MYSQLI_ASYNC' ) ) {
 			$this->markTestSkipped( 'MySQLi async support is unavailable.' );
@@ -138,6 +232,17 @@ final class OptionLeaseStoreTest extends WP_UnitTestCase {
 			$connection->real_escape_string( maybe_serialize( $replacement ) ),
 			$connection->real_escape_string( $this->target_name ),
 			$connection->real_escape_string( maybe_serialize( 'generation-1' ) )
+		);
+	}
+
+	private function takeover_query( \mysqli $connection, array $stale, array $replacement ): string {
+		$table = $this->options_table();
+
+		return sprintf(
+			"UPDATE `{$table}` SET option_value = '%s' WHERE option_name = '%s' AND option_value = '%s'",
+			$connection->real_escape_string( maybe_serialize( $replacement ) ),
+			$connection->real_escape_string( $this->lease_name ),
+			$connection->real_escape_string( maybe_serialize( $stale ) )
 		);
 	}
 

--- a/tests/ai-step-backpressure-smoke.php
+++ b/tests/ai-step-backpressure-smoke.php
@@ -91,6 +91,18 @@ if ( ! function_exists( 'add_option' ) ) {
     }
 }
 
+if ( ! function_exists( 'update_option' ) ) {
+    function update_option( string $name, mixed $value, mixed $autoload = null ): bool {
+		unset( $autoload );
+		if ( array_key_exists( $name, $GLOBALS['datamachine_ai_backpressure_options'] ) && $GLOBALS['datamachine_ai_backpressure_options'][ $name ] === $value ) {
+			return false;
+		}
+
+		$GLOBALS['datamachine_ai_backpressure_options'][ $name ] = $value;
+		return true;
+    }
+}
+
 if ( ! function_exists( 'delete_option' ) ) {
     function delete_option( string $name ): bool {
     	$existed = array_key_exists( $name, $GLOBALS['datamachine_ai_backpressure_options'] );


### PR DESCRIPTION
## Summary
- replace stale lease delete/add takeover with an exact serialized-value compare-and-swap on the existing option row
- preserve the public `acquire()` signature while making stale replacement atomic for every caller
- add deterministic two-session MySQL interleaving coverage and update the AI concurrency smoke harness for exact-value replacement

Closes #3072.

## Race And Atomicity
Previously, callers A and B could both snapshot the same stale payload. A could delete it and add token A, then delayed caller B could unconditionally delete token A and add token B, leaving both callers with `acquired => true`.

Stale takeover now executes one conditional statement:

```sql
UPDATE wp_options
SET option_value = <replacement>
WHERE option_name = <lease>
  AND option_value = <exact serialized stale payload>
```

The options table's unique `option_name` row and InnoDB row locking serialize contenders. Exactly one update can affect one row; after that commit, a delayed caller's stale predicate no longer matches. The winner invalidates the WordPress option cache before returning ownership. No stale caller deletes a replacement token.

## Affected Callers
- recurring schedule signature locks now take over stale leases without exposing a delete/add gap; generation mutation remains fenced by the refreshed exact lease
- worker and drain locks retain their existing retry, heartbeat, and token-conditional release behavior while stale takeover becomes exact-value CAS
- pipeline AI concurrency slots use the same fixed `acquire()` path, including custom stale-owner predicates
- current `origin/main` retention preflight uses Action Scheduler's native pre-claim retention filters and does not currently call `OptionLeaseStore`; no retention behavior changes in this PR, and a future shared-store preflight receives the atomic takeover semantics automatically

## Test Interleaving
The new MySQL integration test seeds one stale lease, starts caller A's exact-value takeover inside a transaction, and launches caller B's takeover asynchronously from a second session using the same stale snapshot. It proves B waits on the row lock, A commits as the sole winner, B affects zero rows, and A's token remains stored. A direct acquisition test also verifies normal stale replacement through `OptionLeaseStore::acquire()`.

## Verification
- `homeboy review audit --placement local --changed-since origin/main --summary` (passed; no introduced findings)
- `homeboy review lint --placement local --changed-since origin/main --summary` (passed; PHPCS, ESLint, and PHPStan clean)
- `composer lint` (passed; host Composer emitted dependency deprecation notices only)
- `php tests/prefix-policy-audit.php` (11 passed)
- `php tests/worker-lock-smoke.php` (33 passed)
- `php tests/worker-cli-smoke.php` (54 passed)
- `php tests/recurring-scheduler-idempotency-smoke.php` (all passed)
- `php tests/ai-step-backpressure-smoke.php` (61 passed)
- `php tests/action-scheduler-native-retention-smoke.php` (10 passed)
- syntax checks and `git diff --check` passed

Local PHPUnit execution is blocked by baseline infrastructure: Homeboy cannot provision its Docker-backed `mysql:8.4` service because Docker is unavailable on this host, so both this branch and unchanged `origin/main` report zero executed tests. The committed two-session test is expected to run in CI. `tests/retention-action-scheduler-batching-smoke.php` also has the same two unrelated expectation failures on this branch and unchanged `origin/main`.

## Residual Database Assumptions
- the options table enforces a unique key on `option_name`, as required by WordPress core
- the production database provides transactional row locking for the conditional update (InnoDB on supported MySQL/MariaDB deployments)
- exact fencing compares `maybe_serialize()` output byte-for-byte; lease payload serialization must remain deterministic between snapshot and takeover
- WordPress runtimes provide `$wpdb`; the non-database fallback exists only for lightweight test stubs and cannot provide cross-process atomicity

## Follow-up
Core API inspection found a separate missing-row race because WordPress 7.0.3 `add_option()` uses duplicate-key replacement semantics. That distinct unlocked-acquisition issue is tracked in #3078 and is intentionally not folded into this stale-takeover fix.