### PR TITLE
docs: remove nonexistent architecture references

### DIFF
--- a/docs/ai-directives.md
+++ b/docs/ai-directives.md
@@ -5,7 +5,6 @@ Data Machine assembles AI request context through directive classes registered o
 Key current facts:
 
 - `AgentModeDirective` injects built-in mode guidance for `chat`, `pipeline`, and `system` at priority 22.
-- The former `PipelineCoreDirective`, `ChatAgentDirective`, `SystemAgentDirective`, and `SiteContextDirective` classes were removed during the AgentMode refactor.
 - `CoreMemoryFilesDirective` injects registered memory files from the shared, agent, and user layers.
 - Pipeline, flow, daily-memory, and chat-inventory directives add request-specific context after the core mode and memory layers.
 - Tools are injected by `RequestBuilder` through `PromptBuilder::setTools()`, not by a directive class.

--- a/docs/ai-tools/tools-overview.md
+++ b/docs/ai-tools/tools-overview.md
@@ -2,7 +2,7 @@
 
 AI tools should be exposed as WordPress Ability projections whenever a single registered ability already owns the execution contract. `inc/Engine/AI/Tools/ToolServiceProvider.php` still instantiates tool classes so they can register configuration handlers and ability projections, but the model-facing declaration should use `datamachine_register_ability_tool()` instead of a class/method handler when possible.
 
-The legacy `datamachine_tools` class/method registry remains for composite orchestration tools and adjacent handler tools that do not map cleanly to one public ability. Tools declare where they can run (`chat`, `pipeline`, or pipeline-policy mode) and the ability or access level required to execute them.
+The `datamachine_tools` class/method registry serves composite orchestration tools and adjacent handler tools that do not map cleanly to one public ability. Tools declare where they can run (`chat`, `pipeline`, or pipeline-policy mode) and the ability or access level required to execute them.
 
 ## Registered Tool Inventory
 

--- a/docs/api/endpoints/auth.md
+++ b/docs/api/endpoints/auth.md
@@ -77,6 +77,5 @@ Force a token refresh for a handler.
 
 ## Notes for Agents
 
-- There is no `/auth/{handler_slug}/callback` REST route in `inc/Api/Auth.php`.
-- Browser OAuth initiation/callback URLs are outside this REST controller, for example `/datamachine-auth/{handler}/`.
+- Browser OAuth initiation and callbacks use `/datamachine-auth/{handler}/`.
 - Do not document static provider field sets here; provider config comes from the registered auth provider/handler metadata.

--- a/docs/api/endpoints/logs.md
+++ b/docs/api/endpoints/logs.md
@@ -298,24 +298,6 @@ $repo->clear_all();
 
 The Data Machine admin UI includes a dedicated Logs page built with React that consumes these endpoints to provide real-time monitoring of system activity, powerful filtering by context and severity, and deep links to associated jobs and flows. Status updates are managed via TanStack Query for optimal performance and zero page reloads.
 
-## Migration from File-Based Logging
-
-The database-backed logging system replaced the Monolog file-based system:
-
-| Aspect | Before (Monolog) | After (Database) |
-|---|---|---|
-| Storage | Per-agent-type log files in uploads | Single `datamachine_logs` database table |
-| Scoping | `agent_type` parameter (pipeline, chat, system, cli) | `agent_id` integer (specific agent instance) |
-| Filtering | Date-based file filtering | SQL WHERE with indexes |
-| Context | Inline in log messages | Structured JSON column |
-| Clearing | `agent_type` + optional `days` parameter | `agent_id` scoping or clear all |
-| Pagination | File offset/seek | SQL LIMIT/OFFSET with total count |
-
-**Breaking changes from the migration**:
-- The `agent_type` parameter is no longer used — use `agent_id` instead
-- The `days` parameter for clearing old logs is no longer supported — use `prune_before()` at the repository level
-- Log file paths no longer apply — all logs are in the database
-
 ## Related Documentation
 
 - [Jobs](jobs.md) - Job execution monitoring

