### PR TITLE
refactor: return native email ability errors

### DIFF
--- a/inc/Abilities/Email/EmailAbilities.php
+++ b/inc/Abilities/Email/EmailAbilities.php
@@ -461,7 +461,7 @@ class EmailAbilities {
 	/**
 	 * Reply to an email with threading headers.
 	 */
-	public function executeReply( array $input ): array {
+	public function executeReply( array $input ): array|\WP_Error {
 		$headers = array();
 
 		$content_type = $input['content_type'] ?? 'text/html';
@@ -495,10 +495,7 @@ class EmailAbilities {
 		$to = array_filter( $to, 'is_email' );
 
 		if ( empty( $to ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'No valid recipient address',
-			);
+			return new \WP_Error( 'invalid_email_recipient', 'No valid recipient address', array( 'status' => 400 ) );
 		}
 
 		$sent = wp_mail( $to, $input['subject'], $input['body'], $headers );
@@ -521,18 +518,15 @@ class EmailAbilities {
 			$error = $phpmailer->ErrorInfo ? $phpmailer->ErrorInfo : $error;
 		}
 
-		return array(
-			'success' => false,
-			'error'   => $error,
-		);
+		return new \WP_Error( 'email_reply_failed', $error, array( 'status' => 400 ) );
 	}
 
 	/**
 	 * Delete an email from the IMAP server.
 	 */
-	public function executeDelete( array $input ): array {
+	public function executeDelete( array $input ): array|\WP_Error {
 		$connection = $this->connect( $input['folder'] ?? 'INBOX' );
-		if ( is_array( $connection ) && ! ( $connection['success'] ?? true ) ) {
+		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
 
@@ -550,9 +544,9 @@ class EmailAbilities {
 	/**
 	 * Move an email to a different folder.
 	 */
-	public function executeMove( array $input ): array {
+	public function executeMove( array $input ): array|\WP_Error {
 		$connection = $this->connect( $input['folder'] ?? 'INBOX' );
-		if ( is_array( $connection ) && ! ( $connection['success'] ?? true ) ) {
+		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
 
@@ -563,10 +557,7 @@ class EmailAbilities {
 		if ( ! $moved ) {
 			$error = imap_last_error();
 			imap_close( $connection );
-			return array(
-				'success' => false,
-				'error'   => 'Move failed: ' . $error,
-			);
+			return new \WP_Error( 'email_move_failed', 'Move failed: ' . $error, array( 'status' => 400 ) );
 		}
 
 		imap_expunge( $connection );
@@ -581,9 +572,9 @@ class EmailAbilities {
 	/**
 	 * Set or clear a flag on an email.
 	 */
-	public function executeFlag( array $input ): array {
+	public function executeFlag( array $input ): array|\WP_Error {
 		$connection = $this->connect( $input['folder'] ?? 'INBOX' );
-		if ( is_array( $connection ) && ! ( $connection['success'] ?? true ) ) {
+		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
 
@@ -593,10 +584,7 @@ class EmailAbilities {
 		$valid_flags = array( '\\Seen', '\\Flagged', '\\Answered', '\\Deleted', '\\Draft' );
 		if ( ! in_array( $flag, $valid_flags, true ) ) {
 			imap_close( $connection );
-			return array(
-				'success' => false,
-				'error'   => 'Invalid flag. Valid flags: Seen, Flagged, Answered, Deleted, Draft',
-			);
+			return new \WP_Error( 'invalid_email_flag', 'Invalid flag. Valid flags: Seen, Flagged, Answered, Deleted, Draft', array( 'status' => 400 ) );
 		}
 
 		$action = $input['action'] ?? 'set';
@@ -609,10 +597,7 @@ class EmailAbilities {
 		imap_close( $connection );
 
 		if ( ! $result ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to ' . $action . ' flag ' . $flag,
-			);
+			return new \WP_Error( 'email_flag_failed', 'Failed to ' . $action . ' flag ' . $flag, array( 'status' => 400 ) );
 		}
 
 		return array(
@@ -624,22 +609,16 @@ class EmailAbilities {
 	/**
 	 * Test the IMAP connection with stored credentials.
 	 */
-	public function executeTestConnection( array $input ): array {
+	public function executeTestConnection( array $input ): array|\WP_Error {
 		unset( $input );
 
 		if ( ! function_exists( 'imap_open' ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'PHP IMAP extension is not installed',
-			);
+			return new \WP_Error( 'email_imap_unavailable', 'PHP IMAP extension is not installed', array( 'status' => 400 ) );
 		}
 
 		$auth = $this->getAuthProvider();
 		if ( ! $auth || ! $auth->is_authenticated() ) {
-			return array(
-				'success' => false,
-				'error'   => 'IMAP credentials not configured',
-			);
+			return new \WP_Error( 'email_imap_not_configured', 'IMAP credentials not configured', array( 'status' => 400 ) );
 		}
 
 		$mailbox = $this->buildMailboxString(
@@ -653,10 +632,7 @@ class EmailAbilities {
 		$connection = @imap_open( $mailbox, $auth->getUser(), $auth->getPassword() );
 
 		if ( false === $connection ) {
-			return array(
-				'success' => false,
-				'error'   => 'Connection failed: ' . imap_last_error(),
-			);
+			return new \WP_Error( 'email_imap_connection_failed', 'Connection failed: ' . imap_last_error(), array( 'status' => 400 ) );
 		}
 
 		$check = imap_check( $connection );
@@ -695,9 +671,9 @@ class EmailAbilities {
 	 * 2. URL without Post header → HTTP POST attempt, fall back to GET
 	 * 3. mailto: → send email via wp_mail()
 	 */
-	public function executeUnsubscribe( array $input ): array {
+	public function executeUnsubscribe( array $input ): array|\WP_Error {
 		$connection = $this->connect( $input['folder'] ?? 'INBOX' );
-		if ( is_array( $connection ) && ! ( $connection['success'] ?? true ) ) {
+		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
 
@@ -707,20 +683,14 @@ class EmailAbilities {
 		$raw_headers = imap_fetchheader( $connection, $uid, FT_UID );
 		if ( empty( $raw_headers ) ) {
 			imap_close( $connection );
-			return array(
-				'success' => false,
-				'error'   => 'Could not fetch message headers',
-			);
+			return new \WP_Error( 'email_headers_fetch_failed', 'Could not fetch message headers', array( 'status' => 400 ) );
 		}
 
 		$parsed = $this->parseUnsubscribeHeaders( $raw_headers );
 		imap_close( $connection );
 
 		if ( empty( $parsed['urls'] ) && empty( $parsed['mailto'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'No List-Unsubscribe header found in this message',
-			);
+			return new \WP_Error( 'email_unsubscribe_header_not_found', 'No List-Unsubscribe header found in this message', array( 'status' => 400 ) );
 		}
 
 		// Try One-Click POST first (RFC 8058).
@@ -751,10 +721,7 @@ class EmailAbilities {
 			}
 		}
 
-		return array(
-			'success' => false,
-			'error'   => 'All unsubscribe methods failed',
-		);
+		return new \WP_Error( 'email_unsubscribe_failed', 'All unsubscribe methods failed', array( 'status' => 400 ) );
 	}
 
 	/**
@@ -763,9 +730,9 @@ class EmailAbilities {
 	 * Deduplicates by sender — if you have 100 emails from linkedin.com,
 	 * it only unsubscribes once using the most recent message's headers.
 	 */
-	public function executeBatchUnsubscribe( array $input ): array {
+	public function executeBatchUnsubscribe( array $input ): array|\WP_Error {
 		$connection = $this->connect( $input['folder'] ?? 'INBOX' );
-		if ( is_array( $connection ) && ! ( $connection['success'] ?? true ) ) {
+		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
 
@@ -1070,9 +1037,9 @@ class EmailAbilities {
 	/**
 	 * Batch move: search → move all matches to destination.
 	 */
-	public function executeBatchMove( array $input ): array {
+	public function executeBatchMove( array $input ): array|\WP_Error {
 		$connection = $this->connect( $input['folder'] ?? 'INBOX' );
-		if ( is_array( $connection ) && ! ( $connection['success'] ?? true ) ) {
+		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
 
@@ -1122,9 +1089,9 @@ class EmailAbilities {
 	/**
 	 * Batch flag: search → set/clear flag on all matches.
 	 */
-	public function executeBatchFlag( array $input ): array {
+	public function executeBatchFlag( array $input ): array|\WP_Error {
 		$connection = $this->connect( $input['folder'] ?? 'INBOX' );
-		if ( is_array( $connection ) && ! ( $connection['success'] ?? true ) ) {
+		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
 
@@ -1136,10 +1103,7 @@ class EmailAbilities {
 		$valid_flags = array( '\\Seen', '\\Flagged', '\\Answered', '\\Deleted', '\\Draft' );
 		if ( ! in_array( $flag, $valid_flags, true ) ) {
 			imap_close( $connection );
-			return array(
-				'success' => false,
-				'error'   => 'Invalid flag. Valid: Seen, Flagged, Answered, Deleted, Draft',
-			);
+			return new \WP_Error( 'invalid_email_flag', 'Invalid flag. Valid: Seen, Flagged, Answered, Deleted, Draft', array( 'status' => 400 ) );
 		}
 
 		$uids = imap_search( $connection, $search, SE_UID );
@@ -1182,9 +1146,9 @@ class EmailAbilities {
 	/**
 	 * Batch delete: search → delete all matches.
 	 */
-	public function executeBatchDelete( array $input ): array {
+	public function executeBatchDelete( array $input ): array|\WP_Error {
 		$connection = $this->connect( $input['folder'] ?? 'INBOX' );
-		if ( is_array( $connection ) && ! ( $connection['success'] ?? true ) ) {
+		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
 
@@ -1227,22 +1191,16 @@ class EmailAbilities {
 	 * Open an IMAP connection using stored credentials.
 	 *
 	 * @param string $folder Mail folder.
-	 * @return resource|array IMAP connection or error array.
+	 * @return resource|\WP_Error IMAP connection or error.
 	 */
 	private function connect( string $folder = 'INBOX' ) {
 		if ( ! function_exists( 'imap_open' ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'PHP IMAP extension is not installed',
-			);
+			return new \WP_Error( 'email_imap_unavailable', 'PHP IMAP extension is not installed', array( 'status' => 400 ) );
 		}
 
 		$auth = $this->getAuthProvider();
 		if ( ! $auth || ! $auth->is_authenticated() ) {
-			return array(
-				'success' => false,
-				'error'   => 'IMAP credentials not configured',
-			);
+			return new \WP_Error( 'email_imap_not_configured', 'IMAP credentials not configured', array( 'status' => 400 ) );
 		}
 
 		$mailbox = $this->buildMailboxString(
@@ -1256,10 +1214,7 @@ class EmailAbilities {
 		$connection = @imap_open( $mailbox, $auth->getUser(), $auth->getPassword() );
 
 		if ( false === $connection ) {
-			return array(
-				'success' => false,
-				'error'   => 'IMAP connection failed: ' . imap_last_error(),
-			);
+			return new \WP_Error( 'email_imap_connection_failed', 'IMAP connection failed: ' . imap_last_error(), array( 'status' => 400 ) );
 		}
 
 		return $connection;
@@ -1330,18 +1285,18 @@ class EmailAbilities {
 		$sent_folder = '[Gmail]/Sent Mail';
 
 		$connection = $this->connect( $sent_folder );
-		if ( is_array( $connection ) && ! ( $connection['success'] ?? true ) ) {
+		if ( is_wp_error( $connection ) ) {
 			// Non-Gmail server or folder not found — try common alternatives.
 			foreach ( array( 'Sent', 'Sent Items', 'INBOX.Sent' ) as $fallback ) {
 				$connection = $this->connect( $fallback );
-				if ( ! is_array( $connection ) ) {
+				if ( ! is_wp_error( $connection ) ) {
 					$sent_folder = $fallback;
 					break;
 				}
 			}
 
 			// If still no connection, silently skip — sending succeeded, saving is best-effort.
-			if ( is_array( $connection ) ) {
+			if ( is_wp_error( $connection ) ) {
 				return;
 			}
 		}

--- a/inc/Abilities/Fetch/FetchEmailAbility.php
+++ b/inc/Abilities/Fetch/FetchEmailAbility.php
@@ -157,9 +157,9 @@ class FetchEmailAbility {
 	 * - default: fetch with bodies (pipeline mode)
 	 *
 	 * @param array $input Input parameters.
-	 * @return array Result with items or error.
+	 * @return array|\WP_Error Result with items or an error.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$logs = array();
 
 		if ( ! function_exists( 'imap_open' ) ) {
@@ -167,11 +167,7 @@ class FetchEmailAbility {
 				'level'   => 'error',
 				'message' => 'Email Fetch: PHP IMAP extension is not installed',
 			);
-			return array(
-				'success' => false,
-				'error'   => 'PHP IMAP extension is required but not installed. Install php-imap and restart your web server.',
-				'logs'    => $logs,
-			);
+			return new \WP_Error( 'email_imap_unavailable', 'PHP IMAP extension is required but not installed. Install php-imap and restart your web server.', array( 'status' => 400 ) );
 		}
 
 		$config = $this->normalizeConfig( $input );
@@ -188,11 +184,7 @@ class FetchEmailAbility {
 
 		if ( false === $connection ) {
 			$imap_error = imap_last_error();
-			return array(
-				'success' => false,
-				'error'   => 'IMAP connection failed: ' . $imap_error,
-				'logs'    => $logs,
-			);
+			return new \WP_Error( 'email_imap_connection_failed', 'IMAP connection failed: ' . $imap_error, array( 'status' => 400 ) );
 		}
 
 		// Single message fetch by UID (detail mode).
@@ -201,11 +193,7 @@ class FetchEmailAbility {
 			imap_close( $connection );
 
 			if ( null === $item ) {
-				return array(
-					'success' => false,
-					'error'   => 'Message UID ' . $config['uid'] . ' not found',
-					'logs'    => $logs,
-				);
+				return new \WP_Error( 'email_message_not_found', 'Message UID ' . $config['uid'] . ' not found', array( 'status' => 400 ) );
 			}
 
 			return array(

--- a/inc/Abilities/Publish/SendEmailAbility.php
+++ b/inc/Abilities/Publish/SendEmailAbility.php
@@ -209,9 +209,9 @@ class SendEmailAbility {
 	 * Execute email send ability.
 	 *
 	 * @param array $input Input parameters.
-	 * @return array Result with success/error and logs.
+	 * @return array|\WP_Error Result with success data or an error.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$logs   = array();
 		$config = $this->normalizeConfig( $input );
 
@@ -228,11 +228,7 @@ class SendEmailAbility {
 				'message' => 'Email: No valid recipient addresses provided',
 				'data'    => array( 'raw_to' => $config['to'] ),
 			);
-			return array(
-				'success' => false,
-				'error'   => 'No valid recipient email addresses',
-				'logs'    => $logs,
-			);
+			return new \WP_Error( 'invalid_email_recipient', 'No valid recipient email addresses', array( 'status' => 400 ) );
 		}
 
 		// 2. Build headers.
@@ -296,11 +292,7 @@ class SendEmailAbility {
 						'registered_templates' => is_array( $templates ) ? array_keys( $templates ) : array(),
 					),
 				);
-				return array(
-					'success' => false,
-					'error'   => $error,
-					'logs'    => $logs,
-				);
+				return new \WP_Error( 'email_template_not_found', $error, array( 'status' => 400 ) );
 			}
 
 			$context = is_array( $config['context'] ) ? $config['context'] : array();
@@ -313,11 +305,7 @@ class SendEmailAbility {
 					'message' => 'Email: Template render threw - ' . $e->getMessage(),
 					'data'    => array( 'template' => $template_id ),
 				);
-				return array(
-					'success' => false,
-					'error'   => 'Template render failed: ' . $e->getMessage(),
-					'logs'    => $logs,
-				);
+				return new \WP_Error( 'email_template_render_failed', 'Template render failed: ' . $e->getMessage(), array( 'status' => 400 ) );
 			}
 
 			if ( ! is_string( $rendered ) ) {
@@ -329,11 +317,7 @@ class SendEmailAbility {
 						'returned_type' => gettype( $rendered ),
 					),
 				);
-				return array(
-					'success' => false,
-					'error'   => sprintf( 'Template "%s" did not return a string', $template_id ),
-					'logs'    => $logs,
-				);
+				return new \WP_Error( 'invalid_email_template_result', sprintf( 'Template "%s" did not return a string', $template_id ), array( 'status' => 400 ) );
 			}
 
 			$body_source = $rendered;
@@ -352,11 +336,7 @@ class SendEmailAbility {
 				'level'   => 'error',
 				'message' => 'Email: Neither `body` nor `template` provided',
 			);
-			return array(
-				'success' => false,
-				'error'   => 'Either `body` or `template` is required',
-				'logs'    => $logs,
-			);
+			return new \WP_Error( 'email_body_required', 'Either `body` or `template` is required', array( 'status' => 400 ) );
 		}
 
 		// 4. Process subject + body placeholders. Runs AFTER template render so
@@ -396,11 +376,7 @@ class SendEmailAbility {
 					'message' => 'Email: mail_site_id provided but multisite is not active',
 					'data'    => array( 'mail_site_id' => $mail_site_id ),
 				);
-				return array(
-					'success' => false,
-					'error'   => 'mail_site_id requires a multisite install',
-					'logs'    => $logs,
-				);
+				return new \WP_Error( 'email_mail_site_requires_multisite', 'mail_site_id requires a multisite install', array( 'status' => 400 ) );
 			}
 
 			$blog_details = get_blog_details( $mail_site_id );
@@ -410,11 +386,7 @@ class SendEmailAbility {
 					'message' => 'Email: mail_site_id refers to an unknown blog',
 					'data'    => array( 'mail_site_id' => $mail_site_id ),
 				);
-				return array(
-					'success' => false,
-					'error'   => sprintf( 'Unknown mail_site_id: %d', $mail_site_id ),
-					'logs'    => $logs,
-				);
+				return new \WP_Error( 'email_mail_site_not_found', sprintf( 'Unknown mail_site_id: %d', $mail_site_id ), array( 'status' => 400 ) );
 			}
 
 			$should_switch = true;
@@ -474,11 +446,7 @@ class SendEmailAbility {
 			'message' => 'Email: Send failed - ' . $error_msg,
 		);
 
-		return array(
-			'success' => false,
-			'error'   => $error_msg,
-			'logs'    => $logs,
-		);
+		return new \WP_Error( 'email_send_failed', $error_msg, array( 'status' => 400 ) );
 	}
 
 	/**

--- a/inc/Abilities/Publish/SendEmailQueuedAbility.php
+++ b/inc/Abilities/Publish/SendEmailQueuedAbility.php
@@ -397,7 +397,7 @@ class SendEmailQueuedAbility {
 			return;
 		}
 
-		$error_msg = is_array( $result ) ? ( $result['error'] ?? 'unknown error' ) : 'invalid result';
+		$error_msg = is_wp_error( $result ) ? $result->get_error_message() : 'invalid result';
 
 		if ( $attempt >= self::MAX_ATTEMPTS ) {
 			do_action(

--- a/inc/Api/Email.php
+++ b/inc/Api/Email.php
@@ -11,7 +11,6 @@
 namespace DataMachine\Api;
 
 use DataMachine\Abilities\PermissionHelper;
-use DataMachine\Core\AbilityResult;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -647,26 +646,9 @@ class Email {
 		return self::to_response( $result );
 	}
 
-	/**
-	 * Convert ability result to REST response.
-	 *
-	 * Accepts WP_Error (from core's WP_Ability::execute() pipeline) or the
-	 * legacy { success: bool, error?: string } array from ability callbacks.
-	 *
-	 * @see https://github.com/Extra-Chill/data-machine/issues/999
-	 */
 	private static function to_response( \WP_Error|array $result ): \WP_REST_Response|\WP_Error {
 		if ( is_wp_error( $result ) ) {
 			return $result;
-		}
-
-		$legacy_error = AbilityResult::legacy_failure_to_wp_error( $result, 'email_error', 'Operation failed', array(), 400 );
-		if ( $legacy_error ) {
-			return $legacy_error;
-		}
-
-		if ( ! ( $result['success'] ?? false ) ) {
-			return new \WP_Error( 'email_error', 'Operation failed', array( 'status' => 400 ) );
 		}
 
 		return rest_ensure_response( $result );

--- a/tests/email-reply-sent-copy-smoke.php
+++ b/tests/email-reply-sent-copy-smoke.php
@@ -45,7 +45,24 @@ function is_email( $email ) {
 	return is_string( $email ) && false !== filter_var( $email, FILTER_VALIDATE_EMAIL ) ? $email : false;
 }
 
+function is_wp_error( $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+class WP_Error {
+	public function __construct( private string $code, private string $message, private array $data = array() ) {}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	public function get_error_data(): array {
+		return $this->data;
+	}
+}
+
 require_once dirname( __DIR__ ) . '/inc/Abilities/Email/EmailAbilities.php';
+require_once dirname( __DIR__ ) . '/inc/Abilities/Publish/SendEmailAbility.php';
 
 $reflection = new ReflectionClass( DataMachine\Abilities\Email\EmailAbilities::class );
 $ability    = $reflection->newInstanceWithoutConstructor();
@@ -64,6 +81,32 @@ email_reply_assert(
 	'external-only recipients retain the synthetic Sent copy',
 	! $method->invoke( $ability, array( 'person@example.net' ), array( 'copy@example.org' ) )
 );
+
+echo "\n[2] Reply ability failure channel\n";
+$result = $ability->executeReply(
+	array(
+		'to'          => 'not-an-email',
+		'subject'     => 'Re: Hello',
+		'body'        => 'Thanks',
+		'in_reply_to' => '<message@example.com>',
+	)
+);
+email_reply_assert( 'invalid recipient returns WP_Error', is_wp_error( $result ) );
+email_reply_assert( 'invalid recipient has useful code', 'invalid_email_recipient' === $result->get_error_code() );
+email_reply_assert( 'invalid recipient preserves HTTP status', 400 === ( $result->get_error_data()['status'] ?? null ) );
+
+$reflection = new ReflectionClass( DataMachine\Abilities\Publish\SendEmailAbility::class );
+$send       = $reflection->newInstanceWithoutConstructor();
+$result     = $send->execute(
+	array(
+		'to'      => 'not-an-email',
+		'subject' => 'Hello',
+		'body'    => 'World',
+	)
+);
+email_reply_assert( 'send invalid recipient returns WP_Error', is_wp_error( $result ) );
+email_reply_assert( 'send invalid recipient has useful code', 'invalid_email_recipient' === $result->get_error_code() );
+email_reply_assert( 'send invalid recipient preserves HTTP status', 400 === ( $result->get_error_data()['status'] ?? null ) );
 
 if ( 0 === $failed ) {
 	echo "\n=== email-reply-sent-copy-smoke: all {$total} assertions passed ===\n";


### PR DESCRIPTION
## Summary
- return native `WP_Error` failures with useful codes and preserved HTTP 400 status from Email REST operation abilities
- remove Email API's direct legacy failure conversion while preserving routes, permissions, schemas, success envelopes, and send/fetch behavior
- keep queued send retries compatible with native send errors and retain global `AbilityResult` compatibility for remaining consumers

## Line delta
- production: +53 / -160, net -107 LOC
- tests: +43 / -0, net +43 LOC

## Verification
- `php tests/email-reply-sent-copy-smoke.php` (9 assertions passed)
- `vendor/bin/phpcs inc/Abilities/Email/EmailAbilities.php inc/Abilities/Fetch/FetchEmailAbility.php inc/Abilities/Publish/SendEmailAbility.php inc/Abilities/Publish/SendEmailQueuedAbility.php inc/Api/Email.php tests/email-reply-sent-copy-smoke.php`
- `homeboy review lint --placement local --changed-since origin/main --summary` (pass, zero findings)
- `homeboy review audit --placement local --changed-since origin/main --profile pr --summary` (pass, zero findings)
- `homeboy review test --placement local --changed-since origin/main --skip-lint --summary` was attempted, but the runner reported zero executed tests
- broader send-email load-order/template smokes remain blocked by the pre-existing `AbilityRegistration` bootstrap bug tracked in #2897

Closes #3150

Part of #2522, #2418, #3113