### PR TITLE
fix: normalize persisted job status state

### DIFF
--- a/docs/admin-interface/jobs-management.md
+++ b/docs/admin-interface/jobs-management.md
@@ -37,7 +37,7 @@ The Jobs interface is a React-based admin dashboard that lists recent job execut
 **Comprehensive Table**: The primary view displays recent jobs with:
 - **Job ID**: Unique identification and tracking.
 - **Pipeline & Flow**: Combined context showing the template and specific instance.
-- **Status**: Reflects the current state (for example `processing`, `completed`, `failed`, `completed_no_items`, `agent_skipped - {reason}`).
+- **Status**: Reflects the canonical state (for example `processing`, `completed`, `failed`, `completed_no_items`, `agent_skipped`) and renders structured reason detail separately.
 - **Timestamps**: Human-readable creation and completion times.
 
 ## Administrative Controls
@@ -48,6 +48,19 @@ The Jobs interface is a React-based admin dashboard that lists recent job execut
 - **System Maintenance**: Database optimization and cleanup tools.
 
 ## Job Status Management
+
+The indexed `datamachine_jobs.status` column stores only Data Machine's bounded base-state vocabulary. Human-readable detail is stored as `engine_data.job_status_reason` and composed into `status_display` by job abilities, so list/detail output stays scannable without increasing status-index cardinality.
+
+### Legacy Status Migration
+
+Existing compound rows are normalized only through the operator command; plugin bootstrap never scans or rewrites the jobs table.
+
+1. Inspect without mutation: `wp datamachine jobs normalize-status --format=json`.
+2. Apply one bounded batch: `wp datamachine jobs normalize-status --apply --limit=250`.
+3. Repeat apply until `status` is `complete` and `remaining` is `0`.
+4. Verify queue summaries and `SELECT status, COUNT(*) ... GROUP BY status` before considering the migration complete operationally.
+
+Progress is durable and per-site, so interrupted runs resume from the last job ID. Each row is locked and writes its reason metadata and base status in one transaction. Unknown noncanonical states are counted but not rewritten; inspect and resolve their owning code before continuing. During rollout, Data Machine readers match exact base states plus bounded legacy delimiters. Once completion is recorded, readers use exact status predicates and direct grouping. Rollback is code rollback only: the normalized base states remain valid to older code, while reason detail remains available in `engine_data`.
 
 **State Synchronization**: Leveraging TanStack Query for:
 - Automatic background refetching of job statuses.

--- a/inc/Abilities/Job/JobHelpers.php
+++ b/inc/Abilities/Job/JobHelpers.php
@@ -17,6 +17,7 @@ use DataMachine\Abilities\PermissionHelper;
 
 use DataMachine\Core\Admin\DateFormatter;
 use DataMachine\Core\JobArtifactSurfaces;
