### PR TITLE
refactor: use native errors for job queries

### DIFF
--- a/inc/Abilities/Job/FlowHealthAbility.php
+++ b/inc/Abilities/Job/FlowHealthAbility.php
@@ -65,29 +65,31 @@ class FlowHealthAbility {
 	 * Execute get-flow-health ability.
 	 *
 	 * @param array $input Input parameters with flow_id.
-	 * @return array Result with health metrics.
+	 * @return array|\WP_Error Result with health metrics or a query failure.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$flow_id = $input['flow_id'] ?? null;
 
 		if ( ! is_numeric( $flow_id ) || (int) $flow_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_id is required and must be a positive integer',
-			);
+			return new \WP_Error( 'invalid_flow_id', 'flow_id is required and must be a positive integer', array( 'status' => 400 ) );
 		}
 
 		$flow_id = (int) $flow_id;
 
-		$flow = $this->db_flows->get_flow( $flow_id );
+		$flow        = $this->db_flows->get_flow( $flow_id );
+		$query_error = $this->jobQueryFailed();
+		if ( $query_error ) {
+			return $query_error;
+		}
 		if ( ! $flow ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Flow %d not found', $flow_id ),
-			);
+			return new \WP_Error( 'flow_not_found', sprintf( 'Flow %d not found', $flow_id ), array( 'status' => 404 ) );
 		}
 
