### PR TITLE
fix: bound action scheduler retention queries

### DIFF
--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -272,16 +272,18 @@ class RetentionCleanup {
 	}
 
 	/**
-	 * Read-only row counts for the Action Scheduler tables.
+	 * Read-only row estimates for the Action Scheduler tables.
 	 *
 	 * Pure read with no side effects — safe for health/diagnostic surfaces.
 	 * Returns the per-table counts plus a `breached` flag against the configured
 	 * threshold. When the threshold is disabled (`<= 0`) `breached` is always
 	 * false but the live counts are still returned for reporting.
 	 *
-	 * NOTE: `SELECT COUNT(*)` on InnoDB is a full index scan. On the very
-	 * installs this guardrail targets (multi-million-row tables) that is not
-	 * free, so callers should treat it as a periodic check, not a hot path.
+	 * InnoDB cannot answer `COUNT(*)` from metadata, so exact counts require a
+	 * full index scan. Use information_schema estimates instead: this guardrail
+	 * only needs to detect orders-of-magnitude bloat and must remain cheap on the
+	 * multi-million-row tables it monitors. SQLite retains exact counts because
+	 * information_schema is unavailable there.
 	 *
 	 * @return array{enabled: bool, threshold: int, actions: int, logs: int, breached: bool}
 	 */
@@ -292,10 +294,27 @@ class RetentionCleanup {
 		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
 		$logs_table    = $wpdb->prefix . 'actionscheduler_logs';
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$actions_rows = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $actions_table ) );
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$logs_rows = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $logs_table ) );
+		if ( class_exists( BaseRepository::class ) && BaseRepository::is_sqlite() ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$actions_rows = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $actions_table ) );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$logs_rows = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $logs_table ) );
+		} else {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$actions_rows = (int) $wpdb->get_var(
+				$wpdb->prepare(
+					'SELECT TABLE_ROWS FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s',
+					$actions_table
+				)
+			);
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$logs_rows = (int) $wpdb->get_var(
+				$wpdb->prepare(
+					'SELECT TABLE_ROWS FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s',
+					$logs_table
+				)
+			);
+		}
 
 		$breached = $threshold > 0 && ( $actions_rows > $threshold || $logs_rows > $threshold );
 
