### PR TITLE
fix: remove all plugin tables on uninstall

### DIFF
--- a/tests/uninstall-tables-smoke.php
+++ b/tests/uninstall-tables-smoke.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Pure-PHP smoke test for complete Data Machine table uninstall cleanup.
+ *
+ * Run with: php tests/uninstall-tables-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$root      = dirname( __DIR__ );
+$main      = file_get_contents( $root . '/data-machine.php' );
+$uninstall = file_get_contents( $root . '/uninstall.php' );
+$failures  = 0;
+$passes    = 0;
+
+function datamachine_uninstall_assert( bool $condition, string $message ): void {
+	global $failures, $passes;
+
+	if ( $condition ) {
+		++$passes;
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	++$failures;
+	fwrite( STDERR, "FAIL: {$message}\n" );
+}
+
+preg_match( '/function datamachine_ensure_all_tables\(\) \{(?<body>.*?)\n\}/s', $main, $ensure_match );
+$ensure_body = $ensure_match['body'] ?? '';
+
+$site_tables = array(
+	'LogRepository::TABLE_NAME'         => 'LogRepository::create_table',
+	'Pipelines::TABLE_NAME'             => '$db_pipelines->create_table',
+	'Flows::TABLE_NAME'                 => '$db_flows->create_table',
+	'Jobs::TABLE_NAME'                  => '$db_jobs->create_table',
+	'ProcessedItems::TABLE_NAME'        => '$db_processed_items->create_table',
+	'BatchItems::TABLE_NAME'            => 'BatchItems::create_table',
+	'TrackedItems::TABLE_NAME'          => '$db_tracked_items->create_table',
+	'PostIdentityIndex::TABLE_NAME'     => '$db_identity_index->create_table',
+	'PostIdentityReservations::TABLE_NAME' => 'PostIdentityReservations::create_table',
+	'InstalledBundleArtifacts::TABLE_NAME' => 'InstalledBundleArtifacts::create_table',
+	'RunMetadata::TABLE_NAME'           => 'RunMetadata::create_table',
+	'PendingActionStore::get_table_name' => 'PendingActionStore::create_table',
+);
+
+$network_tables = array(
+	'Agents::TABLE_NAME'                    => 'Agents::create_table',
+	'AgentAccess::TABLE_NAME'                => 'AgentAccess::create_table',
+	'AgentAccess::PRINCIPAL_TABLE_NAME'      => 'AgentAccess::create_table',
+	'AgentTokens::TABLE_NAME'                => 'AgentTokens::create_table',
+	'Chat::get_prefixed_table_name'          => 'Chat::create_table',
+);
+
+foreach ( $site_tables as $cleanup_name => $create_call ) {
+	datamachine_uninstall_assert( str_contains( $ensure_body, $create_call ), "schema setup creates site table via {$create_call}" );
+	datamachine_uninstall_assert( str_contains( $uninstall, $cleanup_name ), "uninstall drops site table via {$cleanup_name}" );
+}
+
+foreach ( $network_tables as $cleanup_name => $create_call ) {
+	datamachine_uninstall_assert( str_contains( $main, $create_call ), "schema setup creates network table via {$create_call}" );
+	datamachine_uninstall_assert( str_contains( $uninstall, $cleanup_name ), "uninstall drops network table via {$cleanup_name}" );
+}
+
+datamachine_uninstall_assert( 12 === count( $site_tables ), 'inventory contains all 12 site tables' );
+datamachine_uninstall_assert( 5 === count( $network_tables ), 'inventory contains all 5 network tables' );
+datamachine_uninstall_assert( str_contains( $uninstall, 'try {' ) && str_contains( $uninstall, '} finally {' ), 'multisite cleanup restores switched blogs with try/finally' );
+
+// Model nested WordPress blog switching to lock the restoration invariant: an
+// uninstall invoked while already switched must return to that original blog.
+$blog_stack  = array( 1, 7 );
+$original    = end( $blog_stack );
+$site_ids    = array( 1, 2, 7 );
+foreach ( $site_ids as $site_id ) {
+	$blog_stack[] = $site_id;
+	try {
+		// Site cleanup runs here in WordPress.
+	} finally {
+		array_pop( $blog_stack );
+	}
+}
+datamachine_uninstall_assert( $original === end( $blog_stack ), 'multisite iteration restores the original nested blog context' );
+
+echo "\n{$passes} passed, {$failures} failed.\n";
+exit( $failures > 0 ? 1 : 0 );

--- a/uninstall.php
+++ b/uninstall.php
@@ -13,6 +13,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
+require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/inc/Abilities/Media/ImageGenerationAbilities.php';
 require_once __DIR__ . '/inc/Abilities/SettingsAbilities.php';
 require_once __DIR__ . '/inc/Core/ActionScheduler/GroupRegistrar.php';
@@ -23,8 +24,11 @@ if ( is_multisite() ) {
 	$datamachine_sites = get_sites( array( 'fields' => 'ids' ) );
 	foreach ( $datamachine_sites as $datamachine_blog_id ) {
 		switch_to_blog( $datamachine_blog_id );
-		datamachine_uninstall_site();
-		restore_current_blog();
+		try {
+			datamachine_uninstall_site();
+		} finally {
+			restore_current_blog();
+		}
 	}
 
 	// Drop network-scoped tables once (base_prefix), after every subsite is done.
@@ -70,17 +74,24 @@ function datamachine_uninstall_site() {
 		// datamachine_uninstall_network_tables(), not here — dropping it per-site
 		// would destroy the shared table on the first subsite uninstall.
 		$datamachine_tables_to_drop = array(
-			$wpdb->prefix . 'datamachine_post_identity_reservations',
-			$wpdb->prefix . 'datamachine_processed_items',
-			$wpdb->prefix . 'datamachine_jobs',
-			$wpdb->prefix . 'datamachine_flows',
-			$wpdb->prefix . 'datamachine_pipelines',
+			\DataMachine\Engine\AI\Actions\PendingActionStore::get_table_name(),
+			$wpdb->prefix . \DataMachine\Core\Database\RunMetadata\RunMetadata::TABLE_NAME,
+			$wpdb->prefix . \DataMachine\Core\Database\BundleArtifacts\InstalledBundleArtifacts::TABLE_NAME,
+			$wpdb->prefix . \DataMachine\Core\Database\PostIdentityReservations\PostIdentityReservations::TABLE_NAME,
+			$wpdb->prefix . \DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex::TABLE_NAME,
+			$wpdb->prefix . \DataMachine\Core\Database\TrackedItems\TrackedItems::TABLE_NAME,
+			$wpdb->prefix . \DataMachine\Core\Database\BatchItems\BatchItems::TABLE_NAME,
+			$wpdb->prefix . \DataMachine\Core\Database\ProcessedItems\ProcessedItems::TABLE_NAME,
+			$wpdb->prefix . \DataMachine\Core\Database\Jobs\Jobs::TABLE_NAME,
+			$wpdb->prefix . \DataMachine\Core\Database\Flows\Flows::TABLE_NAME,
+			$wpdb->prefix . \DataMachine\Core\Database\Pipelines\Pipelines::TABLE_NAME,
+			$wpdb->prefix . \DataMachine\Core\Database\Logs\LogRepository::TABLE_NAME,
 		);
 
 		// On single-site, base_prefix === prefix, so the network table is dropped
 		// here alongside the per-site tables (there is no separate network pass).
 		if ( ! is_multisite() ) {
-			$datamachine_tables_to_drop[] = $wpdb->base_prefix . 'datamachine_chat_sessions';
+			$datamachine_tables_to_drop = array_merge( $datamachine_tables_to_drop, datamachine_get_network_table_names() );
 		}
 
 		foreach ( $datamachine_tables_to_drop as $datamachine_table_name ) {
@@ -129,20 +140,35 @@ function datamachine_uninstall_site() {
  * destroy the shared table on the first subsite uninstall.
  */
 function datamachine_uninstall_network_tables() {
-	global $wpdb;
-
 	if ( ! current_user_can( 'delete_plugins' ) && ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 		return;
 	}
 
-	$datamachine_network_tables = array(
-		$wpdb->base_prefix . 'datamachine_chat_sessions',
-	);
-
-	foreach ( $datamachine_network_tables as $datamachine_network_table ) {
+	foreach ( datamachine_get_network_table_names() as $datamachine_network_table ) {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $datamachine_network_table ) );
+		$GLOBALS['wpdb']->query( $GLOBALS['wpdb']->prepare( 'DROP TABLE IF EXISTS %i', $datamachine_network_table ) );
 	}
+}
+
+/**
+ * Get the network-scoped tables created by the current schema setup.
+ *
+ * The repository constants are the canonical unprefixed names used by each
+ * create_table() implementation. Order is reversed from dependencies so agent
+ * credentials and grants are removed before agent identities.
+ *
+ * @return string[] Full network table names.
+ */
+function datamachine_get_network_table_names() {
+	global $wpdb;
+
+	return array(
+		\DataMachine\Core\Database\Chat\Chat::get_prefixed_table_name(),
+		$wpdb->base_prefix . \DataMachine\Core\Database\Agents\AgentTokens::TABLE_NAME,
+		$wpdb->base_prefix . \DataMachine\Core\Database\Agents\AgentAccess::PRINCIPAL_TABLE_NAME,
+		$wpdb->base_prefix . \DataMachine\Core\Database\Agents\AgentAccess::TABLE_NAME,
+		$wpdb->base_prefix . \DataMachine\Core\Database\Agents\Agents::TABLE_NAME,
+	);
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove all 12 site-scoped and 5 network-scoped Data Machine tables
- derive names from canonical repository constants and table helpers
- restore nested multisite blog context with `try/finally`
- verify current schema creation and uninstall inventories remain aligned

## Before
Uninstall removed five site tables plus the shared chat table, leaving logs, batch/tracked items, identity indexes, bundle artifacts, run metadata, pending actions, and network agent/access/token tables behind.

## Tests
- `php tests/uninstall-tables-smoke.php` (38 assertions)
- `php tests/migration-runtime-smoke.php` (32 assertions)
- `vendor/bin/phpcs uninstall.php tests/uninstall-tables-smoke.php`
- PHP syntax and `git diff --check`

A packaged-plugin real-database uninstall remains part of the final 1.0 candidate verification.

Fixes #3170

## AI assistance
- **AI assistance:** Yes
- **Tool:** OpenCode (GPT-5.6)
- **Used for:** Schema inventory, implementation, tests, review, and PR preparation.