-		$health = $this->db_jobs->get_flow_health( $flow_id );
+		$health      = $this->db_jobs->get_flow_health( $flow_id );
+		$query_error = $this->jobQueryFailed();
+		if ( $query_error ) {
+			return $query_error;
+		}
 
 		return array(
 			'success'              => true,

--- a/inc/Abilities/Job/GetJobsAbility.php
+++ b/inc/Abilities/Job/GetJobsAbility.php
@@ -139,9 +139,9 @@ class GetJobsAbility {
 	 * Execute get-jobs ability.
 	 *
 	 * @param array $input Input parameters.
-	 * @return array Result with jobs list.
+	 * @return array|\WP_Error Result with jobs list or a query failure.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$job_id          = $input['job_id'] ?? null;
 		$flow_id         = $input['flow_id'] ?? null;
 		$pipeline_id     = $input['pipeline_id'] ?? null;
@@ -161,25 +161,21 @@ class GetJobsAbility {
 			null !== $user_id ? (int) $user_id : null,
 			null !== $agent_id ? (int) $agent_id : null
 		);
-		if ( isset( $ownership_scope['error'] ) ) {
-			return array(
-				'success'    => false,
-				'error_code' => 'job_access_denied',
-				'error'      => $ownership_scope['error'],
-				'status'     => 403,
-			);
+		if ( is_wp_error( $ownership_scope ) ) {
+			return $ownership_scope;
 		}
 
 		// Direct job lookup by ID - bypasses pagination and filters.
-		if ( $job_id ) {
+		if ( null !== $job_id ) {
 			if ( ! is_numeric( $job_id ) || (int) $job_id <= 0 ) {
-				return array(
-					'success' => false,
-					'error'   => 'job_id must be a positive integer',
-				);
+				return new \WP_Error( 'invalid_job_id', 'job_id must be a positive integer', array( 'status' => 400 ) );
 			}
 
-			$job = $this->db_jobs->get_job( (int) $job_id );
+			$job         = $this->db_jobs->get_job( (int) $job_id );
+			$query_error = $this->jobQueryFailed();
+			if ( $query_error ) {
+				return $query_error;
+			}
 
 			if ( ! $job ) {
 				return array(
@@ -193,7 +189,7 @@ class GetJobsAbility {
 			}
 
 			if ( ! $this->canAccessJob( $job ) ) {
-				return $this->jobAccessDenied();
+				return $this->jobQueryAccessDenied();
 			}
 
 			$jobs_enriched = $this->enrichJobNames( array( $job ) );
@@ -275,12 +271,25 @@ class GetJobsAbility {
 			$args['metadata']            = $metadata;
 			$args['metadata_scan_limit'] = (int) ( $input['metadata_scan_limit'] ?? 1000 );
 			$metadata_query              = $this->db_jobs->query_executions_by_metadata( $args );
+			$query_error                 = $this->jobQueryFailed();
+			if ( $query_error ) {
+				return $query_error;
+			}
 			$jobs                        = $metadata_query['jobs'];
 			$total                       = $metadata_query['total'];
 			$filters_applied['metadata'] = $metadata;
 		} else {
-			$jobs  = $this->db_jobs->get_jobs_for_list_table( $args );
-			$total = $this->db_jobs->get_jobs_count( $args );
+			$jobs        = $this->db_jobs->get_jobs_for_list_table( $args );
+			$query_error = $this->jobQueryFailed();
+			if ( $query_error ) {
+				return $query_error;
+			}
+
+			try {
+				$total = $this->db_jobs->get_jobs_count( $args, true );
+			} catch ( \RuntimeException ) {
+				return new \WP_Error( 'job_query_failed', __( 'Unable to query jobs.', 'data-machine' ), array( 'status' => 500 ) );
+			}
 		}
 
 		if ( empty( $args['fields'] ) ) {

--- a/inc/Abilities/Job/JobHelpers.php
+++ b/inc/Abilities/Job/JobHelpers.php
@@ -87,14 +87,34 @@ trait JobHelpers {
 		);
 	}
 
+	/** Return the native failure used by read-only job query abilities. */
+	protected function jobQueryAccessDenied( string $message = 'You do not have permission to access this job.' ): \WP_Error {
+		return new \WP_Error( 'job_access_denied', $message, array( 'status' => 403 ) );
+	}
+
+	/** Convert a database query error into the bounded job-query failure contract. */
+	protected function jobQueryFailed(): ?\WP_Error {
+		global $wpdb;
+
+		if ( '' === (string) $wpdb->last_error ) {
+			return null;
+		}
+
+		return new \WP_Error(
+			'job_query_failed',
+			__( 'Unable to query jobs.', 'data-machine' ),
+			array( 'status' => 500 )
+		);
+	}
+
 	/**
 	 * Apply authoritative ownership constraints to a job collection query.
 	 *
 	 * @param int|null $requested_user_id  Caller-selected user filter.
 	 * @param int|null $requested_agent_id Caller-selected agent filter.
-	 * @return array{user_id?:int,agent_id?:int}|array{error:string}
+	 * @return array{user_id?:int,agent_id?:int}|\WP_Error
 	 */
-	protected function jobCollectionScope( ?int $requested_user_id, ?int $requested_agent_id ): array {
+	protected function jobCollectionScope( ?int $requested_user_id, ?int $requested_agent_id ): array|\WP_Error {
 		if ( PermissionHelper::has_privileged_resource_access( 'manage_flows' ) ) {
 			if ( null !== $requested_agent_id ) {
 				return array( 'agent_id' => $requested_agent_id );
@@ -106,7 +126,7 @@ trait JobHelpers {
 		if ( null !== $requested_agent_id ) {
 			return PermissionHelper::can_access_agent( $requested_agent_id )
 				? array( 'agent_id' => $requested_agent_id )
-				: array( 'error' => 'You do not have permission to access jobs for this agent.' );
+				: $this->jobQueryAccessDenied( 'You do not have permission to access jobs for this agent.' );
 		}
 
 		$acting_agent_id = PermissionHelper::get_acting_agent_id();
@@ -115,11 +135,11 @@ trait JobHelpers {
 		}
 
 		if ( null !== $requested_user_id && $requested_user_id !== $acting_user_id ) {
-			return array( 'error' => 'You do not have permission to access jobs for this user.' );
+			return $this->jobQueryAccessDenied( 'You do not have permission to access jobs for this user.' );
 		}
 
 		if ( $acting_user_id <= 0 ) {
-			return array( 'error' => 'An authenticated acting caller is required to list owned jobs.' );
+			return $this->jobQueryAccessDenied( 'An authenticated acting caller is required to list owned jobs.' );
 		}
 
 		return array( 'user_id' => $acting_user_id );

--- a/inc/Abilities/Job/JobsSummaryAbility.php
+++ b/inc/Abilities/Job/JobsSummaryAbility.php
@@ -90,20 +90,15 @@ class JobsSummaryAbility {
 	 * are normalized to their base status.
 	 *
 	 * @param array $input Filter parameters.
-	 * @return array Result with summary counts.
+	 * @return array|\WP_Error Result with summary counts or a query failure.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$ownership_scope = $this->jobCollectionScope(
 			isset( $input['user_id'] ) ? (int) $input['user_id'] : null,
 			isset( $input['agent_id'] ) ? (int) $input['agent_id'] : null
 		);
-		if ( isset( $ownership_scope['error'] ) ) {
-			return array(
-				'success'    => false,
-				'error_code' => 'job_access_denied',
-				'error'      => $ownership_scope['error'],
-				'status'     => 403,
-			);
+		if ( is_wp_error( $ownership_scope ) ) {
+			return $ownership_scope;
 		}
 
 		$filters = array();
@@ -114,7 +109,11 @@ class JobsSummaryAbility {
 		}
 		$filters = array_merge( $filters, $ownership_scope );
 
-		$summary = empty( $input['compact'] ) ? $this->db_jobs->get_jobs_summary( $filters ) : $this->getCompactSummary( $filters );
+		$summary     = empty( $input['compact'] ) ? $this->db_jobs->get_jobs_summary( $filters ) : $this->getCompactSummary( $filters );
+		$query_error = $this->jobQueryFailed();
+		if ( $query_error ) {
+			return $query_error;
+		}
 
 		return array(
 			'success' => true,

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -1709,8 +1709,9 @@ class JobsCommand extends BaseCommand {
 
 		$result = ( new GetJobsAbility() )->execute( array( 'job_id' => (int) $job_id ) );
 
-		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['error'] ?? 'Unknown error occurred' );
+		$error = AbilityResult::failure_to_wp_error( $result, 'get_jobs_failed', 'Unknown error occurred' );
+		if ( $error ) {
+			WP_CLI::error( $error->get_error_message() );
 			return;
 		}
 
@@ -1785,8 +1786,9 @@ class JobsCommand extends BaseCommand {
 
 		$result = ( new GetJobsAbility() )->execute( array( 'job_id' => $job_id ) );
 
-		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['error'] ?? 'Unknown error occurred' );
+		$error = AbilityResult::failure_to_wp_error( $result, 'get_jobs_failed', 'Unknown error occurred' );
+		if ( $error ) {
+			WP_CLI::error( $error->get_error_message() );
 			return;
 		}
 

--- a/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
+++ b/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
@@ -10,6 +10,7 @@ namespace DataMachine\Tests\Unit\Abilities\Job;
 use AgentsAPI\AI\WP_Agent_Execution_Principal;
 use DataMachine\Abilities\Job\ExecuteWorkflowAbility;
 use DataMachine\Abilities\Job\FailJobAbility;
+use DataMachine\Abilities\Job\FlowHealthAbility;
 use DataMachine\Abilities\Job\GetJobsAbility;
 use DataMachine\Abilities\Job\HydrateJobArtifactAbility;
 use DataMachine\Abilities\Job\JobsSummaryAbility;
@@ -24,6 +25,7 @@ use DataMachine\Core\DirectJobEnqueuer;
 use DataMachine\Core\DirectOperationRecoveryPolicy;
 use DataMachine\Core\JobRetryPolicy;
 use DataMachine\Core\JobStatus;
+use DataMachine\Api\Jobs as JobsApi;
 use WP_UnitTestCase;
 
 class DirectJobOwnershipTest extends WP_UnitTestCase {
@@ -117,7 +119,7 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertTrue( $internal['success'] );
 
 		wp_set_current_user( $this->other_user_id );
-		$this->assertSame( 'job_access_denied', ( new GetJobsAbility() )->execute( array( 'job_id' => $internal['job_id'] ) )['error_code'] );
+		$this->assertSame( 'job_access_denied', ( new GetJobsAbility() )->execute( array( 'job_id' => $internal['job_id'] ) )->get_error_code() );
 		wp_set_current_user( $this->admin_id );
 		$this->assertTrue( ( new GetJobsAbility() )->execute( array( 'job_id' => $internal['job_id'] ) )['success'] );
 	}
@@ -153,8 +155,8 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 
 		wp_set_current_user( $this->other_user_id );
 		$denied = ( new GetJobsAbility() )->execute( array( 'job_id' => $job_id ) );
-		$this->assertFalse( $denied['success'] );
-		$this->assertSame( 'job_access_denied', $denied['error_code'] );
+		$this->assertWPError( $denied );
+		$this->assertSame( 'job_access_denied', $denied->get_error_code() );
 		$this->assertSame( 'job_access_denied', ( new RunMetricsAbility() )->execute( array( 'job_id' => $job_id ) )['error_code'] );
 		$this->assertFalse( ( new FailJobAbility() )->execute( array( 'job_id' => $job_id ) )['success'] );
 		$this->assertSame( 'job_access_denied', ( new RetryJobAbility() )->execute( array( 'job_id' => $job_id ) )['error_code'] );
@@ -175,10 +177,11 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertNotContains( $other['job_id'], array_map( 'intval', array_column( $list['jobs'], 'job_id' ) ) );
 
 		$forged = ( new GetJobsAbility() )->execute( array( 'user_id' => $this->other_user_id ) );
-		$this->assertFalse( $forged['success'] );
-		$this->assertSame( 'job_access_denied', $forged['error_code'] );
+		$this->assertWPError( $forged );
+		$this->assertSame( 'job_access_denied', $forged->get_error_code() );
 		$forged_summary = ( new JobsSummaryAbility() )->execute( array( 'user_id' => $this->other_user_id ) );
-		$this->assertSame( 'job_access_denied', $forged_summary['error_code'] );
+		$this->assertWPError( $forged_summary );
+		$this->assertSame( 'job_access_denied', $forged_summary->get_error_code() );
 
 		$owner_summary = ( new JobsSummaryAbility() )->execute( array() );
 		$this->assertTrue( $owner_summary['success'] );
@@ -187,8 +190,8 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 
 		wp_set_current_user( 0 );
 		$anonymous_summary = ( new JobsSummaryAbility() )->execute( array() );
-		$this->assertFalse( $anonymous_summary['success'] );
-		$this->assertSame( 'job_access_denied', $anonymous_summary['error_code'] );
+		$this->assertWPError( $anonymous_summary );
+		$this->assertSame( 'job_access_denied', $anonymous_summary->get_error_code() );
 
 		wp_set_current_user( $this->admin_id );
 		$operator_list = ( new GetJobsAbility() )->execute( array() );
@@ -200,6 +203,43 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertTrue( $operator_summary['success'] );
 		$this->assertArrayNotHasKey( 'user_id', $operator_summary['summary']['filters'] );
 		$this->assertArrayNotHasKey( 'jobs', $operator_summary['summary'] );
+	}
+
+	public function test_query_validation_and_not_found_use_native_errors(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$invalid_job = ( new GetJobsAbility() )->execute( array( 'job_id' => 0 ) );
+		$this->assertWPError( $invalid_job );
+		$this->assertSame( 'invalid_job_id', $invalid_job->get_error_code() );
+		$this->assertSame( 400, $invalid_job->get_error_data()['status'] );
+
+		$invalid_flow = ( new FlowHealthAbility() )->execute( array( 'flow_id' => 0 ) );
+		$this->assertWPError( $invalid_flow );
+		$this->assertSame( 'invalid_flow_id', $invalid_flow->get_error_code() );
+
+		$missing_flow = ( new FlowHealthAbility() )->execute( array( 'flow_id' => PHP_INT_MAX ) );
+		$this->assertWPError( $missing_flow );
+		$this->assertSame( 'flow_not_found', $missing_flow->get_error_code() );
+		$this->assertSame( 404, $missing_flow->get_error_data()['status'] );
+	}
+
+	public function test_successful_rest_collection_contract_is_unchanged(): void {
+		wp_set_current_user( $this->admin_id );
+		$request = new \WP_REST_Request( 'GET', '/datamachine/v1/jobs' );
+		$request->set_param( 'orderby', 'job_id' );
+		$request->set_param( 'order', 'DESC' );
+		$request->set_param( 'per_page', 50 );
+		$request->set_param( 'offset', 0 );
+
+		$response = JobsApi::handle_get_jobs( $request );
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$data = $response->get_data();
+		$this->assertTrue( $data['success'] );
+		$this->assertIsArray( $data['data'] );
+		$this->assertArrayHasKey( 'total', $data );
+		$this->assertArrayHasKey( 'per_page', $data );
+		$this->assertArrayHasKey( 'offset', $data );
+		$this->assertArrayHasKey( 'filters_applied', $data );
 	}
 
 	public function test_artifact_authorization_runs_before_hydration(): void {

--- a/tests/job-query-wp-error-contract-smoke.php
+++ b/tests/job-query-wp-error-contract-smoke.php
@@ -1,0 +1,30 @@
+<?php
+/** Bounded contract checks for native job-query ability failures. */
+
+$root    = dirname( __DIR__ );
+$get     = file_get_contents( $root . '/inc/Abilities/Job/GetJobsAbility.php' ) ?: '';
+$summary = file_get_contents( $root . '/inc/Abilities/Job/JobsSummaryAbility.php' ) ?: '';
+$health  = file_get_contents( $root . '/inc/Abilities/Job/FlowHealthAbility.php' ) ?: '';
+$rest    = file_get_contents( $root . '/inc/Api/Jobs.php' ) ?: '';
+$cli     = file_get_contents( $root . '/inc/Cli/Commands/JobsCommand.php' ) ?: '';
+
+$assert = static function ( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+	printf( "PASS: %s\n", $message );
+};
+
+$assert( str_contains( $get, 'array|\\WP_Error' ), 'get-jobs declares native failures' );
+$assert( str_contains( $summary, 'array|\\WP_Error' ), 'jobs summary declares native failures' );
+$assert( str_contains( $health, 'array|\\WP_Error' ), 'flow health declares native failures' );
+$assert( ! str_contains( $get, "'success'    => false" ), 'get-jobs has no legacy failure envelope' );
+$assert( ! str_contains( $summary, "'success'    => false" ), 'jobs summary has no legacy failure envelope' );
+$assert( ! str_contains( $health, "'success' => false" ), 'flow health has no legacy failure envelope' );
+$assert( str_contains( $rest, "rest_collection_response( \$result, 'jobs'" ), 'REST collection presenter remains intact' );
+$assert( str_contains( $rest, "'job_not_found'" ), 'REST item not-found presenter remains intact' );
+$assert( str_contains( $cli, "cli_collection_payload( \$items, \$result, 'jobs' )" ), 'CLI JSON rows remain intact' );
+$assert( substr_count( $cli, "failure_to_wp_error( \$result, 'get_jobs_failed'" ) >= 2, 'CLI item presenters accept native failures' );
+
+printf( "Job query WP_Error contract smoke tests passed.\n" );


### PR DESCRIPTION
## Summary
- migrate `GetJobsAbility`, `JobsSummaryAbility`, and `FlowHealthAbility` validation, permission, not-found, and query failures from legacy `success:false` arrays to native `WP_Error`
- preserve successful ability payloads and the curated `datamachine/v1` REST and `wp datamachine jobs` presentation contracts
- update direct CLI item presenters and add representative ability, REST, and CLI contract coverage

## Failure contract
Previously, scoped callback failures returned arrays such as `success:false`, `error_code`, `error`, and `status`. They now return `WP_Error` with machine-readable codes (`invalid_job_id`, `invalid_flow_id`, `flow_not_found`, `job_access_denied`, or `job_query_failed`) and HTTP status data. Successful results retain their existing `success:true` schemas exactly, including empty job collections as successful domain data.

## Compatibility proof
- REST collection presentation still uses `AbilityResult::rest_collection_response()` and retains `success`, `data`, pagination metadata, `filters_applied`, and `metadata_query` behavior.
- REST item lookup still translates an empty successful job collection to the existing `job_not_found` 404 response.
- CLI list tables and JSON rows still use the existing formatting and `AbilityResult::cli_collection_payload()` paths.
- CLI `show` and `transcript` now accept native failures through `AbilityResult::failure_to_wp_error()` while preserving existing messages and successful output.
- broad `AbilityResult` compatibility helpers and mutation/retry/recovery behavior remain untouched.

## Verification
- `php tests/job-query-wp-error-contract-smoke.php`
- `php tests/jobs-list-efficiency-smoke.php`
- `php tests/job-status-accounting-smoke.php`
- `php tests/ability-result-wp-error-smoke.php`
- focused PHPCS over all changed PHP files
- `homeboy review lint data-machine --placement local --changed-only --summary` (passed, zero findings)
- `homeboy review audit data-machine --placement local --changed-since origin/main --profile pr --summary` (passed, no introduced findings)
- focused WordPress PHPUnit command completed without failures in this checkout; Homeboy's PHPUnit provider separately reported zero discovered tests because the repository has no PHPUnit configuration

Closes #3127
Refs #2522
Part of #3113