### PR TITLE
refactor: declare canonical WP-CLI aliases once

### DIFF
--- a/inc/Cli/CommandRegistry.php
+++ b/inc/Cli/CommandRegistry.php
@@ -2,11 +2,12 @@
 /**
  * Command Registry
  *
- * Single source of truth mapping `wp datamachine ...` command strings to their
- * implementing command classes. The WP-CLI bootstrap calls
- * WP_CLI::add_command for each entry. Generated agent guidance advertises a
- * bounded set of routing entrypoints and tests those roots against this map;
- * live `--help` remains authoritative for the complete command surface.
+ * Single source of truth declaring canonical `wp datamachine ...` commands,
+ * their compatibility aliases, and implementing command classes. The WP-CLI
+ * bootstrap calls WP_CLI::add_command for each flattened map entry. Generated
+ * agent guidance advertises a bounded set of routing entrypoints and tests
+ * those roots against this map; live `--help` remains authoritative for the
+ * complete command surface.
  *
  * This keeps command registration centralized while Data Machine itself owns
  * the concise routing guidance previously narrated by a downstream plugin
@@ -22,73 +23,114 @@ defined( 'ABSPATH' ) || exit;
 class CommandRegistry {
 
 	/**
-	 * Map of command string => fully-qualified command class.
+	 * Canonical command declarations.
 	 *
-	 * Keys are the exact strings passed to WP_CLI::add_command (the command
-	 * namespace, e.g. "datamachine memory" or "datamachine step-types").
-	 * Order here determines registration order.
+	 * Keys are canonical command strings. Compatibility spellings are declared
+	 * beside the implementation rather than as independent commands.
 	 *
-	 * Singular/plural aliases that resolve to the same class are intentionally
-	 * included so `WP_CLI::add_command` registers every accepted spelling. The
-	 * AGENTS.md introspection helpers de-duplicate by class when grouping.
+	 * @return array<string, array{class: class-string, aliases?: string[]}>
+	 */
+	public static function declarations(): array {
+		return array(
+			'datamachine settings'         => array(
+				'class'   => Commands\SettingsCommand::class,
+				'aliases' => array( 'datamachine setting' ),
+			),
+			'datamachine flows'            => array(
+				'class'   => Commands\Flows\FlowsCommand::class,
+				'aliases' => array( 'datamachine flow' ),
+			),
+			'datamachine alt-text'         => array( 'class' => Commands\AltTextCommand::class ),
+			'datamachine jobs'             => array(
+				'class'   => Commands\JobsCommand::class,
+				'aliases' => array( 'datamachine job' ),
+			),
+			'datamachine cycle'            => array(
+				'class'   => Commands\CycleCommand::class,
+				'aliases' => array( 'datamachine cycles' ),
+			),
+			'datamachine drain'            => array( 'class' => Commands\DrainCommand::class ),
+			'datamachine worker'           => array( 'class' => Commands\WorkerCommand::class ),
+			'datamachine ai'               => array( 'class' => Commands\AICommand::class ),
+			'datamachine pipelines'        => array(
+				'class'   => Commands\PipelinesCommand::class,
+				'aliases' => array( 'datamachine pipeline' ),
+			),
+			'datamachine posts'            => array(
+				'class'   => Commands\PostsCommand::class,
+				'aliases' => array( 'datamachine post' ),
+			),
+			'datamachine logs'             => array(
+				'class'   => Commands\LogsCommand::class,
+				'aliases' => array( 'datamachine log' ),
+			),
+			'datamachine agents'           => array(
+				'class'   => Commands\AgentsCommand::class,
+				'aliases' => array( 'datamachine agent' ),
+			),
+			'datamachine pending-actions'  => array(
+				'class'   => Commands\PendingActionsCommand::class,
+				'aliases' => array( 'datamachine pending-action' ),
+			),
+			'datamachine memory'           => array( 'class' => Commands\MemoryCommand::class ),
+			'datamachine batch'            => array( 'class' => Commands\BatchCommand::class ),
+			'datamachine image'            => array( 'class' => Commands\ImageCommand::class ),
+			'datamachine auth'             => array( 'class' => Commands\AuthCommand::class ),
+			'datamachine email'            => array( 'class' => Commands\EmailCommand::class ),
+			'datamachine system'           => array( 'class' => Commands\SystemCommand::class ),
+			'datamachine handlers'         => array(
+				'class'   => Commands\HandlersCommand::class,
+				'aliases' => array( 'datamachine handler' ),
+			),
+			'datamachine taxonomy'         => array( 'class' => Commands\TaxonomyCommand::class ),
+			'datamachine step-types'       => array(
+				'class'   => Commands\StepTypesCommand::class,
+				'aliases' => array( 'datamachine step-type' ),
+			),
+			'datamachine processed-items'  => array(
+				'class'   => Commands\ProcessedItemsCommand::class,
+				'aliases' => array( 'datamachine processed-item' ),
+			),
+			'datamachine tracked-items'    => array(
+				'class'   => Commands\TrackedItemsCommand::class,
+				'aliases' => array( 'datamachine tracked-item' ),
+			),
+			'datamachine retention'        => array( 'class' => Commands\RetentionCommand::class ),
+			'datamachine test'             => array(
+				'class'   => Commands\TestCommand::class,
+				'aliases' => array( 'datamachine fetch test' ),
+			),
+			'datamachine external'         => array( 'class' => Commands\ExternalCommand::class ),
+			'datamachine links'            => array(
+				'class'   => Commands\LinksCommand::class,
+				'aliases' => array( 'datamachine link' ),
+			),
+			'datamachine blocks'           => array(
+				'class'   => Commands\BlocksCommand::class,
+				'aliases' => array( 'datamachine block' ),
+			),
+			'datamachine meta-description' => array( 'class' => Commands\MetaDescriptionCommand::class ),
+			'datamachine indexnow'         => array( 'class' => Commands\IndexNowCommand::class ),
+			'datamachine chat'             => array( 'class' => Commands\ChatCommand::class ),
+		);
+	}
+
+	/**
+	 * Map every accepted command string to its implementation.
 	 *
 	 * @return array<string, class-string>
 	 */
 	public static function map(): array {
-		return array(
-			// Primary commands.
-			'datamachine settings'         => Commands\SettingsCommand::class,
-			'datamachine flows'            => Commands\Flows\FlowsCommand::class,
-			'datamachine alt-text'         => Commands\AltTextCommand::class,
-			'datamachine jobs'             => Commands\JobsCommand::class,
-			'datamachine cycle'            => Commands\CycleCommand::class,
-			'datamachine cycles'           => Commands\CycleCommand::class,
-			'datamachine drain'            => Commands\DrainCommand::class,
-			'datamachine worker'           => Commands\WorkerCommand::class,
-			'datamachine ai'               => Commands\AICommand::class,
-			'datamachine pipelines'        => Commands\PipelinesCommand::class,
-			'datamachine posts'            => Commands\PostsCommand::class,
-			'datamachine logs'             => Commands\LogsCommand::class,
-			'datamachine agent'            => Commands\AgentsCommand::class,
-			'datamachine agents'           => Commands\AgentsCommand::class,
-			'datamachine pending-actions'  => Commands\PendingActionsCommand::class,
-			'datamachine pending-action'   => Commands\PendingActionsCommand::class,
+		$map = array();
 
-			// Canonical home for agent memory-file operations.
-			'datamachine memory'           => Commands\MemoryCommand::class,
-			'datamachine batch'            => Commands\BatchCommand::class,
-			'datamachine image'            => Commands\ImageCommand::class,
-			'datamachine auth'             => Commands\AuthCommand::class,
-			'datamachine email'            => Commands\EmailCommand::class,
-			'datamachine system'           => Commands\SystemCommand::class,
-			'datamachine handlers'         => Commands\HandlersCommand::class,
-			'datamachine taxonomy'         => Commands\TaxonomyCommand::class,
-			'datamachine step-types'       => Commands\StepTypesCommand::class,
-			'datamachine processed-items'  => Commands\ProcessedItemsCommand::class,
-			'datamachine tracked-items'    => Commands\TrackedItemsCommand::class,
-			'datamachine retention'        => Commands\RetentionCommand::class,
-			'datamachine test'             => Commands\TestCommand::class,
-			'datamachine fetch test'       => Commands\TestCommand::class,
-			'datamachine external'         => Commands\ExternalCommand::class,
+		foreach ( self::declarations() as $command => $declaration ) {
+			$map[ $command ] = $declaration['class'];
 
-			// Aliases for AI agent compatibility (singular/plural variants).
-			'datamachine setting'          => Commands\SettingsCommand::class,
-			'datamachine flow'             => Commands\Flows\FlowsCommand::class,
-			'datamachine job'              => Commands\JobsCommand::class,
-			'datamachine pipeline'         => Commands\PipelinesCommand::class,
-			'datamachine post'             => Commands\PostsCommand::class,
-			'datamachine log'              => Commands\LogsCommand::class,
-			'datamachine links'            => Commands\LinksCommand::class,
-			'datamachine link'             => Commands\LinksCommand::class,
-			'datamachine blocks'           => Commands\BlocksCommand::class,
-			'datamachine block'            => Commands\BlocksCommand::class,
-			'datamachine meta-description' => Commands\MetaDescriptionCommand::class,
-			'datamachine indexnow'         => Commands\IndexNowCommand::class,
-			'datamachine chat'             => Commands\ChatCommand::class,
-			'datamachine handler'          => Commands\HandlersCommand::class,
-			'datamachine step-type'        => Commands\StepTypesCommand::class,
-			'datamachine processed-item'   => Commands\ProcessedItemsCommand::class,
-			'datamachine tracked-item'     => Commands\TrackedItemsCommand::class,
-		);
+			foreach ( $declaration['aliases'] ?? array() as $alias ) {
+				$map[ $alias ] = $declaration['class'];
+			}
+		}
+
+		return $map;
 	}
 }

