### PR TITLE
fix: separate runtime ability execution from registration

### DIFF
--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -454,7 +454,7 @@ class PipelineBatchScheduler {
 			? (int) as_has_scheduled_action( 'datamachine_execute_step', $action_args, GroupRegistrar::GROUP )
 			: 0;
 		if ( $action_id <= 0 ) {
-			$result    = ( new ScheduleNextStepAbility() )->execute(
+			$result    = ( new ScheduleNextStepAbility( false ) )->execute(
 				array(
 					'job_id'       => $child_job_id,
 					'flow_step_id' => $next_flow_step_id,

--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -22,10 +22,12 @@ class ScheduleNextStepAbility {
 
 	use EngineHelpers;
 
-	public function __construct() {
+	public function __construct( bool $register = true ) {
 		$this->initDatabases();
 
-		$this->registerAbility();
+		if ( $register ) {
+			$this->registerAbility();
+		}
 	}
 
 	/**

--- a/inc/Abilities/Taxonomy/ResolveTermAbility.php
+++ b/inc/Abilities/Taxonomy/ResolveTermAbility.php
@@ -20,8 +20,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class ResolveTermAbility {
 
-	public function __construct() {
-		$this->registerAbility();
+	public function __construct( bool $register = true ) {
+		if ( $register ) {
+			$this->registerAbility();
+		}
 	}
 
 	private function registerAbility(): void {
@@ -370,7 +372,7 @@ class ResolveTermAbility {
 	 * @return array Result with success, term data, or error.
 	 */
 	public static function resolve( string $identifier, string $taxonomy, bool $create = false, array $args = array(), bool $fuzzy = false ): array {
-		$instance = new self();
+		$instance = new self( false );
 		$result   = $instance->execute(
 			array(
 				'identifier' => $identifier,

--- a/inc/Engine/Debug/SyncRunner.php
+++ b/inc/Engine/Debug/SyncRunner.php
@@ -194,7 +194,7 @@ class SyncRunner {
 		\add_action(
 			'datamachine_schedule_next_step',
 			static function ( $job_id, $flow_step_id, $data_packets = array() ): void {
-				( new ScheduleNextStepAbility() )->execute(
+				( new ScheduleNextStepAbility( false ) )->execute(
 					array(
 						'job_id'       => (int) $job_id,
 						'flow_step_id' => (string) $flow_step_id,

--- a/tests/runtime-ability-execution-registration-smoke.php
+++ b/tests/runtime-ability-execution-registration-smoke.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Regression smoke for runtime execution after ability bootstrap.
+ *
+ * Run with: php tests/runtime-ability-execution-registration-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+	define( 'ABSPATH', __DIR__ );
+
+	$GLOBALS['datamachine_3054_state'] = (object) array(
+		'actions'       => array(),
+		'did'           => 0,
+		'doing'         => false,
+		'notices'       => 0,
+		'registrations' => array(),
+	);
+
+	function add_action( string $hook, callable $callback ): void {
+		$GLOBALS['datamachine_3054_state']->actions[ $hook ][] = $callback;
+	}
+
+	function did_action( string $hook ): int {
+		return 'wp_abilities_api_init' === $hook ? $GLOBALS['datamachine_3054_state']->did : 0;
+	}
+
+	function doing_action( string $hook ): bool {
+		return 'wp_abilities_api_init' === $hook && $GLOBALS['datamachine_3054_state']->doing;
+	}
+
+	function wp_register_ability( string $name, array $args ): object {
+		unset( $args );
+		$state = $GLOBALS['datamachine_3054_state'];
+		if ( isset( $state->registrations[ $name ] ) ) {
+			++$state->notices;
+		}
+		$state->registrations[ $name ] = ( $state->registrations[ $name ] ?? 0 ) + 1;
+
+		return new \stdClass();
+	}
+
+	function __( string $text, string $domain = 'default' ): string {
+		unset( $domain );
+		return $text;
+	}
+
+	function taxonomy_exists( string $taxonomy ): bool {
+		unset( $taxonomy );
+		return false;
+	}
+
+	function is_wp_error( mixed $value ): bool {
+		return $value instanceof \WP_Error;
+	}
+
+	function datamachine_get_engine_data( int $job_id ): array {
+		unset( $job_id );
+		return array();
+	}
+
+	function as_has_scheduled_action( string $hook, array $args, string $group ): int {
+		unset( $hook, $args, $group );
+		return 0;
+	}
+
+	function as_schedule_single_action( int $timestamp, string $hook, array $args, string $group ): int {
+		static $action_id = 100;
+		unset( $timestamp, $hook, $args, $group );
+		return ++$action_id;
+	}
+
+	function do_action( string $hook, mixed ...$args ): void {
+		unset( $hook, $args );
+	}
+
+	class WP_Error {
+		public function __construct( private string $code, private string $message, private array $data = array() ) {}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\Flows {
+	class Flows {}
+}
+
+namespace DataMachine\Core\Database\Jobs {
+	class Jobs {
+		public function get_job( int $job_id ): array {
+			return array(
+				'job_id'          => $job_id,
+				'status'          => 'pending',
+				'operation_state' => 'preparing',
+			);
+		}
+
+		public function claim_operation_enqueue( int $job_id ): array {
+			unset( $job_id );
+			return array(
+				'token'      => 'claim',
+				'generation' => 1,
+			);
+		}
+
+		public function finish_operation_enqueue( int $job_id, string $state, int $action_id, string $token, int $generation ): bool {
+			unset( $job_id, $state, $action_id, $token, $generation );
+			return true;
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\Pipelines {
+	class Pipelines {}
+}
+
+namespace DataMachine\Core\Database\ProcessedItems {
+	class ProcessedItems {}
+}
+
+namespace DataMachine\Core {
+	class EngineData {
+		public function __construct( array $snapshot, int $job_id ) {
+			unset( $snapshot, $job_id );
+		}
+
+		public function getFlowStepConfig( string $flow_step_id ): array {
+			unset( $flow_step_id );
+			return array();
+		}
+
+		public function getJobContext(): array {
+			return array();
+		}
+	}
+}
+
+namespace DataMachine\Core\ActionScheduler {
+	class GroupRegistrar {
+		public const GROUP = 'data-machine';
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Abilities/AbilityRegistration.php';
+	require_once dirname( __DIR__ ) . '/inc/Abilities/Engine/EngineHelpers.php';
+	require_once dirname( __DIR__ ) . '/inc/Abilities/Engine/ScheduleNextStepAbility.php';
+	require_once dirname( __DIR__ ) . '/inc/Abilities/Engine/PipelineBatchScheduler.php';
+	require_once dirname( __DIR__ ) . '/inc/Abilities/Taxonomy/ResolveTermAbility.php';
+
+	new \DataMachine\Abilities\Engine\ScheduleNextStepAbility();
+	new \DataMachine\Abilities\Taxonomy\ResolveTermAbility();
+
+	$state        = $GLOBALS['datamachine_3054_state'];
+	$state->doing = true;
+	$state->did   = 1;
+	foreach ( $state->actions['wp_abilities_api_init'] as $callback ) {
+		$callback();
+	}
+	$state->doing = false;
+
+	$scheduler      = new \DataMachine\Abilities\Engine\PipelineBatchScheduler();
+	$schedule_child = new \ReflectionMethod( $scheduler, 'ensureChildScheduled' );
+	for ( $run = 0; $run < 2; ++$run ) {
+		$schedule_child->invoke( $scheduler, 42, 'next-step', array() );
+		\DataMachine\Abilities\Taxonomy\ResolveTermAbility::resolve( 'missing', 'missing' );
+	}
+
+	foreach ( array( 'datamachine/resolve-term', 'datamachine/schedule-next-step' ) as $name ) {
+		if ( 1 !== ( $state->registrations[ $name ] ?? 0 ) ) {
+			fwrite( STDERR, "FAIL: runtime execution re-registered {$name}\n" );
+			exit( 1 );
+		}
+	}
+
+	if ( 0 !== $state->notices ) {
+		fwrite( STDERR, "FAIL: runtime execution emitted duplicate-registration notices\n" );
+		exit( 1 );
+	}
+
+	$sync_source = file_get_contents( dirname( __DIR__ ) . '/inc/Engine/Debug/SyncRunner.php' ) ?: '';
+	if ( ! str_contains( $sync_source, 'new ScheduleNextStepAbility( false )' ) ) {
+		fwrite( STDERR, "FAIL: sync runtime path must construct schedule-next-step without registration\n" );
+		exit( 1 );
+	}
+
+	echo "PASS: runtime ability execution does not register abilities\n";
+}

--- a/tests/runtime-ability-execution-registration-smoke.php
+++ b/tests/runtime-ability-execution-registration-smoke.php
@@ -181,11 +181,5 @@ namespace {
 		exit( 1 );
 	}
 
-	$sync_source = file_get_contents( dirname( __DIR__ ) . '/inc/Engine/Debug/SyncRunner.php' ) ?: '';
-	if ( ! str_contains( $sync_source, 'new ScheduleNextStepAbility( false )' ) ) {
-		fwrite( STDERR, "FAIL: sync runtime path must construct schedule-next-step without registration\n" );
-		exit( 1 );
-	}
-
 	echo "PASS: runtime ability execution does not register abilities\n";
 }


### PR DESCRIPTION
## Summary
- keep `datamachine/schedule-next-step` and `datamachine/resolve-term` registration on the canonical WordPress Abilities API bootstrap lifecycle
- let internal runtime callers construct those providers without registration, including the Events pipeline batch scheduler and sync runner bridge
- add regression coverage that boots each ability once, executes the real batch scheduling path and resolve-term path repeatedly, and proves `wp_register_ability()` remains at one call per public name with no duplicate notices

## Root Cause
`ScheduleNextStepAbility` and `ResolveTermAbility` registered their public abilities from every constructor. `AbilityRegistration::on_abilities_api_init()` correctly supports providers loaded after the one-shot WordPress lifecycle, but runtime construction after bootstrap therefore attempted another `wp_register_ability()` call. The request-local registration-owner dedupe added in #3068 masks repeated instances from the same declaration in many requests, but runtime execution still owned an inappropriate registration side effect and production showed that coupling failing on Events jobs.

## Lifecycle Change
Both constructors retain their existing default registration behavior for canonical bootstrap, preserving external construction and all public ability definitions. Internal execution passes `false`, following the existing `ExecuteWorkflowAbility(false)` convention:

- `PipelineBatchScheduler::ensureChildScheduled()` constructs schedule-next-step without registration
- `SyncRunner` restores its schedule bridge with a non-registering provider
- `ResolveTermAbility::resolve()` constructs a non-registering provider

No parallel registry, notice suppression, facade, compatibility wrapper, ability rename, schema change, permission change, or adapter change was introduced.

## Sibling Audit
Execute-via-construction paths were audited across `inc/Engine`, `inc/Core/Steps`, `inc/Cli`, `inc/Api`, and ability-to-ability delegation. Engine siblings include `RunFlowAbility`, `DrainJobAbility`, `ExecuteWorkflowAbility`, `SourceInventoryAbility`, and fetch/publish handlers. Most remain protected by the existing request-local provider-owner idempotency and were outside the two active production signatures; `ExecuteWorkflowAbility` already has the explicit non-registering constructor used here as the local pattern. Scope is limited to the reported schedule-next-step and resolve-term paths, including the actual Events batch path.

## Preserved Contracts
- public names: `datamachine/schedule-next-step`, `datamachine/resolve-term`
- schemas, REST visibility, CLI/chat callers, permission callbacks, and execute return shapes
- Action Scheduler handoff, batch operation claims, sync-runner bridge restoration, and taxonomy create/fuzzy behavior
- default no-argument constructors continue registering for bootstrap and external consumers

## Production LOC
Production PHP delta: +11 / -7, net +4 lines. The added branches only expose the existing registration choice; runtime behavior remains in the same provider classes.

## Verification
- `php tests/runtime-ability-execution-registration-smoke.php`
- `php tests/ability-provider-bootstrap-idempotency-smoke.php`
- `php tests/schedule-next-step-failure-smoke.php`
- `php tests/drain-job-ability-smoke.php`
- `php tests/lazy-runtime-ability-registration-smoke.php`
- `vendor/bin/phpunit --filter TaxonomyAbilityWpErrorTest`
- changed-file Homeboy lint: PHPCS, PHPStan level 7, ESLint, zero findings
- `homeboy review audit --profile pr --changed-since origin/main --placement local`
- `php tests/prefix-policy-audit.php`
- changed-file PHP syntax and `git diff --check`

The repository-wide `homeboy review test --placement local --summary` wrapper reported zero discovered PHPUnit tests and exited 1; it did not report a failing test. Focused behavioral smokes and the targeted PHPUnit test exited successfully.

Fixes #3054