### PR TITLE
refactor: use native errors for flow REST abilities

### DIFF
--- a/inc/Abilities/Flow/GetFlowsAbility.php
+++ b/inc/Abilities/Flow/GetFlowsAbility.php
@@ -103,9 +103,9 @@ class GetFlowsAbility {
 	 * Execute get flows ability.
 	 *
 	 * @param array $input Input parameters.
-	 * @return array Result with flows data.
+	 * @return array|\WP_Error Result with flows data or a query failure.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		try {
 			$flow_id      = $input['flow_id'] ?? null;
 			$pipeline_id  = $input['pipeline_id'] ?? null;
@@ -193,10 +193,9 @@ class GetFlowsAbility {
 				'filters_applied' => $filters_applied,
 			);
 		} catch ( \Exception $e ) {
-			return array(
-				'success' => false,
-				'error'   => $e->getMessage(),
-			);
+			return isset( $input['flow_id'] )
+				? new \WP_Error( 'flow_not_found', $e->getMessage(), array( 'status' => 400 ) )
+				: new \WP_Error( 'ability_error', $e->getMessage(), array( 'status' => 500 ) );
 		}
 	}
 }

--- a/inc/Abilities/Flow/UpdateFlowAbility.php
+++ b/inc/Abilities/Flow/UpdateFlowAbility.php
@@ -65,7 +65,6 @@ class UpdateFlowAbility {
 							'flow_name' => array( 'type' => 'string' ),
 							'flow_data' => array( 'type' => 'object' ),
 							'message'   => array( 'type' => 'string' ),
-							'error'     => array( 'type' => 'string' ),
 						),
 					),
 					'execute_callback'    => array( $this, 'execute' ),
@@ -82,47 +81,33 @@ class UpdateFlowAbility {
 	 * Execute update flow ability.
 	 *
 	 * @param array $input Input parameters with flow_id, optional flow_name and scheduling_config.
-	 * @return array Result with updated flow data.
+	 * @return array|\WP_Error Result with updated flow data or failure.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$flow_id           = $input['flow_id'] ?? null;
 		$flow_name         = $input['flow_name'] ?? null;
 		$scheduling_config = $input['scheduling_config'] ?? null;
 		$agent_id          = $input['agent_id'] ?? null;
 
 		if ( ! is_numeric( $flow_id ) || (int) $flow_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_id is required and must be a positive integer',
-			);
+			return new \WP_Error( 'update_failed', 'flow_id is required and must be a positive integer', array( 'status' => 400 ) );
 		}
 
 		$flow_id = (int) $flow_id;
 
 		if ( null === $flow_name && null === $scheduling_config && null === $agent_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'Must provide flow_name, scheduling_config, or agent_id to update',
-			);
+			return new \WP_Error( 'update_failed', 'Must provide flow_name, scheduling_config, or agent_id to update', array( 'status' => 400 ) );
 		}
 
 		$flow = $this->db_flows->get_flow( $flow_id );
 		if ( ! $flow ) {
-			return array(
-				'success'    => false,
-				'error'      => 'Flow not found',
-				'error_code' => 'flow_not_found',
-				'status'     => 404,
-			);
+			return new \WP_Error( 'flow_not_found', 'Flow not found', array( 'status' => 404 ) );
 		}
 
 		if ( null !== $scheduling_config ) {
 			$validation = datamachine_validate_interval( $scheduling_config['interval'] ?? 'manual', $scheduling_config );
 			if ( ! $validation['valid'] ) {
-				return array(
-					'success' => false,
-					'error'   => $validation['error'],
-				);
+				return new \WP_Error( 'update_failed', $validation['error'], array( 'status' => 400 ) );
 			}
 			$scheduling_config['interval'] = $validation['resolved'];
 		}