--- a/tests/command-registry-aliases-smoke.php
+++ b/tests/command-registry-aliases-smoke.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Smoke coverage for canonical WP-CLI commands and compatibility aliases.
+ *
+ * Run with: php tests/command-registry-aliases-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+require_once dirname( __DIR__ ) . '/inc/Cli/CommandRegistry.php';
+
+use DataMachine\Cli\CommandRegistry;
+
+$failures = array();
+$assert   = static function ( bool $condition, string $message ) use ( &$failures ): void {
+	if ( $condition ) {
+		fwrite( STDOUT, "PASS: {$message}\n" );
+		return;
+	}
+
+	$failures[] = $message;
+	fwrite( STDERR, "FAIL: {$message}\n" );
+};
+
+$aliases = array(
+	'datamachine settings'        => array( 'datamachine setting' ),
+	'datamachine flows'           => array( 'datamachine flow' ),
+	'datamachine jobs'            => array( 'datamachine job' ),
+	'datamachine cycle'           => array( 'datamachine cycles' ),
+	'datamachine pipelines'       => array( 'datamachine pipeline' ),
+	'datamachine posts'           => array( 'datamachine post' ),
+	'datamachine logs'            => array( 'datamachine log' ),
+	'datamachine agents'          => array( 'datamachine agent' ),
+	'datamachine pending-actions' => array( 'datamachine pending-action' ),
+	'datamachine handlers'        => array( 'datamachine handler' ),
+	'datamachine step-types'      => array( 'datamachine step-type' ),
+	'datamachine processed-items' => array( 'datamachine processed-item' ),
+	'datamachine tracked-items'   => array( 'datamachine tracked-item' ),
+	'datamachine test'            => array( 'datamachine fetch test' ),
+	'datamachine links'           => array( 'datamachine link' ),
+	'datamachine blocks'          => array( 'datamachine block' ),
+);
+
+$declarations = CommandRegistry::declarations();
+$map          = CommandRegistry::map();
+
+$assert( 32 === count( $declarations ), 'Each implementation has one canonical declaration' );
+$assert( 48 === count( $map ), 'Every existing command string remains registered' );
+$assert( count( $declarations ) === count( array_unique( array_column( $declarations, 'class' ) ) ), 'Implementations are not declared more than once' );
+
+foreach ( $aliases as $canonical => $compatibility_aliases ) {
+	$assert( isset( $declarations[ $canonical ] ), "Canonical command {$canonical} is declared" );
+	$assert( $compatibility_aliases === ( $declarations[ $canonical ]['aliases'] ?? array() ), "Aliases for {$canonical} are explicit" );
+
+	foreach ( $compatibility_aliases as $alias ) {
+		$assert( isset( $map[ $alias ] ), "Compatibility alias {$alias} remains registered" );
+		$assert( $map[ $canonical ] === $map[ $alias ], "{$alias} resolves to the {$canonical} implementation" );
+	}
+}
+
+if ( $failures ) {
+	fwrite( STDERR, sprintf( "\n%d assertion(s) failed.\n", count( $failures ) ) );
+	exit( 1 );
+}
+
+fwrite( STDOUT, "\nAll assertions passed.\n" );


