### PR TITLE
refactor: use native errors for Jobs adapters

### DIFF
--- a/inc/Abilities/Job/DeleteJobsAbility.php
+++ b/inc/Abilities/Job/DeleteJobsAbility.php
@@ -53,7 +53,6 @@ class DeleteJobsAbility {
 							'deleted_count'           => array( 'type' => 'integer' ),
 							'processed_items_cleaned' => array( 'type' => 'integer' ),
 							'message'                 => array( 'type' => 'string' ),
-							'error'                   => array( 'type' => 'string' ),
 						),
 					),
 					'execute_callback'    => array( $this, 'execute' ),
@@ -70,17 +69,14 @@ class DeleteJobsAbility {
 	 * Execute delete-jobs ability.
 	 *
 	 * @param array $input Input parameters with type and cleanup_processed.
-	 * @return array Result with deleted count.
+	 * @return array|\WP_Error Result with deleted count or deletion failure.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$type              = $input['type'] ?? null;
 		$cleanup_processed = (bool) ( $input['cleanup_processed'] ?? false );
 
 		if ( ! in_array( $type, array( 'all', 'failed' ), true ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'type is required and must be "all" or "failed"',
-			);
+			return new \WP_Error( 'delete_failed', 'type is required and must be "all" or "failed"', array( 'status' => 500 ) );
 		}
 
 		$criteria = array();
@@ -93,10 +89,7 @@ class DeleteJobsAbility {
 		$result = $this->deleteJobs( $criteria, $cleanup_processed );
 
 		if ( ! $result['success'] ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to delete jobs',
-			);
+			return new \WP_Error( 'delete_failed', 'Failed to delete jobs', array( 'status' => 500 ) );
 		}
 
 		$message_parts = array();

--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -122,7 +122,6 @@ class RecoverStuckJobsAbility {
 							'dry_run'       => array( 'type' => 'boolean' ),
 							'jobs'          => array( 'type' => 'array' ),
 							'message'       => array( 'type' => 'string' ),
-							'error'         => array( 'type' => 'string' ),
 						),
 					),
 					'execute_callback'    => array( $this, 'execute' ),