+use DataMachine\Core\JobStatus;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\Pipelines\Pipelines;
@@ -192,6 +193,17 @@ trait JobHelpers {
 	 * @return array Job data with *_display fields added.
 	 */
 	protected function addDisplayFields( array $job ): array {
+		$stored_status = (string) ( $job['status'] ?? '' );
+		$status        = JobStatus::fromString( $stored_status );
+		$reason        = $status->getReason();
+		if ( null === $reason && is_array( $job['engine_data'] ?? null ) ) {
+			$reason = is_string( $job['engine_data']['job_status_reason'] ?? null ) ? $job['engine_data']['job_status_reason'] : null;
+		}
+		if ( $status->isCanonical() ) {
+			$job['status']         = $status->getBaseStatus();
+			$job['status_reason']  = $reason;
+			$job['status_display'] = null === $reason || '' === $reason ? $job['status'] : $job['status'] . ' - ' . $reason;
+		}
 		if ( isset( $job['created_at'] ) ) {
 			$job['created_at_display'] = DateFormatter::format_for_display( $job['created_at'] );
 		}

--- a/inc/Abilities/Job/JobHelpers.php
+++ b/inc/Abilities/Job/JobHelpers.php
@@ -200,9 +200,10 @@ trait JobHelpers {
 			$reason = is_string( $job['engine_data']['job_status_reason'] ?? null ) ? $job['engine_data']['job_status_reason'] : null;
 		}
 		if ( $status->isCanonical() ) {
-			$job['status']         = $status->getBaseStatus();
+			$job['base_status']    = $status->getBaseStatus();
 			$job['status_reason']  = $reason;
-			$job['status_display'] = null === $reason || '' === $reason ? $job['status'] : $job['status'] . ' - ' . $reason;
+			$job['status_display'] = null === $reason || '' === $reason ? $job['base_status'] : $job['base_status'] . ' - ' . $reason;
+			$job['status']         = $job['status_display'];
 		}
 		if ( isset( $job['created_at'] ) ) {
 			$job['created_at_display'] = DateFormatter::format_for_display( $job['created_at'] );

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -35,6 +35,7 @@ use DataMachine\Core\Database\Chat\Chat;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\Jobs\LegacyAIConcurrencyReconciler;
+use DataMachine\Core\Database\Jobs\JobStatusMigration;
 use AgentsAPI\AI\WP_Agent_Message;
 use DataMachine\Engine\AI\System\Tasks\SystemTask;
 use DataMachine\Engine\Tasks\TaskRegistry;
@@ -42,6 +43,57 @@ use DataMachine\Engine\Tasks\TaskRegistry;
 defined( 'ABSPATH' ) || exit;
 
 class JobsCommand extends BaseCommand {
+
+	/**
+	 * Inspect or apply one bounded batch of canonical job-status normalization.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--apply]
+	 * : Normalize one bounded batch. Without this flag the command is read-only.
+	 *
+	 * [--limit=<count>]
+	 * : Maximum legacy rows to inspect in this invocation (1-1000).
+	 * ---
+	 * default: 250
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format: table or json.
+	 * ---
+	 * default: table
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine jobs normalize-status
+	 *     wp datamachine jobs normalize-status --apply --limit=250
+	 *
+	 * @subcommand normalize-status
+	 */
+	public function normalize_status( array $args, array $assoc_args ): void {
+		$apply  = isset( $assoc_args['apply'] );
+		$limit  = max( 1, min( 1000, (int) ( $assoc_args['limit'] ?? 250 ) ) );
+		$format = $assoc_args['format'] ?? 'table';
+		$migration = new JobStatusMigration();
+		$result = $apply ? $migration->apply( $limit ) : $migration->inspect();
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( (string) wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+		} else {
+			foreach ( array( 'status', 'cursor', 'scanned', 'migrated', 'unknown', 'conflicts', 'errors', 'remaining' ) as $field ) {
+				WP_CLI::log( sprintf( '%-12s %s', ucfirst( $field ) . ':', (string) ( $result[ $field ] ?? 0 ) ) );
+			}
+		}
+
+		if ( $result['complete'] ) {
+			WP_CLI::success( 'Job status storage is normalized.' );
+		} elseif ( $apply ) {
+			WP_CLI::log( 'Batch complete. Re-run with --apply until status is complete; inspect unknown rows before proceeding if remaining stops decreasing.' );
+		} else {
+			WP_CLI::log( 'Dry run only. Re-run with --apply to process one bounded batch.' );
+		}
+	}
 
 	/**
 	 * Default fields for job list output.
@@ -1471,7 +1523,8 @@ class JobsCommand extends BaseCommand {
 				}
 
 				$source         = $j['source'] ?? 'pipeline';
-				$status_display = strlen( $j['status'] ?? '' ) > 40 ? substr( $j['status'], 0, 40 ) . '...' : ( $j['status'] ?? '' );
+				$full_status    = (string) ( $j['status_display'] ?? $j['status'] ?? '' );
+				$status_display = strlen( $full_status ) > 40 ? substr( $full_status, 0, 40 ) . '...' : $full_status;
 
 				if ( 'system' === $source ) {
 					$flow_display = $j['label'] ?? $j['display_label'] ?? 'System Task';

--- a/inc/Cli/Commands/ProcessedItemsCommand.php
+++ b/inc/Cli/Commands/ProcessedItemsCommand.php
@@ -769,8 +769,8 @@ class ProcessedItemsCommand extends BaseCommand {
 		$before      = $assoc_args['before'] ?? null;
 
 		$parsed_status = JobStatus::fromString( $job_status );
-		$where_parts  = array( 'pi.status = %s' );
-		$values       = array( $processed_table, $jobs_table, ProcessedItems::STATUS_PROCESSED );
+		$where_parts   = array( 'pi.status = %s' );
+		$values        = array( $processed_table, $jobs_table, ProcessedItems::STATUS_PROCESSED );
 		if ( $parsed_status->hasReason() ) {
 			$where_parts[] = '(j.status = %s OR (j.status = %s AND j.engine_data LIKE %s))';
 			$values[]      = $job_status;

--- a/inc/Cli/Commands/ProcessedItemsCommand.php
+++ b/inc/Cli/Commands/ProcessedItemsCommand.php
@@ -15,6 +15,7 @@ use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Abilities\ProcessedItemsAbilities;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachine\Core\JobStatus;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -758,6 +759,8 @@ class ProcessedItemsCommand extends BaseCommand {
 	 * @return array{where_sql:string,values:array<int,mixed>}
 	 */
 	private function build_source_rejected_query_parts( array $assoc_args, string $processed_table, string $jobs_table ): array {
+		global $wpdb;
+
 		$job_status  = (string) ( $assoc_args['job-status'] ?? self::DEFAULT_SOURCE_REJECTED_JOB_STATUS );
 		$pipeline_id = $assoc_args['pipeline'] ?? null;
 		$flow_id     = $assoc_args['flow'] ?? null;
@@ -765,8 +768,18 @@ class ProcessedItemsCommand extends BaseCommand {
 		$after       = $assoc_args['after'] ?? null;
 		$before      = $assoc_args['before'] ?? null;
 
-		$where_parts = array( 'pi.status = %s', 'j.status = %s' );
-		$values      = array( $processed_table, $jobs_table, ProcessedItems::STATUS_PROCESSED, $job_status );
+		$parsed_status = JobStatus::fromString( $job_status );
+		$where_parts  = array( 'pi.status = %s' );
+		$values       = array( $processed_table, $jobs_table, ProcessedItems::STATUS_PROCESSED );
+		if ( $parsed_status->hasReason() ) {
+			$where_parts[] = '(j.status = %s OR (j.status = %s AND j.engine_data LIKE %s))';
+			$values[]      = $job_status;
+			$values[]      = $parsed_status->getBaseStatus();
+			$values[]      = '%' . $wpdb->esc_like( '"job_status_reason":"' . $parsed_status->getReason() . '"' ) . '%';
+		} else {
+			$where_parts[] = 'j.status = %s';
+			$values[]      = $parsed_status->getBaseStatus();
+		}
 
 		if ( null !== $pipeline_id && '' !== (string) $pipeline_id ) {
 			$where_parts[] = 'j.pipeline_id = %s';

--- a/inc/Core/Admin/Pages/Jobs/assets/react/components/JobsTable.jsx
+++ b/inc/Core/Admin/Pages/Jobs/assets/react/components/JobsTable.jsx
@@ -24,10 +24,11 @@ const getStatusClass = ( status ) => {
 	if ( ! status ) {
 		return 'datamachine-status--neutral';
 	}
-	if ( status === 'failed' ) {
+	const baseStatus = status.split( ' - ' )[ 0 ];
+	if ( baseStatus === 'failed' ) {
 		return 'datamachine-status--error';
 	}
-	if ( status === 'completed' ) {
+	if ( baseStatus === 'completed' ) {
 		return 'datamachine-status--success';
 	}
 	return 'datamachine-status--neutral';
@@ -42,6 +43,26 @@ const formatStatus = ( status ) => {
 		status.charAt( 0 ).toUpperCase() +
 		status.slice( 1 ).replace( /_/g, ' ' );
 	return formatted;
+};
+
+/**
+ * Extract the base status (before " - " detail separator).
+ */
+const getBaseStatus = ( status ) => {
+	if ( ! status ) {
+		return '';
+	}
+	return status.split( ' - ' )[ 0 ];
+};
+
+/**
+ * Get the detail portion of a compound status (after " - ").
+ */
+const getStatusDetail = ( status ) => {
+	if ( ! status || ! status.includes( ' - ' ) ) {
+		return null;
+	}
+	return status.split( ' - ' ).slice( 1 ).join( ' - ' );
 };
 
 /**
@@ -218,13 +239,13 @@ const ChildRows = ( { parentJobId } ) => {
 			<td>
 				<span
 					className={ getStatusClass( child.status ) }
-					title={ child.status_reason || undefined }
+					title={ getStatusDetail( child.status ) || undefined }
 				>
-					{ formatStatus( child.status ) }
+					{ formatStatus( getBaseStatus( child.status ) || child.status ) }
 				</span>
-				{ child.status_reason && (
+				{ getStatusDetail( child.status ) && (
 					<span className="datamachine-status-detail">
-						{ child.status_reason }
+						{ getStatusDetail( child.status ) }
 					</span>
 				) }
 			</td>
@@ -303,13 +324,13 @@ const JobRow = ( { job, isExpanded, onToggle } ) => {
 				<td>
 					<span
 						className={ getStatusClass( job.status ) }
-						title={ job.status_reason || undefined }
+						title={ getStatusDetail( job.status ) || undefined }
 					>
-						{ formatStatus( job.status ) }
+						{ formatStatus( getBaseStatus( job.status ) || job.status ) }
 					</span>
-					{ job.status_reason && (
+					{ getStatusDetail( job.status ) && (
 						<span className="datamachine-status-detail">
-							{ job.status_reason }
+							{ getStatusDetail( job.status ) }
 						</span>
 					) }
 				</td>

--- a/inc/Core/Admin/Pages/Jobs/assets/react/components/JobsTable.jsx
+++ b/inc/Core/Admin/Pages/Jobs/assets/react/components/JobsTable.jsx
@@ -24,11 +24,10 @@ const getStatusClass = ( status ) => {
 	if ( ! status ) {
 		return 'datamachine-status--neutral';
 	}
-	const baseStatus = status.split( ' - ' )[ 0 ];
-	if ( baseStatus === 'failed' ) {
+	if ( status === 'failed' ) {
 		return 'datamachine-status--error';
 	}
-	if ( baseStatus === 'completed' ) {
+	if ( status === 'completed' ) {
 		return 'datamachine-status--success';
 	}
 	return 'datamachine-status--neutral';
@@ -43,26 +42,6 @@ const formatStatus = ( status ) => {
 		status.charAt( 0 ).toUpperCase() +
 		status.slice( 1 ).replace( /_/g, ' ' );
 	return formatted;
-};
-
-/**
- * Extract the base status (before " - " detail separator).
- */
-const getBaseStatus = ( status ) => {
-	if ( ! status ) {
-		return '';
-	}
-	return status.split( ' - ' )[ 0 ];
-};
-
-/**
- * Get the detail portion of a compound status (after " - ").
- */
-const getStatusDetail = ( status ) => {
-	if ( ! status || ! status.includes( ' - ' ) ) {
-		return null;
-	}
-	return status.split( ' - ' ).slice( 1 ).join( ' - ' );
 };
 
 /**
@@ -239,13 +218,13 @@ const ChildRows = ( { parentJobId } ) => {
 			<td>
 				<span
 					className={ getStatusClass( child.status ) }
-					title={ getStatusDetail( child.status ) || undefined }
+					title={ child.status_reason || undefined }
 				>
-					{ formatStatus( getBaseStatus( child.status ) || child.status ) }
+					{ formatStatus( child.status ) }
 				</span>
-				{ getStatusDetail( child.status ) && (
+				{ child.status_reason && (
 					<span className="datamachine-status-detail">
-						{ getStatusDetail( child.status ) }
+						{ child.status_reason }
 					</span>
 				) }
 			</td>
@@ -324,13 +303,13 @@ const JobRow = ( { job, isExpanded, onToggle } ) => {
 				<td>
 					<span
 						className={ getStatusClass( job.status ) }
-						title={ getStatusDetail( job.status ) || undefined }
+						title={ job.status_reason || undefined }
 					>
-						{ formatStatus( getBaseStatus( job.status ) || job.status ) }
+						{ formatStatus( job.status ) }
 					</span>
-					{ getStatusDetail( job.status ) && (
+					{ job.status_reason && (
 						<span className="datamachine-status-detail">
-							{ getStatusDetail( job.status ) }
+							{ job.status_reason }
 						</span>
 					) }
 				</td>

--- a/inc/Core/Database/Jobs/JobStatusMigration.php
+++ b/inc/Core/Database/Jobs/JobStatusMigration.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Operator-controlled normalization of legacy compound job statuses.
+ *
+ * @package DataMachine\Core\Database\Jobs
+ */
+
+namespace DataMachine\Core\Database\Jobs;
+
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Explicit operator migration reads and updates the plugin-owned jobs table in bounded batches.
+
+use DataMachine\Core\JobStatus;
+
+defined( 'ABSPATH' ) || exit;
+
+class JobStatusMigration {
+
+	public const STATE_OPTION = 'datamachine_job_status_normalization_v1';
+	private const MAX_BATCH   = 1000;
+
+	/** @var \wpdb */
+	private $wpdb;
+	private string $table;
+
+	public function __construct( ?\wpdb $wpdb = null ) {
+		if ( null === $wpdb ) {
+			global $wpdb;
+		}
+		$this->wpdb = $wpdb;
+		$this->table = $wpdb->prefix . 'datamachine_jobs';
+	}
+
+	/** Inspect durable progress without mutating job rows. */
+	public function inspect(): array {
+		$state     = $this->state();
+		$remaining = $this->countNoncanonicalRows();
+
+		return array_merge(
+			$state,
+			array(
+				'success'             => true,
+				'table'               => $this->table,
+				'remaining'           => $remaining,
+				'complete'            => 0 === $remaining,
+				'status'              => 0 === $remaining ? 'complete' : ( (int) $state['cursor'] > 0 ? 'in_progress' : 'migration_required' ),
+				'canonical_statuses' => JobStatus::ALL_STATUSES,
+			)
+		);
+	}
+
+	/** Process one bounded, resumable batch. */
+	public function apply( int $limit = 250 ): array {
+		$limit = max( 1, min( self::MAX_BATCH, $limit ) );
+		$state = $this->state();
+		$state['complete'] = false;
+		$rows  = $this->windowRows( (int) $state['cursor'], $limit );
+
+		foreach ( $rows as $row ) {
+			$job_id = (int) $row['job_id'];
+			$status = (string) $row['status'];
+			$state['cursor']  = max( (int) $state['cursor'], $job_id );
+			$state['scanned'] = (int) $state['scanned'] + 1;
+			$parsed            = JobStatus::fromString( $status );
+
+			if ( in_array( $status, JobStatus::ALL_STATUSES, true ) ) {
+				continue;
+			}
+			if ( ! $parsed->isCanonical() ) {
+				$state['unknown'] = (int) $state['unknown'] + 1;
+				continue;
+			}
+
+			$result = $this->normalizeRow( $job_id, $status );
+			if ( 'migrated' === $result ) {
+				$state['migrated'] = (int) $state['migrated'] + 1;
+			} elseif ( 'conflict' === $result ) {
+				$state['conflicts'] = (int) $state['conflicts'] + 1;
+			} else {
+				$state['errors'] = (int) $state['errors'] + 1;
+				break;
+			}
+		}
+
+		$state['updated_at'] = gmdate( 'c' );
+		update_option( self::STATE_OPTION, $state, false );
+		$result = array_merge(
+			$state,
+			array(
+				'success'            => true,
+				'table'              => $this->table,
+				'batch_size'         => count( $rows ),
+				'canonical_statuses' => JobStatus::ALL_STATUSES,
+			)
+		);
+		if ( count( $rows ) < $limit ) {
+			$result = $this->inspect();
+		}
+		if ( ! empty( $result['complete'] ) ) {
+			$state['complete'] = true;
+			update_option( self::STATE_OPTION, $state, false );
+			$result = array_merge( $result, $state );
+		} elseif ( count( $rows ) < $limit && (int) ( $result['remaining'] ?? 0 ) > 0 ) {
+			$state['cursor'] = 0;
+			update_option( self::STATE_OPTION, $state, false );
+			$result['cursor'] = 0;
+		}
+		$result['batch_size'] = count( $rows );
+		$result['status']     = ! empty( $result['complete'] ) ? 'complete' : 'in_progress';
+		return $result;
+	}
+
+	public static function isComplete(): bool {
+		$state = get_option( self::STATE_OPTION, array() );
+		return is_array( $state ) && ! empty( $state['complete'] );
+	}
+
+	private function state(): array {
+		$stored = get_option( self::STATE_OPTION, array() );
+		return array_merge(
+			array(
+				'cursor'     => 0,
+				'scanned'    => 0,
+				'migrated'   => 0,
+				'unknown'    => 0,
+				'conflicts'  => 0,
+				'errors'     => 0,
+				'updated_at' => null,
+			),
+			is_array( $stored ) ? $stored : array()
+		);
+	}
+
+	private function windowRows( int $cursor, int $limit ): array {
+		$query = $this->wpdb->prepare(
+			'SELECT job_id, status FROM %i WHERE job_id > %d ORDER BY job_id ASC LIMIT %d',
+			$this->table,
+			$cursor,
+			$limit
+		);
+		$rows = $this->wpdb->get_results( $query, ARRAY_A );
+		return is_array( $rows ) ? $rows : array();
+	}
+
+	private function countNoncanonicalRows(): int {
+		$placeholders = implode( ',', array_fill( 0, count( JobStatus::ALL_STATUSES ), '%s' ) );
+		$query = $this->wpdb->prepare(
+			"SELECT COUNT(*) FROM %i WHERE status NOT IN ({$placeholders})",
+			...array_merge( array( $this->table ), JobStatus::ALL_STATUSES )
+		);
+		return (int) $this->wpdb->get_var( $query );
+	}
+
+	private function normalizeRow( int $job_id, string $expected_status ): string {
+		if ( false === $this->wpdb->query( 'START TRANSACTION' ) ) {
+			return 'error';
+		}
+
+		$query = $this->wpdb->prepare( 'SELECT status, engine_data FROM %i WHERE job_id = %d FOR UPDATE', $this->table, $job_id );
+		$row   = $this->wpdb->get_row( $query, ARRAY_A );
+		if ( ! is_array( $row ) || (string) $row['status'] !== $expected_status ) {
+			$this->wpdb->query( 'ROLLBACK' );
+			return 'conflict';
+		}
+
+		$parsed = JobStatus::fromString( $expected_status );
+		if ( ! $parsed->isCanonical() ) {
+			$this->wpdb->query( 'ROLLBACK' );
+			return 'conflict';
+		}
+
+		$stored_engine = $row['engine_data'] ?? null;
+		$engine        = null === $stored_engine || '' === $stored_engine ? array() : json_decode( (string) $stored_engine, true );
+		if ( ! is_array( $engine ) ) {
+			$this->wpdb->query( 'ROLLBACK' );
+			return 'error';
+		}
+		if ( $parsed->hasReason() ) {
+			$engine['job_status_reason'] = $parsed->getReason();
+		}
+		$encoded = wp_json_encode( $engine );
+		if ( ! is_string( $encoded ) ) {
+			$this->wpdb->query( 'ROLLBACK' );
+			return 'error';
+		}
+		$updated = $this->wpdb->update(
+			$this->table,
+			array(
+				'status'      => $parsed->getBaseStatus(),
+				'engine_data' => $encoded,
+			),
+			array(
+				'job_id' => $job_id,
+				'status' => $expected_status,
+			),
+			array( '%s', '%s' ),
+			array( '%d', '%s' )
+		);
+		if ( 1 !== (int) $updated || false === $this->wpdb->query( 'COMMIT' ) ) {
+			$this->wpdb->query( 'ROLLBACK' );
+			return false === $updated ? 'error' : 'conflict';
+		}
+		wp_cache_delete( $job_id, 'datamachine_engine_data' );
+		return 'migrated';
+	}
+}

--- a/inc/Core/Database/Jobs/JobStatusMigration.php
+++ b/inc/Core/Database/Jobs/JobStatusMigration.php
@@ -26,8 +26,8 @@ class JobStatusMigration {
 		if ( null === $wpdb ) {
 			global $wpdb;
 		}
-		$this->wpdb = $wpdb;
-		$this->table = $wpdb->prefix . 'datamachine_jobs';
+		$this->wpdb  = $wpdb;
+		$this->table = $wpdb->prefix . Jobs::TABLE_NAME;
 	}
 
 	/** Inspect durable progress without mutating job rows. */
@@ -38,11 +38,11 @@ class JobStatusMigration {
 		return array_merge(
 			$state,
 			array(
-				'success'             => true,
-				'table'               => $this->table,
-				'remaining'           => $remaining,
-				'complete'            => 0 === $remaining,
-				'status'              => 0 === $remaining ? 'complete' : ( (int) $state['cursor'] > 0 ? 'in_progress' : 'migration_required' ),
+				'success'            => true,
+				'table'              => $this->table,
+				'remaining'          => $remaining,
+				'complete'           => 0 === $remaining,
+				'status'             => 0 === $remaining ? 'complete' : ( (int) $state['cursor'] > 0 ? 'in_progress' : 'migration_required' ),
 				'canonical_statuses' => JobStatus::ALL_STATUSES,
 			)
 		);
@@ -50,14 +50,14 @@ class JobStatusMigration {
 
 	/** Process one bounded, resumable batch. */
 	public function apply( int $limit = 250 ): array {
-		$limit = max( 1, min( self::MAX_BATCH, $limit ) );
-		$state = $this->state();
+		$limit             = max( 1, min( self::MAX_BATCH, $limit ) );
+		$state             = $this->state();
 		$state['complete'] = false;
-		$rows  = $this->windowRows( (int) $state['cursor'], $limit );
+		$rows              = $this->windowRows( (int) $state['cursor'], $limit );
 
 		foreach ( $rows as $row ) {
-			$job_id = (int) $row['job_id'];
-			$status = (string) $row['status'];
+			$job_id           = (int) $row['job_id'];
+			$status           = (string) $row['status'];
 			$state['cursor']  = max( (int) $state['cursor'], $job_id );
 			$state['scanned'] = (int) $state['scanned'] + 1;
 			$parsed            = JobStatus::fromString( $status );
@@ -137,16 +137,17 @@ class JobStatusMigration {
 			$cursor,
 			$limit
 		);
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The query is prepared immediately above with typed identifier and scalar placeholders.
 		$rows = $this->wpdb->get_results( $query, ARRAY_A );
 		return is_array( $rows ) ? $rows : array();
 	}
 
 	private function countNoncanonicalRows(): int {
-		$placeholders = implode( ',', array_fill( 0, count( JobStatus::ALL_STATUSES ), '%s' ) );
 		$query = $this->wpdb->prepare(
-			"SELECT COUNT(*) FROM %i WHERE status NOT IN ({$placeholders})",
+			'SELECT COUNT(*) FROM %i WHERE status NOT IN (%s, %s, %s, %s, %s, %s, %s, %s)',
 			...array_merge( array( $this->table ), JobStatus::ALL_STATUSES )
 		);
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The query is prepared immediately above from fixed placeholders and canonical constants.
 		return (int) $this->wpdb->get_var( $query );
 	}
 
@@ -156,7 +157,8 @@ class JobStatusMigration {
 		}
 
 		$query = $this->wpdb->prepare( 'SELECT status, engine_data FROM %i WHERE job_id = %d FOR UPDATE', $this->table, $job_id );
-		$row   = $this->wpdb->get_row( $query, ARRAY_A );
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The query is prepared immediately above with typed identifier and integer placeholders.
+		$row = $this->wpdb->get_row( $query, ARRAY_A );
 		if ( ! is_array( $row ) || (string) $row['status'] !== $expected_status ) {
 			$this->wpdb->query( 'ROLLBACK' );
 			return 'conflict';

--- a/inc/Core/Database/Jobs/JobStatusMigration.php
+++ b/inc/Core/Database/Jobs/JobStatusMigration.php
@@ -60,7 +60,7 @@ class JobStatusMigration {
 			$status           = (string) $row['status'];
 			$state['cursor']  = max( (int) $state['cursor'], $job_id );
 			$state['scanned'] = (int) $state['scanned'] + 1;
-			$parsed            = JobStatus::fromString( $status );
+			$parsed           = JobStatus::fromString( $status );
 
 			if ( in_array( $status, JobStatus::ALL_STATUSES, true ) ) {
 				continue;
@@ -145,7 +145,15 @@ class JobStatusMigration {
 	private function countNoncanonicalRows(): int {
 		$query = $this->wpdb->prepare(
 			'SELECT COUNT(*) FROM %i WHERE status NOT IN (%s, %s, %s, %s, %s, %s, %s, %s)',
-			...array_merge( array( $this->table ), JobStatus::ALL_STATUSES )
+			$this->table,
+			JobStatus::PENDING,
+			JobStatus::PROCESSING,
+			JobStatus::WAITING,
+			JobStatus::COMPLETED,
+			JobStatus::FAILED,
+			JobStatus::CANCELLED,
+			JobStatus::COMPLETED_NO_ITEMS,
+			JobStatus::AGENT_SKIPPED
 		);
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The query is prepared immediately above from fixed placeholders and canonical constants.
 		return (int) $this->wpdb->get_var( $query );

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -540,7 +540,7 @@ class Jobs extends BaseRepository {
 			$result['reason'] = 'action_receipt_missing';
 			return $result;
 		}
-		$engine                              = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
 		unset( $engine['job_status_reason'] );
 		$engine['direct_operation_recovery'] = array(
 			'schema'                        => 'datamachine.direct-operation-recovery.v1',
@@ -1066,7 +1066,7 @@ class Jobs extends BaseRepository {
 				WHEN j.status LIKE 'waiting - %' OR j.status LIKE 'waiting:%' THEN 'waiting'
 				WHEN j.status LIKE 'pending - %' OR j.status LIKE 'pending:%' THEN 'pending'
 				ELSE j.status END";
-		$query = $this->wpdb->prepare(
+		$query             = $this->wpdb->prepare(
 			"SELECT {$status_expression} AS status,
 				COUNT(*) AS count
 			 FROM %i j
@@ -1790,7 +1790,7 @@ class Jobs extends BaseRepository {
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
-		$values    = array();
+		$values     = array();
 		$status_sql = $this->status_match_sql( $match, $values );
 		$args       = array_merge( array( "DELETE FROM %i WHERE {$status_sql} AND {$age_column} < %s", $this->table_name ), $values, array( $cutoff_datetime ) );
 		$result     = $this->wpdb->query( $this->wpdb->prepare( ...$args ) );
@@ -2484,7 +2484,7 @@ class Jobs extends BaseRepository {
 		}
 
 		$current_status = is_string( $job['status'] ?? null ) ? $job['status'] : '';
-		$status = $job_status->getBaseStatus();
+		$status         = $job_status->getBaseStatus();
 		$current_engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
 		$current_reason = is_string( $current_engine['job_status_reason'] ?? null ) ? $current_engine['job_status_reason'] : null;
 		if ( $current_status === $status && $current_reason === $job_status->getReason() ) {

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -1737,14 +1737,14 @@ class Jobs extends BaseRepository {
 	}
 
 	/** Build a cleanup predicate that covers only recognized legacy delimiters. */
-	private function status_match_sql( array $match, array &$values ): string {
-		$placeholders = implode( ',', array_fill( 0, count( $match['values'] ), '%s' ) );
-		$values       = array_merge( $values, $match['values'] );
+	private function status_match_sql( array $status_match, array &$values ): string {
+		$placeholders = implode( ',', array_fill( 0, count( $status_match['values'] ), '%s' ) );
+		$values       = array_merge( $values, $status_match['values'] );
 		$sql          = "status IN ({$placeholders})";
-		if ( 'mixed' !== $match['type'] ) {
+		if ( 'mixed' !== $status_match['type'] ) {
 			return $sql;
 		}
-		foreach ( $match['values'] as $base ) {
+		foreach ( $status_match['values'] as $base ) {
 			$sql     .= ' OR status LIKE %s OR status LIKE %s';
 			$values[] = $this->wpdb->esc_like( $base . ' - ' ) . '%';
 			$values[] = $this->wpdb->esc_like( $base . ':' ) . '%';

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -78,33 +78,6 @@ class Jobs extends BaseRepository {
 		}
 	}
 
-	/**
-	 * Known compound status suffixes for exact-match queries.
-	 *
-	 * Each key maps a status prefix to the known variants that share it.
-	 * Used by delete_old_jobs() and count_old_jobs() to build IN clauses
-	 * instead of LIKE, which enables efficient use of the idx_status_created
-	 * composite index.
-	 *
-	 * Only prefixes whose variants are genuinely enumerable belong here.
-	 * `failed` is deliberately absent: real failure statuses embed arbitrary
-	 * error text (e.g. `failed - packet_failure`, `failed: policy not
-	 * satisfied`), so they can never be enumerated and a prefix LIKE
-	 * `failed%` is the honest match. That LIKE is a prefix pattern, so it
-	 * still uses idx_status_created, and it matches both bare `failed` and
-	 * every compound form — matching the LIKE semantics already used by
-	 * get_jobs_count(), get_jobs_for_list_table(), and delete_jobs().
-	 *
-	 * @var array<string, string[]>
-	 */
-	private const STATUS_VARIANTS = array(
-		'completed' => array(
-			'completed',
-			'completed_no_items',
-			'agent_skipped',
-		),
-	);
-
 	// ---------------------------------------------------------------------
 	// CRUD
 	// ---------------------------------------------------------------------
@@ -568,6 +541,7 @@ class Jobs extends BaseRepository {
 			return $result;
 		}
 		$engine                              = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		unset( $engine['job_status_reason'] );
 		$engine['direct_operation_recovery'] = array(
 			'schema'                        => 'datamachine.direct-operation-recovery.v1',
 			'state'                         => 'requeued',
@@ -641,7 +615,18 @@ class Jobs extends BaseRepository {
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL
 
-		return 1 === (int) $updated;
+		if ( 1 !== (int) $updated ) {
+			return false;
+		}
+		EngineData::mutate(
+			$job_id,
+			static function ( array $engine ): array {
+				unset( $engine['job_status_reason'] );
+				return $engine;
+			},
+			'job_reopened'
+		);
+		return true;
 	}
 
 	/** Mark that a direct operation may have entered owner-controlled effects. */
@@ -830,9 +815,7 @@ class Jobs extends BaseRepository {
 		}
 
 		if ( ! empty( $args['status'] ) ) {
-			$status_value    = sanitize_text_field( $args['status'] );
-			$where_clauses[] = 'status LIKE %s';
-			$where_values[]  = $this->wpdb->esc_like( $status_value ) . '%';
+			$this->append_status_filter( $where_clauses, $where_values, 'status', (string) $args['status'] );
 		}
 
 		if ( ! empty( $args['source'] ) ) {
@@ -1018,9 +1001,7 @@ class Jobs extends BaseRepository {
 		}
 
 		if ( ! empty( $args['status'] ) ) {
-			$status_value    = sanitize_text_field( $args['status'] );
-			$where_clauses[] = $prefix . 'status LIKE %s';
-			$where_values[]  = $this->wpdb->esc_like( $status_value ) . '%';
+			$this->append_status_filter( $where_clauses, $where_values, $prefix . 'status', (string) $args['status'] );
 		}
 
 		if ( ! empty( $args['source'] ) ) {
@@ -1073,18 +1054,24 @@ class Jobs extends BaseRepository {
 	 */
 	private function get_status_summary_rows( string $where_sql, array $where_values ): array {
 		// phpcs:disable WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders -- Dynamic clauses are fixed repository fragments; every value is passed to prepare().
+		$status_expression = JobStatusMigration::isComplete()
+			? 'j.status'
+			: "CASE
+				WHEN j.status LIKE 'agent_skipped - %' OR j.status LIKE 'agent_skipped:%' THEN 'agent_skipped'
+				WHEN j.status LIKE 'completed_no_items - %' OR j.status LIKE 'completed_no_items:%' THEN 'completed_no_items'
+				WHEN j.status LIKE 'completed - %' OR j.status LIKE 'completed:%' THEN 'completed'
+				WHEN j.status LIKE 'failed - %' OR j.status LIKE 'failed:%' THEN 'failed'
+				WHEN j.status LIKE 'cancelled - %' OR j.status LIKE 'cancelled:%' THEN 'cancelled'
+				WHEN j.status LIKE 'processing - %' OR j.status LIKE 'processing:%' THEN 'processing'
+				WHEN j.status LIKE 'waiting - %' OR j.status LIKE 'waiting:%' THEN 'waiting'
+				WHEN j.status LIKE 'pending - %' OR j.status LIKE 'pending:%' THEN 'pending'
+				ELSE j.status END";
 		$query = $this->wpdb->prepare(
-			"SELECT
-				CASE
-					WHEN LEFT(j.status, 13) = 'agent_skipped' THEN 'agent_skipped'
-					WHEN LEFT(j.status, 18) = 'completed_no_items' THEN 'completed_no_items'
-					WHEN LEFT(j.status, 6) = 'failed' THEN 'failed'
-					ELSE j.status
-				END AS status,
+			"SELECT {$status_expression} AS status,
 				COUNT(*) AS count
 			 FROM %i j
 			 {$where_sql}
-			 GROUP BY status
+			 GROUP BY 1
 			 ORDER BY count DESC",
 			array_merge( array( $this->table_name ), $where_values )
 		);
@@ -1299,10 +1286,7 @@ class Jobs extends BaseRepository {
 		}
 
 		if ( ! empty( $args['status'] ) ) {
-			$status_value = sanitize_text_field( $args['status'] );
-			// Prefix match: --status=failed matches "failed", "failed:reason", etc.
-			$where_clauses[] = 'j.status LIKE %s';
-			$where_values[]  = $this->wpdb->esc_like( $status_value ) . '%';
+			$this->append_status_filter( $where_clauses, $where_values, 'j.status', (string) $args['status'] );
 		}
 
 		if ( ! empty( $args['source'] ) ) {
@@ -1743,17 +1727,43 @@ class Jobs extends BaseRepository {
 	 * @return array{type: 'in', values: string[]} | array{type: 'like', pattern: string}
 	 */
 	private function resolve_status_match( string $status_prefix ): array {
-		if ( isset( self::STATUS_VARIANTS[ $status_prefix ] ) ) {
-			return array(
-				'type'   => 'in',
-				'values' => self::STATUS_VARIANTS[ $status_prefix ],
-			);
-		}
-
+		$values = 'completed' === $status_prefix
+			? array( JobStatus::COMPLETED, JobStatus::COMPLETED_NO_ITEMS, JobStatus::AGENT_SKIPPED )
+			: array( JobStatus::fromString( $status_prefix )->getBaseStatus() );
 		return array(
-			'type'    => 'like',
-			'pattern' => $this->wpdb->esc_like( $status_prefix ) . '%',
+			'type'   => JobStatusMigration::isComplete() ? 'in' : 'mixed',
+			'values' => $values,
 		);
+	}
+
+	/** Build a cleanup predicate that covers only recognized legacy delimiters. */
+	private function status_match_sql( array $match, array &$values ): string {
+		$placeholders = implode( ',', array_fill( 0, count( $match['values'] ), '%s' ) );
+		$values       = array_merge( $values, $match['values'] );
+		$sql          = "status IN ({$placeholders})";
+		if ( 'mixed' !== $match['type'] ) {
+			return $sql;
+		}
+		foreach ( $match['values'] as $base ) {
+			$sql     .= ' OR status LIKE %s OR status LIKE %s';
+			$values[] = $this->wpdb->esc_like( $base . ' - ' ) . '%';
+			$values[] = $this->wpdb->esc_like( $base . ':' ) . '%';
+		}
+		return '(' . $sql . ')';
+	}
+
+	/** Add an exact canonical filter with a bounded legacy transition fallback. */
+	private function append_status_filter( array &$clauses, array &$values, string $column, string $status ): void {
+		$base = JobStatus::fromString( sanitize_text_field( $status ) )->getBaseStatus();
+		if ( JobStatusMigration::isComplete() ) {
+			$clauses[] = $column . ' = %s';
+			$values[]  = $base;
+			return;
+		}
+		$clauses[] = '(' . $column . ' = %s OR ' . $column . ' LIKE %s OR ' . $column . ' LIKE %s)';
+		$values[]  = $base;
+		$values[]  = $this->wpdb->esc_like( $base . ' - ' ) . '%';
+		$values[]  = $this->wpdb->esc_like( $base . ':' ) . '%';
 	}
 
 	/**
@@ -1780,24 +1790,10 @@ class Jobs extends BaseRepository {
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
-		if ( 'in' === $match['type'] ) {
-			$placeholders = implode( ',', array_fill( 0, count( $match['values'] ), '%s' ) );
-			$args         = array_merge(
-				array( "DELETE FROM %i WHERE status IN ({$placeholders}) AND {$age_column} < %s", $this->table_name ),
-				$match['values'],
-				array( $cutoff_datetime )
-			);
-			$result       = $this->wpdb->query( $this->wpdb->prepare( ...$args ) );
-		} else {
-			$result = $this->wpdb->query(
-				$this->wpdb->prepare(
-					"DELETE FROM %i WHERE status LIKE %s AND {$age_column} < %s",
-					$this->table_name,
-					$match['pattern'],
-					$cutoff_datetime
-				)
-			);
-		}
+		$values    = array();
+		$status_sql = $this->status_match_sql( $match, $values );
+		$args       = array_merge( array( "DELETE FROM %i WHERE {$status_sql} AND {$age_column} < %s", $this->table_name ), $values, array( $cutoff_datetime ) );
+		$result     = $this->wpdb->query( $this->wpdb->prepare( ...$args ) );
 		// phpcs:enable WordPress.DB.PreparedSQL
 
 		do_action(
@@ -1836,24 +1832,10 @@ class Jobs extends BaseRepository {
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
-		if ( 'in' === $match['type'] ) {
-			$placeholders = implode( ',', array_fill( 0, count( $match['values'] ), '%s' ) );
-			$args         = array_merge(
-				array( "SELECT COUNT(*) FROM %i WHERE status IN ({$placeholders}) AND {$age_column} < %s", $this->table_name ),
-				$match['values'],
-				array( $cutoff_datetime )
-			);
-			$count        = $this->wpdb->get_var( $this->wpdb->prepare( ...$args ) );
-		} else {
-			$count = $this->wpdb->get_var(
-				$this->wpdb->prepare(
-					"SELECT COUNT(*) FROM %i WHERE status LIKE %s AND {$age_column} < %s",
-					$this->table_name,
-					$match['pattern'],
-					$cutoff_datetime
-				)
-			);
-		}
+		$values     = array();
+		$status_sql = $this->status_match_sql( $match, $values );
+		$args       = array_merge( array( "SELECT COUNT(*) FROM %i WHERE {$status_sql} AND {$age_column} < %s", $this->table_name ), $values, array( $cutoff_datetime ) );
+		$count      = $this->wpdb->get_var( $this->wpdb->prepare( ...$args ) );
 		// phpcs:enable WordPress.DB.PreparedSQL
 
 		return (int) $count;
@@ -2335,7 +2317,9 @@ class Jobs extends BaseRepository {
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$committed = false !== $this->wpdb->query( 'COMMIT' );
-		wp_cache_delete( $job_id, 'datamachine_engine_data' );
+		if ( function_exists( 'wp_cache_delete' ) ) {
+			wp_cache_delete( $job_id, 'datamachine_engine_data' );
+		}
 		return $committed;
 	}
 
@@ -2368,6 +2352,7 @@ class Jobs extends BaseRepository {
 		}
 
 		$engine  = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		unset( $engine['job_status_reason'] );
 		$receipt = is_array( $engine['scheduler_recovery']['receipt'] ?? null ) ? $engine['scheduler_recovery']['receipt'] : array();
 		if ( (int) ( $receipt['generation'] ?? 0 ) === $generation && (int) ( $receipt['action_id'] ?? 0 ) > 0 ) {
 			$this->wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -2472,7 +2457,11 @@ class Jobs extends BaseRepository {
 			);
 		}
 
-		$is_final = JobStatus::isStatusFinal( $status );
+		$job_status = JobStatus::fromString( $status );
+		if ( ! $job_status->isCanonical() ) {
+			return $this->status_transition_result( false, false, null, $status );
+		}
+		$is_final = $job_status->isFinal();
 		if ( $require_final && ! $is_final ) {
 			return array(
 				'success'        => false,
@@ -2485,74 +2474,50 @@ class Jobs extends BaseRepository {
 			return $this->transition_terminal_job_status_result( $job_id, $status );
 		}
 
-		$job = $this->get_job( $job_id );
+		if ( false === $this->wpdb->query( 'START TRANSACTION' ) ) {
+			return $this->status_transition_result( false, false, null, $status );
+		}
+		$job = $this->get_job_for_update( $job_id );
 		if ( ! is_array( $job ) ) {
-			return array(
-				'success'        => false,
-				'changed'        => false,
-				'current_status' => null,
-				'status'         => $status,
-			);
+			$this->wpdb->query( 'ROLLBACK' );
+			return $this->status_transition_result( false, false, null, $status );
 		}
 
 		$current_status = is_string( $job['status'] ?? null ) ? $job['status'] : '';
-		if ( $current_status === $status ) {
-			return array(
-				'success'        => true,
-				'changed'        => false,
-				'current_status' => $current_status,
-				'status'         => $status,
-			);
+		$status = $job_status->getBaseStatus();
+		$current_engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$current_reason = is_string( $current_engine['job_status_reason'] ?? null ) ? $current_engine['job_status_reason'] : null;
+		if ( $current_status === $status && $current_reason === $job_status->getReason() ) {
+			$this->wpdb->query( 'ROLLBACK' );
+			return $this->status_transition_result( true, false, $current_status, $status );
 		}
 
 		if ( JobStatus::isStatusFinal( $current_status ) ) {
-			return array(
-				'success'        => false,
-				'changed'        => false,
-				'current_status' => $current_status,
-				'status'         => $status,
-			);
+			$this->wpdb->query( 'ROLLBACK' );
+			return $this->status_transition_result( false, false, $current_status, $status );
 		}
 
-		// Truncate to fit varchar(255) column.
-		if ( strlen( $status ) > 255 ) {
-			$status = substr( $status, 0, 252 ) . '...';
-		}
-
-		$updated = LifecycleStateTransition::compare_and_set(
-			$this->wpdb,
+		$engine  = $this->engine_data_with_status_reason( $current_engine, $job_status );
+		$updated = $this->wpdb->update(
 			$this->table_name,
-			array( 'job_id' => $job_id ),
-			'status',
-			$current_status,
-			$status,
-			array(),
-			array( '%d' ),
-			array()
+			array(
+				'status'      => $status,
+				'engine_data' => wp_json_encode( $engine ),
+			),
+			array(
+				'job_id' => $job_id,
+				'status' => $current_status,
+			),
+			array( '%s', '%s' ),
+			array( '%d', '%s' )
 		);
 
-		if ( false === $updated ) {
-			return array(
-				'success'        => false,
-				'changed'        => false,
-				'current_status' => $current_status,
-				'status'         => $status,
-			);
+		if ( 1 !== (int) $updated || false === $this->wpdb->query( 'COMMIT' ) ) {
+			$this->wpdb->query( 'ROLLBACK' );
+			return $this->status_transition_result( false, false, $current_status, $status );
 		}
 
-		if ( 0 === $updated ) {
-			$job_after      = $this->get_job( $job_id );
-			$status_after   = is_array( $job_after ) && is_string( $job_after['status'] ?? null ) ? $job_after['status'] : null;
-			$race_was_no_op = $status_after === $status;
-
-			return array(
-				'success'        => $race_was_no_op,
-				'changed'        => false,
-				'current_status' => $status_after,
-				'status'         => $status,
-			);
-		}
-
+		wp_cache_delete( $job_id, 'datamachine_engine_data' );
 		( new RunLifecycleStore( $this ) )->mark_job_status( $job_id, $status );
 
 		return array(
@@ -2571,6 +2536,10 @@ class Jobs extends BaseRepository {
 	 * @return array{success: bool, changed: bool, current_status: ?string, status: string}
 	 */
 	private function transition_terminal_job_status_result( int $job_id, string $requested_status, ?array $recovery_owner = null, bool $pending_direct_cancel = false ): array {
+		$requested_job_status = JobStatus::fromString( $requested_status );
+		if ( ! $requested_job_status->isCanonical() || ! $requested_job_status->isFinal() ) {
+			return $this->status_transition_result( false, false, null, $requested_status );
+		}
 		if ( null === $recovery_owner && isset( self::$recovery_execution_fences[ $job_id ] ) ) {
 			$fence_stack    = self::$recovery_execution_fences[ $job_id ];
 			$recovery_owner = end( $fence_stack );
@@ -2604,7 +2573,7 @@ class Jobs extends BaseRepository {
 			$this->rollback_terminal_transition( $job_id );
 			return $this->status_transition_result( false, false, $current_status, $current_status );
 		}
-		if ( $current_status === $requested_status ) {
+		if ( $current_status === $requested_job_status->getBaseStatus() ) {
 			$this->rollback_terminal_transition( $job_id );
 			$this->reconcile_terminal_accounting( $job_id );
 			return $this->status_transition_result( true, false, $current_status, $current_status );
@@ -2665,9 +2634,12 @@ class Jobs extends BaseRepository {
 			$this->rollback_terminal_transition( $job_id );
 			return $this->status_transition_result( false, false, $current_status, $current_status );
 		}
-		if ( strlen( $status ) > 255 ) {
-			$status = substr( $status, 0, 252 ) . '...';
+		$prepared_job_status = JobStatus::fromString( $status );
+		if ( ! $prepared_job_status->isCanonical() ) {
+			$this->rollback_terminal_transition( $job_id );
+			return $this->status_transition_result( false, false, $current_status, $current_status );
 		}
+		$status = $prepared_job_status->getBaseStatus();
 
 		try {
 			$accounting_context = apply_filters( 'datamachine_job_terminal_accounting_context', array(), $job_id, $status );
@@ -2701,6 +2673,9 @@ class Jobs extends BaseRepository {
 			'terminal_accounting_processed_count' => $processed_claim_count,
 		);
 		$update_formats = array( '%s', '%s', '%d', null, null, '%d' );
+		$engine = $this->engine_data_with_status_reason( is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array(), $prepared_job_status );
+		$update_data['engine_data'] = wp_json_encode( $engine );
+		$update_formats[] = '%s';
 		$operation_recovery = is_array( $recovery_owner ) && 'operation' === (string) ( $recovery_owner['mode'] ?? '' );
 		if ( $pending_direct_cancel || $operation_recovery ) {
 			$update_data['operation_state']       = 'cancelled';
@@ -2711,7 +2686,6 @@ class Jobs extends BaseRepository {
 			array_push( $update_formats, '%s', null, null, null, '%d' );
 		}
 		if ( $operation_recovery ) {
-			$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
 			$engine['direct_operation_recovery'] = array(
 				'schema'                        => 'datamachine.direct-operation-recovery.v1',
 				'state'                         => 'terminalized',
@@ -2722,10 +2696,8 @@ class Jobs extends BaseRepository {
 				'recovered_at'                  => gmdate( 'c' ),
 			);
 			$update_data['engine_data'] = wp_json_encode( $engine );
-			$update_formats[]           = '%s';
 		}
 		if ( is_array( $recovery_owner ) && ! $operation_recovery ) {
-			$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
 			$engine['scheduler_recovery']['state']        = 'terminalized';
 			$engine['scheduler_recovery']['completed_at'] = gmdate( 'c' );
 			$engine['scheduler_recovery']['receipt']      = array(
@@ -2734,7 +2706,6 @@ class Jobs extends BaseRepository {
 				'committed_at'    => gmdate( 'c' ),
 			);
 			$update_data['engine_data'] = wp_json_encode( $engine );
-			$update_formats[]           = '%s';
 		}
 		// phpcs:enable Generic.Formatting.MultipleStatementAlignment,WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -2765,13 +2736,21 @@ class Jobs extends BaseRepository {
 			$winner_status = is_array( $winner ) && is_string( $winner['status'] ?? null ) ? $winner['status'] : $current_status;
 			return $this->status_transition_result( $status === $winner_status, false, $winner_status, $winner_status );
 		}
-		if ( is_array( $recovery_owner ) ) {
-			wp_cache_delete( $job_id, 'datamachine_engine_data' );
-		}
+		wp_cache_delete( $job_id, 'datamachine_engine_data' );
 
 		$this->reconcile_terminal_accounting( $job_id );
 
 		return $this->status_transition_result( true, true, $current_status, $status );
+	}
+
+	/** Keep status detail structured and clear stale detail on later transitions. */
+	private function engine_data_with_status_reason( array $engine, JobStatus $status ): array {
+		if ( $status->hasReason() ) {
+			$engine['job_status_reason'] = $status->getReason();
+		} else {
+			unset( $engine['job_status_reason'] );
+		}
+		return $engine;
 	}
 
 	/**
@@ -2859,8 +2838,11 @@ class Jobs extends BaseRepository {
 		$status       = (string) $job['status'];
 		$completed_at = is_string( $job['completed_at'] ?? null ) ? $job['completed_at'] : null;
 
+		$reason         = is_array( $job['engine_data'] ?? null ) && is_string( $job['engine_data']['job_status_reason'] ?? null ) ? $job['engine_data']['job_status_reason'] : '';
+		$display_status = '' === $reason ? $status : $status . ' - ' . $reason;
+
 		if ( 'run_metrics' === $stage ) {
-			$completed = RunMetrics::complete( $job_id, $status, $completed_at, max( 0, (int) ( $job['terminal_accounting_processed_count'] ?? 0 ) ) );
+			$completed = RunMetrics::complete( $job_id, $display_status, $completed_at, max( 0, (int) ( $job['terminal_accounting_processed_count'] ?? 0 ) ) );
 			return $completed ? array() : array( $this->terminal_accounting_error( $stage, 'run_metrics_failed', 'Run metrics completion failed.' ) );
 		}
 
@@ -2889,7 +2871,7 @@ class Jobs extends BaseRepository {
 		}
 
 		if ( 'run_lifecycle' === $stage ) {
-			$completed = ( new RunLifecycleStore( $this ) )->mark_job_status( $job_id, $status, $completed_at );
+			$completed = ( new RunLifecycleStore( $this ) )->mark_job_status( $job_id, $display_status, $completed_at );
 			return $completed ? array() : array( $this->terminal_accounting_error( $stage, 'run_lifecycle_failed', 'Run lifecycle completion failed.' ) );
 		}
 
@@ -3318,7 +3300,7 @@ class Jobs extends BaseRepository {
 		// - Numeric string: database flow execution (e.g. '123')
 		// - 'direct': ephemeral workflow execution
 		// - NULL: job execution without pipeline/flow context
-		// status is VARCHAR(255) to support compound statuses with reasons
+		// Keep the shipped width during the data migration; values are bounded base states.
 		$sql = "CREATE TABLE $table_name (
             job_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
             user_id bigint(20) unsigned NOT NULL DEFAULT 0,
@@ -3388,7 +3370,7 @@ class Jobs extends BaseRepository {
 	 * Migrate existing table columns to current schema.
 	 *
 	 * Handles:
-	 * - status column: varchar(20/100) -> varchar(255) for compound statuses with reasons
+	 * - status column: retain the shipped varchar width during status normalization
 	 * - pipeline_id column: bigint -> varchar(20) for 'direct' execution support
 	 * - flow_id column: bigint -> varchar(20) for 'direct' execution support
 	 *

--- a/inc/Core/JobStatus.php
+++ b/inc/Core/JobStatus.php
@@ -5,8 +5,8 @@
  * Centralized job status definitions, validation, and categorization.
  * Single source of truth for all job status handling across the ecosystem.
  *
- * Supports compound statuses like "agent_skipped - not a music event" where
- * the base status is "agent_skipped" and the reason is "not a music event".
+ * Accepts legacy compound statuses at input boundaries while exposing the
+ * canonical base state and human-readable reason separately.
  *
  * @package DataMachine\Core
  * @since 0.9.7
@@ -48,6 +48,17 @@ class JobStatus {
 		self::AGENT_SKIPPED,
 	);
 
+	public const ALL_STATUSES = array(
+		self::PENDING,
+		self::PROCESSING,
+		self::WAITING,
+		self::COMPLETED,
+		self::FAILED,
+		self::CANCELLED,
+		self::COMPLETED_NO_ITEMS,
+		self::AGENT_SKIPPED,
+	);
+
 	private string $baseStatus;
 	private ?string $reason;
 
@@ -66,6 +77,9 @@ class JobStatus {
 	 * base status and reason components.
 	 */
 	public static function fromString( string $status ): self {
+		if ( 'pending_runtime_tool' === $status ) {
+			return new self( self::WAITING, 'runtime_tool_request' );
+		}
 		$baseStatus = self::parseBaseStatus( $status );
 		$reason     = self::parseReason( $status );
 
@@ -259,6 +273,16 @@ class JobStatus {
 		return $this->baseStatus;
 	}
 
+	/** Compose a human-readable status without changing its storage contract. */
+	public function toDisplayString(): string {
+		return $this->toString();
+	}
+
+	/** Whether the parsed base is part of Data Machine's bounded vocabulary. */
+	public function isCanonical(): bool {
+		return in_array( $this->baseStatus, self::ALL_STATUSES, true );
+	}
+
 	/**
 	 * Magic method for string casting.
 	 */
@@ -270,25 +294,13 @@ class JobStatus {
 	 * Parse base status from a potentially compound status string.
 	 */
 	private static function parseBaseStatus( string $status ): string {
-		$base_statuses = self::FINAL_STATUSES;
+		$base_statuses = self::ALL_STATUSES;
 		usort( $base_statuses, static fn( string $a, string $b ): int => strlen( $b ) <=> strlen( $a ) );
 
 		foreach ( $base_statuses as $base ) {
-			if ( str_starts_with( $status, $base ) ) {
+			if ( $status === $base || str_starts_with( $status, $base . ' - ' ) || str_starts_with( $status, $base . ':' ) ) {
 				return $base;
 			}
-		}
-
-		if ( str_starts_with( $status, self::PROCESSING ) ) {
-			return self::PROCESSING;
-		}
-
-		if ( str_starts_with( $status, self::WAITING ) ) {
-			return self::WAITING;
-		}
-
-		if ( str_starts_with( $status, self::PENDING ) ) {
-			return self::PENDING;
 		}
 
 		return $status;
@@ -300,7 +312,13 @@ class JobStatus {
 	private static function parseReason( string $status ): ?string {
 		if ( str_contains( $status, ' - ' ) ) {
 			$parts = explode( ' - ', $status, 2 );
-			return trim( $parts[1] ?? '' );
+			$reason = trim( $parts[1] ?? '' );
+			return '' === $reason ? null : $reason;
+		}
+		if ( str_contains( $status, ':' ) ) {
+			$parts  = explode( ':', $status, 2 );
+			$reason = trim( $parts[1] ?? '' );
+			return '' === $reason ? null : $reason;
 		}
 		return null;
 	}

--- a/inc/Core/JobStatus.php
+++ b/inc/Core/JobStatus.php
@@ -311,7 +311,7 @@ class JobStatus {
 	 */
 	private static function parseReason( string $status ): ?string {
 		if ( str_contains( $status, ' - ' ) ) {
-			$parts = explode( ' - ', $status, 2 );
+			$parts  = explode( ' - ', $status, 2 );
 			$reason = trim( $parts[1] ?? '' );
 			return '' === $reason ? null : $reason;
 		}

--- a/inc/Core/RunLifecycleStore.php
+++ b/inc/Core/RunLifecycleStore.php
@@ -227,14 +227,21 @@ class RunLifecycleStore {
 			return false;
 		}
 
+		$job_status = JobStatus::fromString( $status );
+		$status     = $job_status->getBaseStatus();
 		$result = $this->mutate_run(
 			$job_id,
-			function ( array $meta ) use ( $status, $completed_at ): array {
+			function ( array $meta ) use ( $status, $completed_at, $job_status ): array {
 				if ( ( $meta['status'] ?? null ) === $status && ( ! JobStatus::isStatusFinal( $status ) || ! empty( $meta['completed_at'] ) ) ) {
 					return $meta;
 				}
 				$terminal_time      = JobStatus::isStatusFinal( $status ) && ! empty( $completed_at ) ? $completed_at : $this->now();
 				$meta['status']     = $status;
+				if ( $job_status->hasReason() ) {
+					$meta['status_reason'] = $job_status->getReason();
+				} else {
+					unset( $meta['status_reason'] );
+				}
 				$meta['updated_at'] = $terminal_time;
 				if ( JobStatus::isStatusFinal( $status ) ) {
 					$meta['completed_at'] = $meta['completed_at'] ?? $terminal_time;
@@ -252,6 +259,7 @@ class RunLifecycleStore {
 			return false;
 		}
 
+		$job_status = JobStatus::fromString( $status );
 		$transition = $this->jobs->transition_job_status_result( $job_id, $status, $is_final );
 		if ( empty( $transition['success'] ) ) {
 			return false;
@@ -259,13 +267,18 @@ class RunLifecycleStore {
 
 		return $this->mutate_run(
 			$job_id,
-			function ( array $meta ) use ( $status, $timestamp_key, $context ): array {
-				$meta['status']          = $status;
+			function ( array $meta ) use ( $job_status, $timestamp_key, $context ): array {
+				$meta['status']          = $job_status->getBaseStatus();
+				if ( $job_status->hasReason() ) {
+					$meta['status_reason'] = $job_status->getReason();
+				} else {
+					unset( $meta['status_reason'] );
+				}
 				$meta[ $timestamp_key ]  = $meta[ $timestamp_key ] ?? $this->now();
 				$meta['updated_at']      = $this->now();
 				$meta['attempt']         = max( 1, (int) ( $meta['attempt'] ?? 1 ) + (int) ( $context['attempt_delta'] ?? 0 ) );
 				$meta['last_transition'] = array(
-					'status'  => $status,
+					'status'  => $job_status->getBaseStatus(),
 					'context' => $context,
 				);
 				return $meta;

--- a/inc/Core/RunLifecycleStore.php
+++ b/inc/Core/RunLifecycleStore.php
@@ -229,14 +229,14 @@ class RunLifecycleStore {
 
 		$job_status = JobStatus::fromString( $status );
 		$status     = $job_status->getBaseStatus();
-		$result = $this->mutate_run(
+		$result     = $this->mutate_run(
 			$job_id,
 			function ( array $meta ) use ( $status, $completed_at, $job_status ): array {
 				if ( ( $meta['status'] ?? null ) === $status && ( ! JobStatus::isStatusFinal( $status ) || ! empty( $meta['completed_at'] ) ) ) {
 					return $meta;
 				}
-				$terminal_time      = JobStatus::isStatusFinal( $status ) && ! empty( $completed_at ) ? $completed_at : $this->now();
-				$meta['status']     = $status;
+				$terminal_time  = JobStatus::isStatusFinal( $status ) && ! empty( $completed_at ) ? $completed_at : $this->now();
+				$meta['status'] = $status;
 				if ( $job_status->hasReason() ) {
 					$meta['status_reason'] = $job_status->getReason();
 				} else {
@@ -268,7 +268,7 @@ class RunLifecycleStore {
 		return $this->mutate_run(
 			$job_id,
 			function ( array $meta ) use ( $job_status, $timestamp_key, $context ): array {
-				$meta['status']          = $job_status->getBaseStatus();
+				$meta['status'] = $job_status->getBaseStatus();
 				if ( $job_status->hasReason() ) {
 					$meta['status_reason'] = $job_status->getReason();
 				} else {

--- a/inc/Core/RunMetrics.php
+++ b/inc/Core/RunMetrics.php
@@ -419,8 +419,9 @@ class RunMetrics {
 	private static function outcomeDetails( array $job, array $engine, array $counts, array $outcome_classes ): array {
 		$status             = (string) ( $job['status'] ?? '' );
 		$job_status         = JobStatus::fromString( $status );
+		$status_reason      = $job_status->getReason() ?? ( is_string( $engine['job_status_reason'] ?? null ) ? $engine['job_status_reason'] : null );
 		$source_rejection   = is_array( $engine['source_rejection'] ?? null ) ? $engine['source_rejection'] : array();
-		$is_source_rejected = ! empty( $counts['source_rejected'] ) || ! empty( $source_rejection ) || 'source-rejected' === $job_status->getReason();
+		$is_source_rejected = ! empty( $counts['source_rejected'] ) || ! empty( $source_rejection ) || 'source-rejected' === $status_reason;
 		$class_counts       = array();
 		foreach ( $outcome_classes as $class ) {
 			$class_counts[ $class ] = (int) ( $counts[ $class ] ?? 0 );
@@ -430,7 +431,7 @@ class RunMetrics {
 			array(
 				'status'                  => $status,
 				'base_status'             => $job_status->getBaseStatus(),
-				'status_reason'           => $job_status->getReason(),
+				'status_reason'           => $status_reason,
 				'primary_class'           => $outcome_classes[0] ?? null,
 				'classes'                 => $outcome_classes,
 				'class_counts'            => $class_counts,
@@ -438,7 +439,7 @@ class RunMetrics {
 				'fetch_stages'            => self::firstStepField( $engine, 'fetch_stages' ),
 				'no_content'              => ! empty( $counts['no_content'] ) || JobStatus::COMPLETED_NO_ITEMS === $job_status->getBaseStatus(),
 				'source_rejected'         => $is_source_rejected,
-				'source_rejection_reason' => $source_rejection['reason'] ?? ( $is_source_rejected ? $job_status->getReason() : null ),
+				'source_rejection_reason' => $source_rejection['reason'] ?? ( $is_source_rejected ? $status_reason : null ),
 				'handler_slug'            => self::firstStepField( $engine, 'handler_slug' ),
 				'provider_id'             => self::firstStepField( $engine, 'provider_id' ),
 				'tool_ids'                => self::mergedStepListField( $engine, 'tool_ids' ),

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -1560,7 +1560,7 @@ function datamachine_runtime_tool_request_store(): WP_Agent_Runtime_Tool_Request
 				}
 
 				$jobs_db = new \DataMachine\Core\Database\Jobs\Jobs();
-				$jobs_db->start_job( (int) $job_id, 'pending_runtime_tool' );
+				$jobs_db->start_job( (int) $job_id, \DataMachine\Core\JobStatus::WAITING );
 				$jobs_db->store_engine_data(
 					$job_id,
 					array(

--- a/tests/job-status-normalization-smoke.php
+++ b/tests/job-status-normalization-smoke.php
@@ -69,6 +69,11 @@ class wpdb {
 }
 
 require_once __DIR__ . '/../inc/Core/JobStatus.php';
+
+if ( ! class_exists( 'DataMachine\\Core\\Database\\Jobs\\Jobs' ) ) {
+	eval( 'namespace DataMachine\\Core\\Database\\Jobs; class Jobs { public const TABLE_NAME = "datamachine_jobs"; }' );
+}
+
 require_once __DIR__ . '/../inc/Core/Database/Jobs/JobStatusMigration.php';
 
 use DataMachine\Core\JobStatus;

--- a/tests/job-status-normalization-smoke.php
+++ b/tests/job-status-normalization-smoke.php
@@ -1,0 +1,135 @@
+<?php
+/** Regression coverage for canonical status storage and bounded migration. */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
+
+$GLOBALS['dm_status_options'] = array();
+$GLOBALS['dm_status_cache_deletes'] = array();
+
+function get_option( string $key, $default = false ) {
+	return $GLOBALS['dm_status_options'][ $key ] ?? $default;
+}
+function update_option( string $key, $value, bool $autoload = false ): bool {
+	$GLOBALS['dm_status_options'][ $key ] = $value;
+	return true;
+}
+function wp_json_encode( $value ) {
+	return json_encode( $value );
+}
+function wp_cache_delete( $key, string $group = '' ): bool {
+	$GLOBALS['dm_status_cache_deletes'][] = array( $key, $group );
+	return true;
+}
+
+class wpdb {
+	public string $prefix = 'wp_';
+	public string $last_error = '';
+	public array $rows = array();
+
+	public function prepare( string $query, ...$args ): array {
+		return array( $query, $args );
+	}
+
+	public function get_results( $query, $output = null ): array {
+		$args = $query[1];
+		$cursor = (int) $args[1];
+		$limit = (int) $args[2];
+		$rows = array_filter( $this->rows, static fn( array $row ): bool => $row['job_id'] > $cursor );
+		usort( $rows, static fn( array $a, array $b ): int => $a['job_id'] <=> $b['job_id'] );
+		return array_slice( array_values( $rows ), 0, $limit );
+	}
+
+	public function get_var( $query ) {
+		$canonical = array_slice( $query[1], 1 );
+		return count( array_filter( $this->rows, static fn( array $row ): bool => ! in_array( $row['status'], $canonical, true ) ) );
+	}
+
+	public function get_row( $query, $output = null ) {
+		$job_id = (int) end( $query[1] );
+		return $this->rows[ $job_id ] ?? null;
+	}
+
+	public function update( $table, array $data, array $where, array $formats = array(), array $where_formats = array() ) {
+		$job_id = (int) $where['job_id'];
+		if ( ! isset( $this->rows[ $job_id ] ) || $this->rows[ $job_id ]['status'] !== $where['status'] ) {
+			return 0;
+		}
+		$this->rows[ $job_id ] = array_merge( $this->rows[ $job_id ], $data );
+		return 1;
+	}
+
+	public function query( string $query ) {
+		return 1;
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Core/Database/Jobs/JobStatusMigration.php';
+
+use DataMachine\Core\JobStatus;
+use DataMachine\Core\Database\Jobs\JobStatusMigration;
+
+$failures = array();
+$assert = static function ( bool $condition, string $label ) use ( &$failures ): void {
+	if ( ! $condition ) {
+		$failures[] = $label;
+	}
+};
+
+$compound = JobStatus::fromString( 'failed - provider timeout - retry exhausted' );
+$assert( JobStatus::FAILED === $compound->getBaseStatus(), 'compound base is parsed' );
+$assert( 'provider timeout - retry exhausted' === $compound->getReason(), 'compound reason is lossless' );
+$colon = JobStatus::fromString( 'failed: policy rejected' );
+$assert( 'policy rejected' === $colon->getReason(), 'legacy colon reason is parsed' );
+$assert( ! JobStatus::fromString( 'failedly' )->isCanonical(), 'prefix collisions are rejected' );
+$runtime = JobStatus::fromString( 'pending_runtime_tool' );
+$assert( JobStatus::WAITING === $runtime->getBaseStatus() && 'runtime_tool_request' === $runtime->getReason(), 'legacy runtime-tool state maps explicitly' );
+
+$wpdb = new wpdb();
+$wpdb->rows = array(
+	1 => array( 'job_id' => 1, 'status' => 'failed - provider timeout', 'engine_data' => '{"retry":{"attempt":2}}' ),
+	2 => array( 'job_id' => 2, 'status' => 'completed', 'engine_data' => '{}' ),
+	3 => array( 'job_id' => 3, 'status' => 'pending_runtime_tool', 'engine_data' => '{"runtime_tool_request":{"id":"r1"}}' ),
+);
+$migration = new JobStatusMigration( $wpdb );
+$dry_run = $migration->inspect();
+$assert( 2 === $dry_run['remaining'] && 'migration_required' === $dry_run['status'], 'dry run reports remaining rows' );
+$assert( 'failed - provider timeout' === $wpdb->rows[1]['status'], 'dry run does not mutate rows' );
+
+$first = $migration->apply( 2 );
+$engine = json_decode( $wpdb->rows[1]['engine_data'], true );
+$assert( 'failed' === $wpdb->rows[1]['status'], 'first bounded batch stores base status' );
+$assert( 'provider timeout' === $engine['job_status_reason'], 'first batch preserves reason beside existing metadata' );
+$assert( 1 === $first['migrated'] && 'in_progress' === $first['status'], 'first bounded window exposes resumable progress' );
+
+$second = $migration->apply( 2 );
+$runtime_engine = json_decode( $wpdb->rows[3]['engine_data'], true );
+$assert( 'waiting' === $wpdb->rows[3]['status'], 'second batch normalizes explicit legacy state' );
+$assert( 'runtime_tool_request' === $runtime_engine['job_status_reason'], 'mapped legacy reason is persisted' );
+$assert( $second['complete'] && JobStatusMigration::isComplete(), 'completion is durable after verification' );
+
+$again = $migration->apply( 2 );
+$assert( 0 === $again['remaining'] && 2 === $again['migrated'], 'repeated apply is idempotent' );
+$assert( 2 === count( $GLOBALS['dm_status_cache_deletes'] ), 'each migrated engine snapshot invalidates cache' );
+
+$GLOBALS['dm_status_options'] = array();
+$invalid_wpdb = new wpdb();
+$invalid_wpdb->rows = array(
+	1 => array( 'job_id' => 1, 'status' => 'failed - reason', 'engine_data' => '{not-json' ),
+);
+$invalid = ( new JobStatusMigration( $invalid_wpdb ) )->apply( 1 );
+$assert( 'failed - reason' === $invalid_wpdb->rows[1]['status'], 'malformed engine data fails without changing status' );
+$assert( '{not-json' === $invalid_wpdb->rows[1]['engine_data'], 'malformed engine data is never replaced' );
+$assert( 1 === $invalid['errors'], 'malformed engine data exposes a migration error' );
+
+if ( $failures ) {
+	echo 'FAIL: ' . implode( "\nFAIL: ", $failures ) . "\n";
+	exit( 1 );
+}
+
+echo "Job status normalization smoke complete: all assertions passed.\n";

--- a/tests/job-status-normalization-smoke.php
+++ b/tests/job-status-normalization-smoke.php
@@ -45,7 +45,8 @@ class wpdb {
 	}
 
 	public function get_var( $query ) {
-		$canonical = array_slice( $query[1], 1 );
+		$args      = $query[1];
+		$canonical = 1 === count( $args ) && is_array( $args[0] ) ? array_slice( $args[0], 1 ) : array_slice( $args, 1 );
 		return count( array_filter( $this->rows, static fn( array $row ): bool => ! in_array( $row['status'], $canonical, true ) ) );
 	}
 

--- a/tests/job-status-presentation-smoke.php
+++ b/tests/job-status-presentation-smoke.php
@@ -22,10 +22,10 @@ $legacy = $harness->present( array( 'status' => 'agent_skipped - source-rejected
 $normalized = $harness->present( array( 'status' => 'failed', 'engine_data' => array( 'job_status_reason' => 'provider timeout' ) ) );
 
 $failures = array();
-if ( 'agent_skipped' !== $legacy['status'] || 'source-rejected' !== $legacy['status_reason'] || 'agent_skipped - source-rejected' !== $legacy['status_display'] ) {
+if ( 'agent_skipped' !== $legacy['base_status'] || 'agent_skipped - source-rejected' !== $legacy['status'] || 'source-rejected' !== $legacy['status_reason'] || 'agent_skipped - source-rejected' !== $legacy['status_display'] ) {
 	$failures[] = 'legacy compound row is not composed correctly';
 }
-if ( 'failed' !== $normalized['status'] || 'provider timeout' !== $normalized['status_reason'] || 'failed - provider timeout' !== $normalized['status_display'] ) {
+if ( 'failed' !== $normalized['base_status'] || 'failed - provider timeout' !== $normalized['status'] || 'provider timeout' !== $normalized['status_reason'] || 'failed - provider timeout' !== $normalized['status_display'] ) {
 	$failures[] = 'normalized row is not composed correctly';
 }
 

--- a/tests/job-status-presentation-smoke.php
+++ b/tests/job-status-presentation-smoke.php
@@ -1,0 +1,37 @@
+<?php
+/** Regression coverage for read-time job status presentation. */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Core/JobArtifactSurfaces.php';
+require_once __DIR__ . '/../inc/Abilities/Job/JobHelpers.php';
+
+class JobStatusPresentationHarness {
+	use DataMachine\Abilities\Job\JobHelpers;
+
+	public function present( array $job ): array {
+		return $this->addDisplayFields( $job );
+	}
+}
+
+$harness = new JobStatusPresentationHarness();
+$legacy = $harness->present( array( 'status' => 'agent_skipped - source-rejected', 'engine_data' => array() ) );
+$normalized = $harness->present( array( 'status' => 'failed', 'engine_data' => array( 'job_status_reason' => 'provider timeout' ) ) );
+
+$failures = array();
+if ( 'agent_skipped' !== $legacy['status'] || 'source-rejected' !== $legacy['status_reason'] || 'agent_skipped - source-rejected' !== $legacy['status_display'] ) {
+	$failures[] = 'legacy compound row is not composed correctly';
+}
+if ( 'failed' !== $normalized['status'] || 'provider timeout' !== $normalized['status_reason'] || 'failed - provider timeout' !== $normalized['status_display'] ) {
+	$failures[] = 'normalized row is not composed correctly';
+}
+
+if ( $failures ) {
+	echo 'FAIL: ' . implode( "\nFAIL: ", $failures ) . "\n";
+	exit( 1 );
+}
+
+echo "Job status presentation smoke complete: all assertions passed.\n";

--- a/tests/job-status-transition-smoke.php
+++ b/tests/job-status-transition-smoke.php
@@ -19,6 +19,13 @@ namespace DataMachine\Core {
 	}
 }
 
+namespace DataMachine\Core\Database\RunMetadata {
+	class RunMetadata {
+		public function replace_for_engine_data( int $job_id, array $data ): void {
+		}
+	}
+}
+
 namespace {
 	if ( ! defined( 'ABSPATH' ) ) {
 		define( 'ABSPATH', __DIR__ . '/' );
@@ -67,6 +74,13 @@ namespace {
 		}
 	}
 
+	if ( ! function_exists( 'wp_cache_delete' ) ) {
+		function wp_cache_delete( $key, string $group = '' ): bool {
+			unset( $GLOBALS['datamachine_transition_cache'][ $group ][ $key ] );
+			return true;
+		}
+	}
+
 	$datamachine_transition_hooks = array();
 
 	if ( ! function_exists( 'current_time' ) ) {
@@ -81,6 +95,23 @@ namespace {
 				'hook' => $hook,
 				'args' => $args,
 			);
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook, $value, ...$args ) {
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $value ): bool {
+			return $value instanceof WP_Error;
+		}
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
 		}
 	}
 
@@ -130,6 +161,10 @@ namespace {
 
 		public function prepare( $query, ...$args ) {
 			return array( $query, $args );
+		}
+
+		public function query( $query ) {
+			return 1;
 		}
 
 		public function get_row( $query = null, $output = OBJECT, $y = 0 ) {
@@ -186,15 +221,16 @@ namespace {
 
 	$assert( 'non-final update succeeds', $jobs->update_job_status( 10, 'processing' ) );
 	$non_terminal = $status_updates()[0]['data'] ?? array();
-	$assert( 'non-final update writes status only', array( 'status' ) === array_keys( $non_terminal ) );
+	$assert( 'non-final update writes canonical status and synchronized engine data', array( 'status', 'engine_data' ) === array_keys( $non_terminal ) );
 	$assert( 'non-final update does not fire completion hook', 0 === count( $datamachine_transition_hooks ) );
 
 	$assert( 'terminal update succeeds through update_job_status', $jobs->update_job_status( 11, 'completed' ) );
 	$terminal = $status_updates()[1]['data'] ?? array();
 	$assert( 'terminal update writes completed_at', isset( $terminal['completed_at'] ) && is_string( $terminal['completed_at'] ) && '' !== $terminal['completed_at'] );
 	$assert( 'terminal update records run metrics', 'completed' === ( RunMetrics::$completed[11] ?? '' ) );
-	$assert( 'terminal update fires completion hook once', 1 === count( $datamachine_transition_hooks ) );
-	$assert( 'completion hook receives terminal status', 'completed' === ( $datamachine_transition_hooks[0]['args'][1] ?? '' ) );
+	$completion_hooks = array_values( array_filter( $datamachine_transition_hooks, static fn( array $event ): bool => 'datamachine_job_complete' === $event['hook'] ) );
+	$assert( 'terminal update fires completion hook once', 1 === count( $completion_hooks ) );
+	$assert( 'completion hook receives terminal status', 'completed' === ( $completion_hooks[0]['args'][1] ?? '' ) );
 
 	$assert( 'complete_job rejects non-final statuses', false === $jobs->complete_job( 12, 'processing' ) );
 	$assert( 'rejected complete_job does not write', 2 === count( $status_updates() ) );

--- a/tests/jobs-cleanup-status-variants-smoke.php
+++ b/tests/jobs-cleanup-status-variants-smoke.php
@@ -31,6 +31,12 @@ if ( ! function_exists( 'sanitize_text_field' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $option, $default = false ) {
+		return $default;
+	}
+}
+
 require_once __DIR__ . '/bootstrap-unit.php';
 
 use DataMachine\Core\Database\Jobs\Jobs;
@@ -128,15 +134,16 @@ final class DM_Jobs_Cleanup_Test_Wpdb {
 	private function parse_where( string $sql ): array {
 		$criteria = array();
 
-		if ( preg_match( "/status LIKE '([^']+)'/", $sql, $m ) ) {
-			$criteria['like'] = $m[1];
-		} elseif ( preg_match( '/status IN \(([^)]+)\)/', $sql, $m ) ) {
+		if ( preg_match( '/status IN \(([^)]+)\)/', $sql, $m ) ) {
 			$criteria['in'] = array_map(
 				static function ( string $v ): string {
 					return trim( $v, "' \"" );
 				},
 				explode( ',', $m[1] )
 			);
+		}
+		if ( preg_match_all( "/status LIKE '([^']+)'/", $sql, $matches ) ) {
+			$criteria['like'] = $matches[1];
 		}
 
 		if ( preg_match( "/created_at < '([^']+)'/", $sql, $m ) ) {
@@ -149,14 +156,12 @@ final class DM_Jobs_Cleanup_Test_Wpdb {
 	private function row_matches( array $row, array $criteria ): bool {
 		$status = $row['status'] ?? '';
 
-		if ( isset( $criteria['like'] ) ) {
-			if ( ! $this->like_match( $status, $criteria['like'] ) ) {
-				return false;
-			}
-		} elseif ( isset( $criteria['in'] ) ) {
-			if ( ! in_array( $status, $criteria['in'], true ) ) {
-				return false;
-			}
+		$status_matches = isset( $criteria['in'] ) && in_array( $status, $criteria['in'], true );
+		foreach ( $criteria['like'] ?? array() as $pattern ) {
+			$status_matches = $status_matches || $this->like_match( $status, $pattern );
+		}
+		if ( ( isset( $criteria['in'] ) || isset( $criteria['like'] ) ) && ! $status_matches ) {
+			return false;
 		}
 
 		if ( isset( $criteria['cutoff'] ) ) {
@@ -246,9 +251,10 @@ dm_cleanup_assert(
 	"expected 3, got {$count}; query: " . $GLOBALS['wpdb']->last_query
 );
 dm_cleanup_assert(
-	'count_old_jobs(failed) uses LIKE (not IN) for the failed prefix',
-	false !== strpos( $GLOBALS['wpdb']->last_query, "status LIKE 'failed%'" )
-		&& false === strpos( $GLOBALS['wpdb']->last_query, "status IN ('failed')" )
+	'count_old_jobs(failed) uses exact base plus bounded legacy delimiters',
+	false !== strpos( $GLOBALS['wpdb']->last_query, "status IN ('failed')" )
+		&& false !== strpos( $GLOBALS['wpdb']->last_query, "status LIKE 'failed - %'" )
+		&& false !== strpos( $GLOBALS['wpdb']->last_query, "status LIKE 'failed:%'" )
 );
 dm_cleanup_assert(
 	'count_old_jobs(failed) applies the age cutoff',
@@ -264,8 +270,8 @@ dm_cleanup_assert(
 	"expected 3, got {$deleted}; query: " . $GLOBALS['wpdb']->last_query
 );
 dm_cleanup_assert(
-	'delete_old_jobs(failed) uses LIKE for the failed prefix',
-	false !== strpos( $GLOBALS['wpdb']->last_query, "status LIKE 'failed%'" )
+	'delete_old_jobs(failed) uses bounded legacy delimiters',
+	false !== strpos( $GLOBALS['wpdb']->last_query, "status LIKE 'failed - %'" )
 );
 
 // Recent failed job survived the age-gated delete.

--- a/tests/jobs-list-efficiency-smoke.php
+++ b/tests/jobs-list-efficiency-smoke.php
@@ -35,7 +35,7 @@ $assert( 'jobs repository keeps full SELECT as default behavior', str_contains( 
 $assert( 'jobs summary command accepts dashboard filters', str_contains( $jobs_cli, 'wp datamachine jobs summary --pipeline=42 --since=today --format=json' ) );
 $assert( 'jobs summary ability delegates to aggregate repository query', str_contains( $jobs_summary_ability, 'get_jobs_summary( $filters )' ) );
 $assert( 'jobs repository exposes memory-safe aggregate summary query', str_contains( $jobs_db, 'function get_jobs_summary' ) );
-$assert( 'jobs summary groups status with SQL count', str_contains( $jobs_db, 'GROUP BY status' ) && str_contains( $jobs_db, 'COUNT(*) AS count' ) );
+$assert( 'jobs summary groups the canonical status expression with SQL count', str_contains( $jobs_db, 'GROUP BY 1' ) && str_contains( $jobs_db, 'COUNT(*) AS count' ) );
 $assert( 'jobs summary groups pipelines without selecting engine_data blobs', str_contains( $jobs_db, 'function get_pipeline_summary_rows' ) && false === strpos( substr( $jobs_db, strpos( $jobs_db, 'function get_pipeline_summary_rows' ), 1200 ), 'SELECT j.engine_data' ) );
 $assert( 'jobs summary handler aggregation avoids decoding engine_data', str_contains( $jobs_db, 'function get_handler_summary_rows' ) && false === strpos( substr( $jobs_db, strpos( $jobs_db, 'function get_handler_summary_rows' ), 1700 ), 'json_decode' ) );
 

--- a/tests/processed-items-source-rejected-cli-smoke.php
+++ b/tests/processed-items-source-rejected-cli-smoke.php
@@ -36,6 +36,16 @@ if ( ! class_exists( 'DataMachine\\Core\\Database\\ProcessedItems\\ProcessedItem
 	eval( 'namespace DataMachine\\Core\\Database\\ProcessedItems; class ProcessedItems { public const STATUS_PROCESSED = "processed"; public function get_table_name(): string { return "wp_datamachine_processed_items"; } }' );
 }
 
+if ( ! class_exists( 'wpdb' ) ) {
+	class wpdb {
+		public function esc_like( string $value ): string {
+			return $value;
+		}
+	}
+}
+$wpdb = new wpdb();
+
+require_once __DIR__ . '/../inc/Core/JobStatus.php';
 require_once __DIR__ . '/../inc/Cli/Commands/ProcessedItemsCommand.php';
 
 use DataMachine\Cli\Commands\ProcessedItemsCommand;
@@ -62,8 +72,8 @@ $result = $query_parts->invoke( $cmd, array(), 'wp_datamachine_processed_items',
 datamachine_source_rejected_assert( str_contains( $result['where_sql'], 'pi.status = %s' ), 'filters processed item status' );
 datamachine_source_rejected_assert( str_contains( $result['where_sql'], 'j.status = %s' ), 'filters owning job status' );
 datamachine_source_rejected_assert(
-	array( 'wp_datamachine_processed_items', 'wp_datamachine_jobs', 'processed', 'agent_skipped - source-rejected' ) === $result['values'],
-	'default values include both table names and exact source-rejected status'
+	array( 'wp_datamachine_processed_items', 'wp_datamachine_jobs', 'processed', 'agent_skipped - source-rejected', 'agent_skipped', '%"job_status_reason":"source-rejected"%' ) === $result['values'],
+	'default values cover legacy storage and normalized structured reason'
 );
 
 echo "Test 2: scope filters are added generically\n";

--- a/tests/run-lifecycle-store-smoke.php
+++ b/tests/run-lifecycle-store-smoke.php
@@ -19,6 +19,13 @@ namespace DataMachine\Core {
 	}
 }
 
+namespace DataMachine\Core\Database\RunMetadata {
+	class RunMetadata {
+		public function replace_for_engine_data( int $job_id, array $data ): void {
+		}
+	}
+}
+
 namespace {
 	if ( ! defined( 'ABSPATH' ) ) {
 		define( 'ABSPATH', __DIR__ . '/' );
@@ -65,6 +72,23 @@ namespace {
 		function do_action( string $hook, ...$args ): void {}
 	}
 
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook, $value, ...$args ) {
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $value ): bool {
+			return $value instanceof WP_Error;
+		}
+	}
+
+	if ( ! class_exists( 'WP_Error' ) ) {
+		class WP_Error {
+		}
+	}
+
 	if ( ! function_exists( 'wp_cache_get' ) ) {
 		function wp_cache_get( $key, string $group = '' ) {
 			return $GLOBALS['datamachine_run_lifecycle_cache'][ $group ][ $key ] ?? false;
@@ -74,6 +98,13 @@ namespace {
 	if ( ! function_exists( 'wp_cache_set' ) ) {
 		function wp_cache_set( $key, $value, string $group = '' ): bool {
 			$GLOBALS['datamachine_run_lifecycle_cache'][ $group ][ $key ] = $value;
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'wp_cache_delete' ) ) {
+		function wp_cache_delete( $key, string $group = '' ): bool {
+			unset( $GLOBALS['datamachine_run_lifecycle_cache'][ $group ][ $key ] );
 			return true;
 		}
 	}
@@ -140,6 +171,10 @@ namespace {
 
 		public function prepare( $query, ...$args ) {
 			return array( $query, $args );
+		}
+
+		public function query( $query ) {
+			return 1;
 		}
 
 		public function get_row( $query = null, $output = OBJECT, $y = 0 ) {

--- a/tests/worker-status-job-counts-smoke.php
+++ b/tests/worker-status-job-counts-smoke.php
@@ -22,6 +22,10 @@ function esc_html( $value ): string {
 	return htmlspecialchars( (string) $value, ENT_QUOTES, 'UTF-8' );
 }
 
+function get_option( string $option, $default = false ) {
+	return $default;
+}
+
 final class WorkerStatusCountsWpdb {
 	public string $prefix = 'wp_';
 	public string $last_error = '';
@@ -46,6 +50,8 @@ final class WorkerStatusCountsWpdb {
 }
 
 require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
+require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Core/Database/Jobs/JobStatusMigration.php';
 require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
 require_once __DIR__ . '/../inc/Cli/BaseCommand.php';
 require_once __DIR__ . '/../inc/Cli/Commands/WorkerCommand.php';
@@ -68,9 +74,9 @@ $counts          = $method->invoke( null );
 
 $assert( array( 'processing' => 9, 'pending' => 1122, 'failed' => 5739 ) === $counts, 'operator status returns global repository counts without an acting user' );
 $assert( 3 === count( $wpdb->prepare_calls ), 'operator status performs only three COUNT queries' );
-$assert( 'processing%' === $wpdb->prepare_calls[0][1], 'processing count uses the normalized status prefix' );
-$assert( 'pending%' === $wpdb->prepare_calls[1][1], 'pending count uses the normalized status prefix' );
-$assert( 'failed%' === $wpdb->prepare_calls[2][1], 'failed count includes compound failure statuses' );
+$assert( array( 'processing', 'processing - %', 'processing:%' ) === array_slice( $wpdb->prepare_calls[0], 1 ), 'processing count covers exact and bounded legacy rows' );
+$assert( array( 'pending', 'pending - %', 'pending:%' ) === array_slice( $wpdb->prepare_calls[1], 1 ), 'pending count covers exact and bounded legacy rows' );
+$assert( array( 'failed', 'failed - %', 'failed:%' ) === array_slice( $wpdb->prepare_calls[2], 1 ), 'failed count covers exact and bounded legacy rows' );
 
 $wpdb->counts     = array( null );
 $wpdb->last_error = 'simulated count failure';


### PR DESCRIPTION
## Summary
- Persist only Data Machine's bounded base-state vocabulary in the indexed `datamachine_jobs.status` column.
- Preserve human-readable status reasons in `engine_data.job_status_reason` and compose them into ability, CLI, metrics, and admin presentation at read time.
- Add an operator-controlled, bounded, resumable migration with mixed-state query compatibility and no bootstrap table scan or automatic rewrite.

## Production Evidence
Events production has 87,416 jobs but 7,651 distinct stored status strings across seven observed base states. A direct `GROUP BY status` emitted 7,653 rows, burying 626 stuck `processing` jobs and 591 `pending` jobs under arbitrary reason prose stored in the indexed state column.

## Root Cause
`JobStatus::toString()` serialized `base_status - reason`, and the jobs repository persisted that compound string directly. Generic filters, summaries, cleanup, recovery, processed-item tooling, and queue diagnostics consequently relied on broad prefix matching or custom grouping logic. Reasons were already available through `JobStatus::getReason()` and structured job metadata, so the indexed status value duplicated unbounded prose.

## Canonical Contract
- `datamachine_jobs.status` stores one of the bounded `JobStatus::ALL_STATUSES` base values.
- `engine_data.job_status_reason` owns the optional human-readable detail.
- `status_reason` and `status_display` are composed at read time for abilities, REST-backed admin UI, CLI, and metrics.
- The jobs repository is the write boundary: terminal and non-terminal transitions normalize compound input under row locks and persist state plus reason atomically.
- Legacy `pending_runtime_tool` maps explicitly to `waiting` with `runtime_tool_request` detail; unknown states fail closed.

## Migration Safety And Transition
`wp datamachine jobs normalize-status` is read-only by default. `--apply --limit=<1-1000>` walks one bounded `job_id` window, locks each candidate row, validates existing JSON metadata, writes reason plus base status in one transaction, invalidates cached engine data, and records a per-site durable cursor and evidence counters.

The migration is resumable and idempotent. Malformed/non-object metadata and unknown statuses are counted and left untouched. Completion requires a final verification query; apply clears stale completion before rechecking, so later legacy rows can be detected by another operator pass. During rollout, repository filters, summaries, retention, recovery, worker counts, and processed-item source-rejection queries match exact canonical states plus only recognized legacy delimiters. Verified completion switches generic repository filtering/grouping to exact state operations.

No schema DDL is introduced: retaining the shipped `varchar(255)` avoids an unnecessary production table rebuild while value cardinality becomes bounded. Rollback to older code remains storage-compatible because base states were already accepted; structured reason metadata remains available even if older presentation does not display it.

## Affected Paths
- `JobStatus` strict parsing, canonical vocabulary, display composition, and explicit runtime-tool legacy mapping.
- Jobs repository terminal/non-terminal writes, status filters, summaries, retention cleanup, retry reopening, recovery requeues, terminal metrics, and lifecycle accounting.
- Get-jobs display enrichment, WP-CLI list output, processed-items source-rejected tooling, and React jobs table rendering.
- Runtime-tool deferral now uses canonical `waiting` state.
- Operator migration lifecycle and jobs-management documentation.

## Tests
- `vendor/bin/phpunit --bootstrap tests/bootstrap-unit.php tests/Unit`
- `vendor/bin/phpcs`
- `composer lint`
- `npm run build`
- Focused normalization, presentation, transition, mixed-state cleanup/filter/summary, retry, recovery, terminal accounting, processed-items, worker-count, and outcome-metrics smoke tests.
- Exhaustive root smoke comparison: branch executes 349 smoke files with 51 known standalone-harness failures; `origin/main` executes 347 with the same 51 failures. Both new normalization/presentation smoke tests pass.

## Production Verification And Operator Steps
Do not run the migration until this PR is released and deployed through the normal operator process.

1. Inspect each multisite target independently: `wp --url=<site> datamachine jobs normalize-status --format=json`.
2. Record `remaining`, `unknown`, `errors`, and a pre-migration `SELECT status, COUNT(*) ... GROUP BY status` snapshot.
3. Apply bounded batches: `wp --url=<site> datamachine jobs normalize-status --apply --limit=250 --format=json`.
4. Repeat until `status=complete` and `remaining=0`. Stop if `errors` rises or unknown residue remains; inspect those rows rather than forcing normalization.
5. Re-run jobs summary, worker status, stuck recovery dry-run, processed-items source-rejected listing, and direct grouped status counts.
6. Confirm `COUNT(DISTINCT status)` is bounded by the canonical vocabulary and operational pending/processing counts match the repository/CLI summaries.

No production table was mutated while developing or testing this change.

Closes #3094