### PR TITLE
fix: make artifact permissions cleanup-safe

### DIFF
--- a/inc/Core/FilesRepository/FileCleanup.php
+++ b/inc/Core/FilesRepository/FileCleanup.php
@@ -302,6 +302,20 @@ class FileCleanup {
 	}
 
 	private function artifact_matches_retention_scope( string $file_path, string $retention_scope ): bool {
+		FilesystemHelper::make_group_writable( $file_path, FilesystemHelper::SHARED_FILE_PERMISSIONS );
+		if ( ! is_readable( $file_path ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'FileCleanup: Artifact is not readable by the cleanup runtime user.',
+				array(
+					'file_path'      => $file_path,
+					'retention_scope' => $retention_scope,
+				)
+			);
+			return false;
+		}
+
 		$contents = file_get_contents( $file_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		if ( ! is_string( $contents ) || '' === $contents ) {
 			return false;

--- a/inc/Core/FilesRepository/FilesystemHelper.php
+++ b/inc/Core/FilesRepository/FilesystemHelper.php
@@ -40,6 +40,12 @@ class FilesystemHelper {
 	 */
 	const AGENT_DIR_PERMISSIONS = 0775;
 
+	/** Group-readable permissions for shared runtime artifact files. */
+	const SHARED_FILE_PERMISSIONS = 0664;
+
+	/** Group-accessible permissions for shared runtime artifact directories. */
+	const SHARED_DIR_PERMISSIONS = 0775;
+
 	/**
 	 * Cached initialization result
 	 *
@@ -99,14 +105,14 @@ class FilesystemHelper {
 	 * @param string $filepath Absolute path to the file.
 	 * @return bool True if the file is (or was made) group-writable, false otherwise.
 	 */
-	public static function make_group_writable( string $filepath ): bool {
+	public static function make_group_writable( string $filepath, int $permissions = self::AGENT_FILE_PERMISSIONS ): bool {
 		if ( ! file_exists( $filepath ) ) {
 			return false;
 		}
 
 		// Already group-writable (commonly via setgid dirs) — nothing to do.
 		$perms = fileperms( $filepath );
-		if ( false !== $perms && ( $perms & 0020 ) === 0020 ) {
+		if ( false !== $perms && ( $perms & 0060 ) === 0060 ) {
 			return true;
 		}
 
@@ -121,7 +127,34 @@ class FilesystemHelper {
 
 		// Suppress any residual warning — a failed chmod is non-fatal here.
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod, WordPress.PHP.NoSilencedErrors.Discouraged
-		return @chmod( $filepath, self::AGENT_FILE_PERMISSIONS );
+		return @chmod( $filepath, $permissions );
+	}
+
+	/**
+	 * Make a shared directory accessible to both runtime users.
+	 *
+	 * @param string $directory Absolute directory path.
+	 * @return bool True if the directory is (or was made) group-accessible.
+	 */
+	public static function make_directory_group_accessible( string $directory ): bool {
+		if ( ! is_dir( $directory ) ) {
+			return false;
+		}
+
+		$perms = fileperms( $directory );
+		if ( false !== $perms && ( $perms & 0030 ) === 0030 ) {
+			return true;
+		}
+
+		if ( function_exists( 'posix_getuid' ) ) {
+			$owner = fileowner( $directory );
+			if ( false !== $owner && posix_getuid() !== $owner ) {
+				return false;
+			}
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod, WordPress.PHP.NoSilencedErrors.Discouraged
+		return @chmod( $directory, self::SHARED_DIR_PERMISSIONS );
 	}
 
 	/**

--- a/inc/Core/JobArtifacts.php
+++ b/inc/Core/JobArtifacts.php
@@ -14,6 +14,7 @@ use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\FilesRepository\AgentMemory as AgentMemoryFile;
 use DataMachine\Core\FilesRepository\DailyMemory;
+use DataMachine\Core\FilesRepository\FilesystemHelper;
 use DataMachine\Engine\AI\MemoryFileRegistry;
 
 defined( 'ABSPATH' ) || exit;
@@ -712,6 +713,7 @@ class JobArtifacts {
 				'error'   => sprintf( 'Failed to create artifact directory for job %d.', $job_id ),
 			);
 		}
+		FilesystemHelper::make_directory_group_accessible( $base_dir );
 
 		$file_name = sanitize_file_name( str_replace( '_', '-', $artifact_key ) . '.json' );
 		$file_path = trailingslashit( $base_dir ) . $file_name;
@@ -799,6 +801,9 @@ class JobArtifacts {
 
 		if ( ! rename( $temp_path, $file_path ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
 			unlink( $temp_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+			return false;
+		}
+		if ( ! FilesystemHelper::make_group_writable( $file_path, FilesystemHelper::SHARED_FILE_PERMISSIONS ) ) {
 			return false;
 		}
 

--- a/tests/job-artifact-hashable-smoke.php
+++ b/tests/job-artifact-hashable-smoke.php
@@ -9,6 +9,10 @@
 
 require_once __DIR__ . '/bootstrap-unit.php';
 
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+	define( 'DAY_IN_SECONDS', 86400 );
+}
+
 if ( ! function_exists( 'wp_json_encode' ) ) {
 	function wp_json_encode( $data, int $flags = 0, int $depth = 512 ) {
 		return json_encode( $data, $flags, $depth );
@@ -56,6 +60,32 @@ if ( ! function_exists( 'trailingslashit' ) ) {
 if ( ! function_exists( 'wp_mkdir_p' ) ) {
 	function wp_mkdir_p( $target ): bool {
 		return is_dir( $target ) || mkdir( $target, 0775, true );
+	}
+}
+
+if ( ! function_exists( 'wp_delete_file' ) ) {
+	function wp_delete_file( string $file ): bool {
+		return is_file( $file ) && unlink( $file );
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		unset( $hook, $args );
+	}
+}
+
+if ( ! class_exists( 'WP_Filesystem_Base' ) ) {
+	class WP_Filesystem_Base {
+		public function delete( string $file ): bool { return is_file( $file ) && unlink( $file ); }
+		public function rmdir( string $directory ): bool { return is_dir( $directory ) && rmdir( $directory ); }
+	}
+}
+
+if ( ! function_exists( 'WP_Filesystem' ) ) {
+	function WP_Filesystem(): bool {
+		$GLOBALS['wp_filesystem'] = new WP_Filesystem_Base();
+		return true;
 	}
 }
 
@@ -246,24 +276,30 @@ foreach ( glob( $leftover_temp_glob ) ?: array() as $leftover_temp_path ) {
 	@unlink( $leftover_temp_path );
 }
 file_put_contents( $tool_trace_path, "stale\n" );
+chmod( $artifact_job_dir, 0700 );
+$previous_umask = umask( 0077 );
 
 $file_result = $invoke( $artifacts, 'write_artifact_file', array( 123, 'tool_trace', $tool_trace_artifact ) );
+umask( $previous_umask );
+$assert_true( true === ( $file_result['success'] ?? false ), 'artifact writer succeeds with restrictive producer umask: ' . ( $file_result['error'] ?? 'unknown error' ) );
 $assert_true( true === ( $file_result['success'] ?? false ), 'tool trace artifact file write succeeds' );
-$assert_true( is_file( $file_result['file']['path'] ?? '' ), 'tool trace artifact file exists on disk' );
+$assert_true( is_file( $tool_trace_path ), 'tool trace artifact file exists on disk' );
 $assert_true( 'datamachine-artifacts/jobs/123/tool-trace.json' === ( $file_result['file']['relative_path'] ?? '' ), 'artifact file has stable relative path' );
 $assert_true( $tool_trace_artifact['sha256'] === ( $file_result['file']['payload_sha256'] ?? '' ), 'artifact file references payload hash' );
-$assert_true( hash_file( 'sha256', $file_result['file']['path'] ) === ( $file_result['file']['sha256'] ?? '' ), 'artifact file hash matches written bytes' );
+$assert_true( hash_file( 'sha256', $tool_trace_path ) === ( $file_result['file']['sha256'] ?? '' ), 'artifact file hash matches written bytes' );
 $assert_true( "stale\n" !== file_get_contents( $tool_trace_path ), 'artifact file atomically replaces stale final contents' );
+$assert_true( ( fileperms( $tool_trace_path ) & 0040 ) === 0040, 'artifact file is group-readable after restrictive producer umask' );
+$assert_true( ( fileperms( $artifact_job_dir ) & 0030 ) === 0030, 'artifact directory is group-accessible after restrictive producer umask' );
 
 $second_file_result = $invoke( $artifacts, 'write_artifact_file', array( 123, 'tool_trace', $tool_trace_artifact ) );
 $assert_true( true === ( $second_file_result['success'] ?? false ), 'repeat tool trace artifact write succeeds' );
-$assert_true( $file_result['file']['path'] === ( $second_file_result['file']['path'] ?? '' ), 'repeat artifact write targets same stable path' );
+$assert_true( $file_result['file']['relative_path'] === ( $second_file_result['file']['relative_path'] ?? '' ), 'repeat artifact write targets same stable path' );
 $assert_true( $file_result['file']['sha256'] === ( $second_file_result['file']['sha256'] ?? '' ), 'repeat artifact write is byte-idempotent' );
 $assert_true( array() === ( glob( $leftover_temp_glob ) ?: array() ), 'atomic artifact write leaves no temp files behind' );
 
 $transcript_file_result = $invoke( $artifacts, 'write_artifact_file', array( 123, 'transcript', $transcript_artifact ) );
 $assert_true( true === ( $transcript_file_result['success'] ?? false ), 'transcript artifact file write succeeds' );
-$assert_true( is_file( $transcript_file_result['file']['path'] ?? '' ), 'transcript artifact file exists on disk' );
+$assert_true( is_file( trailingslashit( $artifact_job_dir ) . 'transcript.json' ), 'transcript artifact file exists on disk' );
 $assert_true( 'datamachine-artifacts/jobs/123/transcript.json' === ( $transcript_file_result['file']['relative_path'] ?? '' ), 'transcript artifact file has stable relative path' );
 $assert_true( $transcript_artifact['sha256'] === ( $transcript_file_result['file']['payload_sha256'] ?? '' ), 'transcript artifact file references payload hash' );
 
@@ -282,6 +318,17 @@ $artifact_files = $invoke(
 $assert_true( $transcript_file_result['file']['relative_path'] === ( $artifact_files['transcript']['relative_path'] ?? '' ), 'engine artifact file metadata round-trips transcript relative path' );
 $assert_true( $file_result['file']['relative_path'] === ( $artifact_files['tool_trace']['relative_path'] ?? '' ), 'engine artifact file metadata round-trips relative path' );
 $assert_true( $file_result['file']['sha256'] === ( $artifact_files['tool_trace']['sha256'] ?? '' ), 'engine artifact file metadata round-trips file hash' );
+
+require_once __DIR__ . '/../inc/Core/FilesRepository/DirectoryManager.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/FilesystemHelper.php';
+require_once __DIR__ . '/../inc/Core/FilesRepository/FileCleanup.php';
+$legacy_path = trailingslashit( $artifact_job_dir ) . 'legacy.json';
+file_put_contents( $legacy_path, wp_json_encode( array( 'retention_scope' => 'job_artifacts' ) ) . "\n" );
+chmod( $legacy_path, 0600 );
+touch( $legacy_path, time() - ( 8 * DAY_IN_SECONDS ) );
+$cleanup = new \DataMachine\Core\FilesRepository\FileCleanup();
+$assert_true( 1 === $cleanup->count_old_job_artifacts( 'job_artifacts', 7 ), 'cleanup can repair legacy private artifact modes before reading' );
+$assert_true( 1 === $cleanup->cleanup_old_job_artifacts( 'job_artifacts', 7 ), 'cleanup deletes repaired legacy artifacts across runtime modes' );
 
 if ( $failures ) {
 	echo "FAILED: " . count( $failures ) . " hashable artifact assertions failed.\n";


### PR DESCRIPTION
## Summary
- Normalize artifact files to shared runtime permissions after atomic writes and make job artifact directories group-accessible.
- Repair legacy private artifact modes before retention reads and report genuinely unreadable artifacts without emitting raw file read warnings.
- Add restrictive-umask and legacy cleanup regression coverage.

## Verification
- `vendor/bin/phpunit`
- `composer lint`
- Homeboy deterministic gates passed.

## Risk
Permission repair is owner-aware and best effort. Existing files owned by another runtime user remain untouched and are logged as unreadable rather than causing noisy `file_get_contents` warnings.

Closes #3121

## AI Assistance
AI-assisted investigation, implementation, and regression coverage; operator reviewed the resulting diff and gate evidence.