### PR TITLE
refactor: remove legacy ability tool projections

### DIFF
--- a/inc/Engine/AI/Tools/Sources/AbilityToolSource.php
+++ b/inc/Engine/AI/Tools/Sources/AbilityToolSource.php
@@ -89,7 +89,6 @@ final class AbilityToolSource {
 
 		$declared = $this->declarationsFromContext( $args );
 		$declared = apply_filters( 'datamachine_ability_tool_projections', $declared, $args );
-		$declared = apply_filters( 'datamachine_ability_tools', $declared, $args );
 		if ( ! is_array( $declared ) ) {
 			foreach ( $diagnostic_tool_names as $tool_name ) {
 				$rejections[ $tool_name ] = $this->rejection( $tool_name, 'no_projection' );
@@ -232,7 +231,7 @@ final class AbilityToolSource {
 		 * @param string $tool_name    Model-facing tool name.
 		 * @param string $ability_slug Registered primary ability slug.
 		 * @param object $ability      Registered primary WP_Ability instance.
-		 * @param array  $declaration  Raw `datamachine_ability_tools` declaration.
+		 * @param array  $declaration  Raw ability tool projection declaration.
 		 * @param array  $args         Tool resolution args.
 		 */
 		$ability_slug = (string) ( $tool['ability'] ?? '' );

--- a/tests/ability-tool-source-smoke.php
+++ b/tests/ability-tool-source-smoke.php
@@ -173,6 +173,7 @@ require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-citation-metadata.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-result.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-executor.php';
+require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-executor-registry.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-execution-core.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-policy-filter.php';
 require_once __DIR__ . '/../vendor/wordpress/agents-api/src/Tools/class-wp-agent-tool-policy.php';
@@ -201,6 +202,7 @@ require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/RuntimeToolSource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/DataMachineToolRegistrySource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AdjacentHandlerToolSource.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/Sources/AbilityToolSource.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/HostToolPolicy.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolSourceRegistry.php';
 require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolPolicyResolver.php';
 
@@ -350,19 +352,6 @@ add_filter(
 );
 
 add_filter(
-	'datamachine_ability_tools',
-	static function ( array $tools ): array {
-		$tools['legacy_alias_demo'] = array(
-			'ability' => 'demo/summarize',
-			'modes'   => array( 'chat' ),
-		);
-		return $tools;
-	},
-	10,
-	1
-);
-
-add_filter(
 	'datamachine_ability_tool_definition',
 	static function ( array $tool, string $tool_name ): array {
 		if ( 'summarize_demo' === $tool_name ) {
@@ -380,7 +369,6 @@ $tools  = $source( array( 'chat' ), array( 'allow_only' => array( 'summarize_dem
 assert_ability_tool_source_equals( true, $helper_registered, 'helper registers a valid ability tool projection', $failures, $passes );
 assert_ability_tool_source_equals( true, isset( $tools['summarize_demo'] ), 'chat mode exposes selected ability tool when opted in', $failures, $passes );
 assert_ability_tool_source_equals( true, isset( $tools['helper_demo'] ), 'helper projection feeds ability tool source', $failures, $passes );
-assert_ability_tool_source_equals( true, isset( $tools['legacy_alias_demo'] ), 'legacy ability tools filter remains supported', $failures, $passes );
 assert_ability_tool_source_equals( 'demo/summarize', $tools['summarize_demo']['ability'] ?? '', 'generated tool links ability slug', $failures, $passes );
 assert_ability_tool_source_equals( 'demo/summarize', $tools['summarize_demo']['execution_ability'] ?? '', 'generated tool declares explicit direct-execution ability marker', $failures, $passes );
 assert_ability_tool_source_equals( 'Summarize Demo', $tools['summarize_demo']['label'] ?? '', 'generated tool carries ability label', $failures, $passes );


### PR DESCRIPTION
## Summary
- Remove ingestion of the legacy `datamachine_ability_tools` filter so ability projections register only through `datamachine_register_ability_tool()` or `datamachine_ability_tool_projections`.
- Delete the compatibility-only fixture and assertion while preserving canonical helper/filter, run-scoped declarations, policy, schema, context, and linked-ability execution coverage.
- Confirm organization-wide GitHub code search, current first-party workspace sources, installed source, and Intelligence search show no remaining consumers of the legacy filter.

Production code is net-negative by one line; the full patch removes 13 net lines.

## Verification
- `php tests/ability-tool-source-smoke.php` (39 assertions)
- `php tests/tool-executor-ability-native-smoke.php` (46 assertions)
- `vendor/bin/phpcs inc/Engine/AI/Tools/Sources/AbilityToolSource.php tests/ability-tool-source-smoke.php`
- `homeboy review lint data-machine --path /var/lib/datamachine/workspace/data-machine@trim-2479-tool-projection --changed-since origin/main --placement local --summary`
- `homeboy review test data-machine --path /var/lib/datamachine/workspace/data-machine@trim-2479-tool-projection --changed-since origin/main --placement local --summary`
- `homeboy review audit data-machine --path /var/lib/datamachine/workspace/data-machine@trim-2479-tool-projection --changed-since origin/main --profile pr --placement local --summary`

Tracked unrelated standalone tool-source smoke bootstrap defects discovered during verification in #3145.

Closes #2479
Part of #2418 and #3113