### PR TITLE
refactor: use native pipeline REST errors

### DIFF
--- a/inc/Abilities/Pipeline/GetPipelinesAbility.php
+++ b/inc/Abilities/Pipeline/GetPipelinesAbility.php
@@ -87,7 +87,6 @@ class GetPipelinesAbility {
 							'per_page'    => array( 'type' => 'integer' ),
 							'offset'      => array( 'type' => 'integer' ),
 							'output_mode' => array( 'type' => 'string' ),
-							'error'       => array( 'type' => 'string' ),
 						),
 					),
 					'execute_callback'    => array( $this, 'execute' ),
@@ -104,9 +103,9 @@ class GetPipelinesAbility {
 	 * Execute get pipelines ability.
 	 *
 	 * @param array $input Input parameters.
-	 * @return array Result with pipelines data.
+	 * @return array|\WP_Error Result with pipelines data or a query failure.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		try {
 			$pipeline_id   = $input['pipeline_id'] ?? null;
 			$user_id       = isset( $input['user_id'] ) ? (int) $input['user_id'] : null;
@@ -130,10 +129,7 @@ class GetPipelinesAbility {
 			// opt out with include_flows=false.
 			if ( null !== $pipeline_id ) {
 				if ( ! is_numeric( $pipeline_id ) || (int) $pipeline_id <= 0 ) {
-					return array(
-						'success' => false,
-						'error'   => 'pipeline_id must be a positive integer',
-					);
+					return new \WP_Error( 'pipeline_not_found', 'pipeline_id must be a positive integer', array( 'status' => 404 ) );
 				}
 
 				$pipeline = $this->db_pipelines->get_pipeline( (int) $pipeline_id );
@@ -187,10 +183,9 @@ class GetPipelinesAbility {
 				'output_mode' => $output_mode,
 			);
 		} catch ( \Exception $e ) {
-			return array(
-				'success' => false,
-				'error'   => $e->getMessage(),
-			);
+			return isset( $input['pipeline_id'] )
+				? new \WP_Error( 'pipeline_not_found', $e->getMessage(), array( 'status' => 404 ) )
+				: new \WP_Error( 'get_pipelines_failed', $e->getMessage(), array( 'status' => 500 ) );
 		}
 	}
 }

--- a/inc/Abilities/Pipeline/ImportExportAbility.php
+++ b/inc/Abilities/Pipeline/ImportExportAbility.php
@@ -101,7 +101,6 @@ class ImportExportAbility {
 						'success' => array( 'type' => 'boolean' ),
 						'data'    => array( 'type' => 'string' ),
 						'count'   => array( 'type' => 'integer' ),
-						'error'   => array( 'type' => 'string' ),
 					),
 				),
 				'execute_callback'    => array( $this, 'executeExport' ),
