### PR TITLE
test: align flow factory fixture with tool recorders

### DIFF
--- a/tests/flow-step-config-factory-smoke.php
+++ b/tests/flow-step-config-factory-smoke.php
@@ -97,6 +97,7 @@ function legacy_workflow_step_config_for_test( array $step, int $index ): array 
 		'queue_mode'       => 'static',
 		'agent_modes'      => array(),
 		'disabled_tools'   => $step['disabled_tools'] ?? array(),
+		'tool_recorders'   => array(),
 		'pipeline_id'      => 'direct',
 		'flow_id'          => 'direct',
 	);


### PR DESCRIPTION
## Summary
- update the workflow expected-value fixture to include an empty `tool_recorders` array
- preserve the canonical `FlowStepConfigFactory::buildFromWorkflowStep()` behavior and keep production LOC at zero

## Root cause
`FlowStepConfigFactory::buildFromWorkflowStep()` now emits `tool_recorders` as part of the canonical workflow step shape, defaulting absent or invalid input to an empty array. The smoke test's legacy expected-value helper had not been updated, so all four executed workflow scaffold comparisons differed only by that missing key.

## Fixture update
Added exactly `'tool_recorders' => array()` to `legacy_workflow_step_config_for_test()`. No production files, source inspection, unrelated smoke coverage, versions, or changelogs changed.

## Why canonical behavior is correct
Tool recorders are a supported workflow configuration field consumed by workflow and AI execution paths. Keeping the key in the canonical flow-step shape, including an empty-list default, gives downstream ephemeral and persistent configuration a stable normalized value without requiring callers to distinguish a missing key from no configured recorders.

## Verification
- reproduced current `main`: `php tests/flow-step-config-factory-smoke.php` failed the four workflow comparisons solely on missing empty `tool_recorders`
- corrected smoke: 7/7 assertions passed
- full PHPCS: passed
- prefix policy: 11/11 passed
- PHP syntax: passed
- `git diff --check`: passed
- production LOC: 0
- relevant PHPUnit behavior tests were attempted directly and through Homeboy's `wp-codebox-phpunit` profile; this checkout's runner reported zero executed tests and Homeboy failed closed, so no PHPUnit pass is claimed

Fixes #3161