### PR TITLE
fix: bound engine data persistence

### DIFF
--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -341,7 +341,7 @@ class PipelineBatchScheduler {
 		// like CoreMemoryFilesDirective resolve the correct agent's
 		// MEMORY.md / SOUL.md instead of falling back to the user_id
 		// default-agent lookup.
-		$child_engine        = $this->stripFlowRuntimeQueuePayloads( $engine_snapshot );
+		$child_engine        = $this->stripBatchRuntimeState( \DataMachine\Core\EngineData::stripFlowRuntimeQueuePayloads( $engine_snapshot ) );
 		$child_engine['job'] = array(
 			'job_id'        => $child_job_id,
 			'flow_id'       => $flow_id,
@@ -399,34 +399,7 @@ class PipelineBatchScheduler {
 		return $child_job_id;
 	}
 
-	/**
-	 * Remove large runtime queue payloads before cloning parent engine data.
-	 *
-	 * Queue consumers read live queue state from the flow record. Batch children
-	 * only need the step definitions and queue mode; copying the queue entries
-	 * multiplies stale fetch queues into every child job's engine_data.
-	 *
-	 * @param array $engine_snapshot Parent engine data snapshot.
-	 * @return array Engine data safe to clone to a batch child.
-	 */
-	private function stripFlowRuntimeQueuePayloads( array $engine_snapshot ): array {
-		$flow_config = is_array( $engine_snapshot['flow_config'] ?? null ) ? $engine_snapshot['flow_config'] : array();
-
-		foreach ( $flow_config as $flow_step_id => $flow_step_config ) {
-			if ( ! is_array( $flow_step_config ) ) {
-				continue;
-			}
-
-			unset(
-				$flow_step_config['prompt_queue'],
-				$flow_step_config['config_patch_queue'],
-				$flow_step_config['_queue_consume_revision']
-			);
-
-			$flow_config[ $flow_step_id ] = $flow_step_config;
-		}
-
-		$engine_snapshot['flow_config'] = $flow_config;
+	private function stripBatchRuntimeState( array $engine_snapshot ): array {
 		unset(
 			$engine_snapshot['batch'],
 			$engine_snapshot['batch_state'],

--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -320,6 +320,7 @@ class RunFlowAbility {
 		if ( is_array( $filtered_snapshot ) ) {
 			$engine_snapshot = $filtered_snapshot;
 		}
+		$engine_snapshot = \DataMachine\Core\EngineData::stripFlowRuntimeQueuePayloads( $engine_snapshot );
 
 		datamachine_set_engine_data( $job_id, $engine_snapshot );
 

--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -696,16 +696,9 @@ class BatchScheduler {
 		if ( ! $is_v2 ) {
 			return true;
 		}
-		$result    = EngineData::mutate(
-			$parent_job_id,
-			static function ( array $engine ): array {
-				unset( $engine['batch_state'] );
-				return $engine;
-			},
-			'batch_v2_finalize'
-		);
-		$finalized = ! empty( $result['success'] );
-		if ( ! $finalized ) {
+		$result    = ( new Jobs() )->remove_engine_data_key( $parent_job_id, 'batch_state' );
+		$finalized = ! empty( $result['updated'] );
+		if ( ! $finalized && ! empty( $result['retryable'] ) ) {
 			self::scheduleFinalizeRetry( $current, $parent_job_id );
 		}
 		return $finalized;

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -31,6 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Jobs extends BaseRepository {
+	private ?int $engine_data_query_budget = null;
 
 	const TABLE_NAME = 'datamachine_jobs';
 
@@ -1889,8 +1890,19 @@ class Jobs extends BaseRepository {
 			return false;
 		}
 
-		$encoded          = wp_json_encode( $data );
-		$storage_envelope = $this->engine_data_storage_envelope( $data, is_string( $encoded ) ? $encoded : '' );
+		$encoded = wp_json_encode( $data );
+		if ( ! is_string( $encoded ) ) {
+			$this->log_engine_data_write_rejection( $job_id, 'json_encode_failed', '', null, $data );
+			return false;
+		}
+
+		$estimated_query_bytes = $this->estimate_engine_data_query_bytes( strlen( $encoded ) );
+		if ( $estimated_query_bytes > $this->engine_data_query_budget() ) {
+			$this->log_engine_data_write_rejection( $job_id, 'engine_data_query_oversize', $encoded, null, $data );
+			return false;
+		}
+
+		$storage_envelope = $this->engine_data_storage_envelope( $data, $encoded );
 		$update_data      = $storage_envelope['data'];
 		$format           = $storage_envelope['format'];
 
@@ -1952,10 +1964,22 @@ class Jobs extends BaseRepository {
 		$expected_encoded = wp_json_encode( $expected_data );
 		$new_encoded      = wp_json_encode( $new_data );
 		if ( ! is_string( $expected_encoded ) || ! is_string( $new_encoded ) ) {
+			$this->log_engine_data_write_rejection( $job_id, 'json_encode_failed', is_string( $new_encoded ) ? $new_encoded : '', is_string( $expected_encoded ) ? $expected_encoded : null, $new_data );
 			return array(
 				'updated'  => false,
 				'conflict' => false,
 				'error'    => 'json_encode_failed',
+			);
+		}
+
+		$estimated_query_bytes = $this->estimate_engine_data_query_bytes( strlen( $new_encoded ), strlen( $expected_encoded ) );
+		if ( $estimated_query_bytes > $this->engine_data_query_budget() ) {
+			$this->log_engine_data_write_rejection( $job_id, 'engine_data_query_oversize', $new_encoded, $expected_encoded, $new_data );
+			return array(
+				'updated'   => false,
+				'conflict'  => false,
+				'retryable' => false,
+				'error'     => 'engine_data_query_oversize',
 			);
 		}
 
@@ -2036,6 +2060,109 @@ class Jobs extends BaseRepository {
 			'updated'  => true,
 			'conflict' => false,
 			'error'    => null,
+		);
+	}
+
+	/**
+	 * Remove one top-level key without binding the complete engine_data value.
+	 *
+	 * @return array{updated:bool,retryable:bool,error:string|null}
+	 */
+	public function remove_engine_data_key( int $job_id, string $key ): array {
+		if ( $job_id <= 0 || ! in_array( $key, array( 'batch_state' ), true ) ) {
+			return array(
+				'updated'   => false,
+				'retryable' => false,
+				'error'     => 'invalid_engine_data_key_removal',
+			);
+		}
+
+		$json_path = '$."' . $key . '"';
+		// Atomic JSON mutation avoids binding a potentially oversized snapshot.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- The nested prepare binds the plugin table identifier and every scalar value.
+		// phpcs:disable WordPress.DB.PreparedSQL -- The nested prepare binds the plugin table identifier and every scalar value.
+		$result = $this->wpdb->query(
+			$this->wpdb->prepare(
+				'UPDATE %i SET engine_data = JSON_REMOVE(engine_data, %s) WHERE job_id = %d AND JSON_CONTAINS_PATH(engine_data, %s, %s)',
+				$this->table_name,
+				$json_path,
+				$job_id,
+				'one',
+				$json_path
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( false === $result ) {
+			$db_error  = (string) $this->wpdb->last_error;
+			$retryable = $this->is_retryable_db_error( $db_error );
+			do_action(
+				'datamachine_log',
+				$retryable ? 'warning' : 'error',
+				'Failed to remove engine_data key',
+				array(
+					'job_id'    => $job_id,
+					'key'       => $key,
+					'db_error'  => substr( $db_error, 0, 512 ),
+					'retryable' => $retryable,
+				)
+			);
+			return array(
+				'updated'   => false,
+				'retryable' => $retryable,
+				'error'     => $retryable ? 'deadlock' : 'db_error',
+			);
+		}
+
+		wp_cache_delete( $job_id, 'datamachine_engine_data' );
+		return array(
+			'updated'   => true,
+			'retryable' => false,
+			'error'     => null,
+		);
+	}
+
+	/** Conservatively estimate prepared SQL bytes after string escaping. */
+	private function estimate_engine_data_query_bytes( int $new_bytes, int $expected_bytes = 0 ): int {
+		return 4096 + ( 2 * ( $new_bytes + $expected_bytes ) );
+	}
+
+	/** Keep engine_data statements below the current connection packet limit. */
+	private function engine_data_query_budget(): int {
+		if ( null !== $this->engine_data_query_budget ) {
+			return $this->engine_data_query_budget;
+		}
+
+		$max_allowed_packet             = (int) $this->wpdb->get_var( 'SELECT @@SESSION.max_allowed_packet' );
+		$budget                         = (int) floor( $max_allowed_packet * 0.8 );
+		$this->engine_data_query_budget = max( 0, (int) apply_filters( 'datamachine_engine_data_query_budget', $budget, $max_allowed_packet ) );
+		return $this->engine_data_query_budget;
+	}
+
+	/** Log bounded write diagnostics without exposing engine payload content. */
+	private function log_engine_data_write_rejection( int $job_id, string $error, string $new_encoded, ?string $expected_encoded, array $new_data ): void {
+		$key_sizes = array();
+		foreach ( $new_data as $key => $value ) {
+			$encoded_value              = wp_json_encode( $value );
+			$key_sizes[ (string) $key ] = is_string( $encoded_value ) ? strlen( $encoded_value ) : -1;
+		}
+		arsort( $key_sizes, SORT_NUMERIC );
+		$key_sizes = array_slice( $key_sizes, 0, 10, true );
+
+		$expected_bytes = null === $expected_encoded ? 0 : strlen( $expected_encoded );
+		do_action(
+			'datamachine_log',
+			'error',
+			'Rejected engine_data write before database query',
+			array(
+				'job_id'                => $job_id,
+				'error'                 => $error,
+				'expected_bytes'        => $expected_bytes,
+				'new_bytes'             => strlen( $new_encoded ),
+				'estimated_query_bytes' => $this->estimate_engine_data_query_bytes( strlen( $new_encoded ), $expected_bytes ),
+				'top_level_key_bytes'   => $key_sizes,
+			)
 		);
 	}
 

--- a/inc/Core/EngineData.php
+++ b/inc/Core/EngineData.php
@@ -19,6 +19,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class EngineData {
 
+	private const FLOW_RUNTIME_QUEUE_KEYS = array(
+		'prompt_queue',
+		'config_patch_queue',
+		'_queue_consume_revision',
+	);
+
 	/**
 	 * The raw engine data array.
 	 *
@@ -100,6 +106,31 @@ class EngineData {
 		}
 
 		return $success;
+	}
+
+	/**
+	 * Remove live flow queue payloads from a persisted engine snapshot.
+	 *
+	 * Queue consumers read these values from the authoritative flow row. The
+	 * snapshot still retains step definitions, handler configuration, and queue
+	 * mode so execution semantics remain unchanged.
+	 */
+	public static function stripFlowRuntimeQueuePayloads( array $snapshot ): array {
+		$flow_config = is_array( $snapshot['flow_config'] ?? null ) ? $snapshot['flow_config'] : array();
+
+		foreach ( $flow_config as $flow_step_id => $flow_step_config ) {
+			if ( ! is_array( $flow_step_config ) ) {
+				continue;
+			}
+
+			foreach ( self::FLOW_RUNTIME_QUEUE_KEYS as $queue_key ) {
+				unset( $flow_step_config[ $queue_key ] );
+			}
+			$flow_config[ $flow_step_id ] = $flow_step_config;
+		}
+
+		$snapshot['flow_config'] = $flow_config;
+		return $snapshot;
 	}
 
 	/**

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -174,6 +174,60 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$this->assertFalse( get_transient( 'datamachine_pipeline_batch_' . $parent_id ) );
 	}
 
+	public function test_realistic_batch_keeps_parent_engine_data_bounded(): void {
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+		$packets   = array();
+		for ( $index = 0; $index < 175; $index++ ) {
+			$packet                 = $this->make_data_packet( 'Event ' . $index );
+			$packet['data']['body'] = str_repeat( 'x', 32768 );
+			$packets[]              = $packet;
+		}
+
+		$result = ( new PipelineBatchScheduler() )->fanOut( $parent_id, 'step_abc_123', $packets, $engine );
+
+		$this->assertSame( 175, $result['total'] );
+		$this->assertLessThan( 32768, strlen( (string) wp_json_encode( datamachine_get_engine_data( $parent_id ) ) ) );
+		global $wpdb;
+		$this->assertSame( 175, (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE batch_job_id = %d', $wpdb->prefix . 'datamachine_batch_items', $parent_id ) ) );
+	}
+
+	public function test_finalize_removes_batch_state_from_historical_large_parent_without_retry(): void {
+		global $wpdb;
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+		$engine['historical_payload']    = str_repeat( 'x', 1024 * 1024 );
+		$engine['unrelated_key']         = array( 'preserved' => true );
+		$engine['batch_storage_version'] = 2;
+		$engine['batch_context']         = PipelineBatchScheduler::BATCH_CONTEXT;
+		$engine['batch_hook']            = PipelineBatchScheduler::BATCH_HOOK;
+		$engine['batch_state']           = array(
+			'hook'              => PipelineBatchScheduler::BATCH_HOOK,
+			'offset'            => 175,
+			'worklist_complete' => true,
+		);
+		$wpdb->update(
+			$this->jobs_db->get_table_name(),
+			array( 'engine_data' => wp_json_encode( $engine ) ),
+			array( 'job_id' => $parent_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		wp_cache_delete( $parent_id, 'datamachine_engine_data' );
+		$this->assertTrue( $this->jobs_db->complete_job( $parent_id, JobStatus::COMPLETED ) );
+
+		$before = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}actionscheduler_actions WHERE hook = %s AND args = %s AND status = 'pending'", PipelineBatchScheduler::BATCH_HOOK, wp_json_encode( array( 'parent_job_id' => $parent_id, 'offset' => 175 ) ) ) );
+		$this->assertTrue( BatchScheduler::finalize( $parent_id ) );
+		$after = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}actionscheduler_actions WHERE hook = %s AND args = %s AND status = 'pending'", PipelineBatchScheduler::BATCH_HOOK, wp_json_encode( array( 'parent_job_id' => $parent_id, 'offset' => 175 ) ) ) );
+
+		$final = datamachine_get_engine_data( $parent_id );
+		$this->assertArrayNotHasKey( 'batch_state', $final );
+		$this->assertSame( array( 'preserved' => true ), $final['unrelated_key'] );
+		$this->assertSame( 1024 * 1024, strlen( $final['historical_payload'] ) );
+		$this->assertSame( $before, $after );
+		$this->assertSame( JobStatus::COMPLETED, $this->jobs_db->get_job( $parent_id )['status'] );
+	}
+
 	public function test_exact_retry_rejects_changed_batch_consumer_contract(): void {
 		$parent_id = $this->create_parent_job();
 		$items     = array( $this->make_data_packet( 'Event A' ) );

--- a/tests/Unit/Abilities/Engine/PipelineExecutionContractTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineExecutionContractTest.php
@@ -237,6 +237,12 @@ class PipelineExecutionContractTest extends WP_UnitTestCase
         $this->assertArrayHasKey('flow_ai', $engine_data['flow_config']);
         $this->assertArrayHasKey('flow_publish', $engine_data['flow_config']);
         $this->assertArrayHasKey('pipeline_ai', $engine_data['pipeline_config']);
+		$this->assertArrayNotHasKey('prompt_queue', $engine_data['flow_config']['flow_ai']);
+		$this->assertSame('static', $engine_data['flow_config']['flow_ai']['queue_mode'] ?? '');
+		$this->assertSame(
+			array('fake_fetch' => array('source' => 'contract-test')),
+			$engine_data['flow_config']['flow_fetch']['handler_configs'] ?? array()
+		);
 
         $executor     = new ExecuteStepAbility();
         $fetch_result = $executor->execute(

--- a/tests/Unit/Core/Database/EngineDataPersistenceTest.php
+++ b/tests/Unit/Core/Database/EngineDataPersistenceTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Engine data persistence limits.
+ *
+ * @package DataMachine\Tests\Unit\Core\Database
+ */
+
+namespace DataMachine\Tests\Unit\Core\Database;
+
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\EngineData;
+use WP_UnitTestCase;
+
+class EngineDataPersistenceTest extends WP_UnitTestCase {
+	private $budget_filter;
+	private $log_capture;
+	private array $logs = array();
+	private array $queries = array();
+	private $query_capture;
+
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+		if ( function_exists( 'datamachine_activate_for_site' ) ) {
+			datamachine_activate_for_site();
+		}
+	}
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->budget_filter = static fn(): int => 8192;
+		$this->log_capture   = function ( string $level, string $message, array $context = array() ): void {
+			$this->logs[] = compact( 'level', 'message', 'context' );
+		};
+		$this->query_capture = function ( string $query ): string {
+			$this->queries[] = $query;
+			return $query;
+		};
+		add_filter( 'datamachine_engine_data_query_budget', $this->budget_filter );
+		add_action( 'datamachine_log', $this->log_capture, 10, 3 );
+		add_filter( 'query', $this->query_capture );
+	}
+
+	public function tear_down(): void {
+		remove_filter( 'datamachine_engine_data_query_budget', $this->budget_filter );
+		remove_action( 'datamachine_log', $this->log_capture, 10 );
+		remove_filter( 'query', $this->query_capture );
+		parent::tear_down();
+	}
+
+	public function test_blind_and_cas_writes_reject_oversize_payloads_before_update(): void {
+		$jobs   = new Jobs();
+		$job_id = $jobs->create_job( array( 'source' => 'pipeline', 'label' => 'Engine data budget test' ) );
+		$this->assertIsInt( $job_id );
+		$this->assertTrue( $jobs->store_engine_data( $job_id, array( 'small' => true ) ) );
+		$oversize = array( 'secret_payload' => str_repeat( 'do-not-log', 2048 ) );
+		$this->queries = array();
+
+		$this->assertFalse( $jobs->store_engine_data( $job_id, $oversize ) );
+		$cas = $jobs->compare_and_swap_engine_data( $job_id, array( 'small' => true ), $oversize );
+
+		$this->assertFalse( $cas['updated'] );
+		$this->assertFalse( $cas['retryable'] );
+		$this->assertSame( 'engine_data_query_oversize', $cas['error'] );
+		$this->assertSame( array( 'small' => true ), $jobs->retrieve_engine_data( $job_id ) );
+		$engine_updates = array_filter( $this->queries, static fn( string $query ): bool => str_starts_with( ltrim( $query ), 'UPDATE' ) && str_contains( $query, 'engine_data' ) );
+		$this->assertSame( array(), array_values( $engine_updates ) );
+		$rejections = array_values( array_filter( $this->logs, static fn( array $log ): bool => 'Rejected engine_data write before database query' === $log['message'] ) );
+		$this->assertCount( 2, $rejections );
+		$this->assertArrayHasKey( 'secret_payload', $rejections[0]['context']['top_level_key_bytes'] );
+		$this->assertStringNotContainsString( 'do-not-log', (string) wp_json_encode( $rejections ) );
+	}
+
+	public function test_mutation_stops_after_deterministic_oversize_rejection(): void {
+		$jobs   = new Jobs();
+		$job_id = $jobs->create_job( array( 'source' => 'pipeline', 'label' => 'Mutation budget test' ) );
+		$this->assertIsInt( $job_id );
+		$this->assertTrue( $jobs->store_engine_data( $job_id, array( 'small' => true ) ) );
+		$calls = 0;
+
+		$result = EngineData::mutate(
+			$job_id,
+			static function ( array $current ) use ( &$calls ): array {
+				++$calls;
+				$current['large'] = str_repeat( 'x', 8192 );
+				return $current;
+			},
+			'oversize_test',
+			5
+		);
+
+		$this->assertFalse( $result['success'] );
+		$this->assertFalse( $result['conflict'] );
+		$this->assertSame( 1, $result['attempts'] );
+		$this->assertSame( 1, $calls );
+		$this->assertSame( 'engine_data_query_oversize', $result['error'] );
+	}
+
+	public function test_runtime_queue_sanitizer_preserves_all_execution_configuration(): void {
+		$snapshot = array(
+			'flow_config'     => array(
+				'static_step' => array(
+					'queue_mode'              => 'static',
+					'prompt_queue'            => array( array( 'prompt' => 'large payload' ) ),
+					'_queue_consume_revision' => 9,
+					'handler_configs'         => array( 'fetch' => array( 'limit' => 175 ) ),
+				),
+				'drain_step'  => array(
+					'queue_mode'         => 'drain',
+					'config_patch_queue' => array( array( 'patch' => array( 'page' => 2 ) ) ),
+					'handler_slugs'      => array( 'fetch' ),
+				),
+				'loop_step'   => array(
+					'queue_mode'   => 'loop',
+					'prompt_queue' => array( array( 'prompt' => 'loop payload' ) ),
+					'step_type'    => 'ai',
+				),
+			),
+			'pipeline_config' => array( 'ai' => array( 'system_prompt' => 'preserved' ) ),
+			'execution_plan'  => array( 'static_step', 'drain_step', 'loop_step' ),
+		);
+
+		$sanitized = EngineData::stripFlowRuntimeQueuePayloads( $snapshot );
+
+		foreach ( array( 'static_step', 'drain_step', 'loop_step' ) as $step_id ) {
+			$this->assertArrayNotHasKey( 'prompt_queue', $sanitized['flow_config'][ $step_id ] );
+			$this->assertArrayNotHasKey( 'config_patch_queue', $sanitized['flow_config'][ $step_id ] );
+			$this->assertArrayNotHasKey( '_queue_consume_revision', $sanitized['flow_config'][ $step_id ] );
+		}
+		$this->assertSame( 'static', $sanitized['flow_config']['static_step']['queue_mode'] );
+		$this->assertSame( 'drain', $sanitized['flow_config']['drain_step']['queue_mode'] );
+		$this->assertSame( 'loop', $sanitized['flow_config']['loop_step']['queue_mode'] );
+		$this->assertSame( $snapshot['pipeline_config'], $sanitized['pipeline_config'] );
+		$this->assertSame( $snapshot['execution_plan'], $sanitized['execution_plan'] );
+		$this->assertSame( $snapshot['flow_config']['static_step']['handler_configs'], $sanitized['flow_config']['static_step']['handler_configs'] );
+	}
+}


### PR DESCRIPTION
## Summary
- strip live flow queue payloads before the parent engine snapshot is persisted while preserving step definitions, handler configuration, queue modes, execution plans, and pipeline configuration
- reject blind and compare-and-swap engine-data writes before `$wpdb` when their conservative prepared-query estimate exceeds 80% of the active connection's `max_allowed_packet`
- finalize historical v2 parents with an atomic `JSON_REMOVE` of `batch_state`, and only schedule another finalize action for transient database lock contention

## Root cause
`RunFlowAbility` copied the complete live `flow_config`, including runtime prompt/config-patch queues, into the parent job snapshot. A 175-item Events batch then accumulated a multi-megabyte parent envelope. Finalization used a full compare-and-swap update, binding the full new snapshot in `SET` and the full expected snapshot in `WHERE`. MySQL rejected that statement as larger than `max_allowed_packet`, WordPress logged the complete failed SQL query, and deterministic finalization replayed approximately every 60 seconds. A single repeatable database error therefore appended roughly 26 MB per attempt until `debug.log` reached about 22 GB and exhausted root disk.

The offending Action Scheduler action was canceled separately as operational containment. This PR is the permanent recurrence prevention; it does not perform any production operation.

## Behavior
- Parent and child snapshots share one sanitizer for only `prompt_queue`, `config_patch_queue`, and `_queue_consume_revision`.
- Queue modes, handler configs/slugs, step types, execution order/plan, and pipeline config remain intact. Runtime queue consumers continue reading authoritative live flow state.
- Blind writes budget the new encoded snapshot; CAS writes budget both expected and new snapshots plus conservative 2x escaping overhead and fixed SQL overhead.
- Oversize CAS returns `engine_data_query_oversize` with `retryable: false`, so `EngineData::mutate()` terminates on the first attempt.
- Terminal v2 cleanup removes only `batch_state` in MySQL without binding either historical full snapshot, preserving unrelated JSON keys and invalidating the object cache.
- Completed parent status remains terminal. Finalize replay is limited to transient deadlock/lock-wait failures.

## Bounded logging
Preflight rejection logs never include engine payload content. Diagnostics are limited to job ID, expected/new encoded byte counts, estimated query bytes, and the ten largest top-level keys by encoded byte count. Database error text on the targeted cleanup path is truncated to 512 bytes.

## Tests
- `homeboy review lint data-machine --path /var/lib/datamachine/workspace/data-machine@fix-3156-engine-data-log-flood --placement local --changed-since origin/main` passed: PHPCS and PHPStan, no findings.
- `php tests/prefix-policy-audit.php` passed: 11 passed, 0 failed.
- PHP syntax checks and `git diff --check` passed.
- Added behavioral coverage for parent queue stripping and execution preservation across static/drain/loop modes, a realistic 175-item batch, blind/CAS preflight rejection before an engine-data update, bounded metadata-only logs, immediate non-retryable mutation termination, no recurring finalize retry, and historical-parent atomic cleanup.
- Focused PHPUnit execution was attempted through Homeboy, but the managed MySQL 8.4 runtime service failed provisioning before PHPUnit started (0 tests executed). CI should run the added WordPress integration tests in its managed environment.
- The broad repository audit was also run and reported existing repository-wide drift unrelated to this patch; changed-file lint/static analysis is clean.

## Risk / rollback
Risk is limited to engine snapshot persistence and terminal v2 cleanup. The budget is derived from the active connection rather than a production-specific constant and is filterable for tests/hosts. The JSON cleanup is allowlisted to `batch_state` and preserves all unrelated keys. Rollback is a normal revert of this commit; it would restore the oversized-query exposure, so operational cancellation alone is not a durable substitute.

Fixes #3156