### PR TITLE
Add partition policy for high-churn tables

### DIFF
--- a/data-machine.php
+++ b/data-machine.php
@@ -134,6 +134,7 @@ if ( ! class_exists( 'ActionScheduler' ) ) {
 }
 
 \DataMachine\Core\ActionScheduler\LogPersistencePolicy::register();
+\DataMachine\Core\Database\CanonicalPersistencePolicy::register();
 \DataMachine\Engine\Tasks\RecurringScheduler::registerGenerationFence();
 
 add_action(

--- a/inc/Core/Database/CanonicalPersistencePolicy.php
+++ b/inc/Core/Database/CanonicalPersistencePolicy.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Canonical persistence policy for high-churn Data Machine tables.
+ *
+ * @package DataMachine\Core\Database
+ */
+
+namespace DataMachine\Core\Database;
+
+defined( 'ABSPATH' ) || exit;
+
+class CanonicalPersistencePolicy {
+
+	/** Register optional policy consumed by file-backed database runtimes. */
+	public static function register(): void {
+		if ( function_exists( 'add_filter' ) ) {
+			add_filter( 'markdown_db_table_persistence_policy', array( self::class, 'filterTablePolicy' ) );
+		}
+	}
+
+	/**
+	 * Declare stable row identities without replacing policies owned elsewhere.
+	 *
+	 * @param mixed $policy Existing table policy map.
+	 * @return array<string,mixed>
+	 */
+	public static function filterTablePolicy( $policy ): array {
+		$policy = is_array( $policy ) ? $policy : array();
+		self::addDefaultIdentity( $policy, 'datamachine_jobs', 'job_id' );
+		self::addDefaultIdentity( $policy, 'datamachine_logs', 'id' );
+		return $policy;
+	}
+
+	/** @param array<string,mixed> $policy */
+	private static function addDefaultIdentity( array &$policy, string $table, string $column ): void {
+		if ( ! array_key_exists( $table, $policy ) ) {
+			$policy[ $table ] = array( 'partition_by' => $column );
+			return;
+		}
+		if ( is_array( $policy[ $table ] ) && ! array_key_exists( 'partition_by', $policy[ $table ] ) ) {
+			$policy[ $table ]['partition_by'] = $column;
+		}
+	}
+}

--- a/tests/canonical-persistence-policy-smoke.php
+++ b/tests/canonical-persistence-policy-smoke.php
@@ -1,0 +1,40 @@
+<?php
+/** Data Machine canonical persistence policy coverage. */
+
+declare( strict_types=1 );
+
+define( 'ABSPATH', __DIR__ . '/' );
+$GLOBALS['dm_policy_filters'] = array();
+
+function add_filter( string $tag, callable $callback ): void { $GLOBALS['dm_policy_filters'][ $tag ][] = $callback; }
+function apply_filters( string $tag, mixed $value ): mixed { foreach ( $GLOBALS['dm_policy_filters'][ $tag ] ?? array() as $callback ) { $value = $callback( $value ); } return $value; }
+
+require_once dirname( __DIR__ ) . '/inc/Core/Database/CanonicalPersistencePolicy.php';
+
+use DataMachine\Core\Database\CanonicalPersistencePolicy;
+
+CanonicalPersistencePolicy::register();
+$policy = apply_filters(
+	'markdown_db_table_persistence_policy',
+	array(
+		'other_table'      => false,
+		'datamachine_jobs' => array( 'custom' => 'preserved' ),
+		'datamachine_logs' => false,
+	)
+);
+$overrides = CanonicalPersistencePolicy::filterTablePolicy(
+	array(
+		'datamachine_jobs' => false,
+		'datamachine_logs' => array( 'partition_by' => 'external_id' ),
+	)
+);
+
+$passed = false === $policy['other_table']
+	&& 'preserved' === $policy['datamachine_jobs']['custom']
+	&& 'job_id' === $policy['datamachine_jobs']['partition_by']
+	&& false === $policy['datamachine_logs']
+	&& false === $overrides['datamachine_jobs']
+	&& 'external_id' === $overrides['datamachine_logs']['partition_by'];
+
+echo ( $passed ? 'PASS' : 'FAIL' ) . ': high-churn tables declare stable partition identities without replacing existing policy.' . PHP_EOL;
+exit( $passed ? 0 : 1 );


### PR DESCRIPTION
## Summary

- declare `job_id` as the stable canonical partition identity for `datamachine_jobs`
- declare `id` as the stable canonical partition identity for `datamachine_logs`
- preserve existing table policy, explicit opt-outs, and identity declarations owned elsewhere
- keep the integration optional through the generic MDI policy filter

Downstream integration for Automattic/markdown-database-integration#181.

## Verification

- `php tests/canonical-persistence-policy-smoke.php`
- `php tests/action-scheduler-log-persistence-policy-smoke.php`
- focused PHPCS on changed PHP files
- `composer lint`
- PHP syntax checks and `git diff --check`

## AI assistance

OpenAI gpt-5.6-sol via OpenCode was used to inspect Data Machine table identities, implement the optional persistence policy, review composition with existing policy owners, and run verification. Chris Huber directed the work and is responsible for every line.