### PR TITLE
fix: atomically acquire missing option leases

### DIFF
--- a/inc/Core/OptionLeaseStore.php
+++ b/inc/Core/OptionLeaseStore.php
@@ -56,7 +56,7 @@ class OptionLeaseStore {
 			);
 		}
 
-		if ( add_option( $option_name, $payload, '', false ) ) {
+		if ( self::insertUnlocked( $option_name, $payload ) ) {
 			return array(
 				'acquired'    => true,
 				'status'      => 'held',
@@ -73,6 +73,42 @@ class OptionLeaseStore {
 			'payload'     => $current['payload'],
 			'option_name' => $option_name,
 		);
+	}
+
+	/**
+	 * Atomically insert a lease only while its option row is absent.
+	 *
+	 * @param array<string,mixed> $payload Lease payload.
+	 */
+	private static function insertUnlocked( string $option_name, array $payload ): bool {
+		global $wpdb;
+		if ( isset( $wpdb->options ) && method_exists( $wpdb, 'query' ) && method_exists( $wpdb, 'prepare' ) ) {
+			$previous_suppression = method_exists( $wpdb, 'suppress_errors' ) ? $wpdb->suppress_errors( true ) : null;
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- A plain insert and the option-name unique key are the missing-row fencing primitive.
+			$inserted = $wpdb->query(
+				$wpdb->prepare(
+					'INSERT INTO %i (option_name, option_value, autoload) VALUES (%s, %s, %s)',
+					$wpdb->options,
+					$option_name,
+					maybe_serialize( $payload ),
+					'off'
+				)
+			);
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+			if ( null !== $previous_suppression ) {
+				$wpdb->suppress_errors( $previous_suppression );
+			}
+
+			// Both sessions may have cached the missing row before the unique-key race resolves.
+			wp_cache_delete( $option_name, 'options' );
+			wp_cache_delete( 'notoptions', 'options' );
+			wp_cache_delete( 'alloptions', 'options' );
+
+			return 1 === $inserted;
+		}
+
+		// Lightweight test runtimes may not provide wpdb.
+		return add_option( $option_name, $payload, '', false );
 	}
 
 	/**

--- a/tests/Unit/Core/OptionLeaseStoreTest.php
+++ b/tests/Unit/Core/OptionLeaseStoreTest.php
@@ -77,6 +77,102 @@ final class OptionLeaseStoreTest extends WP_UnitTestCase {
 		$this->assertSame( $fresh, get_option( $this->lease_name ) );
 	}
 
+	public function test_missing_lease_acquisition_is_non_autoloaded_and_readable_after_cached_miss(): void {
+		$lease = $this->lease();
+		$this->assertFalse( get_option( $this->lease_name, false ) );
+
+		$result = OptionLeaseStore::acquire( $this->lease_name, $lease, 300 );
+
+		$this->assertTrue( $result['acquired'] );
+		$this->assertSame( $lease, get_option( $this->lease_name ) );
+		$this->assertNotContains( $this->stored_autoload_value(), wp_autoload_values_to_autoload(), true );
+		$this->assertArrayNotHasKey( $this->lease_name, wp_load_alloptions() );
+		$notoptions = wp_cache_get( 'notoptions', 'options' );
+		$this->assertTrue( false === $notoptions || ! isset( $notoptions[ $this->lease_name ] ) );
+	}
+
+	public function test_contended_missing_lease_acquisition_reads_the_winner_after_cached_miss(): void {
+		global $wpdb;
+
+		$winner = $this->lease();
+		$loser  = $winner;
+		$loser['token'] = 'other-owner';
+		$this->assertFalse( get_option( $this->lease_name, false ) );
+		$this->assertSame(
+			1,
+			$wpdb->insert(
+				$wpdb->options,
+				array(
+					'option_name'  => $this->lease_name,
+					'option_value' => maybe_serialize( $winner ),
+					'autoload'     => 'off',
+				),
+				array( '%s', '%s', '%s' )
+			)
+		);
+
+		$result = OptionLeaseStore::acquire( $this->lease_name, $loser, 300 );
+
+		$this->assertFalse( $result['acquired'] );
+		$this->assertSame( $winner, $result['payload'] );
+		$this->assertSame( $winner, get_option( $this->lease_name ) );
+		$this->assertArrayNotHasKey( $this->lease_name, wp_load_alloptions() );
+	}
+
+	public function test_two_mysql_sessions_allow_only_one_missing_lease_acquisition(): void {
+		if ( ! class_exists( '\mysqli' ) || ! defined( 'MYSQLI_ASYNC' ) ) {
+			$this->markTestSkipped( 'MySQLi async support is unavailable.' );
+		}
+
+		$first  = $this->open_mysql_connection();
+		$second = $this->open_mysql_connection();
+		if ( ! $first instanceof \mysqli || ! $second instanceof \mysqli ) {
+			$this->markTestSkipped( 'Two direct test database connections are unavailable.' );
+		}
+
+		$winner = $this->lease();
+		$loser  = $winner;
+		$loser['token'] = 'other-owner';
+
+		try {
+			$this->assertTrue( $first->query( 'SET SESSION innodb_lock_wait_timeout = 2' ) );
+			$this->assertTrue( $second->query( 'SET SESSION innodb_lock_wait_timeout = 2' ) );
+			$this->assertTrue( $first->query( 'START TRANSACTION' ) );
+			$this->assertTrue( $first->query( $this->insert_query( $first, $winner ) ) );
+			$this->assertSame( 1, $first->affected_rows );
+			$this->assertTrue( $second->query( $this->insert_query( $second, $loser ), MYSQLI_ASYNC ) );
+			$read   = array( $second );
+			$error  = array();
+			$reject = array();
+			$this->assertSame( 0, \mysqli_poll( $read, $error, $reject, 0, 100000 ), 'The competing insert must wait for the option-name unique key.' );
+
+			$this->assertTrue( $first->query( 'COMMIT' ) );
+			$ready = 0;
+			for ( $attempt = 0; $attempt < 20 && 0 === $ready; ++$attempt ) {
+				$read   = array( $second );
+				$error  = array();
+				$reject = array();
+				$ready  = \mysqli_poll( $read, $error, $reject, 0, 100000 );
+			}
+
+			$this->assertSame( 1, $ready, 'The competing insert should resume after the winner commits.' );
+			$this->assertFalse( $second->reap_async_query() );
+			$this->assertSame( 1062, $second->errno );
+			$table      = $this->options_table();
+			$lease_name = $first->real_escape_string( $this->lease_name );
+			$result     = $first->query( "SELECT option_value, autoload FROM `{$table}` WHERE option_name = '{$lease_name}'" );
+			$this->assertInstanceOf( \mysqli_result::class, $result );
+			$row = $result->fetch_assoc();
+			$this->assertSame( $winner, maybe_unserialize( $row['option_value'] ) );
+			$this->assertNotContains( $row['autoload'], wp_autoload_values_to_autoload(), true );
+		} finally {
+			$first->query( 'ROLLBACK' );
+			$second->query( 'ROLLBACK' );
+			$first->close();
+			$second->close();
+		}
+	}
+
 	public function test_two_mysql_sessions_allow_only_one_stale_lease_takeover(): void {
 		if ( ! class_exists( '\mysqli' ) || ! defined( 'MYSQLI_ASYNC' ) ) {
 			$this->markTestSkipped( 'MySQLi async support is unavailable.' );
@@ -243,6 +339,24 @@ final class OptionLeaseStoreTest extends WP_UnitTestCase {
 			$connection->real_escape_string( maybe_serialize( $replacement ) ),
 			$connection->real_escape_string( $this->lease_name ),
 			$connection->real_escape_string( maybe_serialize( $stale ) )
+		);
+	}
+
+	private function insert_query( \mysqli $connection, array $lease ): string {
+		$table = $this->options_table();
+
+		return sprintf(
+			"INSERT INTO `{$table}` (option_name, option_value, autoload) VALUES ('%s', '%s', 'off')",
+			$connection->real_escape_string( $this->lease_name ),
+			$connection->real_escape_string( maybe_serialize( $lease ) )
+		);
+	}
+
+	private function stored_autoload_value(): string {
+		global $wpdb;
+
+		return (string) $wpdb->get_var(
+			$wpdb->prepare( 'SELECT autoload FROM %i WHERE option_name = %s', $wpdb->options, $this->lease_name )
 		);
 	}
 


### PR DESCRIPTION
## Summary
- Replace the unlocked `OptionLeaseStore` path's unsafe WordPress 7 `add_option()` upsert with a prepared plain `INSERT` owned by the lease store.
- Treat exactly one inserted row as acquisition; duplicate-key contention returns false and re-snapshots the winning lease without overwriting its token.
- Add deterministic two-session missing-row contention, cache/read-after-write, non-autoload, and stale-takeover regression coverage.

## Atomicity and return semantics
WordPress 7.0.3 implements `add_option()` with `INSERT ... ON DUPLICATE KEY UPDATE`, so a caller that observed a missing row can overwrite a concurrent winner and still receive a truthy result. The replacement uses a plain prepared `INSERT` against the options table. The options table's unique `option_name` key serializes competing inserts: the winner receives one affected row, while the loser receives duplicate-key failure and is not reported as acquired. Expected duplicate errors are suppressed at the `wpdb` display layer, then the prior suppression state is restored.

The exact stale-payload `UPDATE ... WHERE option_name = ? AND option_value = ?` path introduced for #3072 remains unchanged. Missing-row acquisition and exact stale-row takeover therefore retain separate fencing semantics.

## Cache behavior
The inserted row uses `autoload = off`, matching WordPress's current explicit non-autoload representation. After either insert success or contention, the store invalidates the option's object-cache entry plus `notoptions` and `alloptions`. This removes each session's cached missing-row snapshot and forces the winner and loser to read authoritative database state. Tests verify read-after-write, loser read-after-contention, `notoptions` removal, and absence from `alloptions`.

## Affected callers
The owner-layer change covers all existing consumers without caller workarounds:
- `WorkerLock` global and lane locks
- `RecurringScheduler` schedule mutation leases
- `PipelineAIConcurrencyLimiter` numbered provider/site slots

## Concurrency coverage
The two-session test starts a transaction, inserts the winner lease, and issues the competing plain insert asynchronously. It proves the contender blocks on the unique key until commit, resumes with MySQL duplicate error `1062`, and cannot overwrite the winner token. The persisted row is also verified as non-autoloaded. Existing two-session exact stale-takeover and generation-CAS tests remain in place.

## Database assumptions
- The WordPress options schema has a unique key on `option_name`.
- MySQL/InnoDB unique-key enforcement blocks a competing insert until the first transaction resolves.
- Duplicate-key error `1062` maps to a non-acquired result; no upsert clause is used.

## Verification
- `vendor/bin/phpcs inc/Core/OptionLeaseStore.php tests/Unit/Core/OptionLeaseStoreTest.php`
- Homeboy changed-scope lint: passed, including PHPCS, ESLint, and PHPStan level 7 with zero findings
- Homeboy architecture audit: passed with zero introduced findings
- `php tests/prefix-policy-audit.php`: 11 passed, 0 failed
- `php tests/worker-lock-smoke.php`: 33 assertions passed
- `php tests/recurring-scheduler-idempotency-smoke.php`: all assertions passed
- `php tests/ai-step-backpressure-smoke.php`: 61 assertions passed
- PHP syntax checks: passed
- Local Homeboy PHPUnit gate selected `OptionLeaseStoreTest.php` but the installed PHPUnit 9 launcher on PHP 8.4 emitted no output and reported zero executed tests; Homeboy correctly classified this as a zero-test harness failure. CI should execute the WordPress integration suite in its configured environment.

Closes #3078