### PR TITLE
test: align WP Error smoke contract

### DIFF
--- a/tests/http-client-error-response-contract-smoke.php
+++ b/tests/http-client-error-response-contract-smoke.php
@@ -25,7 +25,8 @@ if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
 		public function __construct(
 			private string $code = '',
-			private string $message = ''
+			private string $message = '',
+			private mixed $data = null
 		) {}
 
 		public function get_error_code(): string {
@@ -34,6 +35,10 @@ if ( ! class_exists( 'WP_Error' ) ) {
 
 		public function get_error_message(): string {
 			return $this->message;
+		}
+
+		public function get_error_data(): mixed {
+			return $this->data;
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- align the HTTP client smoke `WP_Error` double with WordPress core's three-argument constructor
- preserve error response data through `get_error_data()`
- stop the test double from polluting dependency-aware consumer PHPStan runs

## Verification
- HTTP client error-response smoke: 14 assertions, 0 failures
- changed-file PHPCS/PHPStan: zero findings
- architecture audit: zero introduced findings
- PHP syntax and `git diff --check` pass

Fixes #3090