### PR TITLE
refactor: expose capability diagnostics

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -37,4 +37,5 @@ jobs:
       # undeclared inputs to a reusable workflow is a hard startup_failure.
       commands: ${{ github.event_name == 'pull_request' && 'review audit,review lint,review test,refactor lint' || github.event_name == 'workflow_dispatch' && 'review audit,review lint,review test' || 'review test' }}
       expected-commands: ${{ github.event_name == 'pull_request' && 'review audit,review lint,review test' || github.event_name == 'workflow_dispatch' && 'review audit,review lint,review test' || 'review test' }}
+      test-shards: '4'
     secrets: inherit

--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -37,5 +37,4 @@ jobs:
       # undeclared inputs to a reusable workflow is a hard startup_failure.
       commands: ${{ github.event_name == 'pull_request' && 'review audit,review lint,review test,refactor lint' || github.event_name == 'workflow_dispatch' && 'review audit,review lint,review test' || 'review test' }}
       expected-commands: ${{ github.event_name == 'pull_request' && 'review audit,review lint,review test' || github.event_name == 'workflow_dispatch' && 'review audit,review lint,review test' || 'review test' }}
-      test-shards: '4'
     secrets: inherit

--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -19,6 +19,7 @@ use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\PluginSettings;
+use DataMachine\Core\Bootstrap\DependencyChecker;
 use DataMachine\Api\Flows\FlowScheduleReconciler;
 use DataMachine\Engine\Tasks\RecurringRejectionTracker;
 use DataMachine\Engine\Tasks\RecurringScheduler;