@@ -151,9 +150,9 @@ class ImportExportAbility {
 	 * Execute export pipelines ability.
 	 *
 	 * @param array $input Input parameters with optional pipeline_ids.
-	 * @return array Result with CSV data.
+	 * @return array|\WP_Error Result with CSV data or an export failure.
 	 */
-	public function executeExport( array $input ): array {
+	public function executeExport( array $input ): array|\WP_Error {
 		$pipeline_ids = $input['pipeline_ids'] ?? array();
 
 		if ( empty( $pipeline_ids ) ) {
@@ -173,10 +172,7 @@ class ImportExportAbility {
 		$csv_content   = $import_export->handle_export( 'pipelines', $pipeline_ids );
 
 		if ( false === $csv_content ) {
-			return array(
-				'success' => false,
-				'error'   => 'Export failed',
-			);
+			return new \WP_Error( 'export_failed', 'Export failed', array( 'status' => 500 ) );
 		}
 
 		return array(

--- a/inc/Api/Pipelines/Pipelines.php
+++ b/inc/Api/Pipelines/Pipelines.php
@@ -327,9 +327,8 @@ class Pipelines {
 				array( 'pipeline_ids' => $export_ids )
 			);
 
-			$error = AbilityResult::failure_to_wp_error( $result, 'export_failed', __( 'Failed to generate CSV export.', 'data-machine' ) );
-			if ( $error ) {
-				return $error;
+			if ( is_wp_error( $result ) ) {
+				return $result;
 			}
 
 			$response = new \WP_REST_Response( $result['data'] );
@@ -363,12 +362,8 @@ class Pipelines {
 			}
 			$result = ( new GetPipelinesAbility() )->execute( $input );
 
-			if ( ! $result['success'] || empty( $result['pipelines'] ) ) {
-				return new \WP_Error(
-					'pipeline_not_found',
-					$result['error'] ?? __( 'Pipeline not found.', 'data-machine' ),
-					array( 'status' => 404 )
-				);
+			if ( is_wp_error( $result ) || empty( $result['pipelines'] ) ) {
+				return is_wp_error( $result ) ? $result : new \WP_Error( 'pipeline_not_found', __( 'Pipeline not found.', 'data-machine' ), array( 'status' => 404 ) );
 			}
 
 			$pipeline_data = $result['pipelines'][0];
@@ -428,9 +423,8 @@ class Pipelines {
 			}
 			$result = ( new GetPipelinesAbility() )->execute( $input );
 
-			$error = AbilityResult::failure_to_wp_error( $result, 'get_pipelines_failed', __( 'Failed to get pipelines.', 'data-machine' ) );
-			if ( $error ) {
-				return $error;
+			if ( is_wp_error( $result ) ) {
+				return $result;
 			}
 
 			$pipelines = $result['pipelines'];

--- a/inc/Cli/Commands/PipelinesCommand.php
+++ b/inc/Cli/Commands/PipelinesCommand.php
@@ -317,8 +317,8 @@ class PipelinesCommand extends BaseCommand {
 				)
 			);
 
-			if ( ! $result['success'] || empty( $result['pipelines'] ) ) {
-				WP_CLI::error( $result['error'] ?? 'Pipeline not found' );
+			if ( is_wp_error( $result ) || empty( $result['pipelines'] ) ) {
+				WP_CLI::error( is_wp_error( $result ) ? $result->get_error_message() : 'Pipeline not found' );
 				return;
 			}
 
@@ -347,8 +347,8 @@ class PipelinesCommand extends BaseCommand {
 
 			$result = ( new GetPipelinesAbility() )->execute( $ability_input );
 
-			if ( ! $result['success'] ) {
-				WP_CLI::error( $result['error'] ?? 'Failed to get pipelines' );
+			if ( is_wp_error( $result ) ) {
+				WP_CLI::error( $result->get_error_message() );
 				return;
 			}
 
@@ -406,8 +406,8 @@ class PipelinesCommand extends BaseCommand {
 			)
 		);
 
-		if ( empty( $result['success'] ) || empty( $result['pipelines'][0] ) ) {
-			WP_CLI::error( $result['error'] ?? 'Pipeline not found' );
+		if ( is_wp_error( $result ) || empty( $result['pipelines'][0] ) ) {
+			WP_CLI::error( is_wp_error( $result ) ? $result->get_error_message() : 'Pipeline not found' );
 			return;
 		}
 
@@ -884,7 +884,7 @@ class PipelinesCommand extends BaseCommand {
 			)
 		);
 
-		if ( ! $result['success'] || empty( $result['pipelines'] ) ) {
+		if ( is_wp_error( $result ) || empty( $result['pipelines'] ) ) {
 			return array( 'error' => 'Pipeline not found' );
 		}
 
@@ -1031,8 +1031,8 @@ class PipelinesCommand extends BaseCommand {
 		// First, get pipeline info for confirmation.
 		$info = ( new GetPipelinesAbility() )->execute( array( 'pipeline_id' => $pipeline_id ) );
 
-		if ( ! $info['success'] || empty( $info['pipelines'] ) ) {
-			WP_CLI::error( 'Pipeline not found' );
+		if ( is_wp_error( $info ) || empty( $info['pipelines'] ) ) {
+			WP_CLI::error( is_wp_error( $info ) ? $info->get_error_message() : 'Pipeline not found' );
 			return;
 		}
 

--- a/tests/Unit/Api/Pipelines/PipelinesEndpointTest.php
+++ b/tests/Unit/Api/Pipelines/PipelinesEndpointTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Pipelines REST API tests.
+ *
+ * @package DataMachine\Tests\Unit\Api\Pipelines
+ */
+
+namespace DataMachine\Tests\Unit\Api\Pipelines;
+
+use DataMachine\Api\Pipelines\Pipelines;
+use WP_REST_Request;
+use WP_UnitTestCase;
+
+class PipelinesEndpointTest extends WP_UnitTestCase {
+
+	public function test_missing_pipeline_preserves_not_found_response(): void {
+		$request = new WP_REST_Request( 'GET', '/datamachine/v1/pipelines/999999' );
+		$request->set_param( 'pipeline_id', 999999 );
+
+		$response = Pipelines::handle_get_pipelines( $request );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'pipeline_not_found', $response->get_error_code() );
+		$this->assertSame( 404, $response->get_error_data()['status'] );
+	}
+
+	public function test_csv_export_failure_passes_native_error_through(): void {
+		wp_set_current_user( 0 );
+		$request = new WP_REST_Request( 'GET', '/datamachine/v1/pipelines' );
+		$request->set_param( 'format', 'csv' );
+		$request->set_param( 'ids', '999999' );
+
+		$response = Pipelines::handle_get_pipelines( $request );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'export_failed', $response->get_error_code() );
+		$this->assertSame( 'Export failed', $response->get_error_message() );
+		$this->assertSame( 500, $response->get_error_data()['status'] );
+	}
+}


### PR DESCRIPTION
## Summary
- return native `WP_Error` failures from pipeline CSV export and pipeline list/query abilities
- remove the two remaining Pipeline REST calls to `AbilityResult::failure_to_wp_error()` and pass native failures through with `is_wp_error()`
- keep direct Pipeline CLI consumers safe for the native `WP_Error` return type and add behavioral REST coverage

## REST contract
- preserves the existing `datamachine/v1` pipeline routes, permission callbacks, ownership scoping, CSV headers/body behavior, collection envelopes, and success payloads
- CSV export failures remain `export_failed` with message `Export failed` and HTTP 500
- pipeline-list query failures remain `get_pipelines_failed` with HTTP 500
- missing single pipelines remain `pipeline_not_found` with HTTP 404

## LOC
- production: +24 / -39, net -15 LOC
- tests: +40 / -0, net +40 LOC

## Verification
- `vendor/bin/phpcs` on every changed PHP file (passed)
- `homeboy review lint data-machine --placement local --changed-only --summary` (passed; PHPCS and PHPStan level 7 reported zero findings)
- `homeboy review audit data-machine --placement local --changed-since origin/main --profile pr --summary` (passed; no introduced findings)
- `php tests/prefix-policy-audit.php` (11 passed, 0 failed)
- `php -l` on every changed PHP file (passed)
- `git diff --check` (passed)
- focused PHPUnit was attempted both directly and through `homeboy review test`; no tests executed because the host only has PHP 8.4 with the checked-in PHPUnit 9 runner, and Homeboy's managed `wordpress-database` service failed during provisioning before PHPUnit started

Fixes #3154