### PR TITLE
fix: delegate chat scheduling validation

### DIFF
--- a/inc/Abilities/Flow/CreateFlowAbility.php
+++ b/inc/Abilities/Flow/CreateFlowAbility.php
@@ -216,18 +216,14 @@ class CreateFlowAbility {
 		}
 
 		// Validate and resolve interval aliases before storing.
-		$interval = $scheduling_config['interval'] ?? 'manual';
-		if ( 'manual' !== $interval && function_exists( 'datamachine_validate_interval' ) ) {
-			$validation = datamachine_validate_interval( $interval );
-			if ( ! $validation['valid'] ) {
-				return array(
-					'success' => false,
-					'error'   => $validation['error'],
-				);
-			}
-			// Use the resolved canonical key (alias → real key).
-			$scheduling_config['interval'] = $validation['resolved'];
+		$validation = datamachine_validate_interval( $scheduling_config['interval'] ?? 'manual', $scheduling_config );
+		if ( ! $validation['valid'] ) {
+			return array(
+				'success' => false,
+				'error'   => $validation['error'],
+			);
 		}
+		$scheduling_config['interval'] = $validation['resolved'];
 
 		// Store the requested scheduling_config immediately so the DB reflects
 		// the caller's intent. handle_scheduling_update() is called with

--- a/inc/Abilities/Flow/UpdateFlowAbility.php
+++ b/inc/Abilities/Flow/UpdateFlowAbility.php
@@ -116,6 +116,17 @@ class UpdateFlowAbility {
 			);
 		}
 
