### PR TITLE
fix: bound pathless batch action lookup

### DIFF
--- a/inc/Core/ActionScheduler/PathlessBatchRecovery.php
+++ b/inc/Core/ActionScheduler/PathlessBatchRecovery.php
@@ -15,7 +15,8 @@ use DataMachine\Core\EngineData;
 defined( 'ABSPATH' ) || exit;
 
 class PathlessBatchRecovery {
-	private const CLAIM_TTL = 300;
+	private const CLAIM_TTL          = 300;
+	private const ACTION_QUERY_LIMIT = 100;
 
 	/** Whether a v2 batch still has work that can be requeued. */
 	public static function isRecoverable( array $engine_data ): bool {
@@ -28,7 +29,7 @@ class PathlessBatchRecovery {
 		if ( $parent_job_id <= 0 || empty( $engine_data['batch'] ) ) {
 			return false;
 		}
-		if ( self::hasActiveAction( $parent_job_id, $timeout_hours ) ) {
+		if ( self::hasActiveAction( $parent_job_id, $engine_data, $timeout_hours ) ) {
 			return true;
 		}
 
@@ -91,18 +92,73 @@ class PathlessBatchRecovery {
 	}
 
 	/** Check exact pending or fresh in-progress chunk actions for one parent. */
-	private static function hasActiveAction( int $parent_job_id, int $timeout_hours ): bool {
+	private static function hasActiveAction( int $parent_job_id, array $engine_data, int $timeout_hours ): bool {
 		global $wpdb;
 		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
-		$like_parent   = '%"parent_job_id":' . $wpdb->esc_like( (string) $parent_job_id ) . '%';
+		$state         = is_array( $engine_data['batch_state'] ?? null ) ? $engine_data['batch_state'] : array();
+		$offset        = (int) ( $state['offset'] ?? $engine_data['batch_offset'] ?? 0 );
+		$canonical     = wp_json_encode(
+			array(
+				'parent_job_id' => $parent_job_id,
+				'offset'        => $offset,
+			)
+		);
+		$query_limit   = self::ACTION_QUERY_LIMIT + 1;
+
+		// Current producers have a complete identity in Action Scheduler's indexed args column.
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WordPress prefix.
 		$actions = $wpdb->get_results(
-			$wpdb->prepare( "SELECT args, status, scheduled_date_gmt, last_attempt_gmt FROM {$actions_table} WHERE hook = %s AND status IN ( %s, %s ) AND args LIKE %s", 'datamachine_pipeline_batch_chunk', 'pending', 'in-progress', $like_parent )
+			$wpdb->prepare(
+				"SELECT args, status, scheduled_date_gmt, last_attempt_gmt FROM {$actions_table} WHERE args = %s AND hook = %s AND status IN ( %s, %s ) ORDER BY action_id DESC LIMIT %d",
+				$canonical,
+				'datamachine_pipeline_batch_chunk',
+				'pending',
+				'in-progress',
+				$query_limit
+			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		if ( ! is_array( $actions ) || '' !== (string) $wpdb->last_error ) {
+			return true;
+		}
 
 		$timeout_seconds = max( 1, $timeout_hours ) * HOUR_IN_SECONDS;
 		$now_gmt         = strtotime( current_time( 'mysql', true ) );
+		if ( self::containsActiveAction( array_slice( $actions, 0, self::ACTION_QUERY_LIMIT ), $parent_job_id, $timeout_seconds, $now_gmt ) ) {
+			return true;
+		}
+		if ( count( $actions ) > self::ACTION_QUERY_LIMIT ) {
+			return true;
+		}
+
+		// Historical argument shapes cannot use the exact key. Inspect a bounded,
+		// index-ordered window per status and refuse to infer absence if truncated.
+		foreach ( array( 'pending', 'in-progress' ) as $status ) {
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WordPress prefix.
+			$actions = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT args, status, scheduled_date_gmt, last_attempt_gmt FROM {$actions_table} WHERE hook = %s AND status = %s ORDER BY scheduled_date_gmt DESC LIMIT %d",
+					'datamachine_pipeline_batch_chunk',
+					$status,
+					$query_limit
+				)
+			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			if ( ! is_array( $actions ) || '' !== (string) $wpdb->last_error ) {
+				return true;
+			}
+			if ( self::containsActiveAction( array_slice( $actions, 0, self::ACTION_QUERY_LIMIT ), $parent_job_id, $timeout_seconds, $now_gmt ) ) {
+				return true;
+			}
+			if ( count( $actions ) > self::ACTION_QUERY_LIMIT ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/** Check exact parent matches in one bounded scheduler result. */
+	private static function containsActiveAction( array $actions, int $parent_job_id, int $timeout_seconds, int|false $now_gmt ): bool {
 		foreach ( $actions as $action ) {
 			if ( ! hash_equals( (string) $parent_job_id, (string) self::extractParentJobId( (string) ( $action->args ?? '' ) ) ) ) {
 				continue;

--- a/inc/Core/ActionScheduler/PathlessBatchRecovery.php
+++ b/inc/Core/ActionScheduler/PathlessBatchRecovery.php
@@ -118,16 +118,9 @@ class PathlessBatchRecovery {
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		if ( ! is_array( $actions ) || '' !== (string) $wpdb->last_error ) {
-			return true;
-		}
-
 		$timeout_seconds = max( 1, $timeout_hours ) * HOUR_IN_SECONDS;
 		$now_gmt         = strtotime( current_time( 'mysql', true ) );
-		if ( self::containsActiveAction( array_slice( $actions, 0, self::ACTION_QUERY_LIMIT ), $parent_job_id, $timeout_seconds, $now_gmt ) ) {
-			return true;
-		}
-		if ( count( $actions ) > self::ACTION_QUERY_LIMIT ) {
+		if ( self::boundedEvidenceBlocksRecovery( $actions, $parent_job_id, $timeout_seconds, $now_gmt ) ) {
 			return true;
 		}
 
@@ -144,17 +137,21 @@ class PathlessBatchRecovery {
 				)
 			);
 			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			if ( ! is_array( $actions ) || '' !== (string) $wpdb->last_error ) {
-				return true;
-			}
-			if ( self::containsActiveAction( array_slice( $actions, 0, self::ACTION_QUERY_LIMIT ), $parent_job_id, $timeout_seconds, $now_gmt ) ) {
-				return true;
-			}
-			if ( count( $actions ) > self::ACTION_QUERY_LIMIT ) {
+			if ( self::boundedEvidenceBlocksRecovery( $actions, $parent_job_id, $timeout_seconds, $now_gmt ) ) {
 				return true;
 			}
 		}
 		return false;
+	}
+
+	/** Treat active, truncated, or failed scheduler evidence as blocking recovery. */
+	private static function boundedEvidenceBlocksRecovery( mixed $actions, int $parent_job_id, int $timeout_seconds, int|false $now_gmt ): bool {
+		global $wpdb;
+		if ( ! is_array( $actions ) || '' !== (string) $wpdb->last_error ) {
+			return true;
+		}
+		return self::containsActiveAction( array_slice( $actions, 0, self::ACTION_QUERY_LIMIT ), $parent_job_id, $timeout_seconds, $now_gmt )
+			|| count( $actions ) > self::ACTION_QUERY_LIMIT;
 	}
 
 	/** Check exact parent matches in one bounded scheduler result. */

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -229,7 +229,9 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 	public function test_pathless_batch_recovery_preserves_nested_and_serialized_action_args(): void {
 		$extract = new \ReflectionMethod( PathlessBatchRecovery::class, 'extractParentJobId' );
 
+		$this->assertSame( 100, $extract->invoke( null, wp_json_encode( array( 'parent_job_id' => 100, 'offset' => 0 ) ) ) );
 		$this->assertSame( 123, $extract->invoke( null, wp_json_encode( array( array( 'parent_job_id' => 123 ) ) ) ) );
+		$this->assertSame( 321, $extract->invoke( null, serialize( array( 'parent_job_id' => 321, 'offset' => 0 ) ) ) );
 		$this->assertSame( 456, $extract->invoke( null, serialize( array( array( 'parent_job_id' => 456 ) ) ) ) );
 	}
 

--- a/tests/pathless-batch-recovery-bounds-smoke.php
+++ b/tests/pathless-batch-recovery-bounds-smoke.php
@@ -54,12 +54,12 @@ final class PathlessRecoveryWpdb {
 	}
 }
 
-function pathless_action( string $args, string $status = 'pending', string $started = '2026-08-09 11:59:00' ): object {
+function pathless_action( string $args, string $status = 'pending' ): object {
 	return (object) array(
 		'args'               => $args,
 		'status'             => $status,
-		'scheduled_date_gmt' => $started,
-		'last_attempt_gmt'   => 'in-progress' === $status ? $started : '0000-00-00 00:00:00',
+		'scheduled_date_gmt' => '2026-08-09 11:59:00',
+		'last_attempt_gmt'   => 'in-progress' === $status ? '2026-08-09 11:59:00' : '0000-00-00 00:00:00',
 	);
 }
 

--- a/tests/pathless-batch-recovery-bounds-smoke.php
+++ b/tests/pathless-batch-recovery-bounds-smoke.php
@@ -1,0 +1,126 @@
+<?php
+/** Behavioral smoke test for bounded pathless batch action lookup. */
+
+define( 'ABSPATH', __DIR__ );
+define( 'HOUR_IN_SECONDS', 3600 );
+
+function wp_json_encode( mixed $value ): string|false {
+	return json_encode( $value );
+}
+
+function maybe_unserialize( mixed $value ): mixed {
+	if ( ! is_string( $value ) || ! is_serialized( $value ) ) {
+		return $value;
+	}
+	return unserialize( trim( $value ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- Compatibility fixture.
+}
+
+function is_serialized( mixed $value ): bool {
+	return is_string( $value ) && (bool) preg_match( '/^[aOsibdN]:/', trim( $value ) );
+}
+
+function current_time( string $type, bool $gmt = false ): string {
+	return '2026-08-09 12:00:00';
+}
+
+final class PathlessRecoveryWpdb {
+	public string $prefix = 'wp_';
+	public string $last_error = '';
+	public array $responses = array();
+	public array $queries = array();
+	public array $result_counts = array();
+
+	public function prepare( string $query, mixed ...$args ): string {
+		foreach ( $args as $arg ) {
+			$replacement = is_int( $arg ) ? (string) $arg : "'" . addslashes( (string) $arg ) . "'";
+			$query       = preg_replace( '/%[sd]/', $replacement, $query, 1 );
+		}
+		return $query;
+	}
+
+	public function get_results( string $query ): ?array {
+		$this->queries[] = $query;
+		$response        = array_shift( $this->responses );
+		if ( is_callable( $response ) ) {
+			$response = $response( $query );
+		}
+		if ( null === $response ) {
+			$this->last_error = 'simulated query failure';
+			return null;
+		}
+		$this->last_error = '';
+		$this->result_counts[] = count( $response );
+		return $response;
+	}
+}
+
+function pathless_action( string $args, string $status = 'pending', string $started = '2026-08-09 11:59:00' ): object {
+	return (object) array(
+		'args'               => $args,
+		'status'             => $status,
+		'scheduled_date_gmt' => $started,
+		'last_attempt_gmt'   => 'in-progress' === $status ? $started : '0000-00-00 00:00:00',
+	);
+}
+
+function pathless_assert( bool $condition, string $message ): void {
+	global $failures, $passes;
+	if ( $condition ) {
+		++$passes;
+		return;
+	}
+	++$failures;
+	echo "[FAIL] {$message}\n";
+}
+
+require_once __DIR__ . '/../inc/Core/ActionScheduler/PathlessBatchRecovery.php';
+
+$failures = 0;
+$passes   = 0;
+$lookup   = new ReflectionMethod( \DataMachine\Core\ActionScheduler\PathlessBatchRecovery::class, 'hasActiveAction' );
+$engine   = array( 'batch_state' => array( 'offset' => 40 ) );
+
+global $wpdb;
+$wpdb            = new PathlessRecoveryWpdb();
+$wpdb->responses = array( array( pathless_action( '{"parent_job_id":7,"offset":40}' ) ) );
+pathless_assert( true === $lookup->invoke( null, 7, $engine, 1 ), 'canonical indexed action is active' );
+pathless_assert( 1 === count( $wpdb->queries ), 'canonical match avoids compatibility queries' );
+pathless_assert( str_contains( $wpdb->queries[0], 'args = ' ) && str_contains( $wpdb->queries[0], 'LIMIT 101' ), 'canonical query is exact and bounded' );
+
+$wpdb            = new PathlessRecoveryWpdb();
+$wpdb->responses = array(
+	array(),
+	array( pathless_action( '[{"parent_job_id":7,"offset":40}]' ) ),
+);
+pathless_assert( true === $lookup->invoke( null, 7, $engine, 1 ), 'nested JSON compatibility action is active' );
+
+$wpdb            = new PathlessRecoveryWpdb();
+$wpdb->responses = array(
+	array(),
+	array( pathless_action( serialize( array( array( 'parent_job_id' => 7, 'offset' => 40 ) ) ) ) ),
+);
+pathless_assert( true === $lookup->invoke( null, 7, $engine, 1 ), 'serialized compatibility action is active' );
+
+$unrelated       = array_fill( 0, 10000, pathless_action( '{"parent_job_id":999,"offset":0}' ) );
+$wpdb            = new PathlessRecoveryWpdb();
+$wpdb->responses = array(
+	array(),
+	static fn(): array => array_slice( $unrelated, 0, 101 ),
+);
+pathless_assert( true === $lookup->invoke( null, 7, $engine, 1 ), 'truncated unrelated population fails closed' );
+pathless_assert( 10000 === count( $unrelated ), 'fixture represents a large unrelated action population' );
+pathless_assert( 101 === $wpdb->result_counts[1], 'compatibility result cardinality is limit plus sentinel' );
+pathless_assert( 2 === count( $wpdb->queries ), 'truncation stops further scheduler queries' );
+pathless_assert( str_contains( $wpdb->queries[1], 'ORDER BY scheduled_date_gmt DESC LIMIT 101' ), 'compatibility query follows the hook/status/date index with a bound' );
+
+$wpdb            = new PathlessRecoveryWpdb();
+$wpdb->responses = array( null );
+pathless_assert( true === $lookup->invoke( null, 7, $engine, 1 ), 'query failure fails closed' );
+
+$wpdb            = new PathlessRecoveryWpdb();
+$wpdb->responses = array( array(), array(), array() );
+pathless_assert( false === $lookup->invoke( null, 7, $engine, 1 ), 'exhausted exact and compatibility evidence proves absence' );
+pathless_assert( 3 === count( $wpdb->queries ), 'absence requires every bounded status query to be exhausted' );
+
+echo "Pathless batch recovery bounds: {$passes} passed, {$failures} failed.\n";
+exit( $failures > 0 ? 1 : 0 );

--- a/tests/recover-stuck-active-action-guard-smoke.php
+++ b/tests/recover-stuck-active-action-guard-smoke.php
@@ -49,6 +49,9 @@ assert_recover_stuck_guard_smoke( 'active batch guard method exists', str_contai
 assert_recover_stuck_guard_smoke( 'batch guard checks pipeline chunk actions', str_contains( $batch_source, 'datamachine_pipeline_batch_chunk' ) && str_contains( $batch_source, 'parent_job_id' ) );
 assert_recover_stuck_guard_smoke( 'batch guard checks active children', str_contains( $batch_source, 'WHERE parent_job_id = %d' ) && str_contains( $batch_source, 'status IN ( %s, %s )' ) );
 assert_recover_stuck_guard_smoke( 'batch guard confirms exact parent id', str_contains( $batch_source, 'extractParentJobId' ) && str_contains( $batch_source, 'maybe_unserialize' ) );
+assert_recover_stuck_guard_smoke( 'batch guard uses indexed canonical args', str_contains( $batch_source, 'WHERE args = %s AND hook = %s' ) );
+assert_recover_stuck_guard_smoke( 'batch compatibility queries are bounded', str_contains( $batch_source, 'ACTION_QUERY_LIMIT + 1' ) && str_contains( $batch_source, 'LIMIT %d' ) );
+assert_recover_stuck_guard_smoke( 'batch guard fails closed on incomplete evidence', str_contains( $batch_source, 'count( $actions ) > self::ACTION_QUERY_LIMIT' ) && str_contains( $batch_source, "last_error" ) );
 
 echo "\nRecover-stuck active action guard smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary
- replace the unbounded parent `LIKE` scan with an exact lookup using the canonical `parent_job_id` + durable `batch_state.offset` identity stored in Action Scheduler's indexed `args` column
- retain #3065 keyed, nested JSON, and serialized compatibility through status-separated compatibility windows ordered by the existing `hook_status_scheduled_date_gmt` index
- cap every result at 100 rows plus one truncation sentinel and fail closed on truncation or database errors

## Indexed and bounded strategy
`BatchScheduler` already produces a complete action identity: `parent_job_id` and `offset`. The durable batch state supplies the expected offset, while Action Scheduler stores the short canonical JSON in its indexed `args` column. The primary lookup therefore uses exact `args`, hook, and active statuses with `LIMIT 101` instead of introducing another identity table or scheduler abstraction.

Historical #3065 argument shapes cannot all be represented by one exact indexed key. Their compatibility path queries pending and in-progress rows separately, following Action Scheduler's existing `(hook, status, scheduled_date_gmt)` index. Each query returns at most 100 inspectable rows plus one sentinel row.

## Absence-proof semantics and compatibility
The existing boolean API remains compatible with its sole caller. `true` means recovery must skip because active work exists or because bounded evidence cannot prove absence. A truncated exact/compatibility window or query error therefore returns `true`; only exhausted exact, pending, and in-progress evidence can return `false`. This preserves the caller's fail-closed behavior without adding an incomplete-evidence state it does not need to distinguish.

Exact parent decoding remains unchanged for keyed JSON, nested JSON, keyed serialized, and nested serialized arguments. Freshness handling for in-progress rows and unconditional pending protection are also unchanged.

## Query cardinality
- canonical lookup: at most 101 rows
- pending compatibility lookup: at most 101 rows
- in-progress compatibility lookup: at most 101 rows
- processing stops immediately on an active match, query failure, or truncation

The regression fixture models 10,000 unrelated actions and verifies that only the 101-row bounded result is materialized and truncation fails closed.

## Tests
- `php tests/pathless-batch-recovery-bounds-smoke.php` (13 passed)
- `php tests/recover-stuck-active-action-guard-smoke.php` (18 passed)
- `php tests/recover-stuck-bounded-apply-smoke.php` (16 passed)
- `php tests/recover-stuck-bounded-memory-smoke.php` (13 passed)
- `php tests/prefix-policy-audit.php` (11 passed)
- Homeboy changed-file lint: pass, including PHPCS and PHPStan level 7
- Homeboy architecture audit: pass, zero introduced findings

## Baseline limitation
The local Homeboy test umbrella and focused `PipelineBatchSchedulerTest` invocation both reported zero executed tests before loading PHPUnit. This is test-discovery infrastructure rather than a test failure; focused behavioral and caller smokes above executed successfully. PR CI should provide the repository's configured WordPress PHPUnit environment.

No production recovery, mutation, release, deployment, version bump, changelog edit, or parallel scheduler abstraction was added.

Closes #3077