### PR TITLE
fix: make direct workflow retry atomic

### DIFF
--- a/inc/Abilities/Job/RetryJobAbility.php
+++ b/inc/Abilities/Job/RetryJobAbility.php
@@ -11,6 +11,7 @@
 namespace DataMachine\Abilities\Job;
 
 use DataMachine\Core\DirectJobEnqueuer;
+use DataMachine\Core\DirectOperationRecoveryPolicy;
 use DataMachine\Core\JobRetryPolicy;
 
 defined( 'ABSPATH' ) || exit;
@@ -137,9 +138,11 @@ class RetryJobAbility {
 			}
 
 			if ( 'processing' === $previous_status ) {
-				$generation = (int) ( $job['operation_generation'] ?? 0 );
-				$token      = (string) ( $job['operation_claim_token'] ?? '' );
-				if ( $generation > 0 && '' !== $token && ( new DirectJobEnqueuer( $this->db_jobs ) )->hasLiveGenerationAction( $job_id, $generation, $token ) ) {
+				$generation     = (int) ( $job['operation_generation'] ?? 0 );
+				$token          = (string) ( $job['operation_claim_token'] ?? '' );
+				$enqueuer       = new DirectJobEnqueuer( $this->db_jobs );
+				$live_execution = $generation > 0 && '' !== $token ? $enqueuer->liveGenerationExecution( $job_id, $generation, $token ) : 'none';
+				if ( 'none' !== $live_execution ) {
 					return array(
 						'success'         => false,
 						'job_id'          => $job_id,
@@ -147,6 +150,64 @@ class RetryJobAbility {
 						'retryable'       => true,
 						'error_code'      => 'job_execution_in_progress',
 						'error'           => sprintf( 'Job %d still has live execution for generation %d; retry after it exits or is recovered.', $job_id, $generation ),
+					);
+				}
+
+				$missing_action = DirectOperationRecoveryPolicy::diagnose(
+					$job,
+					$live_execution,
+					DirectOperationRecoveryPolicy::recordedActionExists( (int) ( $job['operation_action_id'] ?? 0 ) )
+				);
+				if ( is_array( $missing_action ) ) {
+					if ( ! empty( $job['operation_effects_begun_at'] ) ) {
+						return array(
+							'success'         => false,
+							'job_id'          => $job_id,
+							'previous_status' => $previous_status,
+							'retryable'       => false,
+							'error_code'      => 'job_effects_begun',
+							'error'           => sprintf( 'Job %d may have begun operation effects and cannot be safely retried.', $job_id ),
+						);
+					}
+
+					$requeue = $this->db_jobs->commit_missing_direct_operation_requeue(
+						$job_id,
+						(int) $missing_action['action_id'],
+						(int) $missing_action['generation'],
+						$token,
+						'manual_retry',
+						static fn( int $new_generation, string $new_token ): int => (int) as_schedule_single_action(
+							time(),
+							DirectJobEnqueuer::HOOK,
+							array(
+								'job_id'                => $job_id,
+								'flow_step_id'          => $flow_step_id,
+								'operation_generation'  => $new_generation,
+								'operation_claim_token' => $new_token,
+							),
+							DirectJobEnqueuer::GROUP,
+							true
+						)
+					);
+					if ( empty( $requeue['success'] ) ) {
+						return array(
+							'success'         => false,
+							'job_id'          => $job_id,
+							'previous_status' => $previous_status,
+							'retryable'       => true,
+							'error_code'      => (string) ( $requeue['reason'] ?? 'retry_enqueue_failed' ),
+							'error'           => sprintf( 'Job %d retry could not establish durable scheduler ownership.', $job_id ),
+						);
+					}
+
+					\DataMachine\Core\RunMetrics::increment( $job_id, 'retried' );
+					return array(
+						'success'         => true,
+						'job_id'          => $job_id,
+						'previous_status' => $previous_status,
+						'prompt_requeued' => false,
+						'direct_requeued' => true,
+						'message'         => sprintf( 'Job %d direct workflow retry enqueued.', $job_id ),
 					);
 				}
 				$this->db_jobs->complete_job( $job_id, 'failed - manual_retry' );

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -21,6 +21,7 @@ use DataMachine\Core\Database\LifecycleStateTransition;
 use DataMachine\Core\Database\RunMetadata\RunMetadata;
 use DataMachine\Core\ExecutionQuery;
 use DataMachine\Core\ChildJobRecoveryPolicy;
+use DataMachine\Core\DirectOperationRecoveryPolicy;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\RunMetrics;
 use DataMachine\Core\RunLifecycleStore;
@@ -559,6 +560,11 @@ class Jobs extends BaseRepository {
 		if ( $new_action_id <= 0 ) {
 			$this->wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$result['reason'] = 'schedule_failed';
+			return $result;
+		}
+		if ( ! DirectOperationRecoveryPolicy::recordedActionExists( $new_action_id ) ) {
+			$this->wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result['reason'] = 'action_receipt_missing';
 			return $result;
 		}
 		$engine                              = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();

--- a/inc/Core/DirectJobEnqueuer.php
+++ b/inc/Core/DirectJobEnqueuer.php
@@ -19,15 +19,19 @@ class DirectJobEnqueuer {
 	private Jobs $jobs;
 	private \Closure $scheduler;
 	private \Closure $action_finder;
+	private \Closure $action_receipt_exists;
 
-	public function __construct( ?Jobs $jobs = null, ?callable $scheduler = null, ?callable $action_finder = null ) {
-		$this->jobs          = $jobs ?? new Jobs();
-		$this->scheduler     = null !== $scheduler
+	public function __construct( ?Jobs $jobs = null, ?callable $scheduler = null, ?callable $action_finder = null, ?callable $action_receipt_exists = null ) {
+		$this->jobs                  = $jobs ?? new Jobs();
+		$this->scheduler             = null !== $scheduler
 			? \Closure::fromCallable( $scheduler )
 			: static fn( int $run_at, string $hook, array $args, string $group ) => as_schedule_single_action( $run_at, $hook, $args, $group );
-		$this->action_finder = null !== $action_finder
+		$this->action_finder         = null !== $action_finder
 			? \Closure::fromCallable( $action_finder )
 			: fn( array $args ): int => $this->findScheduledActionId( $args );
+		$this->action_receipt_exists = null !== $action_receipt_exists
+			? \Closure::fromCallable( $action_receipt_exists )
+			: static fn( int $action_id ): bool => DirectOperationRecoveryPolicy::recordedActionExists( $action_id );
 	}
 
 	/**
@@ -92,6 +96,10 @@ class DirectJobEnqueuer {
 		if ( ! is_int( $action_id ) || $action_id <= 0 ) {
 			$this->jobs->finish_operation_enqueue( $job_id, 'enqueue_failed', 0, $token, $generation );
 			return $this->failure( 'action_schedule_failed', $generation, true );
+		}
+		if ( ! ( $this->action_receipt_exists )( $action_id ) ) {
+			$this->jobs->finish_operation_enqueue( $job_id, 'enqueue_failed', 0, $token, $generation );
+			return $this->failure( 'action_receipt_missing', $generation, true );
 		}
 
 		if ( ! $this->jobs->finish_operation_enqueue( $job_id, 'enqueued', $action_id, $token, $generation ) ) {

--- a/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
+++ b/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
@@ -21,6 +21,7 @@ use DataMachine\Abilities\Engine\ExecuteStepAbility;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\DirectJobEnqueuer;
+use DataMachine\Core\DirectOperationRecoveryPolicy;
 use DataMachine\Core\JobRetryPolicy;
 use DataMachine\Core\JobStatus;
 use WP_UnitTestCase;
@@ -291,7 +292,7 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 			)
 		);
 
-		$failing = new DirectJobEnqueuer( $jobs, static fn() => false, static fn() => 0 );
+		$failing = new DirectJobEnqueuer( $jobs, static fn() => false, static fn() => 0, static fn() => false );
 		$this->assertFalse( $failing->enqueue( $job_id, 'ephemeral_step_0' )['success'] );
 		$this->assertSame( 'enqueue_failed', $jobs->get_job( $job_id )['operation_state'] );
 
@@ -306,7 +307,8 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 			},
 			static function () use ( &$scheduled_id ) {
 				return $scheduled_id;
-			}
+			},
+			static fn() => true
 		);
 		$first  = $enqueuer->enqueue( $job_id, 'ephemeral_step_0' );
 		$second = $enqueuer->enqueue( $job_id, 'ephemeral_step_0' );
@@ -329,9 +331,29 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 			array( 'operation_claimed_at' => '2000-01-01 00:00:00' ),
 			array( 'job_id' => $crashed_job_id )
 		);
-		$recovered = ( new DirectJobEnqueuer( $jobs, static fn() => 92, static fn() => 0 ) )->enqueue( $crashed_job_id, 'ephemeral_step_0' );
+		$recovered = ( new DirectJobEnqueuer( $jobs, static fn() => 92, static fn() => 0, static fn() => true ) )->enqueue( $crashed_job_id, 'ephemeral_step_0' );
 		$this->assertTrue( $recovered['success'] );
 		$this->assertSame( 'enqueued', $jobs->get_job( $crashed_job_id )['operation_state'] );
+	}
+
+	public function test_positive_scheduler_id_without_receipt_is_reclaimable(): void {
+		$jobs   = new Jobs();
+		$job_id = $jobs->create_job(
+			array(
+				'pipeline_id'       => 'direct',
+				'flow_id'           => 'direct',
+				'operation_state'   => 'preparing',
+				'operation_step_id' => 'ephemeral_step_0',
+			)
+		);
+
+		$result = ( new DirectJobEnqueuer( $jobs, static fn() => 999999, static fn() => 0, static fn() => false ) )->enqueue( $job_id, 'ephemeral_step_0' );
+		$job    = $jobs->get_job( $job_id );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'action_receipt_missing', $result['error'] );
+		$this->assertSame( 'enqueue_failed', $job['operation_state'] );
+		$this->assertSame( 0, (int) $job['operation_action_id'] );
 	}
 
 	public function test_non_owner_gets_retryable_in_progress_until_action_is_durable(): void {
@@ -346,7 +368,7 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		);
 		$this->assertIsArray( $jobs->claim_operation_enqueue( $job_id ) );
 
-		$result = ( new DirectJobEnqueuer( $jobs, static fn() => 99, static fn() => 0 ) )->enqueue( $job_id, 'ephemeral_step_0' );
+		$result = ( new DirectJobEnqueuer( $jobs, static fn() => 99, static fn() => 0, static fn() => true ) )->enqueue( $job_id, 'ephemeral_step_0' );
 
 		$this->assertFalse( $result['success'] );
 		$this->assertTrue( $result['retryable'] );
@@ -367,7 +389,7 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$claim = $jobs->claim_operation_enqueue( $job_id );
 		$this->assertIsArray( $claim );
 
-		$result = ( new DirectJobEnqueuer( $jobs, static fn() => 999, static fn() => 404 ) )->enqueue( $job_id, 'ephemeral_step_0' );
+		$result = ( new DirectJobEnqueuer( $jobs, static fn() => 999, static fn() => 404, static fn() => true ) )->enqueue( $job_id, 'ephemeral_step_0' );
 		$job    = $jobs->get_job( $job_id );
 
 		$this->assertTrue( $result['success'] );
@@ -402,7 +424,8 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 				$takeover_claim = $jobs->claim_operation_enqueue( $job_id );
 				return 101;
 			},
-			static fn() => 0
+			static fn() => 0,
+			static fn() => true
 		);
 
 		$slow_result = $slow->enqueue( $job_id, 'ephemeral_step_0' );
@@ -445,7 +468,8 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 				$worker_result = ( new ExecuteStepAbility() )->execute( $args );
 				return 303;
 			},
-			static fn() => 0
+			static fn() => 0,
+			static fn() => true
 		) )->enqueue( $job_id, 'ephemeral_step_0' );
 
 		$this->assertTrue( $worker_result['deferred'] );
@@ -514,6 +538,85 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertSame( 'enqueued', $job['operation_state'] );
 		$this->assertSame( $original_action_id, (int) $job['operation_action_id'] );
 		$this->assertSame( $original_generation, (int) $job['operation_generation'] );
+	}
+
+	public function test_processing_direct_retry_atomically_requeues_missing_action(): void {
+		global $wpdb;
+
+		wp_set_current_user( $this->owner_id );
+		$created = $this->execute( 'manual-missing-action-retry' );
+		$jobs    = new Jobs();
+		$job_id  = (int) $created['job_id'];
+		$before  = $jobs->get_job( $job_id );
+		$this->assertTrue( $jobs->start_job( $job_id ) );
+		$this->assertSame( 1, $wpdb->delete( $wpdb->prefix . 'actionscheduler_actions', array( 'action_id' => (int) $before['operation_action_id'] ), array( '%d' ) ) );
+		$job_count = $jobs->get_jobs_count();
+
+		$retry = ( new RetryJobAbility() )->execute( array( 'job_id' => $job_id ) );
+		$after = $jobs->get_job( $job_id );
+
+		$this->assertTrue( $retry['success'] );
+		$this->assertTrue( $retry['direct_requeued'] );
+		$this->assertSame( $job_id, (int) $retry['job_id'] );
+		$this->assertSame( $job_count, $jobs->get_jobs_count() );
+		$this->assertSame( JobStatus::PENDING, $after['status'] );
+		$this->assertSame( 'enqueued', $after['operation_state'] );
+		$this->assertGreaterThan( (int) $before['operation_generation'], (int) $after['operation_generation'] );
+		$this->assertTrue( DirectOperationRecoveryPolicy::recordedActionExists( (int) $after['operation_action_id'] ) );
+		$this->assertSame( 'manual_retry', $after['engine_data']['direct_operation_recovery']['trigger'] );
+		$this->assertNull( $after['terminal_accounting_state'] );
+
+		$duplicate = ( new RetryJobAbility() )->execute( array( 'job_id' => $job_id, 'force' => true ) );
+		$this->assertFalse( $duplicate['success'] );
+		$this->assertSame( $job_count, $jobs->get_jobs_count() );
+	}
+
+	public function test_missing_direct_action_requeue_rolls_back_unusable_receipt(): void {
+		global $wpdb;
+
+		wp_set_current_user( $this->owner_id );
+		$created = $this->execute( 'manual-missing-action-rollback' );
+		$jobs    = new Jobs();
+		$job_id  = (int) $created['job_id'];
+		$before  = $jobs->get_job( $job_id );
+		$this->assertTrue( $jobs->start_job( $job_id ) );
+		$this->assertSame( 1, $wpdb->delete( $wpdb->prefix . 'actionscheduler_actions', array( 'action_id' => (int) $before['operation_action_id'] ), array( '%d' ) ) );
+
+		$result = $jobs->commit_missing_direct_operation_requeue(
+			$job_id,
+			(int) $before['operation_action_id'],
+			(int) $before['operation_generation'],
+			(string) $before['operation_claim_token'],
+			'manual_retry',
+			static fn(): int => 999999
+		);
+		$after = $jobs->get_job( $job_id );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'action_receipt_missing', $result['reason'] );
+		$this->assertSame( JobStatus::PROCESSING, $after['status'] );
+		$this->assertSame( (int) $before['operation_generation'], (int) $after['operation_generation'] );
+		$this->assertSame( (int) $before['operation_action_id'], (int) $after['operation_action_id'] );
+		$this->assertArrayNotHasKey( 'direct_operation_recovery', $after['engine_data'] );
+	}
+
+	public function test_processing_direct_retry_rejects_missing_action_after_effects_begin(): void {
+		global $wpdb;
+
+		wp_set_current_user( $this->owner_id );
+		$created = $this->execute( 'manual-missing-action-effects' );
+		$jobs    = new Jobs();
+		$job_id  = (int) $created['job_id'];
+		$before  = $jobs->get_job( $job_id );
+		$this->assertTrue( $jobs->start_job( $job_id ) );
+		$this->assertTrue( $jobs->mark_operation_effects_begun( $job_id, (int) $before['operation_generation'], (string) $before['operation_claim_token'] ) );
+		$this->assertSame( 1, $wpdb->delete( $wpdb->prefix . 'actionscheduler_actions', array( 'action_id' => (int) $before['operation_action_id'] ), array( '%d' ) ) );
+
+		$retry = ( new RetryJobAbility() )->execute( array( 'job_id' => $job_id ) );
+
+		$this->assertFalse( $retry['success'] );
+		$this->assertSame( 'job_effects_begun', $retry['error_code'] );
+		$this->assertSame( JobStatus::PROCESSING, $jobs->get_job( $job_id )['status'] );
 	}
 
 	public function test_processing_multistep_retry_detects_live_action_for_different_step(): void {

--- a/tests/direct-job-generation-smoke.php
+++ b/tests/direct-job-generation-smoke.php
@@ -88,7 +88,7 @@ $blocked->job['operation_state'] = 'enqueuing';
 $blocked->job['operation_generation'] = 1;
 $blocked->job['operation_claim_token'] = 'owner-token';
 $blocked->claim_blocked = true;
-$blocked_result         = ( new DirectJobEnqueuer( $blocked, static fn() => 100, static fn() => 0 ) )->enqueue( 42, 'ephemeral_step_0' );
+$blocked_result         = ( new DirectJobEnqueuer( $blocked, static fn() => 100, static fn() => 0, static fn() => true ) )->enqueue( 42, 'ephemeral_step_0' );
 direct_generation_assert( false === $blocked_result['success'], 'non-owner does not acknowledge success without durable action' );
 direct_generation_assert( true === $blocked_result['retryable'] && 'enqueue_in_progress' === $blocked_result['error'], 'non-owner receives explicit retryable in-progress result' );
 
@@ -96,7 +96,7 @@ $crash_recovery = new DirectJobGenerationFakeJobs();
 $crash_recovery->job['operation_state']       = 'enqueuing';
 $crash_recovery->job['operation_generation']  = 1;
 $crash_recovery->job['operation_claim_token'] = 'token-1';
-$recovered = ( new DirectJobEnqueuer( $crash_recovery, static fn() => 999, static fn() => 404 ) )->enqueue( 42, 'ephemeral_step_0' );
+$recovered = ( new DirectJobEnqueuer( $crash_recovery, static fn() => 999, static fn() => 404, static fn() => true ) )->enqueue( 42, 'ephemeral_step_0' );
 direct_generation_assert( true === $recovered['success'], 'replay CAS-commits an action left by a crashed submitter' );
 direct_generation_assert( 'enqueued' === $crash_recovery->job['operation_state'] && 404 === $crash_recovery->job['operation_action_id'], 'crash reconciliation durably records the recovered action' );
 
@@ -108,7 +108,8 @@ $slow_result = ( new DirectJobEnqueuer(
 		$takeover = $interleaved->forceTakeover();
 		return 101;
 	},
-	static fn() => 0
+	static fn() => 0,
+	static fn() => true
 ) )->enqueue( 42, 'ephemeral_step_0' );
 direct_generation_assert( false === $slow_result['success'] && 'enqueue_claim_fenced' === $slow_result['error'], 'expired slow generation cannot finish after takeover' );
 direct_generation_assert( 2 === $takeover['generation'], 'takeover advances enqueue generation' );
@@ -130,10 +131,16 @@ $retry_result = ( new DirectJobEnqueuer(
 	},
 	static function ( array $args ): int {
 		return 1 === (int) ( $args['operation_generation'] ?? 0 ) ? 111 : 0;
-	}
+	},
+	static fn() => true
 ) )->enqueue( 42, 'ephemeral_step_0' );
 direct_generation_assert( true === $retry_result['success'], 'retry generation schedules successfully while prior action exists' );
 direct_generation_assert( 2 === $seen_args['operation_generation'], 'retry action is keyed to the next generation' );
+
+$missing_receipt = new DirectJobGenerationFakeJobs();
+$missing_result  = ( new DirectJobEnqueuer( $missing_receipt, static fn() => 505, static fn() => 0, static fn() => false ) )->enqueue( 42, 'ephemeral_step_0' );
+direct_generation_assert( false === $missing_result['success'] && 'action_receipt_missing' === $missing_result['error'], 'positive scheduler ID without a durable receipt fails enqueue' );
+direct_generation_assert( 'enqueue_failed' === $missing_receipt->job['operation_state'], 'missing action receipt leaves the operation reclaimable' );
 
 $jobs_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/Jobs/Jobs.php' ) ?: '';
 $step_source = file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/Engine/ExecuteStepAbility.php' ) ?: '';


### PR DESCRIPTION
## Summary
- route missing-action direct retries through the existing transactional recovery primitive so the original job row is locked, fenced, and advanced exactly once
- require a durable Action Scheduler receipt before normal enqueue or transactional recovery can report success
- reject unsafe replay after operation effects begin and add coverage for rollback, duplicate prevention, terminal accounting, and truthful results

Fixes #3085.

## Root cause
`RetryJobAbility` handled a processing direct job with no live action by terminalizing and reopening it before calling the general enqueuer. That bypassed the newer atomic missing-action recovery path. Separately, `DirectJobEnqueuer` and the transactional recovery primitive treated any positive `as_schedule_single_action()` return as success without confirming that the action row was durably queryable.

The retry path itself reuses the original job ID. The two fresh production IDs were downstream direct submissions emitted after the retried workflow resumed, not replacement rows created by `jobs retry`; each could be left pathless because positive scheduler IDs were accepted without durable receipt confirmation. The command then reported success based on the original enqueue result before scheduler ownership was proven end to end.

## Atomicity and exactly-once behavior
For a processing direct operation whose recorded action is missing and whose effects have not begun, manual retry now calls `commit_missing_direct_operation_requeue()`. That method locks the original row, schedules a unique next-generation action inside the same database transaction, verifies the action receipt by primary key, updates the fenced operation owner, and commits. Scheduler failure, an unusable receipt, ownership drift, or commit failure rolls back without creating or reopening another processing job.

The generation/token fence prevents concurrent retries from scheduling duplicate owner generations. If `operation_effects_begun_at` is present, retry fails instead of replaying potentially completed side effects. Existing failed-job retry behavior remains unchanged.

## Authorization and compatibility
Authorization and ownership checks remain in `RetryJobAbility` before any mutation. Anonymous CLI access remains denied. The Action Scheduler contract is tightened only for success reporting: callers now receive a retryable failure when a returned action ID has no durable receipt. The optional receipt callback added to `DirectJobEnqueuer` preserves existing constructor call compatibility.

## Verification
- `php tests/direct-job-generation-smoke.php` passed: 15 assertions
- PHP syntax checks passed for all five modified files
- focused `vendor/bin/phpcs` passed
- `homeboy review lint data-machine --changed-only --summary --placement=local` passed with zero findings, run `ccbc845a-b5e8-42cd-9781-63f1204dc161`
- clean PR-style `homeboy review --summary --placement=local --changed-since=origin/main data-machine`: audit passed with no introduced findings; lint passed with zero findings; test provisioning failed before executing tests because the managed `wordpress-database` MySQL 8.4 Docker service could not become ready, run `be54de2f-6e0e-4f22-8eb7-4e8070babb99`
- focused Homeboy PHPUnit attempt failed for the same infrastructure reason with zero tests executed; captured error was `RuntimeServiceProvisionError: Managed runtime service failed: wordpress-database`
- `git diff --check origin/main...HEAD` passed

## Existing historical jobs
After this ships, reconcile `649593`, `649599`, and `649600` one at a time. First rerun liveness and confirm the recorded action is still missing, no current-generation scheduler path exists, and `operation_effects_begun=false`. Then run the authorized retry for only that job and immediately verify that the same job ID is pending with a new generation and a durable scheduler action before proceeding to the next. If effects have begun, do not retry; use stuck-job recovery to terminalize and account for it instead. A failed retry is now safe to inspect because it cannot leave a fresh processing orphan.