### PR TITLE
test: align autoloaded WP Error contract

### DIFF
--- a/tests/Unit/Support/WpAiClientTestDoubles.php
+++ b/tests/Unit/Support/WpAiClientTestDoubles.php
@@ -13,10 +13,12 @@ namespace {
 		class WP_Error {
 			private string $code;
 			private string $message;
+			private mixed $data;
 
-			public function __construct( string $code = '', string $message = '' ) {
+			public function __construct( string $code = '', string $message = '', mixed $data = null ) {
 				$this->code    = $code;
 				$this->message = $message;
+				$this->data    = $data;
 			}
 
 			public function get_error_code(): string {
@@ -25,6 +27,10 @@ namespace {
 
 			public function get_error_message(): string {
 				return $this->message;
+			}
+
+			public function get_error_data(): mixed {
+				return $this->data;
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- align the Composer-autoloaded wp-ai-client `WP_Error` double with WordPress core's three-argument constructor
- preserve error data through `get_error_data()`
- remove false consumer PHPStan argument-count failures without production workarounds

## Verification
- direct three-argument contract check passes
- changed-file PHPCS/PHPStan: zero findings
- architecture audit: zero introduced findings
- PHP syntax and `git diff --check` pass

Fixes #3090