@@ -130,10 +115,7 @@ class UpdateFlowAbility {
 		if ( null !== $flow_name ) {
 			$flow_name = sanitize_text_field( wp_unslash( $flow_name ) );
 			if ( empty( trim( $flow_name ) ) ) {
-				return array(
-					'success' => false,
-					'error'   => 'Flow name cannot be empty',
-				);
+				return new \WP_Error( 'update_failed', 'Flow name cannot be empty', array( 'status' => 400 ) );
 			}
 
 			$success = $this->db_flows->update_flow(
@@ -142,10 +124,7 @@ class UpdateFlowAbility {
 			);
 
 			if ( ! $success ) {
-				return array(
-					'success' => false,
-					'error'   => 'Failed to update flow name',
-				);
+				return new \WP_Error( 'update_failed', 'Failed to update flow name', array( 'status' => 400 ) );
 			}
 		}
 
@@ -156,20 +135,14 @@ class UpdateFlowAbility {
 			);
 
 			if ( ! $success ) {
-				return array(
-					'success' => false,
-					'error'   => 'Failed to update flow agent_id',
-				);
+				return new \WP_Error( 'update_failed', 'Failed to update flow agent_id', array( 'status' => 400 ) );
 			}
 		}
 
 		if ( null !== $scheduling_config ) {
 			$result = FlowScheduling::handle_scheduling_update( $flow_id, $scheduling_config );
 			if ( is_wp_error( $result ) ) {
-				return array(
-					'success' => false,
-					'error'   => $result->get_error_message(),
-				);
+				return new \WP_Error( 'update_failed', $result->get_error_message(), array( 'status' => 400 ) );
 			}
 		}
 

--- a/inc/Abilities/Job/ProblemFlowsAbility.php
+++ b/inc/Abilities/Job/ProblemFlowsAbility.php
@@ -62,7 +62,6 @@ class ProblemFlowsAbility {
 							'count'     => array( 'type' => 'integer' ),
 							'threshold' => array( 'type' => 'integer' ),
 							'message'   => array( 'type' => 'string' ),
-							'error'     => array( 'type' => 'string' ),
 						),
 					),
 					'execute_callback'    => array( $this, 'execute' ),

