### PR TITLE
fix: allow operator jobs summary diagnostics

### DIFF
--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -22,7 +22,6 @@ use DataMachine\Cli\UserResolver;
 use DataMachine\Abilities\Job\DeleteJobsAbility;
 use DataMachine\Abilities\Job\FailJobAbility;
 use DataMachine\Abilities\Job\GetJobsAbility;
-use DataMachine\Abilities\Job\JobsSummaryAbility;
 use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
 use DataMachine\Abilities\Job\RetryJobAbility;
 use DataMachine\Abilities\Engine\PipelineBatchScheduler;
@@ -2376,14 +2375,7 @@ class JobsCommand extends BaseCommand {
 			$input['since'] = gmdate( 'Y-m-d H:i:s', $timestamp );
 		}
 
-		$result = ( new JobsSummaryAbility() )->execute( $input );
-
-		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['error'] ?? 'Unknown error occurred' );
-			return;
-		}
-
-		$summary = $result['summary'] ?? array();
+		$summary = ( new Jobs() )->get_jobs_summary( $input );
 
 		if ( empty( $summary ) ) {
 			WP_CLI::warning( 'No job summary data available.' );

--- a/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
+++ b/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
@@ -180,11 +180,26 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$forged_summary = ( new JobsSummaryAbility() )->execute( array( 'user_id' => $this->other_user_id ) );
 		$this->assertSame( 'job_access_denied', $forged_summary['error_code'] );
 
+		$owner_summary = ( new JobsSummaryAbility() )->execute( array() );
+		$this->assertTrue( $owner_summary['success'] );
+		$this->assertSame( $this->owner_id, (int) $owner_summary['summary']['filters']['user_id'] );
+		$this->assertArrayNotHasKey( 'jobs', $owner_summary['summary'] );
+
+		wp_set_current_user( 0 );
+		$anonymous_summary = ( new JobsSummaryAbility() )->execute( array() );
+		$this->assertFalse( $anonymous_summary['success'] );
+		$this->assertSame( 'job_access_denied', $anonymous_summary['error_code'] );
+
 		wp_set_current_user( $this->admin_id );
 		$operator_list = ( new GetJobsAbility() )->execute( array() );
 		$operator_ids  = array_map( 'intval', array_column( $operator_list['jobs'], 'job_id' ) );
 		$this->assertContains( $owned['job_id'], $operator_ids );
 		$this->assertContains( $other['job_id'], $operator_ids );
+
+		$operator_summary = ( new JobsSummaryAbility() )->execute( array() );
+		$this->assertTrue( $operator_summary['success'] );
+		$this->assertArrayNotHasKey( 'user_id', $operator_summary['summary']['filters'] );
+		$this->assertArrayNotHasKey( 'jobs', $operator_summary['summary'] );
 	}
 
 	public function test_artifact_authorization_runs_before_hydration(): void {

--- a/tests/jobs-list-efficiency-smoke.php
+++ b/tests/jobs-list-efficiency-smoke.php
@@ -33,6 +33,8 @@ $assert( 'jobs repository has projected SELECT path', str_contains( $jobs_db, '$
 $assert( 'jobs repository decodes engine_data only when selected', str_contains( $jobs_db, '$decode_engine_data  = in_array' ) );
 $assert( 'jobs repository keeps full SELECT as default behavior', str_contains( $jobs_db, '$select_fields       = \'j.*, p.pipeline_name, f.flow_name\'' ) );
 $assert( 'jobs summary command accepts dashboard filters', str_contains( $jobs_cli, 'wp datamachine jobs summary --pipeline=42 --since=today --format=json' ) );
+$assert( 'operator jobs summary uses the global aggregate repository directly', str_contains( $jobs_cli, '$summary = ( new Jobs() )->get_jobs_summary( $input );' ) );
+$assert( 'operator jobs summary does not cross the user-scoped ability boundary', ! str_contains( $jobs_cli, 'new JobsSummaryAbility()' ) );
 $assert( 'jobs summary ability delegates to aggregate repository query', str_contains( $jobs_summary_ability, 'get_jobs_summary( $filters )' ) );
 $assert( 'jobs repository exposes memory-safe aggregate summary query', str_contains( $jobs_db, 'function get_jobs_summary' ) );
 $assert( 'jobs summary groups the canonical status expression with SQL count', str_contains( $jobs_db, 'GROUP BY 1' ) && str_contains( $jobs_db, 'COUNT(*) AS count' ) );


### PR DESCRIPTION
## Summary
- route the trusted `wp datamachine jobs summary` operator command directly to the existing aggregate jobs repository, matching worker status diagnostics
- keep the REST/ability summary fail-closed for anonymous callers and scoped to the acting user unless an authenticated administrator invokes it
- add regressions proving the CLI does not cross the user-scoped ability boundary and aggregate summaries expose no job-detail collection

## Root Cause
`JobsCommand::summary()` directly called `JobsSummaryAbility::execute()`. That ability correctly applies interactive/REST ownership through `JobHelpers::jobCollectionScope()`, but a normal trusted WP-CLI process has no acting WordPress user. The unscoped operator command therefore failed before reaching the existing aggregate repository query.

WordPress core and the Abilities API do not provide a separate non-user operator principal. Data Machine already establishes the correct trust boundary in worker status: operator-only CLI diagnostics call aggregate repository methods directly, while user-facing abilities retain ownership enforcement.

## Authorization Boundary
- only the established WP-CLI `jobs summary` command uses global aggregate repository access
- explicit `--user` and `--agent` filters continue to flow into the aggregate query
- `JobsSummaryAbility`, REST exposure, job list/detail access, and ownership helpers are unchanged
- anonymous ability execution remains denied; normal authenticated callers remain user-scoped

## Verification
Passed:
- PHP syntax checks for all changed files
- `php tests/jobs-list-efficiency-smoke.php` (15 assertions)
- `php tests/worker-status-job-counts-smoke.php` (6 assertions)
- `php tests/ability-boundary-helpers-smoke.php` (5 checks)
- `php tests/worker-cli-smoke.php` (54 assertions)
- `php tests/jobs-terminal-accounting-cli-smoke.php`
- focused and full `composer lint` / PHPCS
- `composer validate --no-check-publish` (existing version-field warning only)
- Homeboy changed-only lint, including PHPCS, ESLint, and PHPStan level 7
- Homeboy changed-since PR audit (no introduced findings)

Blocked before test discovery:
- focused and full Homeboy/Codebox PHPUnit runs executed zero tests because the managed `wordpress-database` MySQL 8.4 Docker service failed to provision. This is recorded as Homeboy runs `b72adc6f-0844-4964-8242-1ae7cde7da12` and `2d0a0d2f-8090-472b-a1da-57ce184a66ba`; no PHPUnit assertions ran, so these are not claimed as passing.

Production verification after deployment:
```bash
wp --url=https://events.extrachill.com datamachine jobs summary --format=json
```

Closes #3109