### PR TITLE
refactor: keep bundle directories canonical in runner

### DIFF
--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -60,8 +60,11 @@ final class AgentBundleRunner {
 			return $this->response( $loaded, $input, $runtime_imports );
 		}
 
-		$bundle    = $loaded['bundle'];
-		$directory = AgentBundleArrayAdapter::from_array_bundle( $bundle );
+		$bundle    = is_array( $loaded['bundle'] ?? null ) ? $loaded['bundle'] : array();
+		$directory = $loaded['directory'] ?? null;
+		if ( ! $directory instanceof AgentBundleDirectory ) {
+			$directory = AgentBundleArrayAdapter::from_array_bundle( $bundle );
+		}
 		$selection = $this->select_flow( $directory, (string) ( $input['flow'] ?? $input['flow_slug'] ?? '' ) );
 		if ( empty( $selection['success'] ) ) {
 			return $this->response( $selection, $input, $runtime_imports );
@@ -109,7 +112,7 @@ final class AgentBundleRunner {
 			);
 		}
 
-		$identity = $this->ensure_runtime_agent_identity( $bundle, $input );
+		$identity = $this->ensure_runtime_agent_identity( $directory, $bundle, $input );
 		if ( empty( $identity['success'] ) ) {
 			return $this->response( $identity, $input, $runtime_imports, $selection );
 		}
@@ -704,8 +707,9 @@ final class AgentBundleRunner {
 	}
 
 	/** @return array<string,mixed> */
