### PR TITLE
refactor: return native chat ability errors

### DIFF
--- a/inc/Abilities/Chat/ChatSessionHelpers.php
+++ b/inc/Abilities/Chat/ChatSessionHelpers.php
@@ -66,13 +66,13 @@ trait ChatSessionHelpers {
 	 *
 	 * @param string $session_id Session ID to verify.
 	 * @param int    $user_id    User ID to check ownership against.
-	 * @return array|array{error: string} Session data on success, or array with 'error' key on failure.
+	 * @return array|\WP_Error Session data on success, or an error on failure.
 	 */
-	protected function verifySessionOwnership( string $session_id, int $user_id, ?array $transcript_owner = null ): array {
+	protected function verifySessionOwnership( string $session_id, int $user_id, ?array $transcript_owner = null ): array|\WP_Error {
 		$session = $this->chat_db->get_session( $session_id );
 
 		if ( ! $session ) {
-			return array( 'error' => 'session_not_found' );
+			return new \WP_Error( 'session_not_found', __( 'Chat session not found.', 'data-machine' ), array( 'status' => 404 ) );
 		}
 
 		$owns_session = null !== $transcript_owner && method_exists( $this->chat_db, 'session_matches_owner' )
@@ -80,7 +80,7 @@ trait ChatSessionHelpers {
 			: ( (int) $session['user_id'] === $user_id );
 
 		if ( ! $owns_session ) {
-			return array( 'error' => 'session_access_denied' );
+			return new \WP_Error( 'session_access_denied', __( 'You do not have access to this chat session.', 'data-machine' ), array( 'status' => 403 ) );
 		}
 
 		return $session;

--- a/inc/Abilities/Chat/CreateChatSessionAbility.php
+++ b/inc/Abilities/Chat/CreateChatSessionAbility.php
@@ -90,14 +90,11 @@ class CreateChatSessionAbility {
 	 * Execute create-chat-session ability.
 	 *
 	 * @param array $input Input parameters with user_id, optional mode, source, metadata.
-	 * @return array Result with session_id on success.
+	 * @return array|\WP_Error Result with session_id on success.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		if ( empty( $input['user_id'] ) || ! is_numeric( $input['user_id'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'user_id is required and must be a positive integer.',
-			);
+			return new \WP_Error( 'invalid_user_id', __( 'user_id is required and must be a positive integer.', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		$user_id    = (int) $input['user_id'];
@@ -109,10 +106,7 @@ class CreateChatSessionAbility {
 		$source     = ! empty( $input['source'] ) ? sanitize_text_field( $input['source'] ) : null;
 
 		if ( ! $this->can_access_user_sessions( $user_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'session_access_denied',
-			);
+			return new \WP_Error( 'session_access_denied', __( 'You do not have access to this user\'s chat sessions.', 'data-machine' ), array( 'status' => 403 ) );
 		}
 
 		$session_metadata = array(
@@ -138,10 +132,7 @@ class CreateChatSessionAbility {
 		$session_id = $this->chat_db->create_session( WordPressWorkspaceScope::current(), $user_id, $agent_slug, $session_metadata, $mode );
 
 		if ( empty( $session_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to create chat session.',
-			);
+			return new \WP_Error( 'chat_session_create_failed', __( 'Failed to create chat session.', 'data-machine' ), array( 'status' => 500 ) );
 		}
 
 		return array(

--- a/inc/Abilities/Chat/DeleteChatSessionAbility.php
+++ b/inc/Abilities/Chat/DeleteChatSessionAbility.php
@@ -75,56 +75,38 @@ class DeleteChatSessionAbility {
 	 * Execute delete-chat-session ability.
 	 *
 	 * @param array $input Input parameters with session_id and user_id.
-	 * @return array Result with deletion status.
+	 * @return array|\WP_Error Result with deletion status.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		if ( empty( $input['session_id'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'session_id is required.',
-			);
+			return new \WP_Error( 'session_id_required', __( 'session_id is required.', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		if ( empty( $input['user_id'] ) || ! is_numeric( $input['user_id'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'user_id is required and must be a positive integer.',
-			);
+			return new \WP_Error( 'invalid_user_id', __( 'user_id is required and must be a positive integer.', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		$session_id = sanitize_text_field( $input['session_id'] );
 		$user_id    = (int) $input['user_id'];
 		$owner      = $this->resolve_transcript_owner( $input, $user_id );
 		if ( is_wp_error( $owner ) ) {
-			return array(
-				'success' => false,
-				'error'   => $owner->get_error_code(),
-			);
+			return $owner;
 		}
 
 		if ( ! $this->can_access_user_sessions( $user_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'session_access_denied',
-			);
+			return new \WP_Error( 'session_access_denied', __( 'You do not have access to this user\'s chat sessions.', 'data-machine' ), array( 'status' => 403 ) );
 		}
 
 		$session = $this->verifySessionOwnership( $session_id, $user_id, $owner );
 
-		if ( isset( $session['error'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => $session['error'],
-			);
+		if ( is_wp_error( $session ) ) {
+			return $session;
 		}
 
 		$deleted = $this->chat_db->delete_session( $session_id );
 
 		if ( ! $deleted ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to delete session.',
-			);
+			return new \WP_Error( 'chat_session_delete_failed', __( 'Failed to delete session.', 'data-machine' ), array( 'status' => 500 ) );
 		}
 
 		return array(

--- a/inc/Abilities/Chat/GetChatSessionAbility.php
+++ b/inc/Abilities/Chat/GetChatSessionAbility.php
@@ -78,47 +78,32 @@ class GetChatSessionAbility {
 	 * Execute get-chat-session ability.
 	 *
 	 * @param array $input Input parameters with session_id and user_id.
-	 * @return array Result with session conversation and metadata.
+	 * @return array|\WP_Error Result with session conversation and metadata.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		if ( empty( $input['session_id'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'session_id is required.',
-			);
+			return new \WP_Error( 'session_id_required', __( 'session_id is required.', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		if ( empty( $input['user_id'] ) || ! is_numeric( $input['user_id'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'user_id is required and must be a positive integer.',
-			);
+			return new \WP_Error( 'invalid_user_id', __( 'user_id is required and must be a positive integer.', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		$session_id = sanitize_text_field( $input['session_id'] );
 		$user_id    = (int) $input['user_id'];
 		$owner      = $this->resolve_transcript_owner( $input, $user_id );
 		if ( is_wp_error( $owner ) ) {
-			return array(
-				'success' => false,
-				'error'   => $owner->get_error_code(),
-			);
+			return $owner;
 		}
 
 		if ( ! $this->can_access_user_sessions( $user_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'session_access_denied',
-			);
+			return new \WP_Error( 'session_access_denied', __( 'You do not have access to this user\'s chat sessions.', 'data-machine' ), array( 'status' => 403 ) );
 		}
 
 		$session = $this->verifySessionOwnership( $session_id, $user_id, $owner );
 
-		if ( isset( $session['error'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => $session['error'],
-			);
+		if ( is_wp_error( $session ) ) {
+			return $session;
 		}
 
 		return array(

--- a/inc/Abilities/Chat/ListChatSessionsAbility.php
+++ b/inc/Abilities/Chat/ListChatSessionsAbility.php
@@ -97,30 +97,21 @@ class ListChatSessionsAbility {
 	 *
 	 * @param array $input Input parameters with user_id, optional limit, offset, mode.
 	 *
-	 * @return array Result with sessions list and total count.
+	 * @return array|\WP_Error Result with sessions list and total count.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		if ( empty( $input['user_id'] ) || ! is_numeric( $input['user_id'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'user_id is required and must be a positive integer.',
-			);
+			return new \WP_Error( 'invalid_user_id', __( 'user_id is required and must be a positive integer.', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		$user_id = (int) $input['user_id'];
 		$owner   = $this->resolve_transcript_owner( $input, $user_id );
 		if ( is_wp_error( $owner ) ) {
-			return array(
-				'success' => false,
-				'error'   => $owner->get_error_code(),
-			);
+			return $owner;
 		}
 
 		if ( ! $this->can_access_user_sessions( $user_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'session_access_denied',
-			);
+			return new \WP_Error( 'session_access_denied', __( 'You do not have access to this user\'s chat sessions.', 'data-machine' ), array( 'status' => 403 ) );
 		}
 
 		$limit    = min( 100, max( 1, (int) ( $input['limit'] ?? 20 ) ) );

--- a/inc/Abilities/Chat/MarkSessionReadAbility.php
+++ b/inc/Abilities/Chat/MarkSessionReadAbility.php
@@ -73,57 +73,39 @@ class MarkSessionReadAbility {
 	 * Execute mark-session-read ability.
 	 *
 	 * @param array $input Input parameters with session_id and optional user_id.
-	 * @return array Result with last_read_at timestamp.
+	 * @return array|\WP_Error Result with last_read_at timestamp.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		if ( empty( $input['session_id'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'session_id is required.',
-			);
+			return new \WP_Error( 'session_id_required', __( 'session_id is required.', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		$session_id = sanitize_text_field( $input['session_id'] );
 		$user_id    = ! empty( $input['user_id'] ) ? (int) $input['user_id'] : get_current_user_id();
 
 		if ( $user_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'user_id is required and must be a positive integer.',
-			);
+			return new \WP_Error( 'invalid_user_id', __( 'user_id is required and must be a positive integer.', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		if ( ! $this->can_access_user_sessions( $user_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'session_access_denied',
-			);
+			return new \WP_Error( 'session_access_denied', __( 'You do not have access to this user\'s chat sessions.', 'data-machine' ), array( 'status' => 403 ) );
 		}
 
 		$owner = $this->resolve_transcript_owner( $input, $user_id );
 		if ( is_wp_error( $owner ) ) {
-			return array(
-				'success' => false,
-				'error'   => $owner->get_error_code(),
-			);
+			return $owner;
 		}
 
 		$session = $this->verifySessionOwnership( $session_id, $user_id, $owner );
 
-		if ( isset( $session['error'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => $session['error'],
-			);
+		if ( is_wp_error( $session ) ) {
+			return $session;
 		}
 
 		$last_read_at = $this->chat_db->mark_session_read( $session_id, $user_id, $owner );
 
 		if ( false === $last_read_at ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to mark session as read.',
-			);
+			return new \WP_Error( 'chat_session_mark_read_failed', __( 'Failed to mark session as read.', 'data-machine' ), array( 'status' => 500 ) );
 		}
 
 		return array(

--- a/inc/Api/Chat/Chat.php
+++ b/inc/Api/Chat/Chat.php
@@ -15,7 +15,6 @@
 namespace DataMachine\Api\Chat;
 
 use DataMachine\Abilities\PermissionHelper;
-use DataMachine\Core\AbilityResult;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Core\Workspace\WordPressWorkspaceScope;
@@ -686,10 +685,6 @@ class Chat {
 	 * and converts the result into a REST response. Handles WP_Error returns
 	 * from core's execute() pipeline (input validation, permissions, callback).
 	 *
-	 * For ability callbacks that still return { success: false, error: ... }
-	 * arrays (legacy convention), those are mapped to WP_Error. New abilities
-	 * should return WP_Error directly per core best practices.
-	 *
 	 * @since 0.62.0
 	 *
 	 * @see \WP_Ability::execute()
@@ -715,21 +710,6 @@ class Chat {
 		// Core's execute() returns WP_Error for validation/permission/callback failures.
 		if ( is_wp_error( $result ) ) {
 			return $result;
-		}
-
-		$legacy_error = AbilityResult::legacy_failure_to_wp_error(
-			$result,
-			'ability_failed',
-			'Ability execution failed.',
-			array(
-				'session_not_found'     => 404,
-				'session_access_denied' => 403,
-			),
-			500,
-			true
-		);
-		if ( $legacy_error ) {
-			return $legacy_error;
 		}
 
 		return rest_ensure_response(

--- a/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
+++ b/tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php
@@ -16,6 +16,10 @@
 namespace DataMachine\Tests\Unit\Core\Database\Chat;
 
 use DataMachine\Abilities\Chat\ListChatSessionsAbility;
+use DataMachine\Abilities\Chat\CreateChatSessionAbility;
+use DataMachine\Abilities\Chat\DeleteChatSessionAbility;
+use DataMachine\Abilities\Chat\GetChatSessionAbility;
+use DataMachine\Abilities\Chat\MarkSessionReadAbility;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\Chat\Chat;
 use DataMachine\Core\Database\Chat\ConversationReadStateInterface;
@@ -29,6 +33,7 @@ use AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Lock;
 use AgentsAPI\Core\Database\Chat\WP_Agent_Conversation_Store;
 use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
 use WP_UnitTestCase;
+use WP_Error;
 
 class ConversationStoreFactoryTest extends WP_UnitTestCase {
 
@@ -450,6 +455,27 @@ class ConversationStoreFactoryTest extends WP_UnitTestCase {
 		$this->assertCount( 1, $result['sessions'] );
 		$this->assertSame( $session_id, $result['sessions'][0]['session_id'] );
 		$this->assertSame( 'hello', $result['sessions'][0]['first_message'] );
+	}
+
+	/**
+	 * @dataProvider chat_ability_validation_provider
+	 */
+	public function test_chat_ability_validation_failures_return_wp_error( object $ability, array $input, string $code ): void {
+		$result = $ability->execute( $input );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( $code, $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] ?? null );
+	}
+
+	public function chat_ability_validation_provider(): array {
+		return array(
+			'create session user' => array( new CreateChatSessionAbility(), array(), 'invalid_user_id' ),
+			'delete session id'   => array( new DeleteChatSessionAbility(), array(), 'session_id_required' ),
+			'get session id'      => array( new GetChatSessionAbility(), array(), 'session_id_required' ),
+			'list sessions user'  => array( new ListChatSessionsAbility(), array(), 'invalid_user_id' ),
+			'mark session id'     => array( new MarkSessionReadAbility(), array(), 'session_id_required' ),
+		);
 	}
 
 	public function test_canonical_conversation_session_abilities_route_through_swapped_store(): void {


### PR DESCRIPTION
## Summary
- return native `WP_Error` values from the five Data Machine chat session abilities for validation, permission, ownership, not-found, and storage failures
- preserve successful ability payloads and the existing REST success envelope while removing `Chat.php`'s legacy failure conversion
- keep global `AbilityResult` compatibility methods because non-chat consumers remain

## Line delta
- production: +40 / -129, net -89 LOC
- tests: +26 / -0, net +26 LOC

## Verification
- `vendor/bin/phpunit --filter 'ConversationStoreFactoryTest' tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php`
- `vendor/bin/phpcs inc/Abilities/Chat/ChatSessionHelpers.php inc/Abilities/Chat/CreateChatSessionAbility.php inc/Abilities/Chat/DeleteChatSessionAbility.php inc/Abilities/Chat/GetChatSessionAbility.php inc/Abilities/Chat/ListChatSessionsAbility.php inc/Abilities/Chat/MarkSessionReadAbility.php inc/Api/Chat/Chat.php tests/Unit/Core/Database/Chat/ConversationStoreFactoryTest.php`
- `php tests/agents-chat-handler-smoke.php`
- `php tests/chat-session-canonical-path-smoke.php`
- `php tests/chat-transcript-owner-smoke.php`
- `homeboy review lint --placement local --changed-since origin/main --summary` (pass, zero findings)
- `homeboy review audit --placement local --changed-since origin/main --profile pr --summary` (pass, zero findings)
- Homeboy changed and explicitly filtered test runs were attempted, but its runner reported zero executed tests; the same focused PHPUnit class passes directly

Part of #2522, #2418, and #3113