@@ -786,11 +805,9 @@ class RetentionCleanup {
 			$cutoff = $window['cutoff'];
 			$hook   = $window['hook'];
 
-			// Logs are FK-children of actions; prune them first so deleting the
-			// parent action never orphans rows. Both passes are batched by id.
-			$logs_deleted += self::deleteActionSchedulerLogsBatched(
+			$deleted          = self::deleteActionSchedulerWindowBatched(
+				$actions_table,
 				$logs_table,
-				$actions_table,
 				$cutoff,
 				$hook,
 				$batch_size,
@@ -799,17 +816,8 @@ class RetentionCleanup {
 				$iterations_used,
 				$hit_limit
 			);
-
-			$actions_deleted += self::deleteActionSchedulerActionsBatched(
-				$actions_table,
-				$cutoff,
-				$hook,
-				$batch_size,
-				$max_iterations,
-				$deadline,
-				$iterations_used,
-				$hit_limit
-			);
+			$actions_deleted += $deleted['actions_deleted'];
+			$logs_deleted    += $deleted['logs_deleted'];
 		}
 
 		// Hard row-count ceiling per high-churn hook. Age windows above can
@@ -886,7 +894,7 @@ class RetentionCleanup {
 	 * For each hook with a configured ceiling, deletes the oldest completed/
 	 * failed/canceled rows (and their FK-child logs) that sit beyond the cap —
 	 * regardless of age. "Oldest beyond cap" is computed by keeping the most
-	 * recent $max_rows rows (by last_attempt_gmt) and deleting everything older
+	 * recent $max_rows rows (by scheduled_date_gmt) and deleting everything older
 	 * for that hook. Shares the caller's batch/iteration/wall-clock budget.
 	 *
 	 * @param string $actions_table   Actions table name.
@@ -918,53 +926,51 @@ class RetentionCleanup {
 				break;
 			}
 
-			// Resolve the cutoff timestamp that keeps the most recent $max_rows
-			// completed/terminal rows for this hook. Everything at or older than
-			// the cutoff is deleted. One bounded OFFSET probe per hook (indexed
-			// on hook + last_attempt_gmt) — cheap relative to the delete loop.
+			// Bound each status arm before combining them. The existing query
+			// sorted every row for the hook because Action Scheduler has no
+			// (hook, last_attempt_gmt) index. Each arm below reads at most
+			// max_rows + 1 entries through its shipped hook/status/date index;
+			// the outer OFFSET therefore sorts at most 3 * (max_rows + 1) rows.
+			$probe_limit = $max_rows + 1;
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$cutoff = $wpdb->get_var(
 				$wpdb->prepare(
-					'SELECT last_attempt_gmt FROM %i WHERE status IN (%s, %s, %s) AND hook = %s ORDER BY last_attempt_gmt DESC LIMIT 1 OFFSET %d',
+					'(SELECT scheduled_date_gmt FROM %i FORCE INDEX (hook_status_scheduled_date_gmt) WHERE hook = %s AND status = %s ORDER BY scheduled_date_gmt DESC LIMIT %d) UNION ALL (SELECT scheduled_date_gmt FROM %i FORCE INDEX (hook_status_scheduled_date_gmt) WHERE hook = %s AND status = %s ORDER BY scheduled_date_gmt DESC LIMIT %d) UNION ALL (SELECT scheduled_date_gmt FROM %i FORCE INDEX (hook_status_scheduled_date_gmt) WHERE hook = %s AND status = %s ORDER BY scheduled_date_gmt DESC LIMIT %d) ORDER BY scheduled_date_gmt DESC LIMIT 1 OFFSET %d',
 					$actions_table,
-					'complete',
-					'failed',
-					'canceled',
 					$hook,
+					'complete',
+					$probe_limit,
+					$actions_table,
+					$hook,
+					'failed',
+					$probe_limit,
+					$actions_table,
+					$hook,
+					'canceled',
+					$probe_limit,
 					$max_rows
 				)
 			);
 
-			// Fewer than $max_rows rows exist for this hook — nothing to cap.
 			if ( null === $cutoff || '' === $cutoff ) {
 				continue;
 			}
 
-			// Logs first (FK children), then the actions themselves. Reuse the
-			// shared batched id-subquery deleters with this hook's ceiling
-			// cutoff so all the budget/lock-safety guarantees carry over.
-			$logs_deleted += self::deleteActionSchedulerLogsBatched(
+			$deleted          = self::deleteActionSchedulerWindowBatched(
+				$actions_table,
 				$logs_table,
-				$actions_table,
 				$cutoff,
 				$hook,
 				$batch_size,
 				$max_iterations,
 				$deadline,
 				$iterations_used,
-				$hit_limit
+				$hit_limit,
+				null,
+				false
 			);
-
-			$actions_deleted += self::deleteActionSchedulerActionsBatched(
-				$actions_table,
-				$cutoff,
-				$hook,
-				$batch_size,
-				$max_iterations,
-				$deadline,
-				$iterations_used,
-				$hit_limit
-			);
+			$actions_deleted += $deleted['actions_deleted'];
+			$logs_deleted    += $deleted['logs_deleted'];
 		}
 
 		return array(
@@ -1004,14 +1010,15 @@ class RetentionCleanup {
 	}
 
 	/**
-	 * Batched delete of Action Scheduler log rows by id-subquery.
+	 * Delete one retention window through bounded, index-backed action batches.
 	 *
-	 * The multi-table `DELETE l FROM logs l JOIN actions a ... LIMIT` form does
-	 * not reliably affect rows across all runtimes, so we select a bounded set
-	 * of log_ids and delete by primary key — which is reliable and index-fast.
+	 * Selecting action IDs before touching logs is load-bearing: starting from
+	 * the logs table lets MySQL scan millions of child rows before satisfying a
+	 * LIMIT. Each log DELETE here is constrained to a bounded action-id set and
+	 * a row LIMIT, then the same bounded parent set is deleted by primary key.
 	 *
-	 * @param string  $logs_table      Logs table name.
 	 * @param string  $actions_table   Actions table name.
+	 * @param string  $logs_table      Logs table name.
 	 * @param string  $cutoff          GMT cutoff datetime.
 	 * @param ?string $hook            Hook filter, or null for the global window.
 	 * @param int     $batch_size      Rows per batch.
@@ -1019,140 +1026,131 @@ class RetentionCleanup {
 	 * @param float   $deadline        Wall-clock deadline (microtime float).
 	 * @param int     $iterations_used Shared iteration counter (by reference).
 	 * @param bool    $hit_limit       Set true when a budget cap trips (by reference).
-	 * @return int Total rows deleted.
+	 * @param ?string $status               Optional single terminal status.
+	 * @param bool    $require_last_attempt Whether the cutoff also applies to last_attempt_gmt.
+	 * @return array{actions_deleted:int,logs_deleted:int}
 	 */
-	private static function deleteActionSchedulerLogsBatched(
-		string $logs_table,
+	private static function deleteActionSchedulerWindowBatched(
 		string $actions_table,
+		string $logs_table,
 		string $cutoff,
 		?string $hook,
 		int $batch_size,
 		int $max_iterations,
 		float $deadline,
 		int &$iterations_used,
-		bool &$hit_limit
-	): int {
+		bool &$hit_limit,
+		?string $status = null,
+		bool $require_last_attempt = true
+	): array {
 		global $wpdb;
 
-		$deleted = 0;
+		$actions_deleted = 0;
+		$logs_deleted    = 0;
 
 		do {
 			if ( $iterations_used >= $max_iterations || microtime( true ) >= $deadline ) {
 				$hit_limit = true;
 				break;
 			}
-			++$iterations_used;
 
-			if ( null === $hook ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-				$affected = $wpdb->query(
-					$wpdb->prepare(
-						'DELETE FROM %i WHERE log_id IN ( SELECT log_id FROM ( SELECT l.log_id FROM %i l INNER JOIN %i a ON l.action_id = a.action_id WHERE a.status IN (%s, %s, %s) AND a.last_attempt_gmt < %s LIMIT %d ) AS tmp )',
-						$logs_table,
-						$logs_table,
-						$actions_table,
-						'complete',
-						'failed',
-						'canceled',
-						$cutoff,
-						$batch_size
-					)
-				);
-			} else {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-				$affected = $wpdb->query(
-					$wpdb->prepare(
-						'DELETE FROM %i WHERE log_id IN ( SELECT log_id FROM ( SELECT l.log_id FROM %i l INNER JOIN %i a ON l.action_id = a.action_id WHERE a.status IN (%s, %s, %s) AND a.last_attempt_gmt < %s AND a.hook = %s LIMIT %d ) AS tmp )',
-						$logs_table,
-						$logs_table,
-						$actions_table,
-						'complete',
-						'failed',
-						'canceled',
-						$cutoff,
-						$hook,
-						$batch_size
-					)
-				);
+			$action_ids = self::selectActionSchedulerActionIds( $actions_table, $cutoff, $hook, $batch_size, $status, $require_last_attempt );
+			if ( empty( $action_ids ) ) {
+				break;
 			}
 
-			$affected = false !== $affected ? (int) $affected : 0;
-			$deleted += $affected;
+			$placeholders = implode( ', ', array_fill( 0, count( $action_ids ), '%d' ) );
+			do {
+				if ( $iterations_used >= $max_iterations || microtime( true ) >= $deadline ) {
+					$hit_limit = true;
+					break 2;
+				}
+				++$iterations_used;
+				$params = array_merge( array( $logs_table ), $action_ids, array( $batch_size ) );
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$affected      = $wpdb->query(
+					$wpdb->prepare( "DELETE FROM %i WHERE action_id IN ({$placeholders}) LIMIT %d", $params ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+				);
+				$affected      = false !== $affected ? (int) $affected : 0;
+				$logs_deleted += $affected;
+			} while ( $affected >= $batch_size );
+
+			if ( $iterations_used >= $max_iterations || microtime( true ) >= $deadline ) {
+				$hit_limit = true;
+				break;
+			}
+
+			++$iterations_used;
+			$params = array_merge( array( $actions_table ), $action_ids );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$affected         = $wpdb->query(
+				$wpdb->prepare( "DELETE FROM %i WHERE action_id IN ({$placeholders})", $params ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			);
+			$affected         = false !== $affected ? (int) $affected : 0;
+			$actions_deleted += $affected;
 		} while ( $affected > 0 );
 
-		return $deleted;
+		return array(
+			'actions_deleted' => $actions_deleted,
+			'logs_deleted'    => $logs_deleted,
+		);
 	}
 
 	/**
-	 * Batched delete of Action Scheduler action rows by id-subquery.
+	 * Select a bounded action batch using indexes shipped by Action Scheduler.
 	 *
-	 * @param string  $actions_table   Actions table name.
-	 * @param string  $cutoff          GMT cutoff datetime.
-	 * @param ?string $hook            Hook filter, or null for the global window.
-	 * @param int     $batch_size      Rows per batch.
-	 * @param int     $max_iterations  Hard iteration ceiling (shared budget).
-	 * @param float   $deadline        Wall-clock deadline (microtime float).
-	 * @param int     $iterations_used Shared iteration counter (by reference).
-	 * @param bool    $hit_limit       Set true when a budget cap trips (by reference).
-	 * @return int Total rows deleted.
+	 * @return array<int, int> Action IDs.
 	 */
-	private static function deleteActionSchedulerActionsBatched(
+	private static function selectActionSchedulerActionIds(
 		string $actions_table,
 		string $cutoff,
 		?string $hook,
 		int $batch_size,
-		int $max_iterations,
-		float $deadline,
-		int &$iterations_used,
-		bool &$hit_limit
-	): int {
+		?string $only_status,
+		bool $require_last_attempt
+	): array {
 		global $wpdb;
 
-		$deleted = 0;
-
-		do {
-			if ( $iterations_used >= $max_iterations || microtime( true ) >= $deadline ) {
-				$hit_limit = true;
+		$action_ids = array();
+		$statuses   = null === $only_status ? array( 'complete', 'failed', 'canceled' ) : array( $only_status );
+		foreach ( $statuses as $status ) {
+			$remaining = $batch_size - count( $action_ids );
+			if ( $remaining <= 0 ) {
 				break;
 			}
-			++$iterations_used;
 
 			if ( null === $hook ) {
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-				$affected = $wpdb->query(
+				$ids = $wpdb->get_col(
 					$wpdb->prepare(
-						'DELETE FROM %i WHERE action_id IN ( SELECT action_id FROM ( SELECT a.action_id FROM %i a WHERE a.status IN (%s, %s, %s) AND a.last_attempt_gmt < %s LIMIT %d ) AS tmp )',
+						'SELECT action_id FROM %i FORCE INDEX (status_last_attempt_gmt) WHERE status = %s AND last_attempt_gmt < %s ORDER BY last_attempt_gmt ASC LIMIT %d',
 						$actions_table,
-						$actions_table,
-						'complete',
-						'failed',
-						'canceled',
+						$status,
 						$cutoff,
-						$batch_size
+						$remaining
 					)
 				);
 			} else {
+				$last_attempt_sql = $require_last_attempt ? ' AND last_attempt_gmt < %s' : '';
+				$params           = array( $actions_table, $hook, $status, $cutoff );
+				if ( $require_last_attempt ) {
+					$params[] = $cutoff;
+				}
+				$params[] = $remaining;
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-				$affected = $wpdb->query(
+				$ids = $wpdb->get_col(
+					// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 					$wpdb->prepare(
-						'DELETE FROM %i WHERE action_id IN ( SELECT action_id FROM ( SELECT a.action_id FROM %i a WHERE a.status IN (%s, %s, %s) AND a.last_attempt_gmt < %s AND a.hook = %s LIMIT %d ) AS tmp )',
-						$actions_table,
-						$actions_table,
-						'complete',
-						'failed',
-						'canceled',
-						$cutoff,
-						$hook,
-						$batch_size
+						"SELECT action_id FROM %i FORCE INDEX (hook_status_scheduled_date_gmt) WHERE hook = %s AND status = %s AND scheduled_date_gmt < %s{$last_attempt_sql} ORDER BY scheduled_date_gmt ASC LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+						$params
 					)
 				);
 			}
 
-			$affected = false !== $affected ? (int) $affected : 0;
-			$deleted += $affected;
-		} while ( $affected > 0 );
+			$action_ids = array_merge( $action_ids, array_map( 'intval', is_array( $ids ) ? $ids : array() ) );
+		}
 
-		return $deleted;
+		return $action_ids;
 	}
 
 	/**

--- a/tests/retention-action-scheduler-batching-smoke.php
+++ b/tests/retention-action-scheduler-batching-smoke.php
@@ -79,13 +79,15 @@ namespace {
 		! str_contains( $cleanup, 'DELETE l FROM %i l' )
 	);
 	assert_batching(
-		'cleanup deletes logs via id-subquery with LIMIT',
-		str_contains( $cleanup, 'DELETE FROM %i WHERE log_id IN (' )
-			&& str_contains( $cleanup, 'LIMIT %d' )
+		'cleanup selects bounded action ids before touching logs',
+		str_contains( $cleanup, 'selectActionSchedulerActionIds' )
+			&& str_contains( $cleanup, 'FORCE INDEX (status_last_attempt_gmt)' )
+			&& ! str_contains( $cleanup, 'SELECT l.log_id FROM %i l INNER JOIN %i a' )
 	);
 	assert_batching(
-		'cleanup deletes actions via id-subquery with LIMIT',
-		str_contains( $cleanup, 'DELETE FROM %i WHERE action_id IN (' )
+		'cleanup deletes logs and actions only from the selected id set',
+		str_contains( $cleanup, 'DELETE FROM %i WHERE action_id IN ({$placeholders}) LIMIT %d' )
+			&& str_contains( $cleanup, 'DELETE FROM %i WHERE action_id IN ({$placeholders})' )
 	);
 	assert_batching(
 		'batch size is filterable',
@@ -97,7 +99,7 @@ namespace {
 	);
 	assert_batching(
 		'default per-hook override targets execute_step',
-		str_contains( $cleanup, "'datamachine_execute_step' => 1 / 24" )
+		(bool) preg_match( "/'datamachine_execute_step'\\s*=>\\s*1 \/ 24/", $cleanup )
 	);
 	assert_batching(
 		'per-hook row-count ceiling is filterable',
@@ -105,11 +107,17 @@ namespace {
 	);
 	assert_batching(
 		'default row-count ceiling targets execute_step',
-		str_contains( $cleanup, "'datamachine_execute_step' => 100000" )
+		(bool) preg_match( "/'datamachine_execute_step'\\s*=>\\s*100000/", $cleanup )
 	);
 	assert_batching(
-		'ceiling probe selects cutoff via OFFSET on max_rows',
-		str_contains( $cleanup, 'ORDER BY last_attempt_gmt DESC LIMIT 1 OFFSET %d' )
+		'ceiling probe bounds indexed status arms before OFFSET',
+		str_contains( $cleanup, 'FORCE INDEX (hook_status_scheduled_date_gmt)' )
+			&& str_contains( $cleanup, 'UNION ALL' )
+			&& str_contains( $cleanup, '$probe_limit = $max_rows + 1' )
+	);
+	assert_batching(
+		'apply-path table guardrail uses metadata estimates instead of full counts',
+		str_contains( $cleanup, 'SELECT TABLE_ROWS FROM information_schema.TABLES' )
 	);
 	assert_batching(
 		'ceiling enforcement is wired into the cleanup pass',
@@ -171,10 +179,15 @@ namespace {
 			$sql  = $prepared['sql'];
 			$args = $prepared['args'];
 
-			// Row-count ceiling probe: return the last_attempt_gmt at OFFSET
+			if ( str_contains( $sql, 'information_schema.TABLES' ) ) {
+				$table = (string) end( $args );
+				return str_contains( $table, '_logs' ) ? count( $this->logs ) : count( $this->actions );
+			}
+
+			// Row-count ceiling probe: return the scheduled date at OFFSET
 			// $max_rows among the most-recent completed/terminal rows for the
 			// hook (or null when fewer than $max_rows exist).
-			if ( str_contains( $sql, 'ORDER BY last_attempt_gmt DESC LIMIT 1 OFFSET' ) ) {
+			if ( str_contains( $sql, 'UNION ALL' ) && str_contains( $sql, 'OFFSET' ) ) {
 				$hook   = $this->extract_hook( $sql, $args );
 				$offset = (int) end( $args );
 				$rows   = array();
@@ -185,7 +198,7 @@ namespace {
 					if ( null !== $hook && $row['hook'] !== $hook ) {
 						continue;
 					}
-					$rows[] = $row['last_attempt_gmt'];
+					$rows[] = $row['scheduled_date_gmt'] ?? $row['last_attempt_gmt'];
 				}
 				rsort( $rows );
 				return $rows[ $offset ] ?? null;
@@ -201,6 +214,33 @@ namespace {
 			return count( $this->matching_actions( $cutoff, $hook ) );
 		}
 
+		public function get_col( $prepared ): array {
+			$sql    = $prepared['sql'];
+			$args   = $prepared['args'];
+			$hook   = $this->extract_hook( $sql, $args );
+			$status = $this->extract_status( $args );
+			$cutoff = $this->extract_cutoff( $args );
+			$limit  = (int) end( $args );
+			$rows   = array();
+
+			foreach ( $this->actions as $id => $row ) {
+				if ( $row['status'] !== $status || ( null !== $hook && $row['hook'] !== $hook ) ) {
+					continue;
+				}
+				$scheduled = $row['scheduled_date_gmt'] ?? $row['last_attempt_gmt'];
+				if ( null === $hook ? $row['last_attempt_gmt'] >= $cutoff : $scheduled >= $cutoff ) {
+					continue;
+				}
+				if ( str_contains( $sql, 'last_attempt_gmt < %s' ) && $row['last_attempt_gmt'] >= $cutoff ) {
+					continue;
+				}
+				$rows[ $id ] = null === $hook ? $row['last_attempt_gmt'] : $scheduled;
+			}
+
+			asort( $rows );
+			return array_slice( array_keys( $rows ), 0, $limit );
+		}
+
 		public function query( $prepared ): int {
 			$sql  = $prepared['sql'];
 			$args = $prepared['args'];
@@ -211,24 +251,34 @@ namespace {
 			}
 
 			++$this->delete_queries;
-			$cutoff              = $this->extract_cutoff( $args );
-			$hook                = $this->extract_hook( $sql, $args );
-			$limit               = (int) end( $args );
-			$this->batch_sizes[] = $limit;
+			$table = (string) array_shift( $args );
 
-			if ( str_contains( $sql, 'log_id IN' ) ) {
-				$matching = array_slice( $this->matching_logs( $cutoff, $hook ), 0, $limit, true );
-				foreach ( array_keys( $matching ) as $log_id ) {
+			if ( str_contains( $table, '_logs' ) ) {
+				$limit               = (int) array_pop( $args );
+				$this->batch_sizes[] = $limit;
+				$action_ids          = array_map( 'intval', $args );
+				$matching            = array();
+				foreach ( $this->logs as $log_id => $row ) {
+					if ( in_array( $row['action_id'], $action_ids, true ) ) {
+						$matching[] = $log_id;
+					}
+				}
+				$matching = array_slice( $matching, 0, $limit );
+				foreach ( $matching as $log_id ) {
 					unset( $this->logs[ $log_id ] );
 				}
 				return count( $matching );
 			}
 
-			$matching = array_slice( $this->matching_actions( $cutoff, $hook ), 0, $limit, true );
-			foreach ( array_keys( $matching ) as $action_id ) {
-				unset( $this->actions[ $action_id ] );
+			$this->batch_sizes[] = count( $args );
+			$deleted             = 0;
+			foreach ( array_map( 'intval', $args ) as $action_id ) {
+				if ( isset( $this->actions[ $action_id ] ) ) {
+					unset( $this->actions[ $action_id ] );
+					++$deleted;
+				}
 			}
-			return count( $matching );
+			return $deleted;
 		}
 
 		private function extract_cutoff( array $args ): string {
@@ -253,6 +303,15 @@ namespace {
 				}
 			}
 			return null;
+		}
+
+		private function extract_status( array $args ): string {
+			foreach ( $args as $arg ) {
+				if ( is_string( $arg ) && in_array( $arg, array( 'complete', 'failed', 'canceled' ), true ) ) {
+					return $arg;
+				}
+			}
+			return '';
 		}
 
 		private function matching_actions( string $cutoff, ?string $hook ): array {

--- a/tests/retention-action-scheduler-batching-smoke.php
+++ b/tests/retention-action-scheduler-batching-smoke.php
@@ -35,7 +35,8 @@ namespace {
 	$total  = 0;
 
 	// Simple in-memory filter registry so apply_filters() returns overrides.
-	$GLOBALS['__retention_filters'] = array();
+	$GLOBALS['__retention_filters']          = array();
+	$GLOBALS['__retention_filter_callbacks'] = array();
 
 	if ( ! function_exists( 'apply_filters' ) ) {
 		function apply_filters( string $hook, $value ) {
@@ -51,6 +52,29 @@ namespace {
 
 	function retention_set_filter( string $hook, $value ): void {
 		$GLOBALS['__retention_filters'][ $hook ] = $value;
+
+		if ( ! function_exists( 'add_filter' ) ) {
+			return;
+		}
+
+		if ( isset( $GLOBALS['__retention_filter_callbacks'][ $hook ] ) ) {
+			remove_filter( $hook, $GLOBALS['__retention_filter_callbacks'][ $hook ], PHP_INT_MAX );
+		}
+
+		$callback = static fn() => $value;
+		add_filter( $hook, $callback, PHP_INT_MAX );
+		$GLOBALS['__retention_filter_callbacks'][ $hook ] = $callback;
+	}
+
+	function retention_reset_filters(): void {
+		if ( function_exists( 'remove_filter' ) ) {
+			foreach ( $GLOBALS['__retention_filter_callbacks'] as $hook => $callback ) {
+				remove_filter( $hook, $callback, PHP_INT_MAX );
+			}
+		}
+
+		$GLOBALS['__retention_filters']          = array();
+		$GLOBALS['__retention_filter_callbacks'] = array();
 	}
 
 	function assert_batching( string $name, bool $condition, string $detail = '' ): void {
@@ -572,7 +596,7 @@ namespace {
 	// ceiling can delete. Seed 25 fresh execute_step rows with distinct, recent
 	// timestamps (within any age window) — 15 should be deleted by the ceiling,
 	// the 10 most-recent must survive.
-	$GLOBALS['__retention_filters'] = array();
+	retention_reset_filters();
 	retention_set_filter( 'datamachine_as_actions_hook_max_age_days', array( 'datamachine_execute_step' => 3650.0 ) );
 	retention_set_filter( 'datamachine_as_actions_hook_max_rows', array( 'datamachine_execute_step' => 10 ) );
 
@@ -663,6 +687,8 @@ namespace {
 		'disabled guardrail returns enabled=false and breached=false',
 		false === $disabled['enabled'] && false === $disabled['breached']
 	);
+
+	retention_reset_filters();
 
 	if ( $failed > 0 ) {
 		echo "\nretention-action-scheduler-batching-smoke failed: {$failed}/{$total} assertions failed.\n";


### PR DESCRIPTION
## Summary
- select bounded terminal action-ID batches through Action Scheduler's shipped indexes before touching the oversized logs table
- delete child logs with both an action-ID boundary and row limit, then delete only the selected parent actions
- bound row-ceiling probes per indexed status arm and replace apply-path InnoDB `COUNT(*)` scans with metadata estimates
- isolate retention smoke filter overrides so the same query-contract coverage passes in pure PHP and real WordPress

## Root cause
The old log deletion put `actionscheduler_logs` on the driving side of a join and applied `LIMIT` only to the result. On the Events shape, MySQL could examine a substantial portion of the 24.6M-row logs table before finding a batch, so one SQL statement could consume minutes before PHP could observe its wall-clock deadline. The row-ceiling probe also sorted by `last_attempt_gmt` for a hook even though Action Scheduler has no `(hook, last_attempt_gmt)` index, and the post-pass guardrail ran exact `COUNT(*)` scans over both oversized InnoDB tables.

## Algorithm and scale safety
Each retention iteration now:

1. Selects at most the configured batch of terminal action IDs.
2. Uses `status_last_attempt_gmt` for global windows or `hook_status_scheduled_date_gmt` for per-hook windows.
3. Deletes logs only where `action_id IN (<bounded IDs>)`, with an additional row `LIMIT`.
4. Deletes only that bounded parent-ID set after its logs are drained.
5. Rechecks the shared iteration and wall-clock budgets between statements.

The row-ceiling cutoff combines three status-specific index scans, each capped at `max_rows + 1`, before applying the cross-status offset. This preserves the existing combined ceiling semantics while bounding the filesort input. InnoDB table-size guardrails now read `information_schema.TABLES.TABLE_ROWS`; SQLite retains exact counts.

## Locking, indexing, and compatibility
- Log lookups use Action Scheduler's `actionscheduler_logs.action_id` index and lock no more than one configured log batch per statement.
- Parent deletes use the actions primary key and lock no more than the selected action batch.
- Global and per-hook selectors force indexes shipped by the supported Action Scheduler `^3.9` schema; no production schema migration or table rebuild is introduced.
- The native Action Scheduler cleaner remains unchanged as the pre-claim backstop. It does not replace Data Machine's failed-action, per-hook, ceiling, diagnostic, or catch-up behavior.
- Optional `OPTIMIZE TABLE` behavior remains opt-in and unchanged.

## Verification
- `php tests/retention-action-scheduler-batching-smoke.php` - 39 assertions passed
- `php tests/action-scheduler-native-retention-smoke.php` - 10 assertions passed
- `php -l inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php` - passed
- `php -l tests/retention-action-scheduler-batching-smoke.php` - passed
- `homeboy review data-machine lint --path /var/lib/datamachine/workspace/data-machine@fix-3084-bounded-retention --changed-only --summary` - passed, no baseline drift
- `homeboy review test data-machine --path /var/lib/datamachine/workspace/data-machine@fix-3084-bounded-retention --changed-since origin/main --summary` - real-WordPress smoke passed, 1 passed / 0 failed
- Homeboy PR audit - no introduced findings in touched scope
- Production-schema `EXPLAIN` only: global selector used `status_last_attempt_gmt`; per-hook selector and all ceiling arms used `hook_status_scheduled_date_gmt`

The first Homeboy umbrella run exposed inherited real-WordPress filter callbacks in the smoke fixture. The fixture now installs deterministic late-priority overrides and restores only its own callbacks; the final clean-checkout Homeboy test passes.

## Operational follow-up
The existing Events backlog still requires repeated bounded catch-up passes; this change intentionally favors incremental progress over a single large drain. Operators should keep `OPTIMIZE TABLE` disabled during the drain unless they separately provision the lock and temporary disk space for a rebuild. Metadata row estimates may lag exact counts, so verify backlog progress through deleted-row results and periodic table-size observations rather than expecting per-pass file-size shrinkage.

Fixes #3084