-	private function ensure_runtime_agent_identity( array $bundle, array $input ): array {
-		$slug = sanitize_title( (string) ( $bundle['agent']['agent_slug'] ?? '' ) );
+	private function ensure_runtime_agent_identity( AgentBundleDirectory $directory, array $bundle, array $input ): array {
+		$manifest = $directory->manifest()->to_array();
+		$slug     = sanitize_title( (string) ( $manifest['agent']['slug'] ?? '' ) );
 		if ( '' === $slug ) {
 			return array(
 				'success' => false,
@@ -725,16 +729,13 @@ final class AgentBundleRunner {
 		}
 
 		$owner_id = $this->runtime_import_owner_id( $input );
-		$result   = $this->bundler->import(
-			$bundle,
-			null,
-			$owner_id,
-			false,
-			array(
-				'is_upgrade'        => true,
-				'reconcile_runtime' => true,
-			)
+		$options = array(
+			'is_upgrade'        => true,
+			'reconcile_runtime' => true,
 		);
+		$result  = empty( $bundle )
+			? $this->bundler->import_directory_object( $directory, null, $owner_id, false, $options )
+			: $this->bundler->import( $bundle, null, $owner_id, false, $options );
 		if ( empty( $result['success'] ) ) {
 			return array(
 				'success' => false,
@@ -856,10 +857,15 @@ final class AgentBundleRunner {
 		}
 
 		$revision = BundleSource::is_remote( $source ) ? BundleSource::last_resolved_revision() : null;
-		$bundle   = null;
+		$bundle    = null;
+		$directory = null;
 		try {
 			if ( is_dir( $resolved ) ) {
-				$bundle = $this->bundler->from_directory( $resolved );
+				try {
+					$directory = AgentBundleDirectory::read( $resolved );
+				} catch ( BundleValidationException $e ) {
+					$bundle = $this->bundler->from_directory( $resolved );
+				}
 			} elseif ( preg_match( '/\.zip$/i', $resolved ) ) {
 				$bundle = $this->bundler->from_zip( $resolved );
 			} elseif ( preg_match( '/\.json$/i', $resolved ) ) {
@@ -874,7 +880,7 @@ final class AgentBundleRunner {
 		}
 
 		BundleSource::cleanup( $resolved, $source );
-		if ( ! is_array( $bundle ) ) {
+		if ( ! $directory instanceof AgentBundleDirectory && ! is_array( $bundle ) ) {
 			return array(
 				'success' => false,
 				'error'   => 'Failed to parse bundle. Use a bundle directory, .json file, or .zip archive.',
@@ -890,6 +896,7 @@ final class AgentBundleRunner {
 		return array(
 			'success'         => true,
 			'bundle'          => $bundle,
+			'directory'       => $directory,
 			'source_revision' => $revision,
 		);
 	}

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -85,7 +85,10 @@ datamachine_bundle_runner_contains( $abilities, 'array_replace( $raw_input[\'opt
 
 echo "\n[2] Runner projects bundles to ephemeral workflows\n";
 foreach ( array(
-	'AgentBundleArrayAdapter::from_array_bundle' => 'runner consumes portable bundle documents',
+	"AgentBundleDirectory::read( \$resolved )" => 'runner loads schema-v1 directories as the canonical value object',
+	"\$directory = \$loaded['directory'] ?? null" => 'runner carries loaded directory objects into execution',
+	'! $directory instanceof AgentBundleDirectory' => 'runner limits array adaptation to compatibility inputs',
+	'import_directory_object( $directory'       => 'runner preserves direct directory import when runtime identity is absent',
 	'BundleSourceAuth::build_resolve_context'    => 'runner shares bundle token resolution with import/install surfaces',
 	'workflow_from_bundle_flow'                  => 'runner converts selected bundle flow to workflow steps',
 	'workflow_override_from_input'               => 'runner supports caller-supplied workflow overrides',


### PR DESCRIPTION
## Summary
- remove the directory-to-legacy-array-to-directory round-trip from `AgentBundleRunner` for schema-v1 directory sources
- carry `AgentBundleDirectory` directly through flow selection, workflow projection, manifest identity, and direct runtime identity import
- retain legacy arrays as the explicit compatibility edge for JSON, legacy directory, and current zip inputs

## Canonical representation
For a schema-v1 directory source, `AgentBundleDirectory::read()` now produces the runner's canonical internal representation. The runner consumes that object directly instead of calling `AgentBundler::from_directory()`, converting through `AgentBundleArrayAdapter::to_array_bundle()`, and immediately rebuilding it with `from_array_bundle()`.

The direct object path preserves manifest, pipeline/flow documents, handler config, queue state, enabled/disabled tools, scheduling, opaque extras, and extension artifacts without introducing source-install IDs. If the runtime agent identity is absent, the runner passes the same directory object to `import_directory_object()`; the existing persistence importer remains responsible for the compatibility projection at that boundary.

## Compatibility
Legacy array import/export remains unchanged because persisted backup JSON and existing public callers have a concrete compatibility need. Legacy JSON, old monolithic directories, and zip inputs continue through the existing array readers. No bundle schema, hashes, persistence fields, conflict/local-modification policy, CLI arguments, or workflow semantics changed.

## Verification
- `php tests/agent-bundle-runner-contract-smoke.php` (129 assertions passed)
- `php tests/agent-bundler-directory-adapter-smoke.php` (55 assertions passed, including handler config, queue state, enabled/disabled tools, scheduling, and source-ID independence)
- `vendor/bin/phpcs inc/Engine/Bundle/AgentBundleRunner.php tests/agent-bundle-runner-contract-smoke.php` (passed)
- `homeboy review lint --changed-only --placement local ...` (passed; run `71f0877b-0ab4-4399-8526-1d4ec9145459`)
- `homeboy review audit --changed-since origin/main --placement local --profile pr ...` (passed; no introduced findings)
- `homeboy review test --changed-since origin/main --placement local ...` could not provide a deterministic test result because its configured PHPUnit runner executed zero tests (run `9d48ec03-273a-4580-9a91-2abced7eeab9`)
- `php tests/agent-bundle-package-portability-smoke.php` retains an unrelated existing failure at `Data Machine materializer saw applied artifacts`; all 19 preceding portability assertions pass

## Remaining work
- make directory-aware lifecycle/ability import and upgrade paths consume `AgentBundleDirectory` directly rather than projecting to arrays
- add a direct directory-object persistence importer so `import_directory_object()` no longer converts at the DB materialization boundary
- make schema-v1 zip loading return a directory object without the current array projection
- establish the workflow-spec compiler path described by #1501 before replacing runtime config materialization

Refs #1501
Part of #3113