--- a/docs/api/endpoints/parameter-systems.md
+++ b/docs/api/endpoints/parameter-systems.md
@@ -208,7 +208,7 @@ $parameters = WP_Agent_Tool_Parameters::buildParameters(
 
 ## Handler Configuration Defaults
 
-The system employs a priority-based default application logic via `HandlerService::applyDefaults()`. This ensures consistent configuration across flows while allowing granular overrides.
+The system applies handler defaults through `HandlerAbilities`. This ensures consistent configuration across flows while allowing granular overrides.
 
 ### Priority Order (Highest to Lowest)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,13 +57,13 @@ Core registers six step types in `datamachine_load_step_types()`:
 | `webhook_gate` | Park a job until an inbound webhook resumes it | No |
 | `system_task` | Run a registered system task inline | No |
 
-Step constructors register definitions through `StepTypeRegistrationTrait`; `StepTypeAbilities` is the current read and validation surface. Core handlers are loaded explicitly by `datamachine_load_handlers()`. Extensions can add step types, handlers, tools, directives, authentication providers, and other documented registrations. `agent_ping` is not a current step type; outbound agent calls are an ability/system-task concern, while `Api\AgentPing` owns callback routes.
+Step constructors register definitions through `StepTypeRegistrationTrait`; `StepTypeAbilities` is the current read and validation surface. Core handlers are loaded explicitly by `datamachine_load_handlers()`. Extensions can add step types, handlers, tools, directives, authentication providers, and other documented registrations. Outbound agent calls use an ability or system task, and `Api\AgentPing` owns inbound callback routes.
 
 ### Persistence
 
 Workflow definitions and execution state use Data Machine tables. Packet payloads and flow files use `FilesRepository` beneath the WordPress uploads directory. Job `engine_data` stores the resolved execution snapshot and runtime metadata. Run artifacts and bundle artifacts have dedicated persistence. Agent identity, access, and tokens are network-scoped on multisite; most workflow tables are site-scoped, while chat uses its network-aware repository.
 
-Do not infer a fixed table count from old architecture prose. `datamachine_ensure_all_tables()` and each repository's `TABLE_NAME`/`create_table()` implementation are authoritative. See [Database Schema](core-system/database-schema.md) for the current inventory and scope.
+`datamachine_ensure_all_tables()` and each repository's `TABLE_NAME`/`create_table()` implementation define the current persistence inventory. See [Database Schema](core-system/database-schema.md) for table scope and relationships.
 
 ### AI Runtime Boundary
 

--- a/docs/architecture/agent-memory-backends.md
+++ b/docs/architecture/agent-memory-backends.md
@@ -73,9 +73,7 @@ WP_Agent_Memory_Stores::get_store(
 );
 ```
 
-The resolver honors a direct `$context['memory_store']` value or an implementation returned by the `wp_agent_memory_store` filter. Data Machine passes the current scope as `$context['scope']`. Return `null` to keep `DiskAgentMemoryStore`.
-
-Data Machine intentionally does not call the previous `agents_api_memory_store` or `datamachine_memory_store` hooks because a dual-hook ladder would become permanent API. Consumers should register on the canonical Agents API hook.
+The resolver honors a direct `$context['memory_store']` value or an implementation returned by the `wp_agent_memory_store` filter. Data Machine passes the current scope as `$context['scope']`. Return `null` to keep `DiskAgentMemoryStore`. Consumers register alternate backends on `wp_agent_memory_store`.
 
 Backend selection should be capability-driven:
 

--- a/docs/core-system/agent-registration.md
+++ b/docs/core-system/agent-registration.md
@@ -46,40 +46,17 @@ That's it. On the next request where `init` fires, DM reconciles the registratio
 | `default_config` | array | Initial `agent_config` persisted on creation. Subsequent config changes go through the DB — the registration never overrides user-edited config. |
 | `meta` | array | Optional registry metadata for future consumers. Data Machine's current materializer ignores it. |
 
-### Category and metadata policy
-
-The current registry intentionally does **not** implement Abilities API-style categories.
-
-Abilities need first-class categories because abilities are many small executable actions exposed through REST discovery and filtering. Agents are runtime definitions; their executable surface should be discovered through abilities/runtime tool declarations and explicit policy, not through a second category hierarchy on the agent object.
-
-Category semantics are not part of `WP_Agent`:
-
-- There is no `WP_Agent_Category` registry.
-- No category-derived permissions, REST visibility, tool policy, or memory policy.
-- Data Machine admin grouping remains Data Machine product behavior.
-- Future descriptive `metadata`, `type`, `capabilities`, or `annotations` fields can be added after the public class contract is finalized, but they must be non-authoritative until a separate issue defines their semantics.
-
 ### Slug semantics
 
-Slugs are passed through `sanitize_title()`. Empty slugs are rejected. They must be unique across a site (DB column has a UNIQUE constraint on `agent_slug`). Two plugins registering the same slug is resolved by **last-wins** — this intentionally diverges from the Abilities API's duplicate rejection. Data Machine relies on hook priority as a fresh-install override mechanism while the registry lives in-repo.
+Slugs are passed through `sanitize_title()`. Empty slugs are rejected. They must be unique across a site because the database column has a unique constraint on `agent_slug`. When two plugins register the same slug, the registration at the later hook priority wins.
 
 `WP_Agent` is a prepared definition object, not a database row. It validates property types, normalizes the slug and memory seed filenames, and exposes getters (`get_slug()`, `get_label()`, `get_description()`, `get_memory_seeds()`, `get_owner_resolver()`, `get_default_config()`, `get_meta()`).
 
 Invalid property types reject the definition with a `_doing_it_wrong()` notice when WordPress provides that function. Unknown properties are ignored with the same notice style so future registry fields do not accidentally become materializer inputs.
 
-## Lifecycle compared to Abilities API
+## Registration Lifecycle
 
-Agents API deliberately follows the Abilities API vocabulary without copying every lifecycle constraint yet:
-
-| Surface | Abilities API | Agents API in Data Machine |
-|---|---|---|
-| Init action | `wp_abilities_api_init` | `wp_agents_api_init` |
-| Registry initialization | Lazy singleton after `init` | Lazy singleton on first registry read or registration |
-| Registration timing | Must happen during `wp_abilities_api_init` | Should happen during `wp_agents_api_init`, but direct registration remains supported |
-| Duplicate registration | Rejected with `_doing_it_wrong()` | Last registration wins |
-| Lookup helpers | `wp_get_ability()`, `wp_get_abilities()`, `wp_has_ability()`, `wp_unregister_ability()` | `wp_get_agent()`, `wp_get_agents()`, `wp_has_agent()`, `wp_unregister_agent()` |
-
-Data Machine's materializer reads the registry from `init` priority 15, and direct registration before that lazy collection path remains supported. New code should use `wp_agents_api_init` so declarations participate in the documented lifecycle.
+The Agents API registry initializes lazily on its first read or registration. Data Machine's materializer reads it from `init` priority 15. Extensions register definitions during `wp_agents_api_init`; direct registration before materialization is also supported.
 
 ## Reconciliation
 

--- a/docs/core-system/ai-directives.md
+++ b/docs/core-system/ai-directives.md
@@ -29,8 +29,6 @@ Directive outputs are validated by `DirectiveOutputValidator`:
 
 Each registered directive declares which agent **modes** it applies to via the `modes` array. The current built-in modes are `chat`, `pipeline`, and `system`. The literal string `all` matches every mode.
 
-> Historical note: prior to v0.71.0 this field was named `contexts`. The internal terminology was renamed during the AgentMode refactor (#1130). RequestBuilder reads `$directive['modes']`; older `'contexts' =>` registrations are silently treated as `all` because they don't match the canonical key.
-
 ### Priority System
 
 Directives are applied in ascending priority order (lowest number = highest priority).
@@ -47,7 +45,7 @@ Directives are applied in ascending priority order (lowest number = highest prio
 | **45** | `FlowMemoryFilesDirective` | pipeline | `inc/Core/Steps/AI/Directives/FlowMemoryFilesDirective.php` | Per-flow selectable memory files (additive to pipeline memory) |
 | **50** | `PipelineSystemPromptDirective` | pipeline | `inc/Core/Steps/AI/Directives/PipelineSystemPromptDirective.php` | User-configured task instructions + workflow visualization |
 
-> Note: Tools are injected by `RequestBuilder` via `PromptBuilder::setTools()`, not as a directive class. The earlier `GlobalSystemPromptDirective`, `SiteContextDirective`, `PipelineCoreDirective`, `ChatAgentDirective`, and `SystemAgentDirective` classes were removed during the AgentMode refactor — their guidance now lives inline in `AgentModeDirective` and in agent memory files (SITE.md, SOUL.md, MEMORY.md).
+Tools are injected by `RequestBuilder` through `PromptBuilder::setTools()`. `AgentModeDirective` and agent memory files provide runtime and identity guidance.
 
 ## Individual Directives
 
@@ -113,7 +111,7 @@ When `PermissionHelper::in_cross_site_context()` returns false (local request, t
 **Modes**: chat, pipeline
 **Since**: 0.71.0
 
-Injects recent daily archive files for agents that explicitly opt in. Replaces the former `DailyMemorySelectorDirective` + per-flow `flow_config.daily_memory` config.
+Injects recent daily archive files for agents that explicitly opt in.
 
 **Opt-in shape (per agent, in `agent_config`):**
 

--- a/docs/core-system/ai-message-envelope.md
+++ b/docs/core-system/ai-message-envelope.md
@@ -45,13 +45,13 @@ RequestBuilder projects envelopes into wp-ai-client DTOs only for provider dispa
 
 ## Compatibility
 
-`WP_Agent_Message::normalize()` accepts existing `role/content/metadata` rows and versioned envelopes. It also accepts the short-lived `data` envelope key from the initial envelope draft as a read-time compatibility input and rewrites it to `payload`.
+`WP_Agent_Message::normalize()` accepts `role/content/metadata` rows and versioned envelopes. It also accepts `data` as a read-time compatibility input and rewrites it to `payload`.
 
 New writes should store canonical envelopes. Current provider requests use `WP_Agent_Message::to_provider_message()` / `to_provider_messages()` as needed to project envelopes into Data Machine's provider-message shape. That projection folds the envelope `type` and `payload` into provider metadata, after which `RequestBuilder` maps messages to wp-ai-client prompt/history DTOs.
 
 ## Type Payload
 
-Legacy tool-call messages:
+Compatible `role/content/metadata` tool-call messages:
 
 ```php
 [

--- a/docs/core-system/cache-management.md
+++ b/docs/core-system/cache-management.md
@@ -14,8 +14,6 @@ The system relies on WordPress actions to trigger cache clearing. When a new han
 
 Cache invalidation is typically triggered after ecosystem registration actions, then performed via `HandlerAbilities::clearCache()`, `AuthAbilities::clearCache()`, `StepTypeAbilities::clearCache()`, and `ToolManager::clearCache()`.
 
-> **Migration Note (@since v0.11.7):** `HandlerService` and `StepTypeService` have been deleted and replaced by `HandlerAbilities` and `StepTypeAbilities`.
-
 ## Cache Clearing Methods
 
 Call the static `clearCache()` methods on the relevant classes when registrations change:

--- a/docs/core-system/daily-memory-system.md
+++ b/docs/core-system/daily-memory-system.md
@@ -9,7 +9,7 @@ Daily memory has six components:
 1. **DailyMemory service** — filesystem storage with CRUD, search, and date-range queries
 2. **DailyMemoryTask** — AI-powered system task that synthesizes daily summaries and cleans MEMORY.md
 3. **DailyMemoryAbilities** — WordPress 6.9 Abilities API registration
-4. **AgentDailyMemoryDirective** — opt-in injection at Priority 35 for agents that enable it via `agent_config.daily_memory` (chat + pipeline contexts). Since 0.71.0; replaces `DailyMemorySelectorDirective`.
+4. **AgentDailyMemoryDirective** — opt-in injection at Priority 35 for agents that enable it via `agent_config.daily_memory` (chat + pipeline contexts)
 5. **AgentDailyMemory tool** — AI chat tool for agent self-service
 6. **CLI and REST endpoints** — human and programmatic access
 
@@ -248,7 +248,7 @@ wp_execute_ability('datamachine/search-daily-memory', [
 **Priority:** 35
 **Contexts:** `chat`, `pipeline`
 
-Opt-in directive that reads recent daily archive files directly from disk and injects each one as its own `system_text` block into the AI context. Replaces the former `DailyMemorySelectorDirective` + per-flow `flow_config.daily_memory` config.
+Opt-in directive that reads recent daily archive files directly from disk and injects each one as its own `system_text` block into the AI context.
 
 ### Opt-in per agent
 
@@ -293,7 +293,7 @@ Priority 80 — Site Context
 
 ### For precise historical lookups
 
-The directive only injects *recent* days on a rolling window. Anything beyond `recent_days`, or any specific date / date range / month query, should be served by the `agent_daily_memory` tool on demand — it covers every former selector mode with more precision than a pre-configured dropdown ever did.
+The directive only injects recent days on a rolling window. The `agent_daily_memory` tool serves specific dates, date ranges, month queries, and anything beyond `recent_days` on demand.
 
 ## AgentDailyMemory Tool
 

--- a/docs/core-system/database-schema.md
+++ b/docs/core-system/database-schema.md
@@ -11,7 +11,7 @@ The current install path creates 17 named tables. Agent identity tables use `$wp
 | Source and content identity | `datamachine_processed_items`, `datamachine_tracked_items`, `datamachine_post_identity`, `datamachine_post_identity_reservations` |
 | Artifacts, chat, approvals, and operations | `datamachine_bundle_artifacts`, `datamachine_chat_sessions`, `datamachine_pending_actions`, `datamachine_logs` |
 
-The detailed sections below explain the primary product tables. For tables not expanded here, follow the implementation links implied by the inventory (`inc/Core/Database/` and `inc/Engine/AI/Actions/PendingActionStore.php`) rather than assuming an older abbreviated table list is complete.
+The detailed sections below explain the primary product tables. The implementations under `inc/Core/Database/` and `inc/Engine/AI/Actions/PendingActionStore.php` define tables not expanded here.
 
 ## Core Tables
 

--- a/docs/core-system/handler-defaults.md
+++ b/docs/core-system/handler-defaults.md
@@ -87,12 +87,12 @@ The system is exposed via the following REST API endpoints:
 ## Related Documentation
 
 - [Settings API](../api/endpoints/settings.md) - REST API reference
-- [Services Layer](services-layer.md) - Architectural overview (migration in progress)
+- [Services Layer](services-layer.md) - Abilities-first service architecture
 - [Parameter Systems](../api/endpoints/parameter-systems.md) - Data flow patterns
 
-## Migration Note
+## Handler Abilities
 
-As of v0.11.7, `HandlerService` has been deleted and replaced by `HandlerAbilities`. All handler operations now use the WordPress 6.9 Abilities API:
+Handler operations use the WordPress Abilities API:
 
 - `datamachine/get-handlers` - List handlers with optional step_type filter, or get single by handler_slug
 - `datamachine/validate-handler` - Validate handler slug exists

--- a/docs/core-system/prompt-builder.md
+++ b/docs/core-system/prompt-builder.md
@@ -1,12 +1,10 @@
 # PromptBuilder Pattern
 
-**Since**: 0.2.5
-
-The PromptBuilder provides unified directive management for AI requests with priority-based ordering and agent-specific targeting. It replaces the previous scattered filter-based directive application with a structured builder pattern.
+The PromptBuilder provides unified directive management for AI requests with priority-based ordering and agent-specific targeting.
 
 ## Overview
 
-Prior to v0.2.5, AI directives were applied through separate `datamachine_global_directives` and `datamachine_agent_directives` filters, creating inconsistent ordering and maintenance overhead. The PromptBuilder centralizes this functionality into a single, priority-ordered system.
+PromptBuilder centralizes directive application in a single, priority-ordered system.
 
 ## Architecture
 
@@ -34,7 +32,7 @@ Prior to v0.2.5, AI directives were applied through separate `datamachine_global
 
 - **Priority-Based Ordering**: Lower priority numbers applied first (10=core, 20=global, 30=pipeline, 40=context, 50=site)
 - **Agent Targeting**: Directives can target 'all' agents or specific types ('pipeline', 'chat')
-- **Unified Registration**: Single `datamachine_directives` filter replaces multiple filter types
+- **Unified Registration**: Directives register through `datamachine_directives`
 - **Structured Builder Pattern**: Fluent interface for directive configuration and request building
 
 ## Usage
@@ -105,28 +103,6 @@ $promptBuilder->setMessages($messages)
 
 // Apply directives via PromptBuilder
 $request = $promptBuilder->build($agent_modes, $provider, $context);
-```
-
-## Migration from Legacy System
-
-### Before (v0.2.4 and earlier)
-```php
-// Separate filters with inconsistent ordering
-add_filter('datamachine_global_directives', 'apply_global_directive', 10, 5); // LEGACY - use datamachine_directives instead
-add_filter('datamachine_agent_directives', 'apply_agent_directive', 10, 5); // LEGACY - use datamachine_directives with modes to target 'pipeline'/'chat'
-```
-
-### After (v0.2.5+)
-```php
-// Unified registration with explicit priorities
-add_filter('datamachine_directives', function($directives) {
-    $directives[] = [
-        'class' => MyDirective::class,
-        'priority' => 25,
-        'modes' => ['all']
-    ];
-    return $directives;
-});
 ```
 
 ## Benefits

--- a/docs/core-system/request-builder.md
+++ b/docs/core-system/request-builder.md
@@ -65,7 +65,7 @@ if ( $ai_response instanceof \WP_Error ) {
 
 ## Return Types
 
-`RequestBuilder::build()` returns native provider-layer objects, not the older `['success' => true, 'data' => ...]` array shape.
+`RequestBuilder::build()` returns provider-layer result objects.
 
 Success:
 
@@ -157,8 +157,6 @@ If any check fails, `build()` logs `AI request blocked: wp-ai-client unavailable
 ```php
 new \WP_Error( 'wp_ai_client_unavailable', $unavailable_reason );
 ```
-
-Data Machine no longer falls back to `chubes_ai_request` or `ai-http-client` for runtime provider calls.
 
 ## Provider Dispatch
 
@@ -254,4 +252,4 @@ Representative tests:
 - Use the `$request_metadata` output parameter when a caller needs request diagnostics.
 - Keep tool execution outside RequestBuilder.
 - Keep durable multi-turn runtime behavior in `datamachine_run_conversation()` and Agents API, not in RequestBuilder.
-- Prefer wp-ai-client provider plugins over any legacy `chubes_ai_*` path.
+- Use wp-ai-client provider plugins for provider dispatch.

--- a/docs/core-system/services-layer.md
+++ b/docs/core-system/services-layer.md
@@ -2,25 +2,7 @@
 
 Data Machine's public service layer is the WordPress Abilities API. REST controllers, WP-CLI commands, chat tools, system tasks, and extension integrations call `datamachine/*` abilities instead of reaching into manager classes or controller internals.
 
-The legacy Services directory has been removed. Current business operations live in focused ability classes under `inc/Abilities/`, with lower-level repositories and core classes kept as implementation details behind those abilities.
-
-## Migration Status
-
-The migration from OOP service managers to WordPress Abilities API is complete:
-
-| Former Service | Replacement | Location |
-|----------------|-------------|----------|
-| `FlowManager` | Flow ability classes | `inc/Abilities/Flow/` |
-| `PipelineManager` | Pipeline ability classes | `inc/Abilities/Pipeline/` |
-| `PipelineStepManager` | `PipelineStepAbilities` | `inc/Abilities/PipelineStepAbilities.php` |
-| `FlowStepManager` | Flow step ability classes | `inc/Abilities/FlowStep/` |
-| `JobManager` | Job ability classes | `inc/Abilities/Job/` |
-| `ProcessedItemsManager` | `ProcessedItemsAbilities` | `inc/Abilities/ProcessedItemsAbilities.php` |
-| `HandlerService` | `HandlerAbilities` | `inc/Abilities/HandlerAbilities.php` |
-| `StepTypeService` | `StepTypeAbilities` | `inc/Abilities/StepTypeAbilities.php` |
-| `LogsManager` | `LogAbilities` | `inc/Abilities/LogAbilities.php` |
-| `CacheManager` | Ability-level/cache-owner invalidation methods | Per-ability class or owning core class |
-| `AuthProviderService` | `AuthAbilities` | `inc/Abilities/AuthAbilities.php` |
+Current business operations live in focused ability classes under `inc/Abilities/`, with lower-level repositories and core classes kept as implementation details behind those abilities.
 
 ## Abilities Overview
 

--- a/docs/core-system/system-tasks.md
+++ b/docs/core-system/system-tasks.md
@@ -15,8 +15,6 @@ The system tasks framework consists of:
 5. **SystemTaskStep** — pipeline step type that bridges system tasks into pipeline workflows
 6. **RecurringScheduleRegistry** — optional schedule bindings that say when a task should run
 
-> Note: `GitHubIssueTask` was extracted to the `data-machine-code` extension plugin (see PR #926). It is no longer part of core data-machine.
-
 ## SystemTask Base Class
 
 **Source:** `inc/Engine/AI/System/Tasks/SystemTask.php`

--- a/docs/core-system/tool-manager.md
+++ b/docs/core-system/tool-manager.md
@@ -124,7 +124,7 @@ Resolved handler tools automatically receive `handler`, `handler_config`, inheri
 
 `AdjacentHandlerToolSource` reads the previous and next step configs, gathers configured handler slugs through `FlowStepConfig`, and asks `ToolManager::resolveHandlerTools()` for each adjacent handler's dynamic tool definitions.
 
-The generic extension hooks are `agents_api_tool_sources` and `agents_api_tool_sources_for_mode`. Data Machine's legacy `datamachine_tool_sources` filters are not mirrored.
+Extensions register tool sources through `agents_api_tool_sources` and `agents_api_tool_sources_for_mode`.
 
 ## Modes
 

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -346,22 +346,7 @@ the resolved definition follows the same shape:
 ]
 ```
 
-### `chubes_ai_request` (removed runtime path)
-
-**Purpose**: Historical provider-dispatch filter. Agent runtime requests now go
-through `RequestBuilder::build()` and the wp-ai-client adapter instead.
-
-**Parameters**:
-
-- `$request` (array) - AI request data
-- `$provider` (string) - AI provider slug
-- `$streaming_callback` (mixed) - Streaming callback function
-- `$tools` (array) - Available tools array
-- `$pipeline_step_id` (string|null) - Pipeline step ID for context
-
-**Return**: Historical array response shape.
-
-**Universal Engine Directive System** (@since v0.2.0): Centralized AI request construction via `RequestBuilder` with hierarchical directive application through filter-based architecture.
+**AI Runtime Directive System**: Centralized AI request construction via `RequestBuilder` with hierarchical directive application through filter-based architecture.
 
 **Directive Application via RequestBuilder**:
 All AI requests now use `RequestBuilder::build()` which integrates with `PromptBuilder` for unified directive management with priority-based ordering:
@@ -411,7 +396,7 @@ add_filter('datamachine_directives', function($directives) {
 });
 ```
 
-**Note**: All AI request building now uses `RequestBuilder::build()` to ensure consistent request structure and directive application. Do not add new `chubes_ai_request` dispatch sites.
+All AI request building uses `RequestBuilder::build()` for consistent request structure and directive application.
 
 ### `datamachine_session_title_prompt`
 
@@ -517,9 +502,8 @@ type's canonical stored shape.
 Data Machine owns workflow and storage policy at these boundaries. Format repair,
 mixed-content detection, and malformed-input normalization belong in the runtime
 transformer, which Data Machine detects through `blocks_engine_php_transformer_*`
-helpers or `Automattic\BlocksEngine\PhpTransformer` classes. Legacy Block Format
-Bridge functions remain a runtime-only fallback for sites that still provide
-them, but Data Machine no longer bundles that old converter stack.
+helpers or `Automattic\BlocksEngine\PhpTransformer` classes. Sites may also
+provide Block Format Bridge functions as a runtime fallback.
 
 ### `datamachine_post_content_format`
 
@@ -1168,78 +1152,6 @@ add_filter( 'datamachine_directives_enabled', '__return_false' );
 
 Use this for eval or training runs that need to guarantee Data Machine contributes no hidden system-message context. Returning `false` suppresses every registered directive before per-agent policy resolution and before any directive class `get_outputs()` method is called.
 
-### `datamachine_global_directives` (LEGACY — use `datamachine_directives`)
-
-**Deprecated**: v0.2.5
-**Replacement**: Use `datamachine_directives` with `modes => ['all']`
-
-**Purpose**: Modify global AI system directives applied across all AI interactions (pipeline + chat)
-
-**Migration Example**:
-
-```php
-// LEGACY (pre-v0.2.5)
-add_filter('datamachine_global_directives', function($directives) {
-    $directives[] = [
-        'priority' => 25,
-        'content' => 'Custom global directive'
-    ];
-    return $directives;
-});
-
-// CURRENT (v0.2.5+)
-add_filter('datamachine_directives', function($directives) {
-    $directives[] = [
-        'class' => MyGlobalDirective::class,
-        'priority' => 25,
-        'modes' => ['all']
-    ];
-    return $directives;
-});
-```
-
-### `datamachine_agent_directives` (LEGACY — use `datamachine_directives`)
-
-**Deprecated**: v0.2.5
-**Replacement**: Use `datamachine_directives` with mode-specific `modes` targeting
-
-**Purpose**: Modify AI system directives for specific agent types (pipeline or chat)
-
-**Parameters**:
-
-- `$request` (array) - Current AI request being built
-- `$agent_type` (string) - Legacy agent type ('pipeline' or 'chat')
-- `$provider` (string) - AI provider (openai, anthropic, etc.)
-- `$tools` (array) - Available tools for the agent
-- `$context` (array) - Agent-specific context data
-
-**Return**: Modified request array
-
-**Migration Example**:
-
-```php
-// LEGACY (pre-v0.2.5)
-add_filter('datamachine_agent_directives', function($request, $agent_type, $provider, $tools, $context) {
-    if ($agent_type === 'pipeline') {
-        $request['messages'][] = [
-            'role' => 'system',
-            'content' => 'Pipeline-specific directive'
-        ];
-    }
-    return $request;
-}, 10, 5);
-
-// CURRENT (v0.2.5+)
-add_filter('datamachine_directives', function($directives) {
-    $directives[] = [
-        'class' => MyPipelineDirective::class,
-        'priority' => 30,
-        'modes' => ['pipeline']
-    ];
-    return $directives;
-});
-```
-
 ## Navigation Filters
 
 ### `datamachine_get_next_flow_step_id`
@@ -1509,9 +1421,8 @@ selection, tool declarations, provider-turn assembly, completion policy,
 transcript persistence, event emission, and runtime tool mediation. It then
 delegates loop sequencing directly to `WP_Agent_Conversation_Loop::run()`.
 
-There is no Data Machine or Agents API conversation-runner replacement filter
-in this code path. The Agents API loop is the runner; consumers extend runtime
-behavior through Agents API seams such as the provider-turn adapter, tool
+The Agents API loop is the runner. Consumers extend runtime behavior through
+Agents API seams such as the provider-turn adapter, tool
 executor/mediator, completion policy, transcript persister, interrupt source,
 and event callback.
 
@@ -1620,12 +1531,11 @@ arrays are projection shapes at provider boundaries, not the store contract.
 ### WP_Agent_Memory_Store (`/agents-api/inc/Core/FilesRepository/WP_Agent_Memory_Store.php`)
 
 **Purpose**: Single seam between agent memory operations and the underlying
-persistence backend. The contract is generic agent-memory persistence: it does
-not own section parsing, scaffold/default-file creation, editability, ability
-permissions, prompt injection, flows, jobs, or pipeline behavior. The disk
-default ([`DiskAgentMemoryStore`](../../../inc/Core/FilesRepository/DiskAgentMemoryStore.php))
-preserves byte-for-byte the filesystem behavior the codebase used before this
-seam was introduced.
+persistence backend. The contract is generic agent-memory persistence. Section
+parsing, scaffold/default-file creation, editability, ability permissions,
+prompt injection, flows, jobs, and pipeline behavior remain Data Machine
+responsibilities. The disk default is
+[`DiskAgentMemoryStore`](../../../inc/Core/FilesRepository/DiskAgentMemoryStore.php).
 
 **Current resolver/filter: `WP_Agent_Memory_Stores::get_store()` / `wp_agent_memory_store`**
 
@@ -1639,10 +1549,6 @@ The canonical resolver returns a direct `$context['memory_store']` value or an
 `WP_Agent_Memory_Store` implementation provided through the `wp_agent_memory_store`
 filter. Data Machine passes the current scope as `$context['scope']`. Return `null`
 (the default) to let Data Machine read and write through the filesystem.
-
-Data Machine does not mirror the previous `agents_api_memory_store` or
-`datamachine_memory_store` hooks because that would create a permanent
-compatibility ladder instead of using the Agents API-owned seam.
 
 **Use case**: managed-host environments where the local filesystem is not
 writable (e.g. WordPress.com, VIP). A consumer plugin (e.g. Intelligence)

--- a/docs/development/hooks/engine-filters.md
+++ b/docs/development/hooks/engine-filters.md
@@ -1,8 +1,6 @@
-# Universal Engine Filters
+# AI Runtime Filters
 
-Reference for the WordPress filters used by the Universal Engine to register directives, tools, and authentication providers, and to validate tool configuration.
-
-> Modes vs contexts: prior to v0.71.0 the directive-targeting field was named `contexts`. It was renamed to `modes` during the AgentMode refactor (#1130). Both `RequestBuilder` and `PromptBuilder` now read `modes`. Old `contexts =>` registrations are silently ignored and treated as `all`.
+Reference for the WordPress filters used by the AI runtime to register directives, tools, and authentication providers, and to validate tool configuration.
 
 ## Directive System
 
@@ -43,7 +41,7 @@ add_filter( 'datamachine_directives', function ( $directives ) {
 } );
 ```
 
-**Built-in directives** are listed in [AI Directives System](../../core-system/ai-directives.md) with current priority and mode assignments. The earlier `GlobalSystemPromptDirective`, `SiteContextDirective`, `PipelineCoreDirective`, `ChatAgentDirective`, and `SystemAgentDirective` classes were removed during the AgentMode refactor — their guidance now lives inline in `AgentModeDirective` and in agent memory files (SITE.md, SOUL.md, MEMORY.md).
+**Built-in directives** are listed in [AI Directives System](../../core-system/ai-directives.md) with current priority and mode assignments.
 
 ### datamachine_agent_mode_{slug}
 

--- a/inc/Engine/AI/README.md
+++ b/inc/Engine/AI/README.md
@@ -18,7 +18,7 @@ Current conversation ownership:
 - `datamachine_run_conversation()` is Data Machine's public runtime entry point for chat and pipeline turns.
 - `AgentsAPI\AI\WP_Agent_Conversation_Loop::run()` owns generic turn sequencing, budgets, transcripts, locks, events, and normalized result fields.
 - Data Machine's turn runner closure owns `RequestBuilder::build()`, wp-ai-client dispatch, `ToolExecutor::executeTool()`, tool runtime rules, completion assertions, job artifact summaries, and product logging.
-- `RequestBuilder::build()` returns `WordPress\AiClient\Results\DTO\GenerativeAiResult` or `WP_Error`; old `success/data/error` arrays are test compatibility inputs only through `datamachine_wp_ai_client_text_result`.
+- `RequestBuilder::build()` returns `WordPress\AiClient\Results\DTO\GenerativeAiResult` or `WP_Error`; compact arrays are supported as test inputs through `datamachine_wp_ai_client_text_result`.
 - Message storage uses `AgentsAPI\AI\WP_Agent_Message` envelopes. Provider-specific shapes are projections at the wp-ai-client boundary.
 
 Use this quick map before moving or renaming files:

--- a/tests/agents-api-wp-ai-client-vocabulary-smoke.php
+++ b/tests/agents-api-wp-ai-client-vocabulary-smoke.php
@@ -61,13 +61,6 @@ agents_api_smoke_assert_equals( true, str_contains( $engine_readme, 'wp-ai-clien
 agents_api_smoke_assert_equals( true, str_contains( $engine_readme, 'pipeline ai steps should not move to agents api solely for provider dispatch' ), 'Engine AI README blocks pipeline AI migration for provider dispatch only', $failures, $passes );
 agents_api_smoke_assert_equals( true, str_contains( $request_docs, 'plugins that only need one-shot ai operations may call `wp-ai-client` directly' ), 'RequestBuilder docs do not force all plugins through Agents API', $failures, $passes );
 
-$deleted_adapter_path    = '/inc/Engine/AI/WpAiClient' . 'Adapter.php';
-$deleted_capability_path = '/inc/Engine/AI/WpAiClient' . 'Capability.php';
-agents_api_smoke_assert_equals( false, is_file( (string) $root . $deleted_adapter_path ), 'Data Machine provider adapter file is deleted', $failures, $passes );
-agents_api_smoke_assert_equals( false, is_file( (string) $root . $deleted_capability_path ), 'Data Machine capability alias wrapper is deleted', $failures, $passes );
-
-agents_api_smoke_assert_equals( false, is_file( (string) $root . '/vendor/wordpress/agents-api/src/AI/WpAiClient.php' ), 'Agents API carries no low-level wp-ai-client execution wrapper', $failures, $passes );
-
 $agents_api_dir = (string) $root . '/vendor/wordpress/agents-api';
 $host_terms     = array( 'dolly', 'automattic ai framework' );
 $host_matches   = array();


### PR DESCRIPTION
## Summary
- remove negative documentation of classes, registries, hooks, routes, services, and provider paths that do not exist in the current runtime
- rewrite maintained docs around current objects, supported inputs, and active boundaries instead of migration history
- remove deleted-file assertions from the Agents API/wp-ai-client vocabulary smoke while retaining positive current-boundary checks

## Examples removed
- `WP_Agent_Category`, `DailyMemorySelectorDirective`, removed mode directive classes, and extracted `GitHubIssueTask`
- deleted `HandlerService` / `StepTypeService` migration tables and notes
- retired directive, provider-dispatch, memory-store, and tool-source hook documentation
- obsolete file-logging migration notes and nonexistent auth-route callouts
- tests that asserted deleted adapter/wrapper files remain absent

## Validation
- targeted nonexistent-identifier scan across maintained docs: zero matches outside generated `docs/CHANGELOG.md`
- `git diff --check`: passed
- local Markdown target validation across all 150 maintained documentation files: passed
- `php tests/agents-api-wp-ai-client-vocabulary-smoke.php`: all 13 current-boundary assertions passed
- `composer lint`: passed

Follow-up to merged #3117 and #3116.