@@ -222,11 +223,12 @@ class SystemAbilities {
 	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Shared diagnostic callback signature receives per-check options.
 	private function runSystemDiagnostics( array $options = array() ): array {
 		return array(
-			'version'     => defined( 'DATAMACHINE_VERSION' ) ? DATAMACHINE_VERSION : 'unknown',
-			'php_version' => PHP_VERSION,
-			'wp_version'  => get_bloginfo( 'version' ),
-			'abilities'   => $this->listRegisteredAbilities(),
-			'rest_status' => $this->checkRestApi(),
+			'version'      => defined( 'DATAMACHINE_VERSION' ) ? DATAMACHINE_VERSION : 'unknown',
+			'php_version'  => PHP_VERSION,
+			'wp_version'   => get_bloginfo( 'version' ),
+			'abilities'    => $this->listRegisteredAbilities(),
+			'rest_status'  => $this->checkRestApi(),
+			'capabilities' => DependencyChecker::report_all(),
 		);
 	}
 
@@ -274,7 +276,7 @@ class SystemAbilities {
 		$rejected_schedules = RecurringRejectionTracker::degraded();
 
 		$status = 'ok';
-		if ( ! function_exists( 'as_get_scheduled_actions' ) || ! class_exists( '\\ActionScheduler' ) ) {
+		if ( ! DependencyChecker::has( DependencyChecker::CHECK_ACTION_SCHEDULER ) ) {
 			$status = 'unavailable';
 		} elseif ( ! empty( $rejected_schedules ) ) {
 			$status = 'failing';
@@ -351,7 +353,7 @@ class SystemAbilities {
 			'stale_threshold_seconds' => $stale_threshold,
 			'rejected_schedules'      => $rejected_report,
 			'action_scheduler'        => array(
-				'available'        => function_exists( 'as_get_scheduled_actions' ),
+				'available'        => DependencyChecker::has( DependencyChecker::CHECK_ACTION_SCHEDULER ),
 				'class_loaded'     => class_exists( '\\ActionScheduler' ),
 				'is_initialized'   => class_exists( '\\ActionScheduler' ) && method_exists( '\\ActionScheduler', 'is_initialized' ) ? \ActionScheduler::is_initialized() : null,
 				'group'            => RecurringScheduler::GROUP,

--- a/inc/Core/Bootstrap/DependencyChecker.php
+++ b/inc/Core/Bootstrap/DependencyChecker.php
@@ -21,6 +21,17 @@ class DependencyChecker {
 	public const CHECK_WORDPRESS_ABILITIES = 'wordpress_abilities';
 	public const CHECK_ZIP_ARCHIVE         = 'zip_archive';
 
+	/** @return array<string,string> */
+	private static function checks(): array {
+		return array(
+			self::CHECK_ACTION_SCHEDULER    => 'Action Scheduler is available.',
+			self::CHECK_FILESYSTEM_WRITES   => 'The Data Machine directory is writable.',
+			self::CHECK_IMAP                => 'The PHP IMAP extension is available.',
+			self::CHECK_WORDPRESS_ABILITIES => 'The WordPress Abilities API is available.',
+			self::CHECK_ZIP_ARCHIVE         => 'The PHP Zip extension is available.',
+		);
+	}
+
 	/**
 	 * Run a named dependency/capability check.
 	 *
@@ -35,6 +46,51 @@ class DependencyChecker {
 			self::CHECK_WORDPRESS_ABILITIES => self::has_wordpress_abilities(),
 			self::CHECK_ZIP_ARCHIVE         => self::has_zip_archive(),
 			default                         => false,
+		};
+	}
+
+	/**
+	 * Return a structured result for one named check.
+	 *
+	 * @return array{available:bool,code:string,message:string}
+	 */
+	public static function report( string $check ): array {
+		$checks = self::checks();
+		if ( ! isset( $checks[ $check ] ) ) {
+			return array(
+				'available' => false,
+				'code'      => 'unknown_capability',
+				'message'   => 'Unknown dependency or capability check.',
+			);
+		}
+
+		$available = self::has( $check );
+
+		return array(
+			'available' => $available,
+			'code'      => $available ? 'available' : 'unavailable',
+			'message'   => $available ? $checks[ $check ] : self::unavailable_message( $check ),
+		);
+	}
+
+	/** @return array<string,array{available:bool,code:string,message:string}> */
+	public static function report_all(): array {
+		$report = array();
+		foreach ( array_keys( self::checks() ) as $check ) {
+			$report[ $check ] = self::report( $check );
+		}
+
+		return $report;
+	}
+
+	private static function unavailable_message( string $check ): string {
+		return match ( $check ) {
+			self::CHECK_ACTION_SCHEDULER    => 'Action Scheduler is unavailable.',
+			self::CHECK_FILESYSTEM_WRITES   => 'The Data Machine directory is not writable.',
+			self::CHECK_IMAP                => 'The PHP IMAP extension is unavailable.',
+			self::CHECK_WORDPRESS_ABILITIES => 'The WordPress Abilities API is unavailable.',
+			self::CHECK_ZIP_ARCHIVE         => 'The PHP Zip extension is unavailable.',
+			default                         => 'The dependency or capability is unavailable.',
 		};
 	}
 

--- a/tests/bootstrap-runtime-environment-smoke.php
+++ b/tests/bootstrap-runtime-environment-smoke.php
@@ -143,6 +143,34 @@ namespace {
 		! DependencyChecker::has( 'missing-check' )
 	);
 
+	$unknown_report = DependencyChecker::report( 'missing-check' );
+	$assert(
+		'unknown dependency reports are explicit',
+		false === $unknown_report['available']
+			&& 'unknown_capability' === $unknown_report['code']
+			&& '' !== $unknown_report['message']
+	);
+
+	$capability_report = DependencyChecker::report_all();
+	$assert(
+		'all named dependencies expose structured diagnostics',
+		array(
+			DependencyChecker::CHECK_ACTION_SCHEDULER,
+			DependencyChecker::CHECK_FILESYSTEM_WRITES,
+			DependencyChecker::CHECK_IMAP,
+			DependencyChecker::CHECK_WORDPRESS_ABILITIES,
+			DependencyChecker::CHECK_ZIP_ARCHIVE,
+		) === array_keys( $capability_report )
+			&& array_reduce(
+				$capability_report,
+				static fn( bool $valid, array $result ): bool => $valid
+					&& is_bool( $result['available'] ?? null )
+					&& in_array( $result['code'] ?? '', array( 'available', 'unavailable' ), true )
+					&& '' !== ( $result['message'] ?? '' ),
+				true
+			)
+	);
+
 	if ( $failed > 0 ) {
 		fwrite( fopen( 'php://stderr', 'w' ), "bootstrap runtime environment smoke failed: {$failed}/{$total}\n" );
 		exit( 1 );


### PR DESCRIPTION
## Summary
- add structured reports to the existing named dependency checker
- expose all host capability results through `datamachine/system-health-check`
- make scheduler diagnostics consume the canonical Action Scheduler check

## Scope
Agents API remains a bundled requirement rather than a conditional capability. Optional feature guards stay at their current boundaries until the domain extraction work moves IMAP and specialized ZIP consumers to their owning extensions.

This reuses the existing health ability/filter and does not add a parallel registry.

## Tests
- `php tests/bootstrap-runtime-environment-smoke.php` (9 assertions)
- `vendor/bin/phpcs inc/Core/Bootstrap/DependencyChecker.php inc/Abilities/SystemAbilities.php tests/bootstrap-runtime-environment-smoke.php`
- `git diff --check`

Fixes #2417

## AI assistance
- **AI assistance:** Yes
- **Tool:** OpenCode (GPT-5.6)
- **Used for:** Current-code audit, implementation, tests, and PR preparation.