### PR TITLE
refactor: delegate taxonomy search queries

### DIFF
--- a/inc/Api/Chat/Tools/SearchTaxonomyTerms.php
+++ b/inc/Api/Chat/Tools/SearchTaxonomyTerms.php
@@ -14,7 +14,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use DataMachine\Core\WordPress\TaxonomyHandler;
 use DataMachine\Engine\AI\Tools\BaseTool;
 
 class SearchTaxonomyTerms extends BaseTool {
@@ -63,43 +62,45 @@ class SearchTaxonomyTerms extends BaseTool {
 		}
 
 		$taxonomy = sanitize_key( $taxonomy );
-
-		if ( ! taxonomy_exists( $taxonomy ) ) {
+		if ( empty( $taxonomy ) ) {
 			return array(
 				'success'   => false,
-				'error'     => "Taxonomy '{$taxonomy}' does not exist",
+				'error'     => 'taxonomy is required and must be a non-empty string',
 				'tool_name' => 'search_taxonomy_terms',
 			);
 		}
 
-		if ( TaxonomyHandler::shouldSkipTaxonomy( $taxonomy ) ) {
+		$search   = sanitize_text_field( $search );
+		$limit    = max( 1, min( 100, (int) $limit ) );
+		$ability  = wp_get_ability( 'datamachine/get-taxonomy-terms' );
+
+		if ( ! $ability ) {
 			return array(
 				'success'   => false,
-				'error'     => "Taxonomy '{$taxonomy}' is a system taxonomy and cannot be queried",
+				'error'     => 'datamachine/get-taxonomy-terms ability not found',
 				'tool_name' => 'search_taxonomy_terms',
 			);
 		}
 
-		$limit = max( 1, min( 100, (int) $limit ) );
-
-		$args = array(
-			'taxonomy'   => $taxonomy,
-			'hide_empty' => false,
-			'number'     => $limit,
-			'orderby'    => 'count',
-			'order'      => 'DESC',
+		$result = $ability->execute(
+			array(
+				'taxonomy'   => $taxonomy,
+				'search'     => $search,
+				'hide_empty' => false,
+				'number'     => $limit,
+				'orderby'    => 'count',
+				'order'      => 'DESC',
+			)
 		);
 
-		if ( ! empty( $search ) ) {
-			$args['search'] = sanitize_text_field( $search );
-		}
-
-		$terms = get_terms( $args );
-
-		if ( is_wp_error( $terms ) ) {
+		if ( ! $this->isAbilitySuccess( $result ) ) {
+			$error = $this->getAbilityError( $result, 'Failed to search taxonomy terms' );
+			if ( is_wp_error( $result ) && 'taxonomy_not_accessible' === $result->get_error_code() ) {
+				$error = "Taxonomy '{$taxonomy}' is a system taxonomy and cannot be queried";
+			}
 			return array(
 				'success'   => false,
-				'error'     => $terms->get_error_message(),
+				'error'     => $error,
 				'tool_name' => 'search_taxonomy_terms',
 			);
 		}
@@ -107,16 +108,16 @@ class SearchTaxonomyTerms extends BaseTool {
 		$taxonomy_obj = get_taxonomy( $taxonomy );
 		$term_data    = array();
 
-		foreach ( $terms as $term ) {
+		foreach ( $result['terms'] as $term ) {
 			$term_entry = array(
-				'term_id' => $term->term_id,
-				'name'    => $term->name,
-				'slug'    => $term->slug,
-				'count'   => (int) $term->count,
+				'term_id' => $term['term_id'],
+				'name'    => $term['name'],
+				'slug'    => $term['slug'],
+				'count'   => (int) $term['count'],
 			);
 
-			if ( $taxonomy_obj->hierarchical && $term->parent > 0 ) {
-				$parent_term = get_term( $term->parent, $taxonomy );
+			if ( $taxonomy_obj->hierarchical && $term['parent'] > 0 ) {
+				$parent_term = get_term( $term['parent'], $taxonomy );
 				if ( $parent_term && ! is_wp_error( $parent_term ) ) {
 					$term_entry['parent'] = $parent_term->name;
 				}

--- a/tests/search-taxonomy-terms-delegation-smoke.php
+++ b/tests/search-taxonomy-terms-delegation-smoke.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Pure-PHP smoke test for search_taxonomy_terms ability delegation.
+ *
+ * Run with: php tests/search-taxonomy-terms-delegation-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+	define( 'ABSPATH', __DIR__ );
+
+	class WP_Error {
+		public function __construct(
+			private string $code,
+			private string $message
+		) {}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+
+	function add_filter( ...$args ): void {}
+
+	require_once dirname( __DIR__ ) . '/inc/Engine/AI/Tools/BaseTool.php';
+	require_once dirname( __DIR__ ) . '/inc/Api/Chat/Tools/SearchTaxonomyTerms.php';
+}
+
+namespace DataMachine\Api\Chat\Tools {
+	final class SearchTaxonomyTermsTestAbility {
+		public int $calls = 0;
+		public array $input = array();
+		public mixed $result;
+
+		public function __construct() {
+			$this->result = array(
+				'success' => true,
+				'terms'   => array(
+					array(
+						'term_id'    => 9,
+						'name'       => 'Child',
+						'slug'       => 'child',
+						'count'      => 12,
+						'parent'     => 4,
+						'term_group' => 0,
+					),
+				),
+				'total'   => 1,
+			);
+		}
+
+		public function execute( array $input ): mixed {
+			++$this->calls;
+			$this->input = $input;
+			return $this->result;
+		}
+	}
+
+	$GLOBALS['search_taxonomy_terms_test_ability'] = new SearchTaxonomyTermsTestAbility();
+
+	function wp_get_ability( string $name ): ?SearchTaxonomyTermsTestAbility {
+		return 'datamachine/get-taxonomy-terms' === $name ? $GLOBALS['search_taxonomy_terms_test_ability'] : null;
+	}
+
+	function sanitize_key( string $value ): string {
+		return strtolower( preg_replace( '/[^a-z0-9_\-]/i', '', $value ) );
+	}
+
+	function sanitize_text_field( $value ): string {
+		return trim( strip_tags( (string) $value ) );
+	}
+
+	function get_taxonomy( string $taxonomy ): object {
+		return (object) array(
+			'label'        => 'Genres',
+			'hierarchical' => true,
+		);
+	}
+
+	function get_term( int $term_id, string $taxonomy ): object {
+		return (object) array( 'name' => 'Parent' );
+	}
+
+	function wp_count_terms( array $args ): int {
+		return 37;
+	}
+
+	$failed = 0;
+	$total  = 0;
+
+	function assert_search_taxonomy_terms( string $name, bool $condition ): void {
+		global $failed, $total;
+		++$total;
+		if ( $condition ) {
+			echo "  PASS: {$name}\n";
+			return;
+		}
+		echo "  FAIL: {$name}\n";
+		++$failed;
+	}
+
+	echo "=== Search Taxonomy Terms Delegation Smoke ===\n";
+
+	$tool    = new SearchTaxonomyTerms();
+	$ability = $GLOBALS['search_taxonomy_terms_test_ability'];
+	$result  = $tool->handle_tool_call(
+		array(
+			'taxonomy' => 'Genre!',
+			'search'   => '  <b>rock</b>  ',
+		)
+	);
+
+	assert_search_taxonomy_terms( 'registered ability executes exactly once', 1 === $ability->calls );
+	assert_search_taxonomy_terms(
+		'default query input is canonical and bounded',
+		array(
+			'taxonomy'   => 'genre',
+			'search'     => 'rock',
+			'hide_empty' => false,
+			'number'     => 20,
+			'orderby'    => 'count',
+			'order'      => 'DESC',
+		) === $ability->input
+	);
+	assert_search_taxonomy_terms( 'taxonomy metadata is preserved', 'Genres' === $result['data']['taxonomy_label'] && true === $result['data']['hierarchical'] );
+	assert_search_taxonomy_terms( 'parent name enriches canonical row', 'Parent' === $result['data']['terms'][0]['parent'] );
+	assert_search_taxonomy_terms( 'tool row schema excludes ability-only fields', array( 'term_id', 'name', 'slug', 'count', 'parent' ) === array_keys( $result['data']['terms'][0] ) );
+	assert_search_taxonomy_terms( 'tool counts and search envelope are preserved', 37 === $result['data']['total_terms'] && 1 === $result['data']['returned_count'] && 'rock' === $result['data']['search_query'] );
+
+	$ability->calls = 0;
+	$tool->handle_tool_call( array( 'taxonomy' => 'genre', 'limit' => 999 ) );
+	assert_search_taxonomy_terms( 'maximum limit remains 100', 1 === $ability->calls && 100 === $ability->input['number'] );
+
+	$ability->calls = 0;
+	$result         = $tool->handle_tool_call( array( 'taxonomy' => '!!!' ) );
+	assert_search_taxonomy_terms( 'empty sanitized taxonomy retains validation error', 0 === $ability->calls && 'taxonomy is required and must be a non-empty string' === $result['error'] );
+
+	$ability->result = new \WP_Error( 'taxonomy_not_accessible', "Taxonomy 'nav_menu' is a system taxonomy and cannot be accessed" );
+	$result          = $tool->handle_tool_call( array( 'taxonomy' => 'nav_menu' ) );
+	assert_search_taxonomy_terms( 'protected taxonomy error remains model-facing compatible', "Taxonomy 'nav_menu' is a system taxonomy and cannot be queried" === $result['error'] );
+
+	$ability->result = new \WP_Error( 'term_query_failed', 'Canonical query failed' );
+	$result          = $tool->handle_tool_call( array( 'taxonomy' => 'genre' ) );
+	assert_search_taxonomy_terms( 'ability WP_Error maps to stable tool failure', false === $result['success'] && 'Canonical query failed' === $result['error'] );
+
+	$ability->result = array( 'success' => false, 'error' => 'Legacy query failed' );
+	$result          = $tool->handle_tool_call( array( 'taxonomy' => 'genre' ) );
+	assert_search_taxonomy_terms( 'legacy failure maps to stable tool failure', false === $result['success'] && 'Legacy query failed' === $result['error'] );
+
+	$source = (string) file_get_contents( dirname( __DIR__ ) . '/inc/Api/Chat/Tools/SearchTaxonomyTerms.php' );
+	assert_search_taxonomy_terms( 'tool has no direct get_terms query', false === strpos( $source, 'get_terms(' ) );
+
+	echo "\n";
+	if ( 0 === $failed ) {
+		echo "=== search-taxonomy-terms-delegation-smoke: ALL PASS ({$total}) ===\n";
+		exit( 0 );
+	}
+
+	echo "=== search-taxonomy-terms-delegation-smoke: {$failed} FAIL of {$total} ===\n";
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Delegate the curated `search_taxonomy_terms` primary query exactly once to registered `datamachine/get-taxonomy-terms` with sanitized search, `hide_empty: false`, bounded `number`, `orderby: count`, and `order: DESC`.
- Preserve the model-facing tool namespace/schema, default and maximum limits, returned ordering, taxonomy metadata, parent-name enrichment, total count, response shape, protected-taxonomy wording, and adapter error behavior.
- Remove the tool's direct primary `get_terms()` path while retaining direct presentation-only taxonomy, parent, and total-count lookups.

## Tests
- `php tests/search-taxonomy-terms-delegation-smoke.php` (12 assertions passed)
- `vendor/bin/phpcs inc/Api/Chat/Tools/SearchTaxonomyTerms.php tests/search-taxonomy-terms-delegation-smoke.php` (passed)
- `homeboy review lint data-machine --path /var/lib/datamachine/workspace/data-machine@simplify-3131-taxonomy-search --changed-since origin/main --placement local --summary` (passed, run `eb8b79f4-ffb6-494f-a50d-aba77709464d`)
- `homeboy review audit data-machine --path /var/lib/datamachine/workspace/data-machine@simplify-3131-taxonomy-search --changed-since origin/main --profile pr --placement local --summary` (passed, zero introduced findings)
- Homeboy Test runner issue: changed-scope run `7f491bb7-ab97-4969-b7ea-545925e39024` selected 488 files but reported `Total: 0` after 3.60s; full retry `323f41cf-859d-4f93-8a0d-c30ff613c2ed` likewise reported `Total: 0` after 2.70s. Neither run timed out or reported a test failure.

Closes #3131
Part of #3128 and #3113