### PR TITLE
refactor: delegate taxonomy term creation to ability

### DIFF
--- a/inc/Api/Chat/Tools/CreateTaxonomyTerm.php
+++ b/inc/Api/Chat/Tools/CreateTaxonomyTerm.php
@@ -14,9 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use DataMachine\Core\WordPress\TaxonomyHandler;
 use DataMachine\Engine\AI\Tools\BaseTool;
-use DataMachine\Abilities\Taxonomy\ResolveTermAbility;
 
 class CreateTaxonomyTerm extends BaseTool {
 
@@ -60,76 +58,11 @@ class CreateTaxonomyTerm extends BaseTool {
 		$parent      = $parameters['parent'] ?? null;
 		$description = $parameters['description'] ?? '';
 
-		// Validate taxonomy
-		if ( empty( $taxonomy ) || ! is_string( $taxonomy ) ) {
-			return array(
-				'success'   => false,
-				'error'     => 'taxonomy is required and must be a non-empty string',
-				'tool_name' => 'create_taxonomy_term',
-			);
-		}
-
-		$taxonomy = sanitize_key( $taxonomy );
-
-		if ( ! taxonomy_exists( $taxonomy ) ) {
-			return array(
-				'success'   => false,
-				'error'     => "Taxonomy '{$taxonomy}' does not exist",
-				'tool_name' => 'create_taxonomy_term',
-			);
-		}
-
-		if ( TaxonomyHandler::shouldSkipTaxonomy( $taxonomy ) ) {
-			return array(
-				'success'   => false,
-				'error'     => "Taxonomy '{$taxonomy}' is a system taxonomy and cannot be modified",
-				'tool_name' => 'create_taxonomy_term',
-			);
-		}
-
-		// Validate name
-		if ( empty( $name ) || ! is_string( $name ) ) {
-			return array(
-				'success'   => false,
-				'error'     => 'name is required and must be a non-empty string',
-				'tool_name' => 'create_taxonomy_term',
-			);
-		}
-
-		$name = sanitize_text_field( $name );
-		if ( empty( $name ) ) {
-			return array(
-				'success'   => false,
-				'error'     => 'name cannot be empty after sanitization',
-				'tool_name' => 'create_taxonomy_term',
-			);
-		}
-
-		// Check if term already exists using centralized resolution (ID, name, or slug).
-		$resolved = ResolveTermAbility::resolve( $name, $taxonomy, false );
-		if ( $resolved['success'] ) {
-			$existing_term = get_term( $resolved['term_id'], $taxonomy );
-			return array(
-				'success'   => true,
-				'data'      => array(
-					'term_id'          => $existing_term->term_id,
-					'term_taxonomy_id' => $existing_term->term_taxonomy_id,
-					'taxonomy'         => $taxonomy,
-					'name'             => $existing_term->name,
-					'slug'             => $existing_term->slug,
-					'parent_id'        => $existing_term->parent,
-					'already_exists'   => true,
-					'message'          => "Term '{$existing_term->name}' already exists in taxonomy '{$taxonomy}'.",
-				),
-				'tool_name' => 'create_taxonomy_term',
-			);
-		}
-
-		// Resolve parent if provided
+		// Parent names and slugs are a chat convenience; the ability accepts an ID.
 		$parent_id = 0;
-		if ( ! empty( $parent ) ) {
+		if ( ! empty( $parent ) && is_string( $taxonomy ) ) {
 			$taxonomy_obj = get_taxonomy( $taxonomy );
-			if ( ! $taxonomy_obj->hierarchical ) {
+			if ( $taxonomy_obj && ! $taxonomy_obj->hierarchical ) {
 				return array(
 					'success'   => false,
 					'error'     => "Cannot set parent: taxonomy '{$taxonomy}' is not hierarchical",
@@ -137,48 +70,76 @@ class CreateTaxonomyTerm extends BaseTool {
 				);
 			}
 
-			$parent_id = $this->resolveParentTerm( $parent, $taxonomy );
-			if ( false === $parent_id ) {
-				return array(
-					'success'   => false,
-					'error'     => "Parent term '{$parent}' not found in taxonomy '{$taxonomy}'",
-					'tool_name' => 'create_taxonomy_term',
-				);
+			if ( $taxonomy_obj ) {
+				$parent_id = $this->resolveParentTerm( $parent, $taxonomy );
+				if ( false === $parent_id ) {
+					return array(
+						'success'   => false,
+						'error'     => "Parent term '{$parent}' not found in taxonomy '{$taxonomy}'",
+						'tool_name' => 'create_taxonomy_term',
+					);
+				}
 			}
 		}
 
-		// Create the term
-		$term_args = array(
-			'parent' => $parent_id,
-		);
-
-		if ( ! empty( $description ) ) {
-			$term_args['description'] = sanitize_textarea_field( $description );
-		}
-
-		$result = wp_insert_term( $name, $taxonomy, $term_args );
-
-		if ( is_wp_error( $result ) ) {
+		$ability = wp_get_ability( 'datamachine/create-taxonomy-term' );
+		if ( ! $ability ) {
 			return array(
 				'success'   => false,
-				'error'     => $result->get_error_message(),
+				'error'     => 'datamachine/create-taxonomy-term ability not found',
 				'tool_name' => 'create_taxonomy_term',
 			);
 		}
 
-		$term = get_term( $result['term_id'], $taxonomy );
+		$input = array(
+			'taxonomy' => $taxonomy,
+			'name'     => $name,
+			'parent'   => $parent_id,
+		);
+
+		if ( ! empty( $description ) ) {
+			$input['description'] = $description;
+		}
+
+		$result = $ability->execute( $input );
+
+		if ( ! $this->isAbilitySuccess( $result ) ) {
+			return array(
+				'success'   => false,
+				'error'     => $this->getAbilityError( $result, 'Failed to create taxonomy term' ),
+				'tool_name' => 'create_taxonomy_term',
+			);
+		}
+
+		$term           = get_term( $result['term_id'], $result['taxonomy'] ?? $taxonomy );
+		$already_exists = ! empty( $result['existed'] );
+		$term_name      = $term && ! is_wp_error( $term ) ? $term->name : $result['term_name'];
+		$term_slug      = $term && ! is_wp_error( $term ) ? $term->slug : $result['term_slug'];
+		$term_parent    = $term && ! is_wp_error( $term ) ? $term->parent : $parent_id;
+		$message        = $already_exists
+			? "Term '{$term_name}' already exists in taxonomy '{$taxonomy}'."
+			: "Created term '{$term_name}' in taxonomy '{$taxonomy}'.";
+
+		$data = array(
+			'term_id'   => $result['term_id'],
+			'taxonomy'  => $taxonomy,
+			'name'      => $term_name,
+			'slug'      => $term_slug,
+			'parent_id' => $term_parent,
+			'message'   => $message,
+		);
+
+		if ( $already_exists ) {
+			$data['already_exists'] = true;
+		}
+
+		if ( $term && ! is_wp_error( $term ) ) {
+			$data['term_taxonomy_id'] = $term->term_taxonomy_id;
+		}
 
 		return array(
 			'success'   => true,
-			'data'      => array(
-				'term_id'          => $result['term_id'],
-				'term_taxonomy_id' => $result['term_taxonomy_id'],
-				'taxonomy'         => $taxonomy,
-				'name'             => $term->name,
-				'slug'             => $term->slug,
-				'parent_id'        => $parent_id,
-				'message'          => "Created term '{$term->name}' in taxonomy '{$taxonomy}'.",
-			),
+			'data'      => $data,
 			'tool_name' => 'create_taxonomy_term',
 		);
 	}
@@ -191,9 +152,18 @@ class CreateTaxonomyTerm extends BaseTool {
 	 * @return int|false Term ID or false if not found
 	 */
 	private function resolveParentTerm( $parent_item, string $taxonomy ) {
-		// Use centralized resolution for parent term lookup.
-		$result = ResolveTermAbility::resolve( (string) $parent_item, $taxonomy, false );
+		if ( is_numeric( $parent_item ) ) {
+			$term = get_term( absint( $parent_item ), $taxonomy );
+			if ( $term && ! is_wp_error( $term ) ) {
+				return $term->term_id;
+			}
+		}
 
-		return $result['success'] ? $result['term_id'] : false;
+		$term = get_term_by( 'name', (string) $parent_item, $taxonomy );
+		if ( ! $term ) {
+			$term = get_term_by( 'slug', sanitize_title( (string) $parent_item ), $taxonomy );
+		}
+
+		return $term ? $term->term_id : false;
 	}
 }

--- a/tests/Unit/Api/Chat/Tools/CreateTaxonomyTermTest.php
+++ b/tests/Unit/Api/Chat/Tools/CreateTaxonomyTermTest.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * Create Taxonomy Term Tool Tests.
+ *
+ * @package DataMachine\Tests\Unit\Api\Chat\Tools
+ */
+
+namespace DataMachine\Tests\Unit\Api\Chat\Tools;
+
+use DataMachine\Api\Chat\Tools\CreateTaxonomyTerm;
+use WP_Ability;
+use WP_Abilities_Registry;
+use WP_Error;
+use WP_UnitTestCase;
+
+class CreateTaxonomyTermTest extends WP_UnitTestCase {
+
+	private const ABILITY_NAME = 'datamachine/create-taxonomy-term';
+	private const TAXONOMY     = 'datamachine_chat_create_terms';
+
+	private CreateTaxonomyTerm $tool;
+	private WP_Ability $original_ability;
+	private CountingCreateTaxonomyTermAbility $ability;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		register_taxonomy(
+			self::TAXONOMY,
+			array( 'post' ),
+			array( 'hierarchical' => true )
+		);
+
+		$this->original_ability = wp_get_ability( self::ABILITY_NAME );
+		$this->ability          = new CountingCreateTaxonomyTermAbility( self::ABILITY_NAME );
+		$this->replaceAbility( $this->ability );
+		$this->tool = new CreateTaxonomyTerm();
+	}
+
+	public function tear_down(): void {
+		$this->replaceAbility( $this->original_ability );
+		unregister_taxonomy( self::TAXONOMY );
+
+		parent::tear_down();
+	}
+
+	public function test_delegates_new_term_creation_exactly_once(): void {
+		$term = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => self::TAXONOMY,
+				'name'     => 'Charleston',
+			)
+		);
+		$this->ability->result = $this->abilityResult( $term, true, false );
+
+		$result = $this->tool->handle_tool_call(
+			array(
+				'taxonomy'    => self::TAXONOMY,
+				'name'        => 'Charleston',
+				'description' => 'South Carolina music scene',
+			)
+		);
+
+		$this->assertSame( 1, $this->ability->calls );
+		$this->assertSame(
+			array(
+				'taxonomy'    => self::TAXONOMY,
+				'name'        => 'Charleston',
+				'parent'      => 0,
+				'description' => 'South Carolina music scene',
+			),
+			$this->ability->input
+		);
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $term->term_taxonomy_id, $result['data']['term_taxonomy_id'] );
+		$this->assertArrayNotHasKey( 'already_exists', $result['data'] );
+		$this->assertSame( "Created term 'Charleston' in taxonomy '" . self::TAXONOMY . "'.", $result['data']['message'] );
+	}
+
+	public function test_existing_term_remains_successful_no_op(): void {
+		$term = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => self::TAXONOMY,
+				'name'     => 'Existing Term',
+			)
+		);
+		$this->ability->result = $this->abilityResult( $term, false, true );
+
+		$result = $this->tool->handle_tool_call(
+			array(
+				'taxonomy' => self::TAXONOMY,
+				'name'     => 'Existing Term',
+			)
+		);
+
+		$this->assertSame( 1, $this->ability->calls );
+		$this->assertTrue( $result['success'] );
+		$this->assertTrue( $result['data']['already_exists'] );
+		$this->assertSame( "Term 'Existing Term' already exists in taxonomy '" . self::TAXONOMY . "'.", $result['data']['message'] );
+	}
+
+	/**
+	 * @dataProvider parentIdentifierProvider
+	 */
+	public function test_maps_parent_identifier_to_ability_parent_id( callable $identifier ): void {
+		$parent = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => self::TAXONOMY,
+				'name'     => 'Parent Term',
+				'slug'     => 'parent-term',
+			)
+		);
+		$child = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => self::TAXONOMY,
+				'name'     => 'Child Term',
+				'parent'   => $parent->term_id,
+			)
+		);
+		$this->ability->result = $this->abilityResult( $child, true, false );
+
+		$result = $this->tool->handle_tool_call(
+			array(
+				'taxonomy' => self::TAXONOMY,
+				'name'     => 'Child Term',
+				'parent'   => $identifier( $parent ),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 1, $this->ability->calls );
+		$this->assertSame( $parent->term_id, $this->ability->input['parent'] );
+	}
+
+	public function parentIdentifierProvider(): array {
+		return array(
+			'ID'   => array( static fn( $term ) => (string) $term->term_id ),
+			'name' => array( static fn( $term ) => $term->name ),
+			'slug' => array( static fn( $term ) => $term->slug ),
+		);
+	}
+
+	public function test_wp_error_becomes_stable_tool_failure(): void {
+		$this->ability->result = new WP_Error( 'term_create_failed', 'Could not create term' );
+
+		$result = $this->tool->handle_tool_call(
+			array(
+				'taxonomy' => self::TAXONOMY,
+				'name'     => 'Broken Term',
+			)
+		);
+
+		$this->assertSame( 1, $this->ability->calls );
+		$this->assertSame(
+			array(
+				'success'   => false,
+				'error'     => 'Could not create term',
+				'tool_name' => 'create_taxonomy_term',
+			),
+			$result
+		);
+	}
+
+	public function test_legacy_failure_result_becomes_stable_tool_failure(): void {
+		$this->ability->result = array(
+			'success' => false,
+			'error'   => 'Legacy taxonomy failure',
+		);
+
+		$result = $this->tool->handle_tool_call(
+			array(
+				'taxonomy' => self::TAXONOMY,
+				'name'     => 'Broken Term',
+			)
+		);
+
+		$this->assertSame( 1, $this->ability->calls );
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'Legacy taxonomy failure', $result['error'] );
+		$this->assertSame( 'create_taxonomy_term', $result['tool_name'] );
+	}
+
+	public function test_tool_has_no_direct_term_persistence_path(): void {
+		$reflection = new \ReflectionClass( CreateTaxonomyTerm::class );
+		$source     = file_get_contents( $reflection->getFileName() );
+
+		$this->assertStringNotContainsString( 'wp_insert_term(', $source );
+	}
+
+	private function abilityResult( \WP_Term $term, bool $created, bool $existed ): array {
+		return array(
+			'success'   => true,
+			'term_id'   => $term->term_id,
+			'term_name' => $term->name,
+			'term_slug' => $term->slug,
+			'taxonomy'  => $term->taxonomy,
+			'created'   => $created,
+			'existed'   => $existed,
+		);
+	}
+
+	private function replaceAbility( WP_Ability $ability ): void {
+		$registry   = WP_Abilities_Registry::get_instance();
+		$reflection = new \ReflectionProperty( $registry, 'registered_abilities' );
+		$abilities  = $reflection->getValue( $registry );
+
+		$abilities[ self::ABILITY_NAME ] = $ability;
+		$reflection->setValue( $registry, $abilities );
+	}
+}
+
+class CountingCreateTaxonomyTermAbility extends WP_Ability {
+
+	public int $calls = 0;
+	public array $input = array();
+	public $result = array();
+
+	public function __construct( string $name ) {
+		parent::__construct(
+			$name,
+			array(
+				'label'               => 'Counting Create Taxonomy Term',
+				'description'         => 'Captures taxonomy create delegation for tests.',
+				'category'            => 'datamachine-taxonomy',
+				'execute_callback'    => '__return_empty_array',
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	public function execute( $input = null ) {
+		++$this->calls;
+		$this->input = $input;
+
+		return $this->result;
+	}
+}


### PR DESCRIPTION
## Summary
- Keep the curated `create_taxonomy_term` chat namespace while mapping parent ID/name/slug inputs to the ability's integer `parent` field.
- Delegate taxonomy validation, duplicate handling, sanitization, persistence, and logging exactly once to registered `datamachine/create-taxonomy-term`; remove the tool's direct `wp_insert_term()` path.
- Preserve existing-term idempotency, `already_exists`, protected taxonomy behavior, response enrichment, response fields, and human-facing messages, including stable handling for `WP_Error` and legacy failure arrays.

## Tests
- Added focused coverage for exact single delegation, existing-term no-op success, parent ID/name/slug mapping, `WP_Error`, legacy failures, and absence of direct term persistence.
- `vendor/bin/phpcs inc/Api/Chat/Tools/CreateTaxonomyTerm.php tests/Unit/Api/Chat/Tools/CreateTaxonomyTermTest.php` passes.
- `composer lint` passes (Composer emits dependency deprecation notices before PHPCS).
- Homeboy lint passes with zero findings: run `fb65c20e-9045-496a-8585-b1d051258b38`.
- Homeboy PR audit passes with zero introduced findings.
- Homeboy Test did not execute PHPUnit: focused run `4e160da0-8aed-409a-bb16-1a85e57ca190` and full run `a53e24ba-af9c-4710-8582-78d2d84fc45e` both finished in about 2.6 seconds with `Total: 0` and `test runner reported zero executed tests`. This is test-runner discovery evidence, not a code-test failure or command-runner timeout.

Closes #3130
Part of #3128 and #3113