+		if ( null !== $scheduling_config ) {
+			$validation = datamachine_validate_interval( $scheduling_config['interval'] ?? 'manual', $scheduling_config );
+			if ( ! $validation['valid'] ) {
+				return array(
+					'success' => false,
+					'error'   => $validation['error'],
+				);
+			}
+			$scheduling_config['interval'] = $validation['resolved'];
+		}
+
 		if ( null !== $flow_name ) {
 			$flow_name = sanitize_text_field( wp_unslash( $flow_name ) );
 			if ( empty( trim( $flow_name ) ) ) {
@@ -153,19 +164,6 @@ class UpdateFlowAbility {
 		}
 
 		if ( null !== $scheduling_config ) {
-			// Validate and resolve interval aliases before scheduling.
-			$interval = $scheduling_config['interval'] ?? null;
-			if ( null !== $interval && 'manual' !== $interval && function_exists( 'datamachine_validate_interval' ) ) {
-				$validation = datamachine_validate_interval( $interval );
-				if ( ! $validation['valid'] ) {
-					return array(
-						'success' => false,
-						'error'   => $validation['error'],
-					);
-				}
-				$scheduling_config['interval'] = $validation['resolved'];
-			}
-
 			$result = FlowScheduling::handle_scheduling_update( $flow_id, $scheduling_config );
 			if ( is_wp_error( $result ) ) {
 				return array(

--- a/inc/Abilities/Pipeline/CreatePipelineAbility.php
+++ b/inc/Abilities/Pipeline/CreatePipelineAbility.php
@@ -147,6 +147,17 @@ class CreatePipelineAbility {
 		$steps       = $input['steps'] ?? array();
 		$workflow    = isset( $input['workflow'] ) && is_array( $input['workflow'] ) ? $input['workflow'] : array();
 		$flow_config = $input['flow_config'] ?? array();
+		if ( ! empty( $flow_config ) ) {
+			$scheduling_config     = $flow_config['scheduling_config'] ?? array( 'interval' => 'manual' );
+			$scheduling_validation = datamachine_validate_interval( $scheduling_config['interval'] ?? 'manual', $scheduling_config );
+			if ( ! $scheduling_validation['valid'] ) {
+				return array(
+					'success' => false,
+					'error'   => $scheduling_validation['error'],
+				);
+			}
+			$flow_config['scheduling_config']['interval'] = $scheduling_validation['resolved'];
+		}
 
 		// Resolve the owning agent when the caller did not supply one, mirroring
 		// CreateFlowAbility. Without this a pipeline created without an explicit
@@ -333,6 +344,16 @@ class CreatePipelineAbility {
 		// Pre-validation: check handler slugs in template.
 		$template_workflow = isset( $template['workflow'] ) && is_array( $template['workflow'] ) ? $template['workflow'] : array();
 		$template_steps    = $template['steps'] ?? array();
+		if ( isset( $template['scheduling_config'] ) ) {
+			$scheduling_validation = datamachine_validate_interval( $template['scheduling_config']['interval'] ?? 'manual', $template['scheduling_config'] );
+			if ( ! $scheduling_validation['valid'] ) {
+				return array(
+					'success' => false,
+					'error'   => 'Template scheduling validation failed: ' . $scheduling_validation['error'],
+				);
+			}
+			$template['scheduling_config']['interval'] = $scheduling_validation['resolved'];
+		}
 		if ( ! empty( $template_workflow ) ) {
 			$validation = $this->validateWorkflow( $template_workflow );
 			if ( true !== $validation ) {
@@ -372,6 +393,24 @@ class CreatePipelineAbility {
 					'remediation' => 'Provide a "name" property for each pipeline in the pipelines array',
 				);
 				continue;
+			}
+
+			$has_flow_config = isset( $pipeline_config['flow_name'] ) || isset( $pipeline_config['scheduling_config'] ) || isset( $template['scheduling_config'] );
+			if ( $has_flow_config ) {
+				$scheduling_config     = $pipeline_config['scheduling_config'] ?? ( $template['scheduling_config'] ?? array( 'interval' => 'manual' ) );
+				$scheduling_validation = datamachine_validate_interval( $scheduling_config['interval'] ?? 'manual', $scheduling_config );
+				if ( ! $scheduling_validation['valid'] ) {
+					$validation_errors[] = array(
+						'index'       => $index,
+						'name'        => $name,
+						'error'       => $scheduling_validation['error'],
+						'remediation' => 'Fix the scheduling configuration for this pipeline',
+					);
+					continue;
+				}
+				if ( isset( $pipeline_config['scheduling_config'] ) ) {
+					$pipelines[ $index ]['scheduling_config']['interval'] = $scheduling_validation['resolved'];
+				}
 			}
 
 			$per_pipeline_workflow = isset( $pipeline_config['workflow'] ) && is_array( $pipeline_config['workflow'] ) ? $pipeline_config['workflow'] : array();

--- a/inc/Api/Chat/Tools/CreateFlow.php
+++ b/inc/Api/Chat/Tools/CreateFlow.php
@@ -92,11 +92,11 @@ class CreateFlow extends BaseTool {
 		$flow_name         = $parameters['flow_name'] ?? 'Flow';
 		$scheduling_config = $parameters['scheduling_config'] ?? array( 'interval' => 'manual' );
 
-		$validation = $this->validateSchedulingConfig( $scheduling_config );
-		if ( true !== $validation ) {
+		$ability = wp_get_ability( 'datamachine/create-flow' );
+		if ( ! $ability ) {
 			return array(
 				'success'   => false,
-				'error'     => $validation,
+				'error'     => 'Create flow ability not available',
 				'tool_name' => 'create_flow',
 			);
 		}
@@ -106,6 +106,19 @@ class CreateFlow extends BaseTool {
 
 		foreach ( $existing_flows as $existing_flow ) {
 			if ( strcasecmp( $existing_flow['flow_name'], $flow_name ) === 0 ) {
+				$validation = $ability->execute(
+					array(
+						'pipeline_id'       => $pipeline_id,
+						'flow_name'         => $flow_name,
+						'scheduling_config' => $scheduling_config,
+						'validate_only'     => true,
+					)
+				);
+				if ( ! $this->isAbilitySuccess( $validation ) ) {
+					$error = $this->getAbilityError( $validation, 'Failed to validate flow configuration.' );
+					return $this->buildErrorResponse( $error, 'create_flow' );
+				}
+
 				$flow_config   = $existing_flow['flow_config'] ?? array();
 				$flow_step_ids = array_keys( $flow_config );
 
@@ -122,15 +135,6 @@ class CreateFlow extends BaseTool {
 					'tool_name' => 'create_flow',
 				);
 			}
-		}
-
-		$ability = wp_get_ability( 'datamachine/create-flow' );
-		if ( ! $ability ) {
-			return array(
-				'success'   => false,
-				'error'     => 'Create flow ability not available',
-				'tool_name' => 'create_flow',
-			);
 		}
 
 		$result = $ability->execute(
@@ -163,7 +167,7 @@ class CreateFlow extends BaseTool {
 			'pipeline_id'   => $result['pipeline_id'],
 			'synced_steps'  => $result['synced_steps'],
 			'flow_step_ids' => $flow_step_ids,
-			'scheduling'    => $scheduling_config['interval'],
+			'scheduling'    => $result['flow_data']['scheduling_config']['interval'] ?? $scheduling_config['interval'],
 		);
 
 		if ( ! empty( $config_results['applied'] ) ) {
@@ -335,30 +339,4 @@ class CreateFlow extends BaseTool {
 		);
 	}
 
-	private function validateSchedulingConfig( array $config ): bool|string {
-		if ( empty( $config ) ) {
-			return true;
-		}
-
-		$interval = $config['interval'] ?? null;
-
-		if ( null === $interval ) {
-			return 'scheduling_config requires an interval property';
-		}
-
-		$intervals       = array_keys( apply_filters( 'datamachine_scheduler_intervals', array() ) );
-		$valid_intervals = array_merge( array( 'manual', 'one_time' ), $intervals );
-		if ( ! in_array( $interval, $valid_intervals, true ) ) {
-			return 'Invalid interval. Must be one of: ' . implode( ', ', $valid_intervals );
-		}
-
-		if ( 'one_time' === $interval ) {
-			$timestamp = $config['timestamp'] ?? null;
-			if ( ! is_numeric( $timestamp ) || (int) $timestamp <= 0 ) {
-				return 'one_time interval requires a valid unix timestamp';
-			}
-		}
-
-		return true;
-	}
 }

--- a/inc/Api/Chat/Tools/CreatePipeline.php
+++ b/inc/Api/Chat/Tools/CreatePipeline.php
@@ -16,6 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use DataMachine\Abilities\StepTypeAbilities;
+use DataMachine\Core\Database\Flows\Flows as FlowsDB;
 use DataMachine\Engine\AI\Tools\BaseTool;
 
 class CreatePipeline extends BaseTool {
@@ -100,25 +101,7 @@ class CreatePipeline extends BaseTool {
 		$flow_name         = $parameters['flow_name'] ?? $pipeline_name;
 		$scheduling_config = $parameters['scheduling_config'] ?? array( 'interval' => 'manual' );
 
-		$scheduling_validation = $this->validateSchedulingConfig( $scheduling_config );
-		if ( true !== $scheduling_validation ) {
-			return array(
-				'success'   => false,
-				'error'     => $scheduling_validation,
-				'tool_name' => 'create_pipeline',
-			);
-		}
-
 		if ( ! empty( $steps ) ) {
-			$steps_validation = $this->validateSteps( $steps );
-			if ( true !== $steps_validation ) {
-				return array(
-					'success'   => false,
-					'error'     => $steps_validation,
-					'tool_name' => 'create_pipeline',
-				);
-			}
-
 			$steps = $this->normalizeSteps( $steps );
 		}
 
@@ -161,6 +144,7 @@ class CreatePipeline extends BaseTool {
 		$flow_id       = $result['flow_id'] ?? null;
 		$flow_step_ids = $result['flow_step_ids'] ?? array();
 		$steps_created = $result['steps_created'] ?? 0;
+		$flow           = $flow_id ? ( new FlowsDB() )->get_flow( (int) $flow_id ) : null;
 
 		return array(
 			'success'   => true,
@@ -171,7 +155,7 @@ class CreatePipeline extends BaseTool {
 				'flow_name'     => $flow_name,
 				'steps_created' => $steps_created,
 				'flow_step_ids' => $flow_step_ids,
-				'scheduling'    => $scheduling_config['interval'],
+				'scheduling'    => $flow['scheduling_config']['interval'] ?? $scheduling_config['interval'],
 				'message'       => 0 === $steps_created
 					? "Pipeline and flow (ID: {$flow_id}) created. Use add_pipeline_step to add steps, then configure_flow_steps to configure handlers."
 					: "Pipeline and flow (ID: {$flow_id}) created with {$steps_created} steps. Use configure_flow_steps with the flow_step_ids to set handler configurations.",
@@ -191,31 +175,15 @@ class CreatePipeline extends BaseTool {
 		$template      = $parameters['template'] ?? array();
 		$validate_only = ! empty( $parameters['validate_only'] );
 
-		// Normalize template steps if provided
+		// Normalize template steps if provided.
 		$template_steps = $template['steps'] ?? array();
 		if ( ! empty( $template_steps ) ) {
-			$steps_validation = $this->validateSteps( $template_steps );
-			if ( true !== $steps_validation ) {
-				return array(
-					'success'   => false,
-					'error'     => 'Template steps validation failed: ' . $steps_validation,
-					'tool_name' => 'create_pipeline',
-				);
-			}
 			$template['steps'] = $this->normalizeSteps( $template_steps );
 		}
 
-		// Validate and normalize per-pipeline steps
+		// Normalize per-pipeline steps before canonical ability validation.
 		foreach ( $pipelines as $index => &$pipeline_config ) {
 			if ( ! empty( $pipeline_config['steps'] ) ) {
-				$steps_validation = $this->validateSteps( $pipeline_config['steps'] );
-				if ( true !== $steps_validation ) {
-					return array(
-						'success'   => false,
-						'error'     => "Pipeline at index {$index} steps validation failed: " . $steps_validation,
-						'tool_name' => 'create_pipeline',
-					);
-				}
 				$pipeline_config['steps'] = $this->normalizeSteps( $pipeline_config['steps'] );
 			}
 		}
@@ -272,64 +240,16 @@ class CreatePipeline extends BaseTool {
 		return $result;
 	}
 
-	private function validateSchedulingConfig( array $config ): bool|string {
-		if ( empty( $config ) ) {
-			return true;
-		}
-
-		$interval = $config['interval'] ?? null;
-
-		if ( null === $interval ) {
-			return 'scheduling_config requires an interval property';
-		}
-
-		$intervals       = array_keys( apply_filters( 'datamachine_scheduler_intervals', array() ) );
-		$valid_intervals = array_merge( array( 'manual', 'one_time' ), $intervals );
-		if ( ! in_array( $interval, $valid_intervals, true ) ) {
-			return 'Invalid interval. Must be one of: ' . implode( ', ', $valid_intervals );
-		}
-
-		if ( 'one_time' === $interval ) {
-			$timestamp = $config['timestamp'] ?? null;
-			if ( ! is_numeric( $timestamp ) || (int) $timestamp <= 0 ) {
-				return 'one_time interval requires a valid unix timestamp';
-			}
-		}
-
-		return true;
-	}
-
-	private function validateSteps( array $steps ): bool|string {
-		foreach ( $steps as $index => $step ) {
-			// Accept shorthand: "event_import" becomes step_type=event_import
-			if ( is_string( $step ) ) {
-				$step = array( 'step_type' => $step );
-			}
-
-			if ( ! is_array( $step ) ) {
-				return "Step at index {$index} must be a string or object";
-			}
-
-			$step_type = $step['step_type'] ?? null;
-			if ( empty( $step_type ) ) {
-				return "Step at index {$index} is missing required step_type";
-			}
-
-			$valid_types = self::getValidStepTypes();
-			if ( ! in_array( $step_type, $valid_types, true ) ) {
-				return "Step at index {$index} has invalid step_type '{$step_type}'. Must be one of: " . implode( ', ', $valid_types );
-			}
-		}
-
-		return true;
-	}
-
 	private function normalizeSteps( array $steps ): array {
 		$normalized = array();
 		foreach ( $steps as $index => $step ) {
 			// Accept shorthand: "event_import" becomes step_type=event_import
 			if ( is_string( $step ) ) {
 				$step = array( 'step_type' => $step );
+			}
+			if ( ! is_array( $step ) || empty( $step['step_type'] ) ) {
+				$normalized[] = $step;
+				continue;
 			}
 
 			$handler_slug   = $step['handler_slug'] ?? null;

--- a/inc/Api/Chat/Tools/UpdateFlow.php
+++ b/inc/Api/Chat/Tools/UpdateFlow.php
@@ -76,17 +76,6 @@ class UpdateFlow extends BaseTool {
 			);
 		}
 
-		if ( ! empty( $scheduling_config ) ) {
-			$validation = $this->validateSchedulingConfig( $scheduling_config );
-			if ( true !== $validation ) {
-				return array(
-					'success'   => false,
-					'error'     => $validation,
-					'tool_name' => 'update_flow',
-				);
-			}
-		}
-
 		$ability = wp_get_ability( 'datamachine/update-flow' );
 		if ( ! $ability ) {
 			return array(
@@ -120,8 +109,8 @@ class UpdateFlow extends BaseTool {
 			$response_data['flow_name'] = $result['flow_name'] ?? $flow_name;
 		}
 		if ( ! empty( $scheduling_config ) ) {
-			$response_data['scheduling']        = $scheduling_config['interval'];
-			$response_data['scheduling_config'] = $scheduling_config;
+			$response_data['scheduling_config'] = $result['flow_data']['scheduling_config'] ?? $scheduling_config;
+			$response_data['scheduling']        = $response_data['scheduling_config']['interval'] ?? 'manual';
 		}
 
 		return array(
@@ -131,26 +120,4 @@ class UpdateFlow extends BaseTool {
 		);
 	}
 
-	private function validateSchedulingConfig( array $config ): bool|string {
-		$interval = $config['interval'] ?? null;
-
-		if ( null === $interval ) {
-			return 'scheduling_config requires an interval property';
-		}
-
-		$intervals       = array_keys( apply_filters( 'datamachine_scheduler_intervals', array() ) );
-		$valid_intervals = array_merge( array( 'manual', 'one_time' ), $intervals );
-		if ( ! in_array( $interval, $valid_intervals, true ) ) {
-			return 'Invalid interval. Must be one of: ' . implode( ', ', $valid_intervals );
-		}
-
-		if ( 'one_time' === $interval ) {
-			$timestamp = $config['timestamp'] ?? null;
-			if ( ! is_numeric( $timestamp ) || (int) $timestamp <= 0 ) {
-				return 'one_time interval requires a valid unix timestamp';
-			}
-		}
-
-		return true;
-	}
 }

--- a/inc/Engine/Filters/SchedulerIntervals.php
+++ b/inc/Engine/Filters/SchedulerIntervals.php
@@ -96,15 +96,28 @@ function datamachine_resolve_interval_alias( string $interval ): string {
  * Special keys (manual, one_time, cron) and cron expressions are always valid.
  *
  * @param string $interval Interval key, alias, or cron expression.
+ * @param array  $config Optional scheduling configuration for special-key requirements.
  * @return array{valid: bool, resolved: string, error?: string, available?: string[]}
  */
-function datamachine_validate_interval( string $interval ): array {
+function datamachine_validate_interval( string $interval, array $config = array() ): array {
 	// Special scheduling types are always valid.
 	if ( in_array( $interval, array( 'manual', 'one_time', 'cron' ), true ) ) {
-		return array(
+		$validation = array(
 			'valid'    => true,
 			'resolved' => $interval,
 		);
+
+		if ( 'one_time' === $interval && ! empty( $config ) && empty( $config['timestamp'] ) ) {
+			$validation['valid'] = false;
+			$validation['error'] = 'Timestamp required for one-time scheduling';
+		}
+
+		if ( 'cron' === $interval && ! empty( $config ) && empty( $config['cron_expression'] ) ) {
+			$validation['valid'] = false;
+			$validation['error'] = 'cron_expression required when interval is cron';
+		}
+
+		return $validation;
 	}
 
 	// Cron expressions are valid (further validation happens in RecurringScheduler).

--- a/tests/Unit/Api/Chat/Tools/SchedulingDelegationTest.php
+++ b/tests/Unit/Api/Chat/Tools/SchedulingDelegationTest.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Curated chat scheduling delegation tests.
+ *
+ * @package DataMachine\Tests\Unit\Api\Chat\Tools
+ */
+
+namespace DataMachine\Tests\Unit\Api\Chat\Tools;
+
+use DataMachine\Api\Chat\Tools\CreateFlow;
+use DataMachine\Api\Chat\Tools\CreatePipeline;
+use DataMachine\Api\Chat\Tools\UpdateFlow;
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Pipelines\Pipelines;
+use WP_UnitTestCase;
+
+class SchedulingDelegationTest extends WP_UnitTestCase {
+
+	private int $pipeline_id;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$this->pipeline_id = (int) ( new Pipelines() )->create_pipeline(
+			array(
+				'pipeline_name'   => 'Chat scheduling delegation',
+				'pipeline_config' => array(),
+			)
+		);
+	}
+
+	public function test_create_flow_resolves_every_six_hours_through_ability(): void {
+		$result = ( new CreateFlow() )->handle_tool_call(
+			array(
+				'pipeline_id'       => $this->pipeline_id,
+				'flow_name'         => 'Six hour flow',
+				'scheduling_config' => array( 'interval' => 'every_6_hours' ),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'qtrdaily', $result['data']['scheduling'] );
+		$flow = ( new Flows() )->get_flow( (int) $result['data']['flow_id'] );
+		$this->assertSame( 'qtrdaily', $flow['scheduling_config']['interval'] );
+	}
+
+	public function test_update_flow_resolves_every_twelve_hours_through_ability(): void {
+		$created = wp_get_ability( 'datamachine/create-flow' )->execute(
+			array(
+				'pipeline_id' => $this->pipeline_id,
+				'flow_name'   => 'Twelve hour flow',
+			)
+		);
+
+		$result = ( new UpdateFlow() )->handle_tool_call(
+			array(
+				'flow_id'           => $created['flow_id'],
+				'scheduling_config' => array( 'interval' => 'every_12_hours' ),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'twicedaily', $result['data']['scheduling'] );
+		$this->assertSame( 'twicedaily', $result['data']['scheduling_config']['interval'] );
+	}
+
+	/**
+	 * @dataProvider canonicalScheduleProvider
+	 */
+	public function test_create_flow_accepts_canonical_schedule_forms( array $scheduling_config, string $expected ): void {
+		$result = ( new CreateFlow() )->handle_tool_call(
+			array(
+				'pipeline_id'       => $this->pipeline_id,
+				'flow_name'         => 'Canonical schedule ' . $expected,
+				'scheduling_config' => $scheduling_config,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $expected, $result['data']['scheduling'] );
+	}
+
+	public static function canonicalScheduleProvider(): array {
+		return array(
+			'explicit cron'   => array(
+				array(
+					'interval'        => 'cron',
+					'cron_expression' => '0 9 * * 1-5',
+				),
+				'cron',
+			),
+			'cron expression' => array( array( 'interval' => '0 9 * * 1-5' ), '0 9 * * 1-5' ),
+		);
+	}
+
+	public function test_invalid_and_incomplete_schedules_remain_tool_failures(): void {
+		$invalid = ( new CreateFlow() )->handle_tool_call(
+			array(
+				'pipeline_id'       => $this->pipeline_id,
+				'flow_name'         => 'Invalid interval flow',
+				'scheduling_config' => array( 'interval' => 'sometimes' ),
+			)
+		);
+		$one_time = ( new CreateFlow() )->handle_tool_call(
+			array(
+				'pipeline_id'       => $this->pipeline_id,
+				'flow_name'         => 'Incomplete one-time flow',
+				'scheduling_config' => array( 'interval' => 'one_time' ),
+			)
+		);
+
+		$this->assertFalse( $invalid['success'] );
+		$this->assertStringContainsString( 'Invalid interval', $invalid['error'] );
+		$this->assertSame( 'create_flow', $invalid['tool_name'] );
+		$this->assertFalse( $one_time['success'] );
+		$this->assertSame( 'Timestamp required for one-time scheduling', $one_time['error'] );
+		$this->assertSame( 'create_flow', $one_time['tool_name'] );
+	}
+
+	public function test_bulk_flow_validate_only_uses_canonical_resolution_without_writes(): void {
+		$before = ( new Flows() )->count_flows_for_pipeline( $this->pipeline_id );
+		$result = ( new CreateFlow() )->handle_tool_call(
+			array(
+				'flows'         => array(
+					array(
+						'pipeline_id'       => $this->pipeline_id,
+						'flow_name'         => 'Bulk validation flow',
+						'scheduling_config' => array( 'interval' => 'every_6_hours' ),
+					),
+				),
+				'validate_only' => true,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'validate_only', $result['data']['mode'] );
+		$this->assertSame( 'qtrdaily', $result['data']['would_create'][0]['scheduling'] );
+		$this->assertSame( $before, ( new Flows() )->count_flows_for_pipeline( $this->pipeline_id ) );
+	}
+
+	public function test_create_pipeline_preserves_shorthand_and_resolves_seeded_flow_schedule(): void {
+		$result = ( new CreatePipeline() )->handle_tool_call(
+			array(
+				'pipeline_name'     => 'Scheduled shorthand pipeline',
+				'steps'             => array( 'ai' ),
+				'scheduling_config' => array( 'interval' => 'every_6_hours' ),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 1, $result['data']['steps_created'] );
+		$this->assertSame( 'qtrdaily', $result['data']['scheduling'] );
+		$flow = ( new Flows() )->get_flow( (int) $result['data']['flow_id'] );
+		$this->assertSame( 'qtrdaily', $flow['scheduling_config']['interval'] );
+	}
+
+	public function test_pipeline_validate_only_and_invalid_preflight_use_canonical_contract(): void {
+		$pipelines = new Pipelines();
+		$before    = $pipelines->get_pipelines_count();
+		$preview   = ( new CreatePipeline() )->handle_tool_call(
+			array(
+				'pipelines'     => array(
+					array(
+						'name'              => 'Preview pipeline',
+						'scheduling_config' => array( 'interval' => 'every_12_hours' ),
+					),
+				),
+				'validate_only' => true,
+			)
+		);
+		$invalid   = ( new CreatePipeline() )->handle_tool_call(
+			array(
+				'pipeline_name'     => 'Invalid seeded pipeline',
+				'scheduling_config' => array( 'interval' => 'one_time' ),
+			)
+		);
+
+		$this->assertTrue( $preview['success'] );
+		$this->assertSame( 'twicedaily', $preview['data']['would_create'][0]['scheduling'] );
+		$this->assertFalse( $invalid['success'] );
+		$this->assertSame( 'Timestamp required for one-time scheduling', $invalid['error'] );
+		$this->assertSame( $before, $pipelines->get_pipelines_count() );
+	}
+
+	public function test_curated_tools_have_no_copied_interval_registry(): void {
+		foreach ( array( CreateFlow::class, UpdateFlow::class, CreatePipeline::class ) as $class ) {
+			$source = file_get_contents( ( new \ReflectionClass( $class ) )->getFileName() );
+			$this->assertStringNotContainsString( 'datamachine_scheduler_intervals', $source );
+			$this->assertStringNotContainsString( 'valid_intervals', $source );
+			$this->assertStringNotContainsString( 'validateSchedulingConfig', $source );
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- remove divergent interval and step-type validation from the curated `create_flow`, `update_flow`, and `create_pipeline` chat adapters while preserving their model-facing schemas, documentation, envelopes, shorthand normalization, bulk/validate-only behavior, and composed pipeline-plus-flow behavior
- expand chat compatibility to canonical scheduling semantics, including `every_6_hours` -> `qtrdaily`, `every_12_hours` -> `twicedaily`, `cron`, and valid cron expressions
- keep `SchedulerIntervals::datamachine_validate_interval()` and the registered flow abilities as the canonical owners, with pipeline ability preflight preventing partial composed writes for invalid schedules

## Tests
- added focused chat integration coverage for aliases, explicit cron, cron expressions, invalid intervals, missing one-time timestamps, bulk validate-only no-write behavior, seeded-flow pipeline creation, shorthand steps, and copied-validator removal
- `vendor/bin/phpcs ...` passed for all changed PHP files
- `php tests/prefix-policy-audit.php` passed: 11 passed, 0 failed
- `homeboy review lint --placement local --changed-only` passed, including PHPCS and PHPStan
- `homeboy review audit --placement local --profile pr --changed-since origin/main` passed with no introduced findings
- Homeboy tests were attempted focused and unfiltered, but the local PHP 8.4/PHPUnit 9.6 runner reported zero executed tests before assertions; Lab retry was unavailable because no runner was connected

Closes #3134
Part of #3128 and #3113