### PR TITLE
refactor: delegate taxonomy term core updates

### DIFF
--- a/inc/Api/Chat/Tools/UpdateTaxonomyTerm.php
+++ b/inc/Api/Chat/Tools/UpdateTaxonomyTerm.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use DataMachine\Abilities\Taxonomy\ResolveTermAbility;
 use DataMachine\Core\WordPress\TaxonomyHandler;
 use DataMachine\Engine\AI\Tools\BaseTool;
 
@@ -111,11 +112,19 @@ class UpdateTaxonomyTerm extends BaseTool {
 		}
 
 		// Resolve term
-		$term = $this->resolveTerm( $term_identifier, $taxonomy );
-		if ( ! $term ) {
+		$resolved = ResolveTermAbility::resolve( $term_identifier, $taxonomy, false );
+		if ( empty( $resolved['success'] ) ) {
 			return array(
 				'success'   => false,
-				'error'     => "Term '{$term_identifier}' not found in taxonomy '{$taxonomy}'",
+				'error'     => $resolved['error'] ?? "Term '{$term_identifier}' not found in taxonomy '{$taxonomy}'",
+				'tool_name' => 'update_taxonomy_term',
+			);
+		}
+		$term = get_term( $resolved['term_id'], $taxonomy );
+		if ( ! $term || is_wp_error( $term ) ) {
+			return array(
+				'success'   => false,
+				'error'     => is_wp_error( $term ) ? $term->get_error_message() : 'Failed to retrieve taxonomy term',
 				'tool_name' => 'update_taxonomy_term',
 			);
 		}
@@ -182,37 +191,6 @@ class UpdateTaxonomyTerm extends BaseTool {
 	}
 
 	/**
-	 * Resolve term by ID, name, or slug.
-	 *
-	 * @param string $identifier Term identifier
-	 * @param string $taxonomy Taxonomy slug
-	 * @return \WP_Term|null Term object or null if not found
-	 */
-	private function resolveTerm( string $identifier, string $taxonomy ): ?\WP_Term {
-		// Try as ID first
-		if ( is_numeric( $identifier ) ) {
-			$term = get_term( (int) $identifier, $taxonomy );
-			if ( $term && ! is_wp_error( $term ) ) {
-				return $term;
-			}
-		}
-
-		// Try by name
-		$term = get_term_by( 'name', $identifier, $taxonomy );
-		if ( $term ) {
-			return $term;
-		}
-
-		// Try by slug
-		$term = get_term_by( 'slug', $identifier, $taxonomy );
-		if ( $term ) {
-			return $term;
-		}
-
-		return null;
-	}
-
-	/**
 	 * Get meta keys that are blocked (start with underscore).
 	 *
 	 * @param array $meta Meta key-value pairs
@@ -240,22 +218,21 @@ class UpdateTaxonomyTerm extends BaseTool {
 	 * @return array Result with success status and updated fields
 	 */
 	private function updateCoreFields( \WP_Term $term, string $taxonomy, ?string $name, ?string $slug, ?string $description, ?string $parent_item ): array {
-		$args           = array();
-		$updated_fields = array();
+		$input = array(
+			'term'     => (string) $term->term_id,
+			'taxonomy' => $taxonomy,
+		);
 
 		if ( ! empty( $name ) ) {
-			$args['name']     = sanitize_text_field( $name );
-			$updated_fields[] = 'name';
+			$input['name'] = $name;
 		}
 
 		if ( ! empty( $slug ) ) {
-			$args['slug']     = sanitize_title( $slug );
-			$updated_fields[] = 'slug';
+			$input['slug'] = $slug;
 		}
 
 		if ( null !== $description && '' !== $description ) {
-			$args['description'] = sanitize_textarea_field( $description );
-			$updated_fields[]    = 'description';
+			$input['description'] = $description;
 		}
 
 		if ( ! empty( $parent_item ) ) {
@@ -268,16 +245,17 @@ class UpdateTaxonomyTerm extends BaseTool {
 				);
 			}
 
-			$parent_term = $this->resolveTerm( $parent_item, $taxonomy );
-			if ( ! $parent_term ) {
+			$parent_result = ResolveTermAbility::resolve( $parent_item, $taxonomy, false );
+			if ( empty( $parent_result['success'] ) ) {
 				return array(
 					'success'   => false,
-					'error'     => "Parent term '{$parent_item}' not found in taxonomy '{$taxonomy}'",
+					'error'     => $parent_result['error'] ?? "Parent term '{$parent_item}' not found in taxonomy '{$taxonomy}'",
 					'tool_name' => 'update_taxonomy_term',
 				);
 			}
+			$parent_id = (int) $parent_result['term_id'];
 
-			if ( $parent_term->term_id === $term->term_id ) {
+			if ( $parent_id === $term->term_id ) {
 				return array(
 					'success'   => false,
 					'error'     => 'A term cannot be its own parent',
@@ -285,18 +263,26 @@ class UpdateTaxonomyTerm extends BaseTool {
 				);
 			}
 
-			$args['parent']   = $parent_term->term_id;
-			$updated_fields[] = 'parent';
+			$input['parent'] = $parent_id;
 		}
 
-		if ( empty( $args ) ) {
+		if ( 2 === count( $input ) ) {
 			return array(
 				'success'        => true,
 				'updated_fields' => array(),
 			);
 		}
 
-		$result = wp_update_term( $term->term_id, $taxonomy, $args );
+		$ability = wp_get_ability( 'datamachine/update-taxonomy-term' );
+		if ( ! $ability ) {
+			return array(
+				'success'   => false,
+				'error'     => 'Update taxonomy term ability not available',
+				'tool_name' => 'update_taxonomy_term',
+			);
+		}
+
+		$result = $ability->execute( $input );
 
 		if ( is_wp_error( $result ) ) {
 			return array(
@@ -306,9 +292,17 @@ class UpdateTaxonomyTerm extends BaseTool {
 			);
 		}
 
+		if ( ! is_array( $result ) || empty( $result['success'] ) ) {
+			return array(
+				'success'   => false,
+				'error'     => is_array( $result ) && ! empty( $result['error'] ) ? (string) $result['error'] : 'Failed to update taxonomy term',
+				'tool_name' => 'update_taxonomy_term',
+			);
+		}
+
 		return array(
 			'success'        => true,
-			'updated_fields' => $updated_fields,
+			'updated_fields' => array_keys( is_array( $result['changes'] ?? null ) ? $result['changes'] : array() ),
 		);
 	}
 

--- a/tests/update-taxonomy-term-delegation-smoke.php
+++ b/tests/update-taxonomy-term-delegation-smoke.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Pure-PHP smoke test for update_taxonomy_term ability delegation.
+ *
+ * Run with: php tests/update-taxonomy-term-delegation-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Abilities\Taxonomy {
+	class ResolveTermAbility {
+		public static function resolve( string $identifier, string $taxonomy, bool $create = false ): array {
+			unset( $taxonomy, $create );
+			$terms = $GLOBALS['taxonomy_terms'];
+
+			return isset( $terms[ $identifier ] )
+				? array( 'success' => true, 'term_id' => $terms[ $identifier ]->term_id )
+				: array( 'success' => false, 'error' => "Term '{$identifier}' not found" );
+		}
+	}
+}
+
+namespace DataMachine\Core\WordPress {
+	class TaxonomyHandler {
+		public static function shouldSkipTaxonomy( string $taxonomy ): bool {
+			unset( $taxonomy );
+			return false;
+		}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ );
+
+	class WP_Error {
+		public function __construct( private string $message ) {}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+
+	class WP_Term {
+		public function __construct(
+			public int $term_id,
+			public string $name,
+			public string $slug,
+			public string $description = '',
+			public int $parent = 0
+		) {}
+	}
+
+	class UpdateTaxonomyTermTestAbility {
+		public function execute( array $input ) {
+			$GLOBALS['ability_inputs'][] = $input;
+			$GLOBALS['sequence'][]       = 'core';
+			$result                      = $GLOBALS['ability_result'];
+
+			if ( is_callable( $result ) ) {
+				return $result( $input );
+			}
+
+			return $result;
+		}
+	}
+
+	function add_filter(): void {}
+	function taxonomy_exists(): bool { return true; }
+	function sanitize_key( $value ): string { return strtolower( preg_replace( '/[^a-z0-9_\-]/i', '', (string) $value ) ); }
+	function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+	function get_term( $term_id, $taxonomy ) {
+		unset( $taxonomy );
+		return $GLOBALS['taxonomy_terms'][ (string) $term_id ] ?? null;
+	}
+	function get_taxonomy(): object { return (object) array( 'hierarchical' => $GLOBALS['hierarchical'] ); }
+	function wp_get_ability(): ?UpdateTaxonomyTermTestAbility { return $GLOBALS['ability_available'] ? new UpdateTaxonomyTermTestAbility() : null; }
+	function update_term_meta( int $term_id, string $key, $value ): bool {
+		$GLOBALS['meta_writes'][] = compact( 'term_id', 'key', 'value' );
+		$GLOBALS['sequence'][]    = 'meta';
+		return true;
+	}
+
+	require_once dirname( __DIR__ ) . '/inc/Engine/AI/Tools/BaseTool.php';
+	require_once dirname( __DIR__ ) . '/inc/Api/Chat/Tools/UpdateTaxonomyTerm.php';
+
+	use DataMachine\Api\Chat\Tools\UpdateTaxonomyTerm;
+
+	$failed = 0;
+	$total  = 0;
+
+	function assert_update_term( string $name, bool $condition ): void {
+		global $failed, $total;
+		++$total;
+		if ( $condition ) {
+			echo "  PASS: {$name}\n";
+			return;
+		}
+		echo "  FAIL: {$name}\n";
+		++$failed;
+	}
+
+	function reset_update_term_test(): void {
+		$term = new WP_Term( 10, 'Old Name', 'old-name' );
+		$GLOBALS['taxonomy_terms'] = array(
+			'10'          => $term,
+			'Old Name'    => $term,
+			'old-name'    => $term,
+			'20'          => new WP_Term( 20, 'Parent Name', 'parent-slug' ),
+			'Parent Name' => new WP_Term( 20, 'Parent Name', 'parent-slug' ),
+			'parent-slug' => new WP_Term( 20, 'Parent Name', 'parent-slug' ),
+		);
+		$GLOBALS['ability_inputs']    = array();
+		$GLOBALS['meta_writes']       = array();
+		$GLOBALS['sequence']          = array();
+		$GLOBALS['ability_available'] = true;
+		$GLOBALS['ability_result']    = array(
+			'success' => true,
+			'changes' => array( 'name' => array( 'from' => 'Old Name', 'to' => 'New Name' ) ),
+		);
+		$GLOBALS['hierarchical']      = true;
+	}
+
+	$tool = new UpdateTaxonomyTerm();
+
+	echo "=== Update Taxonomy Term Delegation Smoke ===\n";
+
+	reset_update_term_test();
+	$result = $tool->handle_tool_call( array( 'term' => 'old-name', 'taxonomy' => 'category', 'name' => 'New Name' ) );
+	assert_update_term( 'core-only update succeeds', true === $result['success'] );
+	assert_update_term( 'registered ability executes exactly once', 1 === count( $GLOBALS['ability_inputs'] ) );
+	assert_update_term( 'ability receives flexible resolved term ID', '10' === $GLOBALS['ability_inputs'][0]['term'] );
+	assert_update_term( 'updated_fields comes from canonical changes', array( 'name' ) === $result['data']['updated_fields'] );
+
+	foreach ( array( '20', 'Parent Name', 'parent-slug' ) as $parent_identifier ) {
+		reset_update_term_test();
+		$GLOBALS['ability_result']['changes'] = array( 'parent' => array( 'from' => 0, 'to' => 20 ) );
+		$result = $tool->handle_tool_call( array( 'term' => '10', 'taxonomy' => 'category', 'parent' => $parent_identifier ) );
+		assert_update_term( "parent {$parent_identifier} maps to ID", true === $result['success'] && 20 === $GLOBALS['ability_inputs'][0]['parent'] );
+	}
+
+	reset_update_term_test();
+	$result = $tool->handle_tool_call( array( 'term' => '10', 'taxonomy' => 'category', 'parent' => 'old-name' ) );
+	assert_update_term( 'self-parent remains rejected', false === $result['success'] && 'A term cannot be its own parent' === $result['error'] );
+	assert_update_term( 'self-parent rejection skips ability', array() === $GLOBALS['ability_inputs'] );
+
+	reset_update_term_test();
+	$result = $tool->handle_tool_call( array( 'term' => '10', 'taxonomy' => 'category', 'meta' => array( 'empty' => '', 'null' => null, 'capacity' => 500 ) ) );
+	assert_update_term( 'meta-only update skips core ability', true === $result['success'] && array() === $GLOBALS['ability_inputs'] );
+	assert_update_term( 'empty meta values remain no-ops', array( 'capacity' ) === $result['data']['updated_meta'] );
+
+	reset_update_term_test();
+	$result = $tool->handle_tool_call( array( 'term' => '10', 'taxonomy' => 'category', 'meta' => array( '_private' => 'blocked' ) ) );
+	assert_update_term( 'protected meta remains blocked', false === $result['success'] && array() === $GLOBALS['meta_writes'] );
+
+	foreach ( array( new WP_Error( 'Core exploded' ), array( 'success' => false, 'error' => 'Legacy failure' ), false ) as $failure ) {
+		reset_update_term_test();
+		$GLOBALS['ability_result'] = $failure;
+		$result                    = $tool->handle_tool_call( array( 'term' => '10', 'taxonomy' => 'category', 'name' => 'New Name', 'meta' => array( 'capacity' => 500 ) ) );
+		assert_update_term( 'ability failure maps to stable tool failure', false === $result['success'] && isset( $result['error'] ) );
+		assert_update_term( 'ability failure prevents meta writes', array() === $GLOBALS['meta_writes'] );
+	}
+
+	reset_update_term_test();
+	$result = $tool->handle_tool_call( array( 'term' => '10', 'taxonomy' => 'category', 'name' => 'New Name', 'meta' => array( 'capacity' => 500 ) ) );
+	assert_update_term( 'mixed update executes core before meta', true === $result['success'] && array( 'core', 'meta' ) === $GLOBALS['sequence'] );
+
+	$source = (string) file_get_contents( dirname( __DIR__ ) . '/inc/Api/Chat/Tools/UpdateTaxonomyTerm.php' );
+	assert_update_term( 'tool has no direct wp_update_term call', false === strpos( $source, 'wp_update_term(' ) );
+
+	echo "\n";
+	if ( 0 === $failed ) {
+		echo "=== update-taxonomy-term-delegation-smoke: ALL PASS ({$total}) ===\n";
+		exit( 0 );
+	}
+
+	echo "=== update-taxonomy-term-delegation-smoke: {$failed} FAIL of {$total} ===\n";
+	exit( 1 );
+}


### PR DESCRIPTION
## Summary
- Delegate `name`, `slug`, `description`, and mapped `parent` writes exactly once to registered `datamachine/update-taxonomy-term`.
- Preserve the `update_taxonomy_term` adapter's flexible term and parent identifiers, protected/empty term-meta policy, response enrichment, and refreshed model-facing message.
- Sequence mixed updates core-first so ability failures prevent subsequent meta writes; this does not claim transactionality across term and term-meta APIs.

## Compatibility
- Preserves ID/name/slug term and parent resolution, hierarchical/self-parent validation, `updated_fields`, `updated_meta`, refreshed term data, and the existing response envelope.
- Maps canonical ability `WP_Error`, array failure, and legacy non-array failure results to stable tool failures.
- Removes the chat tool's direct `wp_update_term()` path while retaining its term-meta extension.

## Tests
- `php tests/update-taxonomy-term-delegation-smoke.php` (20 assertions passed)
- `vendor/bin/phpcs` (passed)
- `homeboy review lint --path /var/lib/datamachine/workspace/data-machine@simplify-3132-taxonomy-update --changed-only` (passed, run `c2ff1805-8fdd-4d96-b4c9-740f9d33eeb7`)
- `homeboy review audit --path /var/lib/datamachine/workspace/data-machine@simplify-3132-taxonomy-update --changed-since=origin/main` (passed with no findings)
- `homeboy review test --path /var/lib/datamachine/workspace/data-machine@simplify-3132-taxonomy-update` (runner failed before execution with 0 tests in 2.806s, run `b0949751-7512-454c-ae61-ea222f8dc1c7`; this was not the known command-runner budget timeout)

Closes #3132
Part of #3128 and #3113