### PR TITLE
fix: align retention hook policy arrays

### DIFF
--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -101,8 +101,8 @@ class RetentionCleanup {
 			// is millions of rows. Prune them within ~1h to cap steady-state
 			// rows. The row-count ceiling (see actionSchedulerHookMaxRows)
 			// bounds the table regardless of generation rate as a backstop.
-			'datamachine_execute_step'        => 1 / 24,
-			'datamachine_resume_ai_step'      => 1 / 24,
+			'datamachine_execute_step'         => 1 / 24,
+			'datamachine_resume_ai_step'       => 1 / 24,
 			'datamachine_pipeline_batch_chunk' => 1 / 24,
 		);
 
@@ -151,8 +151,8 @@ class RetentionCleanup {
 			// completions/second this is well under an hour of history — more
 			// than enough for diagnostics — while guaranteeing the table can
 			// never balloon into the millions during a generation spike.
-			'datamachine_execute_step'        => 100000,
-			'datamachine_resume_ai_step'      => 100000,
+			'datamachine_execute_step'         => 100000,
+			'datamachine_resume_ai_step'       => 100000,
 			'datamachine_pipeline_batch_chunk' => 100000,
 		);
 


### PR DESCRIPTION
## Summary
- align the two retention hook policy maps with WordPress coding standards
- unblock the normal v0.172.14 release lint gate without skipping checks

## Verification
- `vendor/bin/phpcs inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php`
- `php tests/retention-action-scheduler-batching-smoke.php` (40 assertions)
- `git diff --check`

Closes #3101