### PR DESCRIPTION
## Summary

- declare each `wp datamachine` implementation once under its canonical command spelling, with compatibility aliases stored beside it
- flatten the declarations through the existing `CommandRegistry::map()` API so Bootstrap and generated guidance consumers keep receiving the full registration map
- add focused smoke coverage proving canonical commands and aliases resolve to the same implementation and all 48 existing command strings remain accepted

## Canonical selection

Canonical spellings follow the current README, generated AGENTS.md routing guidance, command PHPDoc examples, and `docs/core-system/wp-cli.md`. Collection/resource commands use the advertised plural forms (`settings`, `flows`, `jobs`, `pipelines`, `posts`, `logs`, `agents`, `pending-actions`, `handlers`, `step-types`, `processed-items`, `tracked-items`, `links`, and `blocks`). The command reference explicitly identifies `agent` as an alias of `agents`. `cycle` remains singular because README entrypoints and `CycleCommand` examples advertise that spelling. `test` remains canonical with the nested `fetch test` compatibility spelling.

## Alias map

- `settings` -> `setting`
- `flows` -> `flow`
- `jobs` -> `job`
- `cycle` -> `cycles`
- `pipelines` -> `pipeline`
- `posts` -> `post`
- `logs` -> `log`
- `agents` -> `agent`
- `pending-actions` -> `pending-action`
- `handlers` -> `handler`
- `step-types` -> `step-type`
- `processed-items` -> `processed-item`
- `tracked-items` -> `tracked-item`
- `test` -> `fetch test`
- `links` -> `link`
- `blocks` -> `block`

## Compatibility

Every previously registered command string remains accepted under the intentional `wp datamachine` namespace. This changes registration metadata only; command arguments, output, permissions, wrappers, and behavior are unchanged.

## Tests

- `php tests/command-registry-aliases-smoke.php` (pass)
- `php tests/agents-md-gated-composition-smoke.php` (pass)
- `homeboy review data-machine lint --path /var/lib/datamachine/workspace/data-machine@simplify-3114-cli-aliases --changed-only --placement local --summary` (pass: PHPCS, ESLint, PHPStan)
- `homeboy review audit data-machine --path /var/lib/datamachine/workspace/data-machine@simplify-3114-cli-aliases --changed-since origin/main --placement local --summary` (pass: no introduced findings)
- `php -l inc/Cli/CommandRegistry.php` and `php -l tests/command-registry-aliases-smoke.php` (pass)
- `git diff --check` (pass)
- `homeboy review data-machine test --path /var/lib/datamachine/workspace/data-machine@simplify-3114-cli-aliases --placement local --summary` (runner reported zero discovered PHPUnit tests; focused repository smoke tests above passed)

Closes #3114

Part of simplification umbrella #3113.