--- a/inc/Api/Flows/Flows.php
+++ b/inc/Api/Flows/Flows.php
@@ -490,16 +490,8 @@ class Flows {
 
 		$result = $ability->execute( array( 'flow_id' => $flow_id ) );
 
-		$error = AbilityResult::failure_to_wp_error( $result, 'flow_not_found', __( 'Flow not found.', 'data-machine' ), 400 );
-		if ( $error || empty( $result['flows'] ) ) {
-			$status = 400;
-			if ( $error && isset( $error->get_error_data()['status'] ) ) {
-				$status = (int) $error->get_error_data()['status'];
-			} elseif ( empty( $result['flows'] ) ) {
-				$status = 404;
-			}
-
-			return $error ? $error : new \WP_Error( 'flow_not_found', __( 'Flow not found.', 'data-machine' ), array( 'status' => $status ) );
+		if ( is_wp_error( $result ) || empty( $result['flows'] ) ) {
+			return is_wp_error( $result ) ? $result : new \WP_Error( 'flow_not_found', __( 'Flow not found.', 'data-machine' ), array( 'status' => 404 ) );
 		}
 
 		return AbilityResult::rest_item_response( $result, $result['flows'][0] );
@@ -544,9 +536,8 @@ class Flows {
 
 		$result = $ability->execute( $input );
 
-		$error = AbilityResult::failure_to_wp_error( $result, 'update_failed', __( 'Failed to update flow', 'data-machine' ), 400 );
-		if ( $error ) {
-			return $error;
+		if ( is_wp_error( $result ) ) {
+			return $result;
 		}
 
 		$flow_id = $result['flow_id'];
@@ -692,9 +683,8 @@ class Flows {
 
 		$result = $ability->execute( $input );
 
-		$error = AbilityResult::failure_to_wp_error( $result, 'get_problem_flows_error', __( 'Failed to get problem flows', 'data-machine' ) );
-		if ( $error ) {
-			return $error;
+		if ( is_wp_error( $result ) ) {
+			return $result;
 		}
 
 		$problem_flows = array_merge( $result['failing'] ?? array(), $result['idle'] ?? array() );

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -480,8 +480,8 @@ class FlowsCommand extends BaseCommand {
 			)
 		);
 
-		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['error'] ?? 'Failed to get flows' );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 

--- a/tests/Unit/Abilities/FlowAbilitiesTest.php
+++ b/tests/Unit/Abilities/FlowAbilitiesTest.php
@@ -518,9 +518,9 @@ class FlowAbilitiesTest extends WP_UnitTestCase {
 			'flow_id' => $this->test_flow_id
 		]);
 
-		$this->assertFalse($result['success']);
-		$this->assertArrayHasKey('error', $result);
-		$this->assertStringContainsString('Must provide', $result['error']);
+		$this->assertWPError( $result );
+		$this->assertSame( 'update_failed', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
 	}
 
 	public function test_update_flow_with_invalid_id_returns_error(): void {
@@ -529,9 +529,9 @@ class FlowAbilitiesTest extends WP_UnitTestCase {
 			'flow_name' => 'Should Not Update'
 		]);
 
-		$this->assertFalse($result['success']);
-		$this->assertArrayHasKey('error', $result);
-		$this->assertStringContainsString('not found', $result['error']);
+		$this->assertWPError( $result );
+		$this->assertSame( 'flow_not_found', $result->get_error_code() );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
 	}
 
 	public function test_update_flow_with_empty_name_returns_error(): void {
@@ -540,9 +540,8 @@ class FlowAbilitiesTest extends WP_UnitTestCase {
 			'flow_name' => ''
 		]);
 
-		$this->assertFalse($result['success']);
-		$this->assertArrayHasKey('error', $result);
-		$this->assertStringContainsString('empty', $result['error']);
+		$this->assertWPError( $result );
+		$this->assertSame( 'update_failed', $result->get_error_code() );
 	}
 
 	public function test_duplicate_flow_ability_registered(): void {

--- a/tests/Unit/Api/Flows/FlowsEndpointTest.php
+++ b/tests/Unit/Api/Flows/FlowsEndpointTest.php
@@ -138,6 +138,29 @@ class FlowsEndpointTest extends WP_UnitTestCase {
 		$this->assertSame('datamachine/get-flows', $ability->get_name());
 	}
 
+	public function test_missing_single_flow_preserves_not_found_response(): void {
+		$request = new WP_REST_Request( 'GET', '/datamachine/v1/flows/999999' );
+		$request->set_param( 'flow_id', 999999 );
+
+		$response = Flows::handle_get_single_flow( $request );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'flow_not_found', $response->get_error_code() );
+		$this->assertSame( 404, $response->get_error_data()['status'] );
+	}
+
+	public function test_update_failure_passes_native_error_through(): void {
+		$request = new WP_REST_Request( 'PATCH', '/datamachine/v1/flows/999999' );
+		$request->set_param( 'flow_id', 999999 );
+		$request->set_param( 'flow_name', 'Missing flow' );
+
+		$response = Flows::handle_update_flow( $request );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'flow_not_found', $response->get_error_code() );
+		$this->assertSame( 404, $response->get_error_data()['status'] );
+	}
+
 	public function test_permission_denied_for_non_admin(): void {
 		wp_set_current_user( 0 );
 		add_filter( 'datamachine_cli_bypass_permissions', '__return_false' );


### PR DESCRIPTION
## Summary
- return native `WP_Error` failures from the bounded get/update Flow abilities while retaining successful empty lookup payloads for CLI and chat consumers
- remove the three Flow REST `AbilityResult::failure_to_wp_error()` compatibility conversions and obsolete failure-only schema fields
- preserve Flow ownership checks, `datamachine/v1` routes, status codes, response envelopes, success payloads, and CLI/chat presentation

## Failure contract
- get-flow query exceptions retain the existing item `flow_not_found`/400 and collection `ability_error`/500 fallbacks
- update validation and persistence failures use `update_failed`/400; missing flows retain `flow_not_found`/404
- WordPress-native permission failures and problem-flow failures pass through unchanged
- global `AbilityResult` compatibility methods remain because unrelated consumers still use them

## LOC
- production: +23 / -62, net -39 LOC
- tests: +31 / -9, net +22 LOC
- total: +54 / -71, net -17 LOC

## Verification
- `vendor/bin/phpunit tests/Unit/Abilities/FlowAbilitiesTest.php tests/Unit/Api/Flows/FlowsEndpointTest.php tests/Unit/Cli/Commands/Flows/FlowsCommandTest.php tests/Unit/Api/Chat/Tools/ListFlowsTest.php`
- focused Flow/ability smoke suites: 46 + 45 + 1 + 1 + 24 assertions/contracts passed
- `vendor/bin/phpcs` over all changed PHP files
- `homeboy review lint data-machine --placement local --changed-only --summary` (passed, zero findings)
- `homeboy review audit data-machine --placement local --changed-since origin/main --profile pr --summary` (passed, no introduced findings)
- `homeboy review test data-machine --placement local --changed-since origin/main --skip-lint --summary` was attempted, but the Homeboy provider reported zero executed tests; the focused PHPUnit command above exited successfully

Closes #3149
Part of #2522, #2418, #3113