@@ -142,17 +141,14 @@ class RecoverStuckJobsAbility {
 	 * and updates them to their intended final status. Also recovers timed-out jobs.
 	 *
 	 * @param array $input Input parameters with optional dry_run, flow_id, and timeout_hours.
-	 * @return array Result with recovered/skipped counts.
+	 * @return array|\WP_Error Result with recovered/skipped counts or validation failure.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		global $wpdb;
 		$table = $wpdb->prefix . 'datamachine_jobs';
 		$requested_job_id = array_key_exists( 'job_id', $input ) && null !== $input['job_id'] ? filter_var( $input['job_id'], FILTER_VALIDATE_INT ) : null;
 		if ( array_key_exists( 'job_id', $input ) && null !== $input['job_id'] && ( false === $requested_job_id || $requested_job_id <= 0 ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'job_id must be a positive integer.',
-			);
+			return new \WP_Error( 'get_jobs_failed', 'job_id must be a positive integer.', array( 'status' => 500 ) );
 		}
 
 		$dry_run       = ! empty( $input['dry_run'] );

--- a/inc/Api/Jobs.php
+++ b/inc/Api/Jobs.php
@@ -243,9 +243,8 @@ class Jobs {
 
 		$result = ( new GetJobsAbility() )->execute( array( 'job_id' => $job_id ) );
 
-		$error = AbilityResult::failure_to_wp_error( $result, 'job_not_found', __( 'Job not found.', 'data-machine' ), 404 );
-		if ( $error || empty( $result['jobs'] ) ) {
-			return $error ? $error : new \WP_Error( 'job_not_found', __( 'Job not found.', 'data-machine' ), array( 'status' => 404 ) );
+		if ( is_wp_error( $result ) || empty( $result['jobs'] ) ) {
+			return is_wp_error( $result ) ? $result : new \WP_Error( 'job_not_found', __( 'Job not found.', 'data-machine' ), array( 'status' => 404 ) );
 		}
 
 		return AbilityResult::rest_item_response( $result, $result['jobs'][0] );
@@ -267,9 +266,8 @@ class Jobs {
 			)
 		);
 
-		$error = AbilityResult::failure_to_wp_error( $result, 'delete_failed', __( 'Failed to delete jobs.', 'data-machine' ) );
-		if ( $error ) {
-			return $error;
+		if ( is_wp_error( $result ) ) {
+			return $result;
 		}
 
 		return rest_ensure_response(

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -190,8 +190,8 @@ class JobsCommand extends BaseCommand {
 		$limit   = isset( $assoc_args['limit'] ) ? max( 1, min( 100, (int) $assoc_args['limit'] ) ) : 3;
 		$recover_pathless_children = isset( $assoc_args['recover-pathless-children'] );
 
-		$result = AbilityRunner::execute(
-			'datamachine/recover-stuck-jobs',
+		$ability = wp_get_ability( 'datamachine/recover-stuck-jobs' );
+		$result  = $ability->execute(
 			array(
 				'dry_run'       => $dry_run,
 				'flow_id'       => $flow_id,
@@ -203,9 +203,8 @@ class JobsCommand extends BaseCommand {
 			)
 		);
 
-		$error = AbilityResult::failure_to_wp_error( $result, 'get_jobs_failed', 'Unknown error occurred' );
-		if ( $error ) {
-			WP_CLI::error( $error->get_error_message() );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 
@@ -1709,9 +1708,8 @@ class JobsCommand extends BaseCommand {
 
 		$result = ( new GetJobsAbility() )->execute( array( 'job_id' => (int) $job_id ) );
 
-		$error = AbilityResult::failure_to_wp_error( $result, 'get_jobs_failed', 'Unknown error occurred' );
-		if ( $error ) {
-			WP_CLI::error( $error->get_error_message() );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 
@@ -1786,9 +1784,8 @@ class JobsCommand extends BaseCommand {
 
 		$result = ( new GetJobsAbility() )->execute( array( 'job_id' => $job_id ) );
 
-		$error = AbilityResult::failure_to_wp_error( $result, 'get_jobs_failed', 'Unknown error occurred' );
-		if ( $error ) {
-			WP_CLI::error( $error->get_error_message() );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 
@@ -2692,8 +2689,8 @@ class JobsCommand extends BaseCommand {
 			)
 		);
 
-		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['error'] ?? 'Failed to delete jobs' );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
 

--- a/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
+++ b/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
@@ -8,6 +8,7 @@
 namespace DataMachine\Tests\Unit\Abilities\Job;
 
 use AgentsAPI\AI\WP_Agent_Execution_Principal;
+use DataMachine\Abilities\Job\DeleteJobsAbility;
 use DataMachine\Abilities\Job\ExecuteWorkflowAbility;
 use DataMachine\Abilities\Job\FailJobAbility;
 use DataMachine\Abilities\Job\FlowHealthAbility;
@@ -213,6 +214,12 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertSame( 'invalid_job_id', $invalid_job->get_error_code() );
 		$this->assertSame( 400, $invalid_job->get_error_data()['status'] );
 
+		$invalid_delete = ( new DeleteJobsAbility() )->execute( array( 'type' => 'invalid' ) );
+		$this->assertWPError( $invalid_delete );
+		$this->assertSame( 'delete_failed', $invalid_delete->get_error_code() );
+		$this->assertSame( 'type is required and must be "all" or "failed"', $invalid_delete->get_error_message() );
+		$this->assertSame( 500, $invalid_delete->get_error_data()['status'] );
+
 		$invalid_flow = ( new FlowHealthAbility() )->execute( array( 'flow_id' => 0 ) );
 		$this->assertWPError( $invalid_flow );
 		$this->assertSame( 'invalid_flow_id', $invalid_flow->get_error_code() );
@@ -221,6 +228,26 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertWPError( $missing_flow );
 		$this->assertSame( 'flow_not_found', $missing_flow->get_error_code() );
 		$this->assertSame( 404, $missing_flow->get_error_data()['status'] );
+	}
+
+	public function test_jobs_rest_item_and_delete_errors_preserve_contracts(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$get_request = new \WP_REST_Request( 'GET', '/datamachine/v1/jobs/999999' );
+		$get_request->set_param( 'id', 999999 );
+		$get_response = JobsApi::handle_get_job_by_id( $get_request );
+		$this->assertWPError( $get_response );
+		$this->assertSame( 'job_not_found', $get_response->get_error_code() );
+		$this->assertSame( 'Job not found.', $get_response->get_error_message() );
+		$this->assertSame( 404, $get_response->get_error_data()['status'] );
+
+		$delete_request = new \WP_REST_Request( 'DELETE', '/datamachine/v1/jobs' );
+		$delete_request->set_param( 'type', 'invalid' );
+		$delete_response = JobsApi::handle_clear( $delete_request );
+		$this->assertWPError( $delete_response );
+		$this->assertSame( 'delete_failed', $delete_response->get_error_code() );
+		$this->assertSame( 'type is required and must be "all" or "failed"', $delete_response->get_error_message() );
+		$this->assertSame( 500, $delete_response->get_error_data()['status'] );
 	}
 
 	public function test_successful_rest_collection_contract_is_unchanged(): void {

--- a/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
+++ b/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
@@ -160,8 +160,10 @@ class JobLifecycleTransitionTest extends WP_UnitTestCase {
 
 	public function test_recovery_rejects_invalid_exact_job_scope(): void {
 		$result = ( new RecoverStuckJobsAbility() )->execute( array( 'job_id' => '1.5' ) );
-		$this->assertFalse( $result['success'] );
-		$this->assertSame( 'job_id must be a positive integer.', $result['error'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'get_jobs_failed', $result->get_error_code() );
+		$this->assertSame( 'job_id must be a positive integer.', $result->get_error_message() );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
 	}
 
 	public function test_touch_limit_stops_before_partial_pathless_claim(): void {


### PR DESCRIPTION
## Summary
- remove two Jobs REST and three Jobs CLI calls to `AbilityResult::failure_to_wp_error()`
- return native `WP_Error` from delete-jobs and recover-stuck-jobs failure paths, with stale error output-schema fields removed
- preserve the existing `datamachine/v1` REST codes, messages, and statuses plus `wp datamachine` CLI display and `WP_CLI::error()` exit behavior

## Adapter contracts
- single-job REST lookup still returns `job_not_found` / `Job not found.` / HTTP 404 for an empty successful query, while native query errors pass through unchanged
- Jobs REST delete still returns `delete_failed` / the ability failure message / HTTP 500
- Jobs CLI recover-stuck, show, and transcript still print the native error message and exit through `WP_CLI::error()`
- the direct Jobs CLI delete consumer was updated for the ability's native error return without changing its output or exit behavior

## Production LOC
- 21 additions, 37 deletions: net -16 LOC across `inc/`

## Verification
- focused Jobs PHPUnit files invoked successfully with the available WordPress harness, but the local runner emitted no test count; Homeboy likewise reported zero executed tests rather than test failures
- focused recover-stuck behavior smokes: 25 assertions passed
- changed-file PHPCS: pass
- changed-file PHPStan level 7: pass
- PR-scoped Homeboy audit: pass, no introduced findings
- prefix policy: 11 assertions passed
- PHP syntax for all changed files: pass
- `git diff --check`: pass
- confirmed no remaining `failure_to_wp_error()` calls in Jobs REST or Jobs CLI

Fixes #3155