### PR TITLE
fix: make scheduler insert failures recoverable

### DIFF
--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -168,12 +168,18 @@ class ScheduleNextStepAbility {
 			$action_args['operation_claim_token'] = (string) ( $job['operation_claim_token'] ?? '' );
 		}
 
-		$action_id = as_schedule_single_action(
-			time(),
-			'datamachine_execute_step',
-			$action_args,
-			'data-machine'
-		);
+		$schedule_exception = null;
+		try {
+			$action_id = as_schedule_single_action(
+				time(),
+				'datamachine_execute_step',
+				$action_args,
+				'data-machine'
+			);
+		} catch ( \Throwable $error ) {
+			$action_id          = 0;
+			$schedule_exception = $error;
+		}
 
 		if ( ! empty( $dataPackets ) ) {
 			do_action(
@@ -193,8 +199,15 @@ class ScheduleNextStepAbility {
 			$this->failScheduling(
 				$job_id,
 				$flow_step_id,
-				'next_step_schedule_failed',
-				array( 'packet_count' => count( $dataPackets ) )
+				null !== $schedule_exception ? 'next_step_schedule_exception' : 'next_step_schedule_failed',
+				array_filter(
+					array(
+						'packet_count'      => count( $dataPackets ),
+						'exception_class'   => null !== $schedule_exception ? get_class( $schedule_exception ) : null,
+						'exception_message' => null !== $schedule_exception ? $schedule_exception->getMessage() : null,
+					),
+					static fn ( $value ): bool => null !== $value
+				)
 			);
 		}
 

--- a/inc/Cli/Commands/SystemCommand.php
+++ b/inc/Cli/Commands/SystemCommand.php
@@ -15,6 +15,7 @@ use DataMachine\Cli\BaseCommand;
 use DataMachine\Abilities\Engine\DrainJobAbility;
 use DataMachine\Abilities\SystemAbilities;
 use DataMachine\Core\ActionScheduler\ClaimIndexMigration;
+use DataMachine\Core\ActionScheduler\ActionInsertReadiness;
 use DataMachine\Core\Bootstrap\DependencyChecker;
 use DataMachine\Engine\Tasks\TaskRegistry;
 use DataMachine\Engine\AI\System\Tasks\SystemTask;
@@ -27,6 +28,66 @@ defined( 'ABSPATH' ) || exit;
  * @since 0.41.0
  */
 class SystemCommand extends BaseCommand {
+
+	/**
+	 * Inspect read-only evidence relevant to Action Scheduler action inserts.
+	 *
+	 * This command does not insert a probe row and cannot prove that a future
+	 * insert will succeed or establish the cause of an earlier engine failure.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp datamachine system action-scheduler-insert-readiness
+	 *     wp datamachine system action-scheduler-insert-readiness --format=json
+	 *
+	 * @subcommand action-scheduler-insert-readiness
+	 */
+	public function action_scheduler_insert_readiness( array $args, array $assoc_args ): void {
+		unset( $args );
+		$format = $assoc_args['format'] ?? 'table';
+		$result = ( new ActionInsertReadiness() )->inspect();
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( (string) wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+		} else {
+			WP_CLI::log( sprintf( 'Table:           %s', $result['table'] ) );
+			WP_CLI::log( sprintf( 'Status:          %s', $result['status'] ) );
+			WP_CLI::log( 'Write test:      not performed' );
+			if ( isset( $result['engine'] ) ) {
+				WP_CLI::log( sprintf( 'Engine:          %s', $result['engine'] ) );
+				WP_CLI::log( sprintf( 'Rows estimate:   %s', number_format_i18n( $result['rows_estimate'] ) ) );
+				WP_CLI::log( sprintf( 'AUTO_INCREMENT:  %s', null === $result['auto_increment'] ? 'unknown' : number_format_i18n( $result['auto_increment'] ) ) );
+				WP_CLI::log( sprintf( 'MAX(action_id):  %s', number_format_i18n( $result['max_action_id'] ) ) );
+			}
+			foreach ( $result['errors'] as $error ) {
+				WP_CLI::warning( $error );
+			}
+			foreach ( $result['limitations'] as $limitation ) {
+				WP_CLI::log( 'Limitation:      ' . $limitation );
+			}
+			if ( isset( $result['recommendation'] ) ) {
+				WP_CLI::log( 'Recommendation:  ' . $result['recommendation'] );
+			}
+		}
+
+		if ( ! $result['success'] ) {
+			WP_CLI::error( 'Action Scheduler insert readiness inspection failed.' );
+			return;
+		}
+
+		WP_CLI::success( 'Read-only Action Scheduler insert evidence collected.' );
+	}
 
 	/**
 	 * Run system health checks.

--- a/inc/Core/ActionScheduler/ActionInsertReadiness.php
+++ b/inc/Core/ActionScheduler/ActionInsertReadiness.php
@@ -54,15 +54,17 @@ class ActionInsertReadiness {
 		}
 
 		// This uses only table metadata visible to the WordPress database user; PROCESS is not required.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$table_info_query = $this->wpdb->prepare(
+			'SELECT ENGINE, TABLE_ROWS, AUTO_INCREMENT, CREATE_TIME, UPDATE_TIME, CHECK_TIME FROM information_schema.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s',
+			$database,
+			$table
+		);
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Prepared immediately above with scalar schema and table values.
 		$table_info = $this->wpdb->get_row(
-			$this->wpdb->prepare(
-				'SELECT ENGINE, TABLE_ROWS, AUTO_INCREMENT, CREATE_TIME, UPDATE_TIME, CHECK_TIME FROM information_schema.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s',
-				$database,
-				$table
-			),
+			$table_info_query,
 			ARRAY_A
 		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		if ( ! is_array( $table_info ) ) {
 			$base['errors'][] = '' !== (string) $this->wpdb->last_error
 				? 'Unable to inspect the actions table: ' . (string) $this->wpdb->last_error
@@ -71,8 +73,10 @@ class ActionInsertReadiness {
 		}
 
 		// MAX(action_id) is a bounded primary-key lookup, not a table scan.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$max_action_id = $this->wpdb->get_var( $this->wpdb->prepare( 'SELECT MAX(action_id) FROM %i', $table ) );
+		$max_action_id_query = $this->wpdb->prepare( 'SELECT MAX(action_id) FROM %i', $table );
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Prepared immediately above with an identifier placeholder.
+		$max_action_id = $this->wpdb->get_var( $max_action_id_query );
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		if ( '' !== (string) $this->wpdb->last_error ) {
 			$base['errors'][] = 'Unable to read the maximum action ID: ' . (string) $this->wpdb->last_error;
 			return $base;
@@ -87,19 +91,19 @@ class ActionInsertReadiness {
 		return array_merge(
 			$base,
 			array(
-				'success'          => true,
-				'status'           => $metadata_ready ? 'metadata_coherent' : 'metadata_warning',
-				'database'         => $database,
-				'engine'           => $engine,
-				'rows_estimate'    => max( 0, (int) ( $table_info['TABLE_ROWS'] ?? 0 ) ),
-				'auto_increment'   => $auto_increment,
-				'max_action_id'    => $max_action_id,
-				'next_id_ahead'    => $next_id_ahead,
-				'metadata_ready'   => $metadata_ready,
-				'create_time'      => $table_info['CREATE_TIME'] ?? null,
-				'update_time'      => $table_info['UPDATE_TIME'] ?? null,
-				'check_time'       => $table_info['CHECK_TIME'] ?? null,
-				'recommendation'   => $metadata_ready
+				'success'        => true,
+				'status'         => $metadata_ready ? 'metadata_coherent' : 'metadata_warning',
+				'database'       => $database,
+				'engine'         => $engine,
+				'rows_estimate'  => max( 0, (int) ( $table_info['TABLE_ROWS'] ?? 0 ) ),
+				'auto_increment' => $auto_increment,
+				'max_action_id'  => $max_action_id,
+				'next_id_ahead'  => $next_id_ahead,
+				'metadata_ready' => $metadata_ready,
+				'create_time'    => $table_info['CREATE_TIME'] ?? null,
+				'update_time'    => $table_info['UPDATE_TIME'] ?? null,
+				'check_time'     => $table_info['CHECK_TIME'] ?? null,
+				'recommendation' => $metadata_ready
 					? 'Metadata is coherent at inspection time. Correlate any insert exception with database server logs before choosing an operator-controlled repair.'
 					: 'Metadata is not coherent enough to infer insert readiness. Escalate with this snapshot and database server evidence; do not repair automatically.',
 			)

--- a/inc/Core/ActionScheduler/ActionInsertReadiness.php
+++ b/inc/Core/ActionScheduler/ActionInsertReadiness.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Read-only Action Scheduler action-insert diagnostics.
+ *
+ * @package DataMachine\Core\ActionScheduler
+ */
+
+namespace DataMachine\Core\ActionScheduler;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Exposes bounded table metadata without attempting a diagnostic write.
+ */
+class ActionInsertReadiness {
+
+	/** @var \wpdb */
+	private $wpdb;
+
+	public function __construct( ?\wpdb $wpdb = null ) {
+		if ( null === $wpdb ) {
+			global $wpdb;
+		}
+
+		$this->wpdb = $wpdb;
+	}
+
+	/** @return array<string,mixed> */
+	public function inspect(): array {
+		$table = $this->wpdb->prefix . 'actionscheduler_actions';
+		$base  = array(
+			'success'              => false,
+			'status'               => 'inspection_failed',
+			'table'                => $table,
+			'write_test_performed' => false,
+			'limitations'          => array(
+				'This read-only snapshot cannot prove that the next insert will succeed or establish the cause of an earlier storage-engine failure.',
+			),
+			'errors'               => array(),
+		);
+
+		// SQLite does not expose MySQL/MariaDB auto-increment storage-engine metadata.
+		if ( str_contains( strtolower( get_class( $this->wpdb ) ), 'sqlite' ) ) {
+			$base['status']   = 'unsupported';
+			$base['errors'][] = 'Action insert metadata inspection is only available for MySQL or MariaDB.';
+			return $base;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$database = (string) $this->wpdb->get_var( 'SELECT DATABASE()' );
+		if ( '' === $database ) {
+			$base['errors'][] = 'Unable to determine the active database.';
+			return $base;
+		}
+
+		// This uses only table metadata visible to the WordPress database user; PROCESS is not required.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$table_info = $this->wpdb->get_row(
+			$this->wpdb->prepare(
+				'SELECT ENGINE, TABLE_ROWS, AUTO_INCREMENT, CREATE_TIME, UPDATE_TIME, CHECK_TIME FROM information_schema.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s',
+				$database,
+				$table
+			),
+			ARRAY_A
+		);
+		if ( ! is_array( $table_info ) ) {
+			$base['errors'][] = '' !== (string) $this->wpdb->last_error
+				? 'Unable to inspect the actions table: ' . (string) $this->wpdb->last_error
+				: 'The Action Scheduler actions table was not found.';
+			return $base;
+		}
+
+		// MAX(action_id) is a bounded primary-key lookup, not a table scan.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$max_action_id = $this->wpdb->get_var( $this->wpdb->prepare( 'SELECT MAX(action_id) FROM %i', $table ) );
+		if ( '' !== (string) $this->wpdb->last_error ) {
+			$base['errors'][] = 'Unable to read the maximum action ID: ' . (string) $this->wpdb->last_error;
+			return $base;
+		}
+
+		$engine         = strtoupper( (string) ( $table_info['ENGINE'] ?? '' ) );
+		$auto_increment = null === ( $table_info['AUTO_INCREMENT'] ?? null ) ? null : (int) $table_info['AUTO_INCREMENT'];
+		$max_action_id  = null === $max_action_id ? 0 : max( 0, (int) $max_action_id );
+		$next_id_ahead  = null !== $auto_increment && $auto_increment > $max_action_id;
+		$metadata_ready = 'INNODB' === $engine && $next_id_ahead;
+
+		return array_merge(
+			$base,
+			array(
+				'success'          => true,
+				'status'           => $metadata_ready ? 'metadata_coherent' : 'metadata_warning',
+				'database'         => $database,
+				'engine'           => $engine,
+				'rows_estimate'    => max( 0, (int) ( $table_info['TABLE_ROWS'] ?? 0 ) ),
+				'auto_increment'   => $auto_increment,
+				'max_action_id'    => $max_action_id,
+				'next_id_ahead'    => $next_id_ahead,
+				'metadata_ready'   => $metadata_ready,
+				'create_time'      => $table_info['CREATE_TIME'] ?? null,
+				'update_time'      => $table_info['UPDATE_TIME'] ?? null,
+				'check_time'       => $table_info['CHECK_TIME'] ?? null,
+				'recommendation'   => $metadata_ready
+					? 'Metadata is coherent at inspection time. Correlate any insert exception with database server logs before choosing an operator-controlled repair.'
+					: 'Metadata is not coherent enough to infer insert readiness. Escalate with this snapshot and database server evidence; do not repair automatically.',
+			)
+		);
+	}
+}

--- a/inc/Core/DirectJobEnqueuer.php
+++ b/inc/Core/DirectJobEnqueuer.php
@@ -91,8 +91,25 @@ class DirectJobEnqueuer {
 			return $this->failure( 'enqueue_claim_fenced', $generation, true, 'enqueuing' );
 		}
 
-		$run_at    = null !== $timestamp && $timestamp > time() ? $timestamp : time();
-		$action_id = ( $this->scheduler )( $run_at, self::HOOK, $args, self::GROUP );
+		$run_at = null !== $timestamp && $timestamp > time() ? $timestamp : time();
+		try {
+			$action_id = ( $this->scheduler )( $run_at, self::HOOK, $args, self::GROUP );
+		} catch ( \Throwable $error ) {
+			$this->jobs->finish_operation_enqueue( $job_id, 'enqueue_failed', 0, $token, $generation );
+			do_action(
+				'datamachine_log',
+				'error',
+				'Direct operation Action Scheduler enqueue failed',
+				array(
+					'job_id'            => $job_id,
+					'flow_step_id'      => $flow_step_id,
+					'operation_state'   => 'enqueue_failed',
+					'exception_class'   => get_class( $error ),
+					'exception_message' => $error->getMessage(),
+				)
+			);
+			return $this->failure( 'action_schedule_exception', $generation, true );
+		}
 		if ( ! is_int( $action_id ) || $action_id <= 0 ) {
 			$this->jobs->finish_operation_enqueue( $job_id, 'enqueue_failed', 0, $token, $generation );
 			return $this->failure( 'action_schedule_failed', $generation, true );

--- a/inc/Core/JobRetryPolicy.php
+++ b/inc/Core/JobRetryPolicy.php
@@ -116,12 +116,27 @@ class JobRetryPolicy {
 			$action_args['operation_claim_token'] = (string) ( $job['operation_claim_token'] ?? '' );
 		}
 
-		$action_id = as_schedule_single_action(
-			$timestamp,
-			'datamachine_execute_step',
-			$action_args,
-			'data-machine'
-		);
+		try {
+			$action_id = as_schedule_single_action(
+				$timestamp,
+				'datamachine_execute_step',
+				$action_args,
+				'data-machine'
+			);
+		} catch ( \Throwable $error ) {
+			$action_id = 0;
+			do_action(
+				'datamachine_log',
+				'error',
+				'Job retry Action Scheduler enqueue failed',
+				array(
+					'job_id'            => $job_id,
+					'flow_step_id'      => $flow_step_id,
+					'exception_class'   => get_class( $error ),
+					'exception_message' => $error->getMessage(),
+				)
+			);
+		}
 
 		if ( ! is_numeric( $action_id ) || (int) $action_id <= 0 ) {
 			self::clearPendingRetryOwnership( $job_id );

--- a/tests/action-scheduler-insert-readiness-smoke.php
+++ b/tests/action-scheduler-insert-readiness-smoke.php
@@ -1,0 +1,77 @@
+<?php
+/** Regression coverage for read-only Action Scheduler insert evidence. */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+if ( ! defined( 'ARRAY_A' ) ) {
+	define( 'ARRAY_A', 'ARRAY_A' );
+}
+if ( ! class_exists( 'wpdb' ) ) {
+	class wpdb {
+		public $prefix = '';
+		public $last_error = '';
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/ActionScheduler/ActionInsertReadiness.php';
+
+use DataMachine\Core\ActionScheduler\ActionInsertReadiness;
+
+final class ActionInsertReadinessSmokeWpdb extends wpdb {
+	public function __construct() {
+		$this->prefix = 'wp_7_';
+	}
+
+	public function prepare( $query, ...$args ): string {
+		foreach ( $args as $argument ) {
+			$query = preg_replace( '/%[is]/', '%i' === substr( $query, strpos( $query, '%' ), 2 ) ? '`' . $argument . '`' : "'{$argument}'", $query, 1 );
+		}
+		return $query;
+	}
+
+	public function get_var( $query = null, $x = 0, $y = 0 ) {
+		unset( $x, $y );
+		if ( 'SELECT DATABASE()' === $query ) {
+			return 'wordpress';
+		}
+		if ( str_contains( (string) $query, 'MAX(action_id)' ) ) {
+			return 82650691;
+		}
+		return null;
+	}
+
+	public function get_row( $query = null, $output = null, $y = 0 ) {
+		unset( $query, $output, $y );
+		return array(
+			'ENGINE'         => 'InnoDB',
+			'TABLE_ROWS'     => 45000,
+			'AUTO_INCREMENT' => 82650692,
+			'CREATE_TIME'    => '2026-08-01 00:00:00',
+			'UPDATE_TIME'    => null,
+			'CHECK_TIME'     => null,
+		);
+	}
+}
+
+$failed = 0;
+$assert = static function ( bool $condition, string $label ) use ( &$failed ): void {
+	if ( $condition ) {
+		echo "PASS: {$label}\n";
+		return;
+	}
+	++$failed;
+	echo "FAIL: {$label}\n";
+};
+
+$result = ( new ActionInsertReadiness( new ActionInsertReadinessSmokeWpdb() ) )->inspect();
+$assert( true === $result['success'] && 'metadata_coherent' === $result['status'], 'coherent metadata is reported without claiming a write' );
+$assert( false === $result['write_test_performed'], 'diagnostic never inserts a probe action' );
+$assert( 82650692 === $result['auto_increment'] && 82650691 === $result['max_action_id'], 'diagnostic preserves sequence evidence' );
+$assert( str_contains( $result['limitations'][0], 'cannot prove' ), 'diagnostic states its evidentiary limit' );
+
+$command = file_get_contents( __DIR__ . '/../inc/Cli/Commands/SystemCommand.php' ) ?: '';
+$assert( str_contains( $command, '@subcommand action-scheduler-insert-readiness' ), 'operator command exposes the diagnostic' );
+$assert( ! str_contains( file_get_contents( __DIR__ . '/../inc/Core/ActionScheduler/ActionInsertReadiness.php' ) ?: '', 'INSERT INTO' ), 'diagnostic contains no repair or insert statement' );
+
+exit( $failed > 0 ? 1 : 0 );

--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -30,6 +30,12 @@ if ( ! function_exists( 'add_action' ) ) {
 	}
 }
 
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( ...$args ) {
+		// no-op
+	}
+}
+
 require_once __DIR__ . '/agents-api-loader.php';
 datamachine_tests_require_agents_api();
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/direct-job-generation-smoke.php
+++ b/tests/direct-job-generation-smoke.php
@@ -142,6 +142,20 @@ $missing_result  = ( new DirectJobEnqueuer( $missing_receipt, static fn() => 505
 direct_generation_assert( false === $missing_result['success'] && 'action_receipt_missing' === $missing_result['error'], 'positive scheduler ID without a durable receipt fails enqueue' );
 direct_generation_assert( 'enqueue_failed' === $missing_receipt->job['operation_state'], 'missing action receipt leaves the operation reclaimable' );
 
+$insert_failure = new DirectJobGenerationFakeJobs();
+$failure_result = ( new DirectJobEnqueuer(
+	$insert_failure,
+	static function (): never {
+		throw new RuntimeException( 'Error saving action: Failed to read auto-increment value from storage engine' );
+	},
+	static fn() => 0,
+	static fn() => false
+) )->enqueue( 42, 'ephemeral_step_0' );
+direct_generation_assert( false === $failure_result['success'] && 'action_schedule_exception' === $failure_result['error'], 'scheduler insert exception returns an explicit failure' );
+direct_generation_assert( true === $failure_result['retryable'], 'scheduler insert exception remains recoverable' );
+direct_generation_assert( 'enqueue_failed' === $insert_failure->job['operation_state'], 'scheduler insert exception releases the enqueue claim into a recoverable state' );
+direct_generation_assert( 1 === $insert_failure->job['operation_generation'], 'scheduler insert exception does not create another enqueue generation' );
+
 $jobs_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Database/Jobs/Jobs.php' ) ?: '';
 $step_source = file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/Engine/ExecuteStepAbility.php' ) ?: '';
 direct_generation_assert( str_contains( $jobs_source, 'operation_claim_token = %s' ) && str_contains( $jobs_source, 'operation_generation = %d' ), 'enqueue finish is fenced by token and generation' );

--- a/tests/schedule-next-step-failure-smoke.php
+++ b/tests/schedule-next-step-failure-smoke.php
@@ -31,6 +31,8 @@ echo "Case 1: schedule-next-step owns Action Scheduler failures\n";
 assert_schedule_next_step_failure_smoke( 'helper exists', str_contains( $source, 'private function failScheduling' ) );
 assert_schedule_next_step_failure_smoke( 'non-positive action scheduler result is checked', str_contains( $execute, '(int) $action_id <= 0' ) );
 assert_schedule_next_step_failure_smoke( 'failed scheduling routes through helper', str_contains( $execute, "'next_step_schedule_failed'") );
+assert_schedule_next_step_failure_smoke( 'scheduler insert exceptions are contained', str_contains( $execute, 'catch ( \\Throwable $error )' ) && str_contains( $execute, "'next_step_schedule_exception'") );
+assert_schedule_next_step_failure_smoke( 'scheduler exception evidence reaches failure handling', str_contains( $execute, "'exception_message' => null !== \$schedule_exception") );
 assert_schedule_next_step_failure_smoke( 'helper failure happens before returning action result', strpos( $execute, 'if ( ! is_numeric( $action_id )' ) < strrpos( $execute, "'success'   => is_numeric( $" . 'action_id' ) );
 
 echo "Case 2: unscheduled jobs are requeued or finalized through fail-job\n";


### PR DESCRIPTION
## Summary
- add a bounded, read-only `wp datamachine system action-scheduler-insert-readiness` diagnostic for engine, row estimate, `AUTO_INCREMENT`, and `MAX(action_id)` evidence
- contain Action Scheduler insert exceptions at direct enqueue, next-step handoff, and retry scheduling boundaries
- preserve direct jobs as explicit `enqueue_failed`, retryable operations while retaining generation fencing and duplicate-action reconciliation
- add regression coverage for the observed storage-engine exception and diagnostic contract

## Evidence and limits

Observed in production: MariaDB repeatedly returned `Failed to read auto-increment value from storage engine` while Action Scheduler inserted into `c8c_7_actionscheduler_actions`. A later snapshot reported InnoDB, `AUTO_INCREMENT` 82650692, `MAX(action_id)` 82650691, and approximately 45,000 rows.

Those observations establish an action-insert failure followed by coherent table metadata. They do not prove sequence corruption, concurrency, or another storage-engine root cause. The new diagnostic performs no write and explicitly reports that its snapshot cannot prove the next insert will succeed. Database server logs remain necessary to distinguish transient/concurrency and engine hypotheses.

No database repair, activation-time repair, request-time repair, or probe insertion is included. Any repair remains explicit and operator-controlled outside Data Machine request paths.

## Recoverability

Action Scheduler's DB store throws when an insert produces no action ID. Data Machine now catches that exception before it escapes job ownership boundaries:

- direct operations CAS-transition the owned generation from `enqueuing` to `enqueue_failed` and return a retryable `action_schedule_exception`
- next-step scheduling routes exception evidence through the existing retryable fail-job policy instead of leaving a processing job pathless
- retry scheduling clears pending retry ownership and leaves the job on the existing failure path when the retry action itself cannot be inserted
- exact-generation action lookup and receipt checks remain unchanged, so retries reconcile existing actions rather than multiplying pending work

## Verification
- `php tests/direct-job-generation-smoke.php`
- `php tests/schedule-next-step-failure-smoke.php`
- `php tests/action-scheduler-insert-readiness-smoke.php`
- `php tests/action-scheduler-claim-index-migration-smoke.php`
- `php tests/direct-operation-missing-action-recovery-smoke.php`
- `php tests/job-retry-policy-smoke.php`
- `php tests/retry-schedule-lifecycle-smoke.php`
- `php tests/system-health-scheduler-smoke.php`
- `php tests/worker-dispatch-health-smoke.php`
- `vendor/bin/phpunit --testdox tests/Unit tests/SanityTest.php`
- `composer lint`
- `php tests/prefix-policy-audit.php`
- `git diff --check`

The complete `tests/*-smoke.php` sweep reaches the pre-existing, unrelated `abilities-send-email-load-order-smoke.php` failure tracked in #2897. All scheduler/recovery tests listed above pass.

Closes #3125

Assisted by OpenCode.