### PR TITLE
refactor: remove dead ability error adapter

### DIFF
--- a/inc/Core/AbilityResult.php
+++ b/inc/Core/AbilityResult.php
@@ -151,23 +151,6 @@ class AbilityResult {
 	}
 
 	/**
-	 * Convert ability output into a REST-ready WP_Error when execution failed.
-	 *
-	 * @param mixed  $result          Ability execution result.
-	 * @param string $default_code    Error code to use when the result has no error code.
-	 * @param string $default_message Error message to use when the result has no message.
-	 * @param int    $default_status  Default HTTP status.
-	 * @return \WP_Error|null WP_Error for failures, null for successful results.
-	 */
-	public static function failure_to_wp_error( $result, string $default_code = 'ability_failed', string $default_message = 'Ability execution failed.', int $default_status = 500 ): ?\WP_Error {
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		return self::legacy_failure_to_wp_error( $result, $default_code, $default_message, array(), $default_status );
-	}
-
-	/**
 	 * Present a successful ability collection with Data Machine's canonical page envelope.
 	 *
 	 * @param array  $result     Successful ability result.
@@ -223,7 +206,11 @@ class AbilityResult {
 	 * @return \WP_REST_Response|\WP_Error REST response or error.
 	 */
 	public static function rest_collection_response( $result, string $items_key, array $options = array(), string $default_code = 'ability_failed', string $default_message = 'Ability execution failed.', int $default_status = 500 ) {
-		$error = self::failure_to_wp_error( $result, $default_code, $default_message, $default_status );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$error = self::legacy_failure_to_wp_error( $result, $default_code, $default_message, array(), $default_status );
 		if ( $error ) {
 			return $error;
 		}
@@ -262,7 +249,11 @@ class AbilityResult {
 	 * @return \WP_REST_Response|\WP_Error REST response or error.
 	 */
 	public static function rest_item_response( $result, $data = null, array $extra = array(), string $default_code = 'ability_failed', string $default_message = 'Ability execution failed.', int $default_status = 500 ) {
-		$error = self::failure_to_wp_error( $result, $default_code, $default_message, $default_status );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$error = self::legacy_failure_to_wp_error( $result, $default_code, $default_message, array(), $default_status );
 		if ( $error ) {
 			return $error;
 		}

--- a/tests/ability-result-wp-error-smoke.php
+++ b/tests/ability-result-wp-error-smoke.php
@@ -190,19 +190,24 @@ $default_code_error = AbilityResult::legacy_failure_to_wp_error(
 $assert( 'legacy failures default to provided error code', 'email_error' === $default_code_error->get_error_code() );
 $assert( 'legacy failures keep error message', 'Human readable failure.' === $default_code_error->get_error_message() );
 
-$status_error = AbilityResult::failure_to_wp_error(
+$status_error = AbilityResult::rest_item_response(
 	array(
 		'success'    => false,
 		'error'      => 'Pipeline not found.',
 		'error_code' => 'pipeline_not_found',
 		'status'     => 404,
 	),
+	null,
+	array(),
 	'pipeline_failed',
 	'Pipeline failed.',
 	500
 );
 $assert( 'machine-readable legacy error_code is preserved', 'pipeline_not_found' === $status_error->get_error_code() );
 $assert( 'machine-readable status controls HTTP status', 404 === ( $status_error->get_error_data()['status'] ?? null ) );
+
+$native_item_error = new WP_Error( 'flow_not_found', 'Flow not found.', array( 'status' => 404 ) );
+$assert( 'REST item presenter preserves native WP_Error', $native_item_error === AbilityResult::rest_item_response( $native_item_error ) );
 
 $collection = AbilityResult::collection_envelope(
 	array(
@@ -238,6 +243,9 @@ $rest_collection_error = AbilityResult::rest_collection_response(
 );
 $assert( 'REST collection presenter returns WP_Error for failed ability results', $rest_collection_error instanceof WP_Error );
 $assert( 'REST collection presenter preserves failure status', 503 === ( $rest_collection_error->get_error_data()['status'] ?? null ) );
+
+$native_collection_error = new WP_Error( 'jobs_forbidden', 'Jobs denied.', array( 'status' => 403 ) );
+$assert( 'REST collection presenter preserves native WP_Error', $native_collection_error === AbilityResult::rest_collection_response( $native_collection_error, 'jobs' ) );
 
 $rest_item = AbilityResult::rest_item_response(
 	array( 'success' => true ),


### PR DESCRIPTION
## Summary
- delete the dead `AbilityResult::failure_to_wp_error()` compatibility wrapper
- make REST collection/item presenters preserve native `WP_Error` directly
- retain `legacy_failure_to_wp_error()` only for supported `success:false` envelopes

## Dead method proof
A repository-wide first-party and test audit found no external production callers of `failure_to_wp_error()`. Its only production references were its declaration and the two internal REST presenter calls; the sole test call exercised the wrapper itself. The presenters now implement the two actual branches directly, leaving no references to the deleted method.

## Retained legacy edge
`legacy_failure_to_wp_error()` remains because concrete REST behavior still accepts legacy `success:false` arrays, including machine-readable `error_code`, explicit `status`, default code/message handling, and `RestResultSpec` failure-status mapping. Existing behavior tests cover these contracts, so removing that edge would be premature without consumer migration evidence.

## Preserved contracts
- native `WP_Error` identity, message, code, and status pass through unchanged
- legacy failure code/message/status conversion is unchanged
- successful Flows, Jobs, and Pipelines collection/item envelopes are unchanged
- `RestResultSpec` data, extras, and failure-status behavior is unchanged

## Production LOC
`inc/Core/AbilityResult.php`: 10 additions, 19 deletions, net **-9 production lines**. Entire patch: net **-1 line** including behavioral coverage.

## Verification
- `php tests/ability-result-wp-error-smoke.php` (48 assertions)
- `php tests/rest-schema-validation-smoke.php`
- `php tests/prefix-policy-audit.php` (11 assertions)
- `vendor/bin/phpcs inc/Core/AbilityResult.php tests/ability-result-wp-error-smoke.php`
- syntax checks for both changed PHP files
- Homeboy changed-file lint: PHPCS, PHPStan level 7, and ESLint producers passed with zero findings
- Homeboy refactor lint dry-run: zero proposed edits
- `git diff --check`

Homeboy's generic test gate reported zero executed PHPUnit tests because this focused contract is a standalone smoke suite; the changed-test selection defect is tracked in Extra-Chill/homeboy#12023. Two local Homeboy audit attempts outlived their caller and left stale runs without findings; broader local gate hygiene is tracked in Extra-Chill/homeboy#7469.

Refs #2522