### PR TITLE
refactor: keep directory imports canonical

### DIFF
--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -555,15 +555,41 @@ class AgentBundler {
 			);
 		}
 
-		try {
-			$bundle = $this->canonical_import_bundle( $bundle );
-		} catch ( BundleValidationException $e ) {
-			return array(
-				'success'    => false,
-				'error_code' => 'install_invalid_bundle',
-				'error'      => $e->getMessage(),
+		if ( (string) ( $bundle['bundle_schema_version'] ?? '' ) === (string) BundleSchema::VERSION ) {
+			try {
+				$directory = AgentBundleArrayAdapter::from_array_bundle( $bundle );
+			} catch ( BundleValidationException $e ) {
+				return array(
+					'success'    => false,
+					'error_code' => 'install_invalid_bundle',
+					'error'      => $e->getMessage(),
+				);
+			}
+
+			return $this->import_directory_materialization(
+				$directory,
+				$new_slug,
+				$owner_id,
+				$dry_run,
+				$options,
+				is_array( $bundle['abilities_manifest'] ?? null ) ? $bundle['abilities_manifest'] : array()
 			);
 		}
+
+		return $this->materialize_import_bundle( $bundle, $new_slug, $owner_id, $dry_run, $options );
+	}
+
+	/**
+	 * Materialize an import payload into runtime records.
+	 *
+	 * @param array       $bundle Import materialization payload.
+	 * @param string|null $new_slug Optional override slug.
+	 * @param int         $owner_id WordPress user ID to own the imported agent.
+	 * @param bool        $dry_run If true, validate without writing.
+	 * @param array       $options Import options.
+	 * @return array{success: bool, message?: string, error?: string, error_code?: string, summary?: array}
+	 */
+	private function materialize_import_bundle( array $bundle, ?string $new_slug, int $owner_id, bool $dry_run, array $options ): array {
 
 		$agent_data             = $bundle['agent'];
 		$slug                   = $new_slug
@@ -1322,28 +1348,27 @@ class AgentBundler {
 	 * @return array{success: bool, message?: string, error?: string, error_code?: string, summary?: array}
 	 */
 	public function import_directory_object( AgentBundleDirectory $directory, ?string $new_slug = null, int $owner_id = 0, bool $dry_run = false, array $options = array() ): array {
-		return $this->import( AgentBundleArrayAdapter::to_array_bundle( $directory ), $new_slug, $owner_id, $dry_run, $options );
+		return $this->import_directory_materialization( $directory, $new_slug, $owner_id, $dry_run, $options );
 	}
 
 	/**
-	 * Normalize schema-versioned bundle arrays through directory value objects before import.
+	 * Project a directory bundle once at the runtime materialization boundary.
 	 *
-	 * Legacy backup arrays intentionally keep the raw runtime-config path for compatibility.
-	 *
-	 * @param array $bundle Bundle array.
-	 * @return array Importable bundle array.
+	 * @param AgentBundleDirectory $directory Bundle directory value object.
+	 * @param string|null          $new_slug Optional override slug.
+	 * @param int                  $owner_id WordPress user ID to own the imported agent.
+	 * @param bool                 $dry_run If true, validate without writing.
+	 * @param array                $options Import options.
+	 * @param array                $abilities_manifest Compatibility abilities manifest.
+	 * @return array{success: bool, message?: string, error?: string, error_code?: string, summary?: array}
 	 */
-	private function canonical_import_bundle( array $bundle ): array {
-		if ( (string) ( $bundle['bundle_schema_version'] ?? '' ) !== (string) BundleSchema::VERSION ) {
-			return $bundle;
+	private function import_directory_materialization( AgentBundleDirectory $directory, ?string $new_slug, int $owner_id, bool $dry_run, array $options, array $abilities_manifest = array() ): array {
+		$payload = AgentBundleArrayAdapter::to_import_payload( $directory );
+		if ( ! empty( $abilities_manifest ) ) {
+			$payload['abilities_manifest'] = $abilities_manifest;
 		}
 
-		$canonical = AgentBundleArrayAdapter::to_array_bundle( AgentBundleArrayAdapter::from_array_bundle( $bundle ) );
-		if ( is_array( $bundle['abilities_manifest'] ?? null ) ) {
-			$canonical['abilities_manifest'] = $bundle['abilities_manifest'];
-		}
-
-		return $canonical;
+		return $this->materialize_import_bundle( $payload, $new_slug, $owner_id, $dry_run, $options );
 	}
 
 	/**

--- a/inc/Engine/Bundle/AgentBundleArrayAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleArrayAdapter.php
@@ -63,6 +63,20 @@ final class AgentBundleArrayAdapter {
 	 * @return array Bundle array.
 	 */
 	public static function to_array_bundle( AgentBundleDirectory $directory ): array {
+		return self::to_import_payload( $directory );
+	}
+
+	/**
+	 * Project directory value objects into the established importer payload.
+	 *
+	 * Unlike to_array_bundle(), this is an internal materialization boundary,
+	 * not a compatibility export. Source install IDs are synthesized only long
+	 * enough for BundleStepIdRemapper to assign fresh runtime IDs.
+	 *
+	 * @param AgentBundleDirectory $directory Bundle directory value object.
+	 * @return array Import materialization payload.
+	 */
+	public static function to_import_payload( AgentBundleDirectory $directory ): array {
 		$manifest      = $directory->manifest()->to_array();
 		$memory_files  = $directory->memory_files();
 		$pipeline_ids  = array();

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -344,7 +344,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$this->assertSame( 'broken.json', $data['errors'][0]['source_path'] ?? null );
 	}
 
-	public function test_directory_value_object_import_preserves_workflow_runtime_seed_fields(): void {
+	public function test_directory_and_compatibility_array_imports_converge_without_source_ids(): void {
 		$bundle = $this->fixture_bundle( 'directory-import-agent' );
 		$bundle['flows'][0]['flow_config']['1_step-uuid_1'] = array_merge(
 			$bundle['flows'][0]['flow_config']['1_step-uuid_1'],
@@ -378,6 +378,14 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 
 		$this->assertTrue( (bool) $result['success'], 'Directory value-object import succeeds.' );
 
+		$compatibility_bundle = AgentBundleArrayAdapter::to_array_bundle( $directory );
+		unset( $compatibility_bundle['pipelines'][0]['original_id'], $compatibility_bundle['flows'][0]['original_id'], $compatibility_bundle['flows'][0]['original_pipeline_id'] );
+		$compatibility_result = $this->bundler->import( $compatibility_bundle, 'compatibility-import-agent', $this->owner_id );
+
+		$this->assertTrue( (bool) $compatibility_result['success'], 'Compatibility array import succeeds without source install IDs.' );
+		$this->assertSame( $result['summary']['pipelines_imported'] ?? null, $compatibility_result['summary']['pipelines_imported'] ?? null );
+		$this->assertSame( $result['summary']['flows_imported'] ?? null, $compatibility_result['summary']['flows_imported'] ?? null );
+
 		$agent    = $this->agents_repo->get_by_slug( 'directory-import-agent' );
 		$pipeline = $this->pipelines_repo->get_by_portable_slug( (int) $agent['agent_id'], 'static-site-pipeline' );
 		$flow     = $this->flows_repo->get_by_portable_slug( (int) $pipeline['pipeline_id'], 'static-site-flow' );
@@ -391,6 +399,24 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$this->assertFalse( $step['enabled'] ?? true, 'Disabled step state imports from directory document.' );
 		$this->assertSame( 'daily', $flow['scheduling_config']['interval'] ?? null, 'Schedule imports from directory document.' );
 		$this->assertSame( array( 'mcp' => 7 ), $flow['scheduling_config']['max_items'] ?? null, 'Schedule limits import from directory document.' );
+
+		$directory_export     = $this->bundler->export_directory_object( 'directory-import-agent' );
+		$compatibility_export = $this->bundler->export_directory_object( 'compatibility-import-agent' );
+		$this->assertTrue( (bool) $directory_export['success'] );
+		$this->assertTrue( (bool) $compatibility_export['success'] );
+
+		$directory_output     = $directory_export['directory'];
+		$compatibility_output = $compatibility_export['directory'];
+		$this->assertSame(
+			array_map( static fn( $pipeline ) => $pipeline->to_array(), $directory_output->pipelines() ),
+			array_map( static fn( $pipeline ) => $pipeline->to_array(), $compatibility_output->pipelines() ),
+			'Direct directory and compatibility array imports materialize identical pipeline documents.'
+		);
+		$this->assertSame(
+			array_map( static fn( $flow_file ) => $flow_file->to_array(), $directory_output->flows() ),
+			array_map( static fn( $flow_file ) => $flow_file->to_array(), $compatibility_output->flows() ),
+			'Direct directory and compatibility array imports materialize identical flow documents.'
+		);
 	}
 
 	public function test_schema_versioned_array_import_does_not_require_source_install_ids(): void {

--- a/tests/agent-bundler-directory-adapter-smoke.php
+++ b/tests/agent-bundler-directory-adapter-smoke.php
@@ -366,6 +366,8 @@ assert_adapter( 'export composes AgentBundlePipelineFile directly', false !== st
 assert_adapter( 'export composes AgentBundleFlowFile directly', false !== strpos( $agent_bundler_source, 'new AgentBundleFlowFile' ) );
 assert_adapter( 'to_directory writes AgentBundleArrayAdapter output', false !== strpos( $agent_bundler_source, 'AgentBundleArrayAdapter::from_array_bundle( $bundle )->write( $directory )' ) );
 assert_adapter( 'from_directory reads AgentBundleDirectory before array fallback', false !== strpos( $agent_bundler_source, 'AgentBundleArrayAdapter::to_array_bundle( AgentBundleDirectory::read( $directory ) )' ) );
+assert_adapter( 'directory import projects directly to the materialization payload', false !== strpos( $agent_bundler_source, 'AgentBundleArrayAdapter::to_import_payload( $directory )' ) );
+assert_adapter( 'directory import does not bounce through legacy array import', false === strpos( $agent_bundler_source, 'return $this->import( AgentBundleArrayAdapter::to_array_bundle( $directory )' ) );
 assert_adapter( 'import tracks bundle file artifacts', false !== strpos( $agent_bundler_source, 'self::bundle_file_artifacts( $bundle )' ) );
 
 rm_adapter_tree( $tmp );


### PR DESCRIPTION
## Summary
- remove the `AgentBundleDirectory -> AgentBundleArrayAdapter::to_array_bundle() -> AgentBundler::import()` bounce from direct directory imports
- keep schema-v1 arrays as compatibility ingress by normalizing them to `AgentBundleDirectory`, then project directories once at the established runtime materialization boundary
- preserve legacy backup arrays and the existing ID remapper because the repository has validation, not a reusable workflow compiler/factory

## Canonical and compatibility boundaries
`AgentBundler::import_directory_object()` now sends the directory object directly to a private directory materialization helper instead of converting it to the public legacy array shape and re-entering `import()`.

Schema-v1 array callers remain supported at the compatibility ingress: `import()` converts them to `AgentBundleDirectory`, carries the compatibility-only abilities manifest, and then uses the same directory materialization path. Unversioned backup arrays retain the established raw runtime-config path.

`AgentBundleArrayAdapter::to_import_payload()` names the remaining load-bearing projection explicitly. It synthesizes temporary IDs only for `BundleStepIdRemapper` to assign fresh runtime IDs; it is not presented as workflow compilation. A real workflow compiler/factory still does not exist in the repository, so #1501 remains open.

## Tests
- expanded the importer integration test to prove direct directory and schema-array imports without source IDs converge on identical re-exported pipeline and flow documents, including handler auth references, queue state, enabled/disabled tools, disabled step state, and scheduling
- `php tests/agent-bundler-directory-adapter-smoke.php` (57 assertions passed)
- `php tests/agent-bundle-runner-contract-smoke.php` (129 assertions passed)
- extras transport, site-scope round-trip, and import-agent ability smokes passed
- changed-file PHPCS passed
- Homeboy lint passed: `a7c3cf4e-cd07-48fa-a063-f6a6a03e94ca`
- Homeboy audit passed with no introduced findings
- Homeboy test infrastructure selected the suite but executed zero tests: `68e82f4d-0de7-4442-a11f-b28fe796c89e`; a focused retry had the same zero-test result: `a1a690a4-0168-4544-a8f7-fa7e997901a7`
- package portability and extension artifact smokes retain their existing unrelated callback/materializer assertions after their preceding assertions pass

Refs #1501
Part of #3113