### PR TITLE
fix: bound pipeline batch action retention

### DIFF
--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -101,8 +101,9 @@ class RetentionCleanup {
 			// is millions of rows. Prune them within ~1h to cap steady-state
 			// rows. The row-count ceiling (see actionSchedulerHookMaxRows)
 			// bounds the table regardless of generation rate as a backstop.
-			'datamachine_execute_step'   => 1 / 24,
-			'datamachine_resume_ai_step' => 1 / 24,
+			'datamachine_execute_step'        => 1 / 24,
+			'datamachine_resume_ai_step'      => 1 / 24,
+			'datamachine_pipeline_batch_chunk' => 1 / 24,
 		);
 
 		$overrides = apply_filters( 'datamachine_as_actions_hook_max_age_days', $defaults );
@@ -150,8 +151,9 @@ class RetentionCleanup {
 			// completions/second this is well under an hour of history — more
 			// than enough for diagnostics — while guaranteeing the table can
 			// never balloon into the millions during a generation spike.
-			'datamachine_execute_step'   => 100000,
-			'datamachine_resume_ai_step' => 100000,
+			'datamachine_execute_step'        => 100000,
+			'datamachine_resume_ai_step'      => 100000,
+			'datamachine_pipeline_batch_chunk' => 100000,
 		);
 
 		$overrides = apply_filters( 'datamachine_as_actions_hook_max_rows', $defaults );

--- a/tests/retention-action-scheduler-batching-smoke.php
+++ b/tests/retention-action-scheduler-batching-smoke.php
@@ -122,16 +122,18 @@ namespace {
 		str_contains( $cleanup, "apply_filters( 'datamachine_as_actions_hook_max_age_days'" )
 	);
 	assert_batching(
-		'default per-hook override targets execute_step',
+		'default per-hook override targets high-volume fan-out hooks',
 		(bool) preg_match( "/'datamachine_execute_step'\\s*=>\\s*1 \/ 24/", $cleanup )
+			&& (bool) preg_match( "/'datamachine_pipeline_batch_chunk'\\s*=>\\s*1 \/ 24/", $cleanup )
 	);
 	assert_batching(
 		'per-hook row-count ceiling is filterable',
 		str_contains( $cleanup, "apply_filters( 'datamachine_as_actions_hook_max_rows'" )
 	);
 	assert_batching(
-		'default row-count ceiling targets execute_step',
+		'default row-count ceiling targets high-volume fan-out hooks',
 		(bool) preg_match( "/'datamachine_execute_step'\\s*=>\\s*100000/", $cleanup )
+			&& (bool) preg_match( "/'datamachine_pipeline_batch_chunk'\\s*=>\\s*100000/", $cleanup )
 	);
 	assert_batching(
 		'ceiling probe bounds indexed status arms before OFFSET',
@@ -350,7 +352,7 @@ namespace {
 				if ( null !== $hook && $row['hook'] !== $hook ) {
 					continue;
 				}
-				if ( null === $hook && in_array( $row['hook'], array( 'datamachine_execute_step' ), true ) ) {
+				if ( null === $hook && in_array( $row['hook'], array( 'datamachine_execute_step', 'datamachine_resume_ai_step', 'datamachine_pipeline_batch_chunk' ), true ) ) {
 					// Global window must exclude hooks with their own window.
 					continue;
 				}
@@ -372,10 +374,8 @@ namespace {
 	};
 
 	// Seed enough rows to force the batching loop to iterate past the 1000-row
-	// floor on batch size: 2500 old completed execute_step actions (7h old,
-	// beyond the 6h per-hook window) each with one log, 30 old "other" hook
-	// actions (8 days), plus 5 fresh execute_step actions (within 6h) that must
-	// survive.
+	// floor on batch size: 2500 old completed actions for each high-volume hook,
+	// 30 old "other" hook actions, plus fresh and active actions that must survive.
 	$now       = time();
 	$seven_h   = gmdate( 'Y-m-d H:i:s', $now - ( 7 * 3600 ) );
 	$eight_day = gmdate( 'Y-m-d H:i:s', $now - ( 8 * DAY_IN_SECONDS ) );
@@ -387,6 +387,20 @@ namespace {
 		$fake_wpdb->actions[ $aid ] = array(
 			'action_id'        => $aid,
 			'hook'             => 'datamachine_execute_step',
+			'status'           => 'complete',
+			'last_attempt_gmt' => $seven_h,
+		);
+		$fake_wpdb->logs[ $lid ] = array(
+			'log_id'    => $lid,
+			'action_id' => $aid,
+		);
+		++$aid;
+		++$lid;
+	}
+	for ( $i = 0; $i < 2500; $i++ ) {
+		$fake_wpdb->actions[ $aid ] = array(
+			'action_id'        => $aid,
+			'hook'             => 'datamachine_pipeline_batch_chunk',
 			'status'           => 'complete',
 			'last_attempt_gmt' => $seven_h,
 		);
@@ -412,6 +426,24 @@ namespace {
 			'hook'             => 'datamachine_execute_step',
 			'status'           => 'complete',
 			'last_attempt_gmt' => $fresh,
+		);
+		++$aid;
+	}
+	for ( $i = 0; $i < 5; $i++ ) {
+		$fake_wpdb->actions[ $aid ] = array(
+			'action_id'        => $aid,
+			'hook'             => 'datamachine_pipeline_batch_chunk',
+			'status'           => 'complete',
+			'last_attempt_gmt' => $fresh,
+		);
+		++$aid;
+	}
+	foreach ( array( 'pending', 'in-progress' ) as $status ) {
+		$fake_wpdb->actions[ $aid ] = array(
+			'action_id'        => $aid,
+			'hook'             => 'datamachine_pipeline_batch_chunk',
+			'status'           => $status,
+			'last_attempt_gmt' => $eight_day,
 		);
 		++$aid;
 	}
@@ -471,8 +503,8 @@ namespace {
 			&& 0 === $fake_wpdb->delete_queries
 	);
 	assert_batching(
-		'count includes expired logs attached to canceled Data Machine recurrences (2501 logs + 2531 actions)',
-		5032 === $count_total,
+		'count includes expired high-volume hooks and canceled recurrences (5001 logs + 5031 actions)',
+		10032 === $count_total,
 		"got {$count_total}"
 	);
 
@@ -512,8 +544,19 @@ namespace {
 		0 === count( $stale_execute_step )
 	);
 	assert_batching(
-		'fresh execute_step rows (within 6h) survived',
+		'fresh execute_step rows (within 1h) survived',
 		5 === count( $surviving_execute_step )
+	);
+	$surviving_batch_chunks = array_filter(
+		$fake_wpdb->actions,
+		static fn( $r ) => 'datamachine_pipeline_batch_chunk' === $r['hook']
+	);
+	assert_batching(
+		'pipeline batch retention purges stale terminal rows but preserves fresh and active work',
+		7 === count( $surviving_batch_chunks )
+			&& 5 === count( array_filter( $surviving_batch_chunks, static fn( $r ) => 'complete' === $r['status'] ) )
+			&& 1 === count( array_filter( $surviving_batch_chunks, static fn( $r ) => 'pending' === $r['status'] ) )
+			&& 1 === count( array_filter( $surviving_batch_chunks, static fn( $r ) => 'in-progress' === $r['status'] ) )
 	);
 	assert_batching(
 		'global window purged 8-day-old other-hook rows',
@@ -526,8 +569,8 @@ namespace {
 	);
 	assert_batching(
 		'result reports per-table deletion counts + batch metadata',
-		2531 === $result['actions_deleted']
-			&& 2501 === $result['logs_deleted']
+		5031 === $result['actions_deleted']
+			&& 5001 === $result['logs_deleted']
 			&& 1000 === $result['batch_size']
 			&& isset( $result['iterations'] )
 			&& false === $result['hit_limit'],
@@ -591,21 +634,21 @@ namespace {
 	$fake_wpdb->optimize_calls = 0;
 	$fake_wpdb->batch_sizes    = array();
 
-	// Reset filters from the OPTIMIZE block, then cap execute_step at 10 rows
+	// Reset filters from the OPTIMIZE block, then cap pipeline chunks at 10 rows
 	// and disable the age window for it (large negative-ish window) so ONLY the
-	// ceiling can delete. Seed 25 fresh execute_step rows with distinct, recent
+	// ceiling can delete. Seed 25 fresh pipeline chunk rows with distinct, recent
 	// timestamps (within any age window) — 15 should be deleted by the ceiling,
 	// the 10 most-recent must survive.
 	retention_reset_filters();
-	retention_set_filter( 'datamachine_as_actions_hook_max_age_days', array( 'datamachine_execute_step' => 3650.0 ) );
-	retention_set_filter( 'datamachine_as_actions_hook_max_rows', array( 'datamachine_execute_step' => 10 ) );
+	retention_set_filter( 'datamachine_as_actions_hook_max_age_days', array( 'datamachine_pipeline_batch_chunk' => 3650.0 ) );
+	retention_set_filter( 'datamachine_as_actions_hook_max_rows', array( 'datamachine_pipeline_batch_chunk' => 10 ) );
 
 	$caid = 1;
 	for ( $i = 0; $i < 25; $i++ ) {
 		// Distinct timestamps, all very recent (i seconds ago).
 		$fake_wpdb->actions[ $caid ] = array(
 			'action_id'        => $caid,
-			'hook'             => 'datamachine_execute_step',
+			'hook'             => 'datamachine_pipeline_batch_chunk',
 			'status'           => 'complete',
 			'last_attempt_gmt' => gmdate( 'Y-m-d H:i:s', $now - ( 25 - $i ) ),
 		);
@@ -616,7 +659,7 @@ namespace {
 
 	$surviving = array_filter(
 		$fake_wpdb->actions,
-		static fn( $r ) => 'datamachine_execute_step' === $r['hook']
+		static fn( $r ) => 'datamachine_pipeline_batch_chunk' === $r['hook']
 	);
 
 	// Boundary semantics: the deleters use strictly `< cutoff`, and the cutoff


### PR DESCRIPTION
## Summary
- apply Data Machine's existing one-hour high-volume retention window to completed `datamachine_pipeline_batch_chunk` actions
- cap retained terminal batch-chunk history at 100,000 rows even when generation outruns age-based cleanup
- cover stale, fresh, pending, and in-progress chunk actions plus the row-ceiling path in the retention regression smoke test

## Root cause
Production Events retained 7,891,458 completed `datamachine_pipeline_batch_chunk` actions scheduled from 2026-08-01 07:20:29 through 2026-08-09 18:00:16 UTC. The self-perpetuating duplicate/recovery producer was corrected by #3063 on August 9, which matches the end of the observed production range. Exact batch retries, stale deliveries, and completed deliveries on current `main` are already idempotent.

The remaining storage failure was a retention-policy omission: `datamachine_execute_step` and `datamachine_resume_ai_step` had a one-hour max-age override and a 100,000-row hard ceiling, while the equally high-volume pipeline batch chunk hook fell through to the generic seven-day window. At the observed write rate, that generic window retained millions of terminal rows and their logs even after production stopped generating them.

## Why Data Machine owns the fix
Data Machine creates the hook and already owns the bounded, per-hook Action Scheduler retention policy in `RetentionCleanup`. Action Scheduler's native cleaner provides only a global terminal-action window and cannot express this hook's high-volume policy. Extending the existing Data Machine policy fixes the owning layer without production configuration or a parallel cleanup system.

## Before / after
Before: completed, failed, and canceled pipeline batch chunk actions used the generic seven-day retention window with no per-hook row ceiling.

After: terminal pipeline batch chunk actions older than one hour are eligible for the existing bounded cleanup, and the oldest terminal rows beyond 100,000 are eligible regardless of age. Pending and in-progress actions are excluded by the existing terminal-status queries and are explicitly covered by regression tests; recent terminal evidence remains available.

## Production scale evidence
- 7,891,458 completed pipeline batch chunk actions in about eight days
- next-highest completed hook: 3,891 actions
- actions table: 7.13 GiB
- logs table: 2.78 GiB
- observed completed scheduled-date range: 2026-08-01 07:20:29 through 2026-08-09 18:00:16 UTC
- storage pressure contributed to a 90%-full root filesystem and lock-table claim failures

## Safeguards
- cleanup remains limited to `complete`, `failed`, and `canceled` statuses
- pending and in-progress batch work is preserved
- deletes use the existing bounded action-ID batches, shared iteration ceiling, and wall-clock deadline
- the row ceiling removes oldest terminal evidence first and preserves the newest 100,000-row boundary
- no scheduler producer, chunk granularity, retry, or reconciliation behavior changes

## Tests
- `php tests/retention-action-scheduler-batching-smoke.php`
- `php tests/action-scheduler-native-retention-smoke.php`
- `php tests/pathless-batch-recovery-bounds-smoke.php`
- `php tests/batch-v2-contract-smoke.php`
- `vendor/bin/phpunit tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php tests/Unit/Core/Database/BatchItemsTest.php`
- `composer lint`

All passed. Composer emitted host dependency deprecation notices only; the repository does not expose a separate static-analysis command.

## Residual cleanup
This PR does not mutate production or delete existing rows. After a future merge, release, and deployment, the normal Data Machine retention recurrence and its bounded catch-up passes can drain eligible terminal actions and attached logs. Existing table files may still require an operator-reviewed space-reclamation step after row cleanup because InnoDB does not automatically return deleted tablespace pages to the filesystem.

Closes #3096