### PR TITLE
fix: paginate image optimization candidates

### DIFF
--- a/inc/Abilities/Media/ImageOptimizationAbilities.php
+++ b/inc/Abilities/Media/ImageOptimizationAbilities.php
@@ -287,8 +287,9 @@ class ImageOptimizationAbilities {
 		} else {
 			$offset        = 0;
 			$scan_complete = false;
+			$eligible_count = 0;
 
-			while ( count( $attachment_ids ) < $limit ) {
+			while ( $eligible_count < $limit ) {
 				$page = get_posts(
 					array(
 						'post_type'      => 'attachment',
@@ -318,7 +319,8 @@ class ImageOptimizationAbilities {
 					$file_size = filesize( $file_path );
 					if ( $file_size > $size_threshold ) {
 						$attachment_ids[] = $id;
-						if ( count( $attachment_ids ) >= $limit ) {
+						++$eligible_count;
+						if ( $eligible_count >= $limit ) {
 							break;
 						}
 					}

--- a/inc/Abilities/Media/ImageOptimizationAbilities.php
+++ b/inc/Abilities/Media/ImageOptimizationAbilities.php
@@ -29,6 +29,11 @@ class ImageOptimizationAbilities {
 	 */
 	const DEFAULT_QUALITY = 82;
 
+	/**
+	 * Number of attachments inspected per optimization candidate query.
+	 */
+	const OPTIMIZATION_SCAN_PAGE_SIZE = 100;
+
 	private static bool $registered = false;
 
 	public function __construct() {
@@ -127,11 +132,14 @@ class ImageOptimizationAbilities {
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success'      => array( 'type' => 'boolean' ),
-							'queued_count' => array( 'type' => 'integer' ),
-							'batch_id'     => array( 'anyOf' => array( array( 'type' => 'integer' ), array( 'type' => 'null' ) ) ),
-							'message'      => array( 'type' => 'string' ),
-							'error'        => array( 'type' => 'string' ),
+							'success'        => array( 'type' => 'boolean' ),
+							'queued_count'   => array( 'type' => 'integer' ),
+							'batch_id'       => array( 'anyOf' => array( array( 'type' => 'integer' ), array( 'type' => 'null' ) ) ),
+							'scanned_count'  => array( 'type' => 'integer' ),
+							'eligible_count' => array( 'type' => 'integer' ),
+							'scan_complete'  => array( 'type' => 'boolean' ),
+							'message'        => array( 'type' => 'string' ),
+							'error'          => array( 'type' => 'string' ),
 						),
 					),
 					'execute_callback'    => array( self::class, 'optimizeImages' ),
@@ -270,41 +278,71 @@ class ImageOptimizationAbilities {
 
 		// Resolve eligible attachment IDs.
 		$attachment_ids = array();
+		$scanned_count  = 0;
+		$scan_complete  = true;
 
 		if ( $attachment_id > 0 ) {
 			$attachment_ids[] = $attachment_id;
+			$scanned_count    = 1;
 		} else {
-			$all = get_posts(
-				array(
-					'post_type'      => 'attachment',
-					'post_mime_type' => 'image',
-					'post_status'    => 'inherit',
-					'posts_per_page' => $limit,
-					'fields'         => 'ids',
-					'orderby'        => 'date',
-					'order'          => 'DESC',
-				)
-			);
+			$offset        = 0;
+			$scan_complete = false;
 
-			foreach ( $all as $id ) {
-				$file_path = get_attached_file( $id );
-				if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
-					continue;
+			while ( count( $attachment_ids ) < $limit ) {
+				$page = get_posts(
+					array(
+						'post_type'      => 'attachment',
+						'post_mime_type' => 'image',
+						'post_status'    => 'inherit',
+						'posts_per_page' => self::OPTIMIZATION_SCAN_PAGE_SIZE,
+						'offset'         => $offset,
+						'fields'         => 'ids',
+						'orderby'        => array(
+							'date' => 'DESC',
+							'ID'   => 'DESC',
+						),
+						'no_found_rows'  => true,
+					)
+				);
+
+				$page_count = count( $page );
+				$offset    += $page_count;
+
+				foreach ( $page as $id ) {
+					++$scanned_count;
+					$file_path = get_attached_file( $id );
+					if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
+						continue;
+					}
+
+					$file_size = filesize( $file_path );
+					if ( $file_size > $size_threshold ) {
+						$attachment_ids[] = $id;
+						if ( count( $attachment_ids ) >= $limit ) {
+							break;
+						}
+					}
 				}
 
-				$file_size = filesize( $file_path );
-				if ( $file_size > $size_threshold ) {
-					$attachment_ids[] = $id;
+				if ( $scanned_count === $offset && $page_count < self::OPTIMIZATION_SCAN_PAGE_SIZE ) {
+					$scan_complete = true;
+					break;
 				}
 			}
 		}
 
+		$scan_coverage = array(
+			'scanned_count'  => $scanned_count,
+			'eligible_count' => count( $attachment_ids ),
+			'scan_complete'  => $scan_complete,
+		);
+
 		if ( empty( $attachment_ids ) ) {
-			return array(
+			return array_merge( array(
 				'success'      => true,
 				'queued_count' => 0,
 				'message'      => 'No oversized images found to optimize.',
-			);
+			), $scan_coverage );
 		}
 
 		if ( $dry_run ) {
@@ -320,13 +358,13 @@ class ImageOptimizationAbilities {
 				);
 			}
 
-			return array(
+			return array_merge( array(
 				'success'        => true,
 				'queued_count'   => 0,
 				'dry_run'        => true,
 				'would_optimize' => $preview,
 				'message'        => sprintf( '%d image(s) would be optimized (dry run).', count( $preview ) ),
-			);
+			), $scan_coverage );
 		}
 
 		// Build per-item params for batch scheduling.
@@ -356,15 +394,15 @@ class ImageOptimizationAbilities {
 		);
 
 		if ( false === $batch ) {
-			return array(
+			return array_merge( array(
 				'success'      => false,
 				'queued_count' => 0,
 				'message'      => 'Failed to schedule optimization batch.',
 				'error'        => 'Task batch scheduling failed.',
-			);
+			), $scan_coverage );
 		}
 
-		return array(
+		return array_merge( array(
 			'success'      => true,
 			'queued_count' => count( $attachment_ids ),
 			'batch_id'     => $batch['batch_id'] ?? null,
@@ -372,6 +410,6 @@ class ImageOptimizationAbilities {
 				'Image optimization scheduled for %d image(s).',
 				count( $attachment_ids )
 			),
-		);
+		), $scan_coverage );
 	}
 }

--- a/tests/image-optimization-pagination-smoke.php
+++ b/tests/image-optimization-pagination-smoke.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Pure-PHP smoke test for image optimization candidate pagination.
+ *
+ * Run with: php tests/image-optimization-pagination-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+$GLOBALS['__image_optimization_attachments'] = array();
+$GLOBALS['__image_optimization_files']       = array();
+$GLOBALS['__image_optimization_queries']     = array();
+$GLOBALS['__image_optimization_failures']    = 0;
+
+function absint( $value ): int {
+	return abs( (int) $value );
+}
+
+function get_posts( array $args ): array {
+	$GLOBALS['__image_optimization_queries'][] = $args;
+	return array_slice(
+		$GLOBALS['__image_optimization_attachments'],
+		(int) ( $args['offset'] ?? 0 ),
+		(int) $args['posts_per_page']
+	);
+}
+
+function get_attached_file( int $attachment_id ): string {
+	return $GLOBALS['__image_optimization_files'][ $attachment_id ] ?? '';
+}
+
+function get_the_title( int $attachment_id ): string {
+	return 'Image ' . $attachment_id;
+}
+
+function get_post_mime_type( int $attachment_id ): string {
+	unset( $attachment_id );
+	return 'image/jpeg';
+}
+
+function size_format( int $bytes ): string {
+	return $bytes . ' B';
+}
+
+function image_optimization_assert( bool $condition, string $message ): void {
+	if ( $condition ) {
+		echo "  PASS: {$message}\n";
+		return;
+	}
+
+	echo "  FAIL: {$message}\n";
+	++$GLOBALS['__image_optimization_failures'];
+}
+
+function image_optimization_fixture( array $sizes ): void {
+	$GLOBALS['__image_optimization_attachments'] = array_keys( $sizes );
+	$GLOBALS['__image_optimization_files']       = array();
+	$GLOBALS['__image_optimization_queries']     = array();
+
+	foreach ( $sizes as $attachment_id => $size ) {
+		$file = tempnam( sys_get_temp_dir(), 'dm-image-scan-' );
+		file_put_contents( $file, str_repeat( 'x', $size ) );
+		$GLOBALS['__image_optimization_files'][ $attachment_id ] = $file;
+	}
+}
+
+function image_optimization_cleanup(): void {
+	foreach ( $GLOBALS['__image_optimization_files'] as $file ) {
+		unlink( $file );
+	}
+}
+}
+
+namespace {
+require_once dirname( __DIR__ ) . '/inc/Abilities/Media/ImageOptimizationAbilities.php';
+
+use DataMachine\Abilities\Media\ImageOptimizationAbilities;
+
+echo "=== image-optimization-pagination-smoke ===\n";
+
+$sizes      = array_fill( 1, 100, 5 );
+$sizes[101] = 20;
+image_optimization_fixture( $sizes );
+$result = ImageOptimizationAbilities::optimizeImages(
+	array(
+		'size_threshold' => 10,
+		'limit'          => 1,
+		'dry_run'        => true,
+	)
+);
+image_optimization_assert( array( 101 ) === array_column( $result['would_optimize'], 'attachment_id' ), 'finds an eligible image beyond the first page' );
+image_optimization_assert( 101 === $result['scanned_count'], 'reports all inspected attachments across pages' );
+image_optimization_assert( true === $result['scan_complete'], 'reports complete coverage when the final page is exhausted' );
+image_optimization_cleanup();
+
+$sizes      = array_fill( 1, 100, 5 );
+$sizes[101] = 20;
+$sizes[102] = 20;
+$sizes[103] = 20;
+$sizes[104] = 20;
+image_optimization_fixture( $sizes );
+$result = ImageOptimizationAbilities::optimizeImages(
+	array(
+		'size_threshold' => 10,
+		'limit'          => 3,
+		'dry_run'        => true,
+	)
+);
+image_optimization_assert( array( 101, 102, 103 ) === array_column( $result['would_optimize'], 'attachment_id' ), 'stops at the eligible limit across pages' );
+image_optimization_assert( 3 === $result['eligible_count'], 'reports the bounded eligible result count' );
+image_optimization_assert( 103 === $result['scanned_count'], 'counts only attachments evaluated for eligibility' );
+image_optimization_assert( false === $result['scan_complete'], 'reports partial coverage when the eligible limit stops the scan' );
+image_optimization_cleanup();
+
+$sizes = array_fill( 1, 205, 5 );
+image_optimization_fixture( $sizes );
+$result = ImageOptimizationAbilities::optimizeImages(
+	array(
+		'size_threshold' => 10,
+		'limit'          => 2,
+		'dry_run'        => true,
+	)
+);
+image_optimization_assert( 205 === $result['scanned_count'], 'continues until all attachments are exhausted' );
+image_optimization_assert( 0 === $result['eligible_count'], 'reports no eligible images after a complete scan' );
+image_optimization_assert( true === $result['scan_complete'], 'marks exhausted attachment coverage complete' );
+image_optimization_assert( array( 0, 100, 200 ) === array_column( $GLOBALS['__image_optimization_queries'], 'offset' ), 'uses deterministic bounded offsets' );
+image_optimization_cleanup();
+
+if ( $GLOBALS['__image_optimization_failures'] > 0 ) {
+	exit( 1 );
+}
+
+echo "All image optimization pagination checks passed.\n";
+}

--- a/tests/image-optimization-pagination-smoke.php
+++ b/tests/image-optimization-pagination-smoke.php
@@ -17,6 +17,36 @@ $GLOBALS['__image_optimization_files']       = array();
 $GLOBALS['__image_optimization_queries']     = array();
 $GLOBALS['__image_optimization_failures']    = 0;
 
+function image_optimization_assert( bool $condition, string $message ): void {
+	if ( $condition ) {
+		echo "  PASS: {$message}\n";
+		return;
+	}
+
+	echo "  FAIL: {$message}\n";
+	++$GLOBALS['__image_optimization_failures'];
+}
+
+function image_optimization_fixture( array $sizes ): void {
+	$GLOBALS['__image_optimization_attachments'] = array_keys( $sizes );
+	$GLOBALS['__image_optimization_files']       = array();
+	$GLOBALS['__image_optimization_queries']     = array();
+
+	foreach ( $sizes as $attachment_id => $size ) {
+		$file = tempnam( sys_get_temp_dir(), 'dm-image-scan-' );
+		file_put_contents( $file, str_repeat( 'x', $size ) );
+		$GLOBALS['__image_optimization_files'][ $attachment_id ] = $file;
+	}
+}
+
+function image_optimization_cleanup(): void {
+	foreach ( $GLOBALS['__image_optimization_files'] as $file ) {
+		unlink( $file );
+	}
+}
+}
+
+namespace DataMachine\Abilities\Media {
 function absint( $value ): int {
 	return abs( (int) $value );
 }
@@ -45,34 +75,6 @@ function get_post_mime_type( int $attachment_id ): string {
 
 function size_format( int $bytes ): string {
 	return $bytes . ' B';
-}
-
-function image_optimization_assert( bool $condition, string $message ): void {
-	if ( $condition ) {
-		echo "  PASS: {$message}\n";
-		return;
-	}
-
-	echo "  FAIL: {$message}\n";
-	++$GLOBALS['__image_optimization_failures'];
-}
-
-function image_optimization_fixture( array $sizes ): void {
-	$GLOBALS['__image_optimization_attachments'] = array_keys( $sizes );
-	$GLOBALS['__image_optimization_files']       = array();
-	$GLOBALS['__image_optimization_queries']     = array();
-
-	foreach ( $sizes as $attachment_id => $size ) {
-		$file = tempnam( sys_get_temp_dir(), 'dm-image-scan-' );
-		file_put_contents( $file, str_repeat( 'x', $size ) );
-		$GLOBALS['__image_optimization_files'][ $attachment_id ] = $file;
-	}
-}
-
-function image_optimization_cleanup(): void {
-	foreach ( $GLOBALS['__image_optimization_files'] as $file ) {
-		unlink( $file );
-	}
 }
 }
 


### PR DESCRIPTION
## Summary
- paginate image attachment queries in deterministic 100-row pages until the eligible candidate limit is reached or attachments are exhausted
- expose `scanned_count`, `eligible_count`, and `scan_complete` so callers can distinguish partial from complete coverage
- add focused regressions for candidates beyond page one, eligible limits reached across pages, and complete exhausted scans

## Root Cause
`ImageOptimizationAbilities::optimizeImages()` passed `limit` directly to the newest-first `get_posts()` query and filtered by file size afterward. This treated `limit` as inspected rows, so eligible older attachments outside the newest window were never evaluated and dry runs could falsely report that no oversized images existed.

## Pagination And Coverage Contract
- `limit` now caps eligible results, not inspected attachments.
- Queries scan image attachments in bounded pages of 100 ordered by `date DESC, ID DESC`.
- Scanning stops when `limit` eligible images have been evaluated or a short page proves attachment exhaustion.
- `scanned_count` reports attachments actually evaluated for eligibility.
- `eligible_count` reports candidates selected by the scan.
- `scan_complete` is `false` when the eligible limit stops scanning and `true` when exhaustion is proven. A direct `attachment_id` request is complete for that explicitly bounded target.

## Verification
- `php tests/image-optimization-pagination-smoke.php` - passed all 11 focused assertions
- `php -l inc/Abilities/Media/ImageOptimizationAbilities.php && php -l tests/image-optimization-pagination-smoke.php` - passed
- `/var/lib/datamachine/workspace/data-machine/vendor/bin/phpcs --standard=phpcs.xml.dist inc/Abilities/Media/ImageOptimizationAbilities.php tests/image-optimization-pagination-smoke.php` - passed
- `git diff --check` - passed
- `composer audit --locked --no-interaction` - completed and reported 9 pre-existing advisories affecting 4 locked packages, plus system Composer deprecation notices; no dependencies changed in this PR

The worktree intentionally lacks bootstrapped dependencies, so the full PHPUnit suite was not run. The focused dependency-free regression test was used, and PHPCS was invoked from the read-only primary dependency tree against this worktree's changed files.

No production images, files, database rows, or other production state were modified.

Closes #3167