### PR TITLE
fix: coalesce recurring schedule reconciliation

### DIFF
--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -59,9 +59,8 @@ class SystemAgentServiceProvider {
 		$this->registerBuiltInSchedules();
 		$this->registerActionSchedulerHooks();
 		RetentionActionSchedulerTask::registerNativeRetention();
-		// Bootstrap immediately after AS initializes, then let AS's native daily
-		// recurring-ensure action repair schedules that are later interrupted.
-		add_action( 'action_scheduler_init', array( $this, 'manageRecurringTaskSchedules' ) );
+		// Action Scheduler owns the daily reconciliation cadence so this does not
+		// repeat across every request that initializes its datastore.
 		add_action( 'action_scheduler_ensure_recurring_actions', array( $this, 'manageRecurringTaskSchedules' ) );
 		WakeBriefingTask::registerStalenessGuard();
 	}
@@ -445,15 +444,20 @@ class SystemAgentServiceProvider {
 			);
 
 			if ( $result instanceof \WP_Error ) {
+				$error_code = $result->get_error_code();
+				$level      = in_array( $error_code, array( 'schedule_lock_timeout', 'schedule_lock_lost' ), true )
+					? 'debug'
+					: 'warning';
 				do_action(
 					'datamachine_log',
-					'warning',
+					$level,
 					'Recurring schedule reconciliation failed: ' . $result->get_error_message(),
 					array(
 						'schedule_id' => $schedule['schedule_id'],
 						'task_type'   => $schedule['task_type'],
 						'hook'        => $hook,
 						'interval'    => $schedule['interval'],
+						'error_code'  => $error_code,
 					)
 				);
 			}

--- a/tests/recurring-schedule-reconciliation-logging-smoke.php
+++ b/tests/recurring-schedule-reconciliation-logging-smoke.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Pure-PHP smoke for recurring schedule reconciliation logging.
+ *
+ * Run with: php tests/recurring-schedule-reconciliation-logging-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Engine\Tasks {
+	class RecurringScheduleRegistry {
+		public static array $schedules = array();
+
+		public static function all(): array {
+			return self::$schedules;
+		}
+
+		public static function hookFor( array $schedule ): string {
+			return 'datamachine_recurring_' . $schedule['schedule_id'];
+		}
+
+		public static function isEnabled( array $schedule ): bool {
+			unset( $schedule );
+			return true;
+		}
+	}
+
+	class RecurringScheduler {
+		public static array $results = array();
+
+		public static function ensureSchedule( string $hook, array $args, string $interval, array $options, bool $enabled ) {
+			unset( $hook, $args, $interval, $options, $enabled );
+			return array_shift( self::$results );
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	class WP_Error {
+		private string $code;
+		private string $message;
+
+		public function __construct( string $code, string $message ) {
+			$this->code    = $code;
+			$this->message = $message;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+namespace DataMachine\Engine\AI\System {
+	use DataMachine\Engine\Tasks\RecurringScheduleRegistry;
+	use DataMachine\Engine\Tasks\RecurringScheduler;
+
+	$GLOBALS['datamachine_reconciliation_logs'] = array();
+
+	function wp_installing(): bool {
+		return false;
+	}
+
+	function do_action( string $hook, ...$args ): void {
+		if ( 'datamachine_log' === $hook ) {
+			$GLOBALS['datamachine_reconciliation_logs'][] = $args;
+		}
+	}
+
+	function datamachine_reconciliation_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+
+		echo "  [FAIL] {$message}\n";
+		exit( 1 );
+	}
+
+	require_once __DIR__ . '/../inc/Engine/AI/System/SystemAgentServiceProvider.php';
+
+	$provider = ( new \ReflectionClass( SystemAgentServiceProvider::class ) )->newInstanceWithoutConstructor();
+	$schedule = array(
+		'schedule_id' => 'retention_logs',
+		'task_type'   => 'retention_logs',
+		'interval'    => 'daily',
+	);
+
+	echo "=== recurring-schedule-reconciliation-logging-smoke ===\n";
+
+	echo "\n[1] request bootstrap does not reconcile the registry\n";
+	$provider_source = file_get_contents( __DIR__ . '/../inc/Engine/AI/System/SystemAgentServiceProvider.php' ) ?: '';
+	datamachine_reconciliation_assert( ! str_contains( $provider_source, "add_action( 'action_scheduler_init', array( \$this, 'manageRecurringTaskSchedules' ) );" ), 'per-request Action Scheduler initialization does not trigger reconciliation' );
+	datamachine_reconciliation_assert( str_contains( $provider_source, "add_action( 'action_scheduler_ensure_recurring_actions', array( \$this, 'manageRecurringTaskSchedules' ) );" ), 'native daily recurring-action repair remains registered' );
+
+	echo "\n[2] expected ownership contention is diagnostic, not a warning\n";
+	$lost_schedule                              = $schedule;
+	$lost_schedule['schedule_id']               = 'retention_jobs';
+	RecurringScheduleRegistry::$schedules       = array( $schedule, $lost_schedule );
+	RecurringScheduler::$results                = array(
+		new \WP_Error( 'schedule_lock_timeout', 'Another request is updating this schedule; retry shortly.' ),
+		new \WP_Error( 'schedule_lock_lost', 'Schedule ownership changed during reconciliation; retry without mutating the existing schedule.' ),
+	);
+	$GLOBALS['datamachine_reconciliation_logs'] = array();
+	$provider->manageRecurringTaskSchedules();
+	$timeout_log = $GLOBALS['datamachine_reconciliation_logs'][0] ?? array();
+	$lost_log    = $GLOBALS['datamachine_reconciliation_logs'][1] ?? array();
+	datamachine_reconciliation_assert( 'debug' === ( $timeout_log[0] ?? '' ) && 'debug' === ( $lost_log[0] ?? '' ), 'expected lease contention is classified below persistent warning level' );
+	datamachine_reconciliation_assert( 'schedule_lock_timeout' === ( $timeout_log[2]['error_code'] ?? '' ) && 'schedule_lock_lost' === ( $lost_log[2]['error_code'] ?? '' ), 'both contention diagnostics preserve their scheduler error codes' );
+
+	echo "\n[3] terminal reconciliation failures remain warning-level\n";
+	RecurringScheduleRegistry::$schedules       = array( $schedule );
+	RecurringScheduler::$results                = array( new \WP_Error( 'invalid_interval', 'Invalid interval: missing' ) );
+	$GLOBALS['datamachine_reconciliation_logs'] = array();
+	$provider->manageRecurringTaskSchedules();
+	$terminal_log = $GLOBALS['datamachine_reconciliation_logs'][0] ?? array();
+	datamachine_reconciliation_assert( 'warning' === ( $terminal_log[0] ?? '' ), 'terminal scheduler failures remain observable warnings' );
+	datamachine_reconciliation_assert( 'invalid_interval' === ( $terminal_log[2]['error_code'] ?? '' ), 'terminal warning preserves the scheduler error code' );
+
+	echo "\nAll recurring schedule reconciliation logging assertions passed.\n";
+}

--- a/tests/recurring-schedule-reconciliation-logging-smoke.php
+++ b/tests/recurring-schedule-reconciliation-logging-smoke.php
@@ -8,29 +8,36 @@
  */
 
 namespace DataMachine\Engine\Tasks {
-	class RecurringScheduleRegistry {
-		public static array $schedules = array();
-
-		public static function all(): array {
-			return self::$schedules;
-		}
-
-		public static function hookFor( array $schedule ): string {
-			return 'datamachine_recurring_' . $schedule['schedule_id'];
-		}
-
-		public static function isEnabled( array $schedule ): bool {
-			unset( $schedule );
-			return true;
-		}
+	$real_wordpress = function_exists( 'add_action' );
+	if ( ! defined( 'DATAMACHINE_RECONCILIATION_REAL_WORDPRESS' ) ) {
+		define( 'DATAMACHINE_RECONCILIATION_REAL_WORDPRESS', $real_wordpress );
 	}
 
-	class RecurringScheduler {
-		public static array $results = array();
+	if ( ! $real_wordpress ) {
+		class RecurringScheduleRegistry {
+			public static array $schedules = array();
 
-		public static function ensureSchedule( string $hook, array $args, string $interval, array $options, bool $enabled ) {
-			unset( $hook, $args, $interval, $options, $enabled );
-			return array_shift( self::$results );
+			public static function all(): array {
+				return self::$schedules;
+			}
+
+			public static function hookFor( array $schedule ): string {
+				return 'datamachine_recurring_' . $schedule['schedule_id'];
+			}
+
+			public static function isEnabled( array $schedule ): bool {
+				unset( $schedule );
+				return true;
+			}
+		}
+
+		class RecurringScheduler {
+			public static array $results = array();
+
+			public static function ensureSchedule( string $hook, array $args, string $interval, array $options, bool $enabled ) {
+				unset( $hook, $args, $interval, $options, $enabled );
+				return array_shift( self::$results );
+			}
 		}
 	}
 }
@@ -40,21 +47,23 @@ namespace {
 		define( 'ABSPATH', __DIR__ . '/' );
 	}
 
-	class WP_Error {
-		private string $code;
-		private string $message;
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+			private string $code;
+			private string $message;
 
-		public function __construct( string $code, string $message ) {
-			$this->code    = $code;
-			$this->message = $message;
-		}
+			public function __construct( string $code, string $message ) {
+				$this->code    = $code;
+				$this->message = $message;
+			}
 
-		public function get_error_code(): string {
-			return $this->code;
-		}
+			public function get_error_code(): string {
+				return $this->code;
+			}
 
-		public function get_error_message(): string {
-			return $this->message;
+			public function get_error_message(): string {
+				return $this->message;
+			}
 		}
 	}
 }
@@ -87,19 +96,23 @@ namespace DataMachine\Engine\AI\System {
 
 	require_once __DIR__ . '/../inc/Engine/AI/System/SystemAgentServiceProvider.php';
 
-	$provider = ( new \ReflectionClass( SystemAgentServiceProvider::class ) )->newInstanceWithoutConstructor();
-	$schedule = array(
-		'schedule_id' => 'retention_logs',
-		'task_type'   => 'retention_logs',
-		'interval'    => 'daily',
-	);
-
 	echo "=== recurring-schedule-reconciliation-logging-smoke ===\n";
 
 	echo "\n[1] request bootstrap does not reconcile the registry\n";
 	$provider_source = file_get_contents( __DIR__ . '/../inc/Engine/AI/System/SystemAgentServiceProvider.php' ) ?: '';
 	datamachine_reconciliation_assert( ! str_contains( $provider_source, "add_action( 'action_scheduler_init', array( \$this, 'manageRecurringTaskSchedules' ) );" ), 'per-request Action Scheduler initialization does not trigger reconciliation' );
 	datamachine_reconciliation_assert( str_contains( $provider_source, "add_action( 'action_scheduler_ensure_recurring_actions', array( \$this, 'manageRecurringTaskSchedules' ) );" ), 'native daily recurring-action repair remains registered' );
+	if ( DATAMACHINE_RECONCILIATION_REAL_WORDPRESS ) {
+		echo "\nReal WordPress runtime: standalone stub behavior skipped after source contract passed.\n";
+		return;
+	}
+
+	$provider = ( new \ReflectionClass( SystemAgentServiceProvider::class ) )->newInstanceWithoutConstructor();
+	$schedule = array(
+		'schedule_id' => 'retention_logs',
+		'task_type'   => 'retention_logs',
+		'interval'    => 'daily',
+	);
 
 	echo "\n[2] expected ownership contention is diagnostic, not a warning\n";
 	$lost_schedule                              = $schedule;


### PR DESCRIPTION
## Summary
- stop reconciling the full recurring schedule registry on every `action_scheduler_init` request and rely on Action Scheduler's native daily recurring-action repair hook
- classify expected `schedule_lock_timeout` and `schedule_lock_lost` ownership contention as debug diagnostics while retaining warning persistence for all other failures
- add focused regression coverage for both production contention signatures and terminal failure observability

## Root Cause
`SystemAgentServiceProvider` registered `manageRecurringTaskSchedules()` on `action_scheduler_init`. That hook fires whenever Action Scheduler initializes in a request, so every full-runtime request walked the entire recurring schedule registry. Concurrent requests then entered the per-signature lease path together. The bounded five-attempt lock retry did not hot-loop by itself; redundant request-level reconciliation repeatedly generated the contention results.

Action Scheduler already provides `action_scheduler_ensure_recurring_actions` specifically as a daily repair primitive so plugins do not query or schedule recurring actions independently on every request. Data Machine was registered on that hook as well, making the request bootstrap redundant.

## Concurrency And Retry Behavior
Before: every Action Scheduler initialization reconciled every registered schedule. Overlapping requests retried each signature lease five times at 25 ms intervals, then returned `schedule_lock_timeout`; owners that lost their fenced generation returned `schedule_lock_lost`. The provider persisted either expected contention outcome as a warning on every occurrence.

After: registry reconciliation runs through Action Scheduler's native daily ensure action rather than every request. Per-schedule locking, bounded retries, generation fencing, stale-owner protection, and exact cleanup behavior remain unchanged. If another reconciliation still overlaps, the two expected ownership-contention codes are emitted only as debug diagnostics instead of persistent warnings.

## Why This Is Not Log Suppression
The primary fix removes the redundant per-request producer of concurrent reconciliation work and uses the scheduling primitive Action Scheduler ships for this purpose. The log-level change is limited to the two explicit compare-and-swap ownership-contention outcomes that mean another owner is safely handling or superseding the same schedule. Their error codes remain available in debug diagnostics.

## Terminal Failures
Every other `WP_Error`, including invalid configuration, scheduler/datastore failures, persistence failures, and exact-cleanup failures, remains warning-level and includes its scheduler error code in log context. Focused coverage verifies a terminal `invalid_interval` error remains observable as a warning.

## Production Evidence
Issue #3098 reports 2,221,883 warning rows persisted in about six days on Studio:
- 2,204,787 x `Recurring schedule reconciliation failed: Another request is updating this schedule; retry shortly.`
- 17,094 x `Recurring schedule reconciliation failed: Schedule ownership changed during reconciliation; retry without mutating the existing schedule.`

The `c8c_12_datamachine_logs` table reached 1.49 GiB while the production root filesystem reached 90% usage.

## Tests
- `php tests/recurring-schedule-reconciliation-logging-smoke.php`
- `php tests/recurring-scheduler-idempotency-smoke.php`
- `vendor/bin/phpcs inc/Engine/AI/System/SystemAgentServiceProvider.php tests/recurring-schedule-reconciliation-logging-smoke.php`
- `composer validate --no-check-publish`
- `homeboy review --changed-since origin/main --summary --placement local`

Homeboy audit, PHPCS, ESLint, and PHPStan passed with zero findings. Its changed-scope test wrapper selected smoke files but reported zero PHPUnit tests; both relevant pure-PHP smoke entrypoints were run directly and passed.

## Residual Cleanup
This PR intentionally does not modify production or delete existing log rows. The historical 1.49 GiB log table still requires an operator-authorized retention/cleanup run after deployment; normal retention remains responsible for bounded cleanup going forward.

Closes #3098