### PR TITLE
Add portable subagent bundle graphs

### DIFF
--- a/docs/core-system/agent-bundles.md
+++ b/docs/core-system/agent-bundles.md
@@ -104,9 +104,20 @@ Consumer plugins coordinate corpus and Markdown/frontmatter profile semantics ou
 - `bundle_version`: explicit bundle version for upgrade planning.
 - `source_ref` and `source_revision`: optional source coordinates.
 - `exported_at` and `exported_by`: export metadata.
-- `agent`: `slug`, `label`, `description`, and `agent_config` defaults.
+- `agent`: `slug`, `label`, `description`, and `agent_config` defaults. Optional
+  `skills` and `references` are `{path,sha256}` lists backed by package-owned
+  `skills/` and `references/` files; optional `tool_policy` and `skill_policy`
+  are projected with the root runtime graph node.
 - `included`: lists of `memory`, `pipelines`, `flows`, `prompts`, `rubrics`, `tool_policies`, `auth_refs`, and `seed_queues`, plus `handler_auth` mode.
 - `capabilities`: optional package-level capability strings required by the bundle.
+- `subagents`: optional coordinator child definitions. Each child includes its slug,
+  label, description, `agent_config`, identity memory files, tool policy, skills,
+  references, and child edge list. Data Machine validates unique slugs, containment,
+  resolved edges, no self-edge/cycle, and deterministic ordering before install.
+
+The graph is persisted in the existing `agent_config.subagents` field, avoiding a
+schema migration. Runtime adapters read it through the access-controlled
+`datamachine/project-agent-graph` ability or `wp datamachine agent graph <slug>`.
 
 `handler_auth` is one of:
 

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -161,7 +161,7 @@ class AgentAbilities {
 						),
 					),
 					'execute_callback'    => array( self::class, 'exportAgent' ),
-					'permission_callback' => fn() => PermissionHelper::can_manage(),
+					'permission_callback' => fn() => PermissionHelper::can( 'manage_agents' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -462,6 +462,20 @@ class AgentAbilities {
 							'idempotent' => true,
 						),
 					),
+				)
+			);
+
+			self::registerAbility(
+				'datamachine/project-agent-graph',
+				array(
+					'label'               => 'Project Agent Graph',
+					'description'         => 'Return the persisted coordinator graph, identity paths, and generic child runtime policy.',
+					'category'            => 'datamachine-agent',
+					'input_schema'        => array( 'type' => 'object', 'required' => array( 'slug' ), 'properties' => array( 'slug' => array( 'type' => 'string' ) ) ),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'projectAgentGraph' ),
+					'permission_callback' => fn() => PermissionHelper::can( 'manage_agents' ),
+					'meta'                => array( 'show_in_rest' => true, 'annotations' => array( 'readonly' => true, 'idempotent' => true ) ),
 				)
 			);
 
@@ -1535,6 +1549,11 @@ class AgentAbilities {
 	public static function listAgentBundles( array $input = array() ): array {
 		unset( $input );
 		return self::bundleLifecycleService()->list_installed();
+	}
+
+	/** @return array<string,mixed> */
+	public static function projectAgentGraph( array $input ): array {
+		return \DataMachine\Engine\Agents\PersistedAgentGraphProjector::project( (string) ( $input['slug'] ?? '' ) );
 	}
 
 	/**

--- a/inc/Cli/Commands/AgentBundleCommand.php
+++ b/inc/Cli/Commands/AgentBundleCommand.php
@@ -185,6 +185,20 @@ class AgentBundleCommand extends BaseCommand {
 	}
 
 	/**
+	 * Project a persisted coordinator graph for generic runtime adapters.
+	 *
+	 * @subcommand graph
+	 */
+	public function graph( array $args, array $assoc_args ): void {
+		$slug = (string) ( $args[0] ?? '' );
+		if ( '' === $slug ) {
+			WP_CLI::error( 'Agent slug is required.' );
+		}
+		$assoc_args['format'] = $assoc_args['format'] ?? 'json';
+		$this->output( \DataMachine\Abilities\AgentAbilities::projectAgentGraph( array( 'slug' => $slug ) ), $assoc_args, array( 'success', 'coordinator', 'nodes', 'error' ) );
+	}
+
+	/**
 	 * Show installed package status for an agent or package slug.
 	 *
 	 * Includes manifest drift detection when the on-disk bundle directory

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -38,11 +38,13 @@ use DataMachine\Engine\Bundle\AgentConfigArtifactProjector;
 use DataMachine\Engine\Bundle\AgentTemplateMetadata;
 use DataMachine\Engine\Bundle\AgentPackageProjection;
 use DataMachine\Engine\Bundle\BundleSchema;
+use DataMachine\Engine\Bundle\BundleRelativePath;
 use DataMachine\Engine\Bundle\BundleValidationException;
 use DataMachine\Engine\Bundle\PortableSlug;
 use DataMachine\Engine\Bundle\PromptArtifact;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Engine\AI\System\SystemTaskPromptRegistry;
+use DataMachine\Engine\Agents\AgentSubagentGraph;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -72,6 +74,12 @@ class AgentBundler {
 	 * @var DirectoryManager
 	 */
 	private DirectoryManager $directory_manager;
+
+	/** @var array<string,string|null> Original contents, keyed by mutated path. */
+	private array $filesystem_journal = array();
+
+	/** @var array<string,array{agent_id:int,snapshot:array{artifact_id:string,exists:bool,content:?string}}> */
+	private array $identity_journal = array();
 
 	public function __construct() {
 		$this->agents_repo       = new Agents();
@@ -232,6 +240,13 @@ class AgentBundler {
 			\DataMachine\Engine\Bundle\BundleSchema::PROMPTS_DIR => SystemTaskPromptRegistry::bundle_prompt_files(),
 		);
 		$extension_paths = array_map( static fn( array $artifact ) => (string) ( $artifact['source_path'] ?? '' ), $extension_artifacts );
+		$subagents       = $this->export_subagents( is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array() );
+		$root_subagent   = is_array( $agent['agent_config']['datamachine_subagent'] ?? null ) ? $agent['agent_config']['datamachine_subagent'] : array();
+		$coordinator_edges = AgentSubagentGraph::coordinator_edges(
+			is_array( $agent['agent_config'] ?? null ) ? ( $agent['agent_config']['subagents'] ?? array() ) : array(),
+			$subagents,
+			(string) $agent['agent_slug']
+		);
 		$manifest        = new AgentBundleManifest(
 			gmdate( 'c' ),
 			defined( 'DATAMACHINE_VERSION' ) ? 'data-machine/' . DATAMACHINE_VERSION : 'data-machine/unknown',
@@ -247,6 +262,11 @@ class AgentBundler {
 					is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array(),
 					(string) ( $context['profile'] ?? 'share' )
 				),
+				'subagents'    => $coordinator_edges,
+				'tool_policy'  => is_array( $root_subagent['tool_policy'] ?? null ) ? $root_subagent['tool_policy'] : array(),
+				'skill_policy' => is_array( $root_subagent['skill_policy'] ?? null ) ? $root_subagent['skill_policy'] : array(),
+				'skills'       => $this->collect_subagent_runtime_artifacts( (string) $agent['agent_slug'], is_array( $root_subagent['skills'] ?? null ) ? $root_subagent['skills'] : array(), 'skills' ),
+				'references'   => $this->collect_subagent_runtime_artifacts( (string) $agent['agent_slug'], is_array( $root_subagent['references'] ?? null ) ? $root_subagent['references'] : array(), 'references' ),
 				// Preserve the agent's actual scope through the bundle round-trip:
 				// null = network-wide, positive int = a specific blog. The manifest
 				// drops legacy/unknown values so import never re-pins to a blog.
@@ -259,7 +279,10 @@ class AgentBundler {
 				'prompts'      => array_keys( $artifact_files[ \DataMachine\Engine\Bundle\BundleSchema::PROMPTS_DIR ] ),
 				'extensions'   => array_values( array_filter( $extension_paths ) ),
 				'handler_auth' => $handler_auth,
-			)
+			),
+			array(),
+			array(),
+			$subagents
 		);
 
 		$extras    = self::collect_export_extras( $agent_id, $agent );
@@ -271,6 +294,40 @@ class AgentBundler {
 			'directory' => $directory,
 			'package'   => AgentPackageProjection::from_directory( $directory ),
 		);
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private function export_subagents( array $coordinator_config ): array {
+		$edges = AgentSubagentGraph::edges_from_config( $coordinator_config['subagents'] ?? array() );
+		$nodes = array();
+		while ( ! empty( $edges ) ) {
+			$slug = array_shift( $edges );
+			if ( isset( $nodes[ $slug ] ) ) {
+				continue;
+			}
+			$child = $this->agents_repo->get_by_slug( $slug );
+			if ( ! $child ) {
+				throw new BundleValidationException( sprintf( 'Coordinator edge %s does not resolve to a persisted agent.', esc_html( $slug ) ) );
+			}
+			$config    = is_array( $child['agent_config'] ?? null ) ? $child['agent_config'] : array();
+			$subagent  = is_array( $config['datamachine_subagent'] ?? null ) ? $config['datamachine_subagent'] : array();
+			$memory    = $this->collect_agent_files( (string) $child['agent_slug'] );
+			$node      = array(
+				'slug'         => (string) $child['agent_slug'],
+				'label'        => (string) $child['agent_name'],
+				'description'  => (string) ( $config['description'] ?? '' ),
+				'agent_config' => AgentBundleAgentConfig::export_payload( $config ),
+				'memory'       => $memory,
+				'tool_policy'  => is_array( $subagent['tool_policy'] ?? null ) ? $subagent['tool_policy'] : array(),
+				'skill_policy' => is_array( $subagent['skill_policy'] ?? null ) ? $subagent['skill_policy'] : array(),
+				'skills'       => $this->collect_subagent_runtime_artifacts( (string) $child['agent_slug'], is_array( $subagent['skills'] ?? null ) ? $subagent['skills'] : array(), 'skills' ),
+				'references'   => $this->collect_subagent_runtime_artifacts( (string) $child['agent_slug'], is_array( $subagent['references'] ?? null ) ? $subagent['references'] : array(), 'references' ),
+				'subagents'    => AgentSubagentGraph::edges_from_config( $config['subagents'] ?? array(), (string) $child['agent_slug'] ),
+			);
+			$nodes[ $slug ] = $node;
+			$edges          = array_merge( $edges, $node['subagents'] );
+		}
+		return AgentSubagentGraph::normalize( array_values( $nodes ) );
 	}
 
 	/**
@@ -566,14 +623,27 @@ class AgentBundler {
 				);
 			}
 
-			return $this->import_directory_materialization(
-				$directory,
-				$new_slug,
-				$owner_id,
-				$dry_run,
-				$options,
-				is_array( $bundle['abilities_manifest'] ?? null ) ? $bundle['abilities_manifest'] : array()
-			);
+			$payload = AgentBundleArrayAdapter::to_import_payload( $directory );
+			$payload['abilities_manifest'] = is_array( $bundle['abilities_manifest'] ?? null ) ? $bundle['abilities_manifest'] : array();
+			try {
+				$this->validate_import_file_maps( $payload );
+			} catch ( BundleValidationException $e ) {
+				return array( 'success' => false, 'error_code' => 'install_invalid_bundle', 'error' => $e->getMessage() );
+			}
+			if ( ! empty( $payload['subagents'] ) && empty( $options['_graph_node'] ) ) {
+				return $this->import_subagent_graph( $payload, $new_slug, $owner_id, $dry_run, $options );
+			}
+			return $this->materialize_import_bundle( $payload, $new_slug, $owner_id, $dry_run, $options );
+		}
+
+		try {
+			$this->validate_import_file_maps( $bundle );
+		} catch ( BundleValidationException $e ) {
+			return array( 'success' => false, 'error_code' => 'install_invalid_bundle', 'error' => $e->getMessage() );
+		}
+
+		if ( ! empty( $bundle['subagents'] ) && empty( $options['_graph_node'] ) ) {
+			return $this->import_subagent_graph( $bundle, $new_slug, $owner_id, $dry_run, $options );
 		}
 
 		return $this->materialize_import_bundle( $bundle, $new_slug, $owner_id, $dry_run, $options );
@@ -692,7 +762,19 @@ class AgentBundler {
 		$created_agent_id     = 0; // Tracks an agent row this call inserted, for manual rollback.
 		$created_pipeline_ids = array();
 		$created_flow_ids     = array();
-		$transaction_started  = $this->begin_transaction();
+		$root_import          = empty( $options['_graph_transaction'] );
+		if ( $root_import ) {
+			$this->filesystem_journal = array();
+			$this->identity_journal   = array();
+		}
+		$transaction_started  = $root_import ? $this->begin_transaction() : false;
+		if ( $root_import && ! $transaction_started ) {
+			return array(
+				'success'    => false,
+				'error_code' => 'install_transaction_unavailable',
+				'error'      => 'Agent installation requires a database transaction.',
+			);
+		}
 
 		try {
 			// Test fault-injection seam. Production code path is a no-op. Tests load the
@@ -704,12 +786,37 @@ class AgentBundler {
 			$incoming_config = $agent_data['agent_config'] ?? array();
 
 			$incoming_config                = is_array( $incoming_config ) ? $incoming_config : array();
+			$root_artifacts                 = array();
+			foreach ( array( 'skills', 'references' ) as $kind ) {
+				if ( array_key_exists( $kind, $agent_data ) && is_array( $agent_data[ $kind ] ) ) {
+					$root_artifacts[ $kind ] = $agent_data[ $kind ];
+				}
+			}
+			$artifact_file_conflicts = array();
+			$existing_root_metadata  = is_array( $existing['agent_config']['datamachine_subagent'] ?? null ) ? $existing['agent_config']['datamachine_subagent'] : array();
+			foreach ( $root_artifacts as $kind => $files ) {
+				$this->detect_locally_modified_subagent_artifacts( $slug, $kind, $files, is_array( $existing_root_metadata[ $kind ] ?? null ) ? $existing_root_metadata[ $kind ] : array(), $artifact_file_conflicts );
+			}
+			if ( ! empty( $root_artifacts ) || array_key_exists( 'skill_policy', $agent_data ) || array_key_exists( 'tool_policy', $agent_data ) ) {
+				$incoming_config['datamachine_subagent'] = array_merge(
+					is_array( $incoming_config['datamachine_subagent'] ?? null ) ? $incoming_config['datamachine_subagent'] : array(),
+					array_filter(
+						array(
+							'tool_policy'  => is_array( $agent_data['tool_policy'] ?? null ) ? $agent_data['tool_policy'] : null,
+							'skill_policy' => is_array( $agent_data['skill_policy'] ?? null ) ? $agent_data['skill_policy'] : null,
+							'skills'       => isset( $root_artifacts['skills'] ) ? $this->subagent_artifact_metadata( $root_artifacts['skills'] ) : null,
+							'references'   => isset( $root_artifacts['references'] ) ? $this->subagent_artifact_metadata( $root_artifacts['references'] ) : null,
+						),
+						static fn( $value ) => null !== $value
+					)
+				);
+			}
 			$existing_bundle_state          = is_array( $existing['agent_config']['datamachine_bundle'] ?? null )
 				? $existing['agent_config']['datamachine_bundle']
 				: array();
 			$artifact_records               = $existing ? AgentBundleArtifactState::installed_for_agent( $existing ) : array();
 			$artifact_records               = self::index_artifacts( $artifact_records );
-			$config_conflicts               = array();
+			$config_conflicts               = $artifact_file_conflicts;
 			$agent_config_key               = self::artifact_key( 'agent_config', 'config' );
 			$incoming_config_payload        = AgentBundleAgentConfig::tracked_payload( $incoming_config );
 			$current_config_payload         = AgentBundleAgentConfig::tracked_payload( is_array( $existing['agent_config'] ?? null ) ? $existing['agent_config'] : array() );
@@ -788,6 +895,11 @@ class AgentBundler {
 			// (MEMORY.md, WAKE.md, daily/*) must never be clobbered by a deploy.
 			if ( ! $existing ) {
 				$this->write_agent_files( $slug, $agent_id, $owner_id, $bundle['files'] ?? array() );
+			}
+			if ( empty( $config_conflicts ) ) {
+				foreach ( $root_artifacts as $kind => $files ) {
+					$this->write_guarded_subagent_runtime_artifacts( $slug, $kind, $files, is_array( $existing_root_metadata[ $kind ] ?? null ) ? $existing_root_metadata[ $kind ] : array(), $config_conflicts );
+				}
 			}
 
 			// 3. Write USER.md template if provided.
@@ -1121,6 +1233,7 @@ class AgentBundler {
 				// Materialize authored identity through the memory store seam on
 				// BOTH fresh install and upgrade, so non-disk stores receive the
 				// content (write_agent_files only touches the disk store).
+				$this->journal_identity_artifact( $agent_id, (string) $artifact['artifact_id'] );
 				$applied = AgentBundleMemoryArtifact::apply( $artifact, $agent_id );
 				if ( is_wp_error( $applied ) ) {
 					$conflicts[] = array(
@@ -1237,6 +1350,10 @@ class AgentBundler {
 			}
 
 			$this->commit_transaction( $transaction_started );
+			if ( $root_import ) {
+				$this->filesystem_journal = array();
+				$this->identity_journal   = array();
+			}
 
 			$extras = is_array( $bundle['extras'] ?? null ) ? $bundle['extras'] : array();
 			try {
@@ -1313,7 +1430,11 @@ class AgentBundler {
 			// Roll back any DB writes from this call. Run native ROLLBACK first; if the underlying engine
 			// (e.g. the SQLite drop-in) silently no-ops on rollback, fall back to manual cleanup of rows
 			// we created so the next install attempt sees a clean slate.
-			$this->rollback_transaction( $transaction_started );
+			$rollback_error = $this->rollback_transaction( $transaction_started );
+			if ( $root_import ) {
+				$this->rollback_filesystem();
+				$this->rollback_identity();
+			}
 			$this->manual_rollback( $created_agent_id, $created_pipeline_ids, $created_flow_ids );
 
 			do_action(
@@ -1329,10 +1450,14 @@ class AgentBundler {
 				)
 			);
 
+			$error = sprintf( 'Agent install rolled back: %s', $e->getMessage() );
+			if ( null !== $rollback_error ) {
+				$error .= sprintf( ' Rollback also failed: %s', $rollback_error );
+			}
 			return array(
 				'success'    => false,
 				'error_code' => 'install_post_claim_failure',
-				'error'      => sprintf( 'Agent install rolled back: %s', $e->getMessage() ),
+				'error'      => $error,
 			);
 		}
 	}
@@ -1364,21 +1489,204 @@ class AgentBundler {
 	 */
 	private function import_directory_materialization( AgentBundleDirectory $directory, ?string $new_slug, int $owner_id, bool $dry_run, array $options, array $abilities_manifest = array() ): array {
 		$payload = AgentBundleArrayAdapter::to_import_payload( $directory );
+		try {
+			$this->validate_import_file_maps( $payload );
+		} catch ( BundleValidationException $e ) {
+			return array( 'success' => false, 'error_code' => 'install_invalid_bundle', 'error' => $e->getMessage() );
+		}
 		if ( ! empty( $abilities_manifest ) ) {
 			$payload['abilities_manifest'] = $abilities_manifest;
 		}
 
+		if ( ! empty( $payload['subagents'] ) && empty( $options['_graph_node'] ) ) {
+			return $this->import_subagent_graph( $payload, $new_slug, $owner_id, $dry_run, $options );
+		}
+
 		return $this->materialize_import_bundle( $payload, $new_slug, $owner_id, $dry_run, $options );
+	}
+
+	/** Validate every raw legacy file map before an import can mutate the filesystem. */
+	private function validate_import_file_maps( array $bundle ): void {
+		$this->validate_file_map( $bundle['files'] ?? array(), 'agent memory' );
+		foreach ( $bundle['pipelines'] ?? array() as $pipeline ) {
+			if ( is_array( $pipeline ) ) {
+				$this->validate_file_map( $pipeline['memory_file_contents'] ?? array(), 'pipeline memory' );
+			}
+		}
+		foreach ( $bundle['flows'] ?? array() as $flow ) {
+			if ( is_array( $flow ) ) {
+				$this->validate_file_map( $flow['memory_file_contents'] ?? array(), 'flow memory' );
+			}
+		}
+		$this->validate_file_map( $bundle['agent']['skills'] ?? array(), 'agent skill' );
+		$this->validate_file_map( $bundle['agent']['references'] ?? array(), 'agent reference' );
+		foreach ( $bundle['subagents'] ?? array() as $child ) {
+			if ( ! is_array( $child ) ) {
+				continue;
+			}
+			$this->validate_file_map( $child['memory'] ?? array(), 'subagent memory' );
+			$this->validate_file_map( $child['skills'] ?? array(), 'subagent skill' );
+			$this->validate_file_map( $child['references'] ?? array(), 'subagent reference' );
+		}
+	}
+
+	/** @param mixed $files */
+	private function validate_file_map( mixed $files, string $label ): void {
+		if ( ! is_array( $files ) ) {
+			return;
+		}
+		foreach ( $files as $path => $_contents ) {
+			BundleRelativePath::validate( (string) $path, $label );
+		}
+	}
+
+	/**
+	 * Materialize a package coordinator and all of its declared child agents.
+	 *
+	 * The outer transaction covers every database-backed node. Filesystem writes
+	 * retain the existing importer semantics; authored identity upgrades remain
+	 * protected by the per-node artifact ledger.
+	 */
+	private function import_subagent_graph( array $bundle, ?string $new_slug, int $owner_id, bool $dry_run, array $options ): array {
+		try {
+			$coordinator_slug = sanitize_title( (string) ( $new_slug ?? ( $bundle['agent']['agent_slug'] ?? '' ) ) );
+			$children          = AgentSubagentGraph::normalize( $bundle['subagents'], $coordinator_slug );
+			$coordinator_edges = AgentSubagentGraph::coordinator_edges( $bundle['agent']['subagents'] ?? array(), $children, $coordinator_slug );
+		} catch ( BundleValidationException $e ) {
+			return array(
+				'success'    => false,
+				'error_code' => 'install_invalid_subagent_graph',
+				'error'      => $e->getMessage(),
+			);
+		}
+
+		if ( $dry_run ) {
+			$probe                 = $bundle;
+			unset( $probe['subagents'] );
+			$probe['agent']['subagents'] = $coordinator_edges;
+			$result                = $this->import( $probe, $new_slug, $owner_id, true, array_merge( $options, array( '_graph_node' => true ) ) );
+			$result['summary']['subagents'] = $coordinator_edges;
+			return $result;
+		}
+
+		$transaction_started      = $this->begin_transaction();
+		if ( ! $transaction_started ) {
+			return array(
+				'success'    => false,
+				'error_code' => 'install_subagent_graph_transaction_unavailable',
+				'error'      => 'Subagent graph installation requires a database transaction.',
+			);
+		}
+		$this->filesystem_journal = array();
+		$this->identity_journal   = array();
+		$created_graph_agents     = array();
+		try {
+			foreach ( $children as $child ) {
+				$existing_child = $this->agents_repo->get_by_slug( $child['slug'] );
+				if ( ! $existing_child ) {
+					continue;
+				}
+				$metadata = is_array( $existing_child['agent_config']['datamachine_subagent'] ?? null ) ? $existing_child['agent_config']['datamachine_subagent'] : array();
+				$conflicts = array();
+				foreach ( array( 'skills', 'references' ) as $kind ) {
+					$this->detect_locally_modified_subagent_artifacts( $child['slug'], $kind, $child[ $kind ], is_array( $metadata[ $kind ] ?? null ) ? $metadata[ $kind ] : array(), $conflicts );
+				}
+				if ( ! empty( $conflicts ) ) {
+					$this->rollback_transaction( $transaction_started );
+					return array( 'success' => false, 'error_code' => 'install_subagent_graph_local_modified', 'error' => sprintf( 'Subagent %s has locally modified package artifacts.', $child['slug'] ), 'conflicts' => $conflicts );
+				}
+			}
+			foreach ( $children as $child ) {
+				$existing_child = $this->agents_repo->get_by_slug( $child['slug'] );
+				$child_existed = (bool) $existing_child;
+				$child_bundle = array(
+					'bundle_version' => $bundle['bundle_version'],
+					'bundle_slug'    => $bundle['bundle_slug'],
+					'source_ref'     => $bundle['source_ref'] ?? '',
+					'source_revision'=> $bundle['source_revision'] ?? '',
+					'agent'           => array(
+						'agent_slug'   => $child['slug'],
+						'agent_name'   => $child['label'],
+						'agent_config' => array_merge(
+							$child['agent_config'],
+							array(
+								'description'          => $child['description'],
+								'subagents'            => $child['subagents'],
+								'datamachine_subagent' => array(
+									'tool_policy' => $child['tool_policy'],
+									'skill_policy' => $child['skill_policy'],
+									'skills'      => $this->subagent_artifact_metadata( $child['skills'] ),
+									'references'  => $this->subagent_artifact_metadata( $child['references'] ),
+								),
+							)
+						),
+					),
+					'files'          => $child['memory'],
+					'skills'         => $child['skills'],
+					'references'     => $child['references'],
+					'skill_policy'   => $child['skill_policy'],
+					'tool_policy'    => $child['tool_policy'],
+					'pipelines'      => array(),
+					'flows'          => array(),
+				);
+				$result = $this->import( $child_bundle, null, $owner_id, false, array_merge( $options, array( '_graph_node' => true, '_graph_transaction' => true ) ) );
+				if ( empty( $result['success'] ) ) {
+					throw new \RuntimeException( (string) ( $result['error'] ?? 'Failed to import subagent.' ) );
+				}
+				if ( ! $child_existed && ! empty( $result['summary']['agent_id'] ) ) {
+					$created_graph_agents[] = array( 'agent_id' => (int) $result['summary']['agent_id'], 'slug' => $child['slug'] );
+				}
+				$this->write_subagent_runtime_artifacts( $child['slug'], $child['skills'], $child['references'] );
+			}
+
+			unset( $bundle['subagents'] );
+			$bundle['agent']['subagents'] = $coordinator_edges;
+			$bundle['agent']['agent_config'] = array_merge(
+				is_array( $bundle['agent']['agent_config'] ?? null ) ? $bundle['agent']['agent_config'] : array(),
+				array( 'subagents' => $coordinator_edges )
+			);
+			$coordinator_existed = (bool) $this->agents_repo->get_by_slug( $coordinator_slug );
+			$result = $this->import( $bundle, $new_slug, $owner_id, false, array_merge( $options, array( '_graph_node' => true, '_graph_transaction' => true ) ) );
+			if ( empty( $result['success'] ) ) {
+				throw new \RuntimeException( (string) ( $result['error'] ?? 'Failed to import coordinator.' ) );
+			}
+			if ( ! $coordinator_existed && ! empty( $result['summary']['agent_id'] ) ) {
+				$created_graph_agents[] = array( 'agent_id' => (int) $result['summary']['agent_id'], 'slug' => $coordinator_slug );
+			}
+			$this->commit_transaction( $transaction_started );
+			$this->filesystem_journal = array();
+			$this->identity_journal   = array();
+			$result['summary']['subagents'] = $coordinator_edges;
+			return $result;
+		} catch ( \Throwable $e ) {
+			$rollback_error = $this->rollback_transaction( $transaction_started );
+			$this->rollback_filesystem();
+			$this->rollback_identity();
+			foreach ( $created_graph_agents as $created ) {
+				$this->safe_graph_agent_rollback( (int) $created['agent_id'], (string) $created['slug'] );
+			}
+			$error = sprintf( 'Subagent graph install rolled back: %s', $e->getMessage() );
+			if ( null !== $rollback_error ) {
+				$error .= sprintf( ' Rollback also failed: %s', $rollback_error );
+			}
+			return array(
+				'success'    => false,
+				'error_code' => 'install_subagent_graph_rolled_back',
+				'error'      => $error,
+			);
+		}
 	}
 
 	/**
 	 * Open a DB transaction for the import critical section.
 	 *
 	 * Returns true when the engine accepted `START TRANSACTION`. SQLite via the Studio drop-in maps this
-	 * to `BEGIN`. If the engine refuses (returns false), we still proceed — the manual_rollback() path
-	 * is the safety net that cleans up any rows we know we created.
+	 * to `BEGIN`. Imports fail closed when an atomic transaction cannot be opened.
 	 */
 	private function begin_transaction(): bool {
+		if ( ! apply_filters( 'datamachine_bundle_import_transaction_available', true ) ) {
+			return false;
+		}
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		$result = $wpdb->query( 'START TRANSACTION' );
@@ -1392,16 +1700,116 @@ class AgentBundler {
 		}
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
-		$wpdb->query( 'COMMIT' );
+		if ( false === $wpdb->query( 'COMMIT' ) ) {
+			throw new \RuntimeException( sprintf( 'Database COMMIT failed: %s', (string) ( $wpdb->last_error ?? 'unknown database error' ) ) );
+		}
 	}
 
-	private function rollback_transaction( bool $started ): void {
+	private function rollback_transaction( bool $started ): ?string {
 		if ( ! $started ) {
-			return;
+			return null;
 		}
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
-		$wpdb->query( 'ROLLBACK' );
+		if ( false === $wpdb->query( 'ROLLBACK' ) ) {
+			return (string) ( $wpdb->last_error ?? 'unknown database error' );
+		}
+		return null;
+	}
+
+	private function write_journaled_file( string $path, string $contents ): void {
+		if ( ! array_key_exists( $path, $this->filesystem_journal ) ) {
+			$this->filesystem_journal[ $path ] = is_file( $path ) ? (string) file_get_contents( $path ) : null;
+		}
+		if ( ! is_dir( dirname( $path ) ) ) {
+			wp_mkdir_p( dirname( $path ) );
+		}
+		if ( false === file_put_contents( $path, $contents ) ) {
+			throw new \RuntimeException( sprintf( 'Failed to write bundle file %s.', $path ) );
+		}
+	}
+
+	private function rollback_filesystem(): void {
+		foreach ( array_reverse( $this->filesystem_journal, true ) as $path => $previous ) {
+			if ( null === $previous ) {
+				if ( is_file( $path ) ) {
+					unlink( $path );
+				}
+			} else {
+				wp_mkdir_p( dirname( $path ) );
+				file_put_contents( $path, $previous );
+			}
+		}
+		$this->filesystem_journal = array();
+	}
+
+	private function journal_identity_artifact( int $agent_id, string $artifact_id ): void {
+		$key = $agent_id . ':' . $artifact_id;
+		if ( isset( $this->identity_journal[ $key ] ) ) {
+			return;
+		}
+		$snapshot = AgentBundleMemoryArtifact::snapshot( $agent_id, $artifact_id );
+		if ( is_array( $snapshot ) ) {
+			$this->identity_journal[ $key ] = array( 'agent_id' => $agent_id, 'snapshot' => $snapshot );
+		}
+	}
+
+	private function rollback_identity(): void {
+		foreach ( array_reverse( $this->identity_journal, true ) as $entry ) {
+			AgentBundleMemoryArtifact::restore( $entry['agent_id'], $entry['snapshot'] );
+		}
+		$this->identity_journal = array();
+	}
+
+	/** @param array<string,string> $skills @param array<string,string> $references */
+	private function write_subagent_runtime_artifacts( string $slug, array $skills, array $references ): void {
+		$root = $this->directory_manager->get_agent_identity_directory( $slug );
+		foreach ( array( 'skills' => $skills, 'references' => $references ) as $kind => $files ) {
+			foreach ( $files as $path => $contents ) {
+				$this->write_journaled_file( BundleRelativePath::contained_join( $root . '/' . $kind, (string) $path, 'subagent artifact' ), $contents );
+			}
+		}
+	}
+
+	/** @param array<string,string> $files @param array<string,string> $installed_hashes @param array<int,array<string,string>> $conflicts */
+	private function write_guarded_subagent_runtime_artifacts( string $slug, string $kind, array $files, array $installed_hashes, array &$conflicts ): void {
+		$root = $this->directory_manager->get_agent_identity_directory( $slug ) . '/' . $kind;
+		foreach ( $files as $path => $contents ) {
+			$path   = (string) $path;
+			$target = BundleRelativePath::contained_join( $root, $path, 'subagent artifact' );
+			$installed_hash = $installed_hashes[ $path ] ?? null;
+			if ( is_string( $installed_hash ) && is_file( $target ) ) {
+				$current = file_get_contents( $target );
+				if ( is_string( $current ) && ! hash_equals( $installed_hash, hash( 'sha256', $current ) ) ) {
+					$conflicts[] = array( 'artifact_type' => 'subagent_' . rtrim( $kind, 's' ), 'artifact_id' => $path, 'reason' => 'local_modified' );
+					continue;
+				}
+			}
+			$this->write_journaled_file( $target, $contents );
+		}
+	}
+
+	/** @param array<string,string> $files @param array<string,string> $installed_hashes @param array<int,array<string,string>> $conflicts */
+	private function detect_locally_modified_subagent_artifacts( string $slug, string $kind, array $files, array $installed_hashes, array &$conflicts ): void {
+		$root = $this->directory_manager->get_agent_identity_directory( $slug ) . '/' . $kind;
+		foreach ( $files as $path => $_contents ) {
+			$path = ltrim( str_replace( '\\', '/', $path ), '/' );
+			$installed_hash = $installed_hashes[ $path ] ?? null;
+			$current = is_file( $root . '/' . $path ) ? file_get_contents( $root . '/' . $path ) : false;
+			if ( is_string( $installed_hash ) && is_string( $current ) && ! hash_equals( $installed_hash, hash( 'sha256', $current ) ) ) {
+				$conflicts[] = array( 'artifact_type' => 'subagent_' . rtrim( $kind, 's' ), 'artifact_id' => $slug . '/' . $path, 'reason' => 'local_modified' );
+			}
+		}
+	}
+
+	/** @param array<string,string> $files @return array<string,string> */
+	private function subagent_artifact_metadata( array $files ): array {
+		$metadata = array();
+		foreach ( $files as $path => $contents ) {
+			$metadata[ $path ] = hash( 'sha256', $contents );
+		}
+		ksort( $metadata, SORT_STRING );
+		return $metadata;
 	}
 
 	/**
@@ -1428,6 +1836,14 @@ class AgentBundler {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->delete( $agents_table, array( 'agent_id' => (int) $created_agent_id ), array( '%d' ) );
 		}
+	}
+
+	private function safe_graph_agent_rollback( int $agent_id, string $slug ): void {
+		$row = $this->agents_repo->get_agent( $agent_id );
+		if ( ! $row || (string) ( $row['agent_slug'] ?? '' ) !== $slug ) {
+			return;
+		}
+		$this->manual_rollback( $agent_id, array(), array() );
 	}
 
 	private function bundle_has_portable_artifacts( array $bundle ): bool {
@@ -1670,6 +2086,25 @@ class AgentBundler {
 		return $files;
 	}
 
+	/** @param array<string,string> $metadata @return array<string,string> */
+	private function collect_subagent_runtime_artifacts( string $slug, array $metadata, string $kind ): array {
+		$files = array();
+		$root  = $this->directory_manager->get_agent_identity_directory( $slug ) . '/' . $kind;
+		foreach ( $metadata as $path => $sha256 ) {
+			$path = ltrim( str_replace( '\\', '/', (string) $path ), '/' );
+			if ( '' === $path || str_contains( $path, '..' ) || ! is_string( $sha256 ) ) {
+				throw new BundleValidationException( sprintf( 'Subagent %s has invalid %s metadata.', esc_html( $slug ), esc_html( $kind ) ) );
+			}
+			$contents = file_get_contents( $root . '/' . $path );
+			if ( ! is_string( $contents ) || ! hash_equals( $sha256, hash( 'sha256', $contents ) ) ) {
+				throw new BundleValidationException( sprintf( 'Subagent %s %s artifact is missing or modified: %s.', esc_html( $slug ), esc_html( $kind ), esc_html( $path ) ) );
+			}
+			$files[ $path ] = $contents;
+		}
+		ksort( $files, SORT_STRING );
+		return $files;
+	}
+
 	/**
 	 * Collect USER.md template for the agent owner.
 	 *
@@ -1827,7 +2262,8 @@ class AgentBundler {
 		$this->directory_manager->ensure_directory_exists( $agent_dir );
 
 		foreach ( $files as $relative_path => $content ) {
-			$relative_path = str_replace( '\\', '/', (string) $relative_path );
+			$relative_path = (string) $relative_path;
+			BundleRelativePath::validate( $relative_path, 'agent memory' );
 
 			// Authored identity (SOUL.md) is materialized through the memory
 			// store seam by the importer's memory-artifact block, on both fresh
@@ -1842,7 +2278,7 @@ class AgentBundler {
 				continue;
 			}
 
-			$full_path = $agent_dir . '/' . $relative_path;
+			$full_path = BundleRelativePath::contained_join( $agent_dir, $relative_path, 'agent memory' );
 
 			// Ensure subdirectories exist (e.g., contexts/).
 			$dir = dirname( $full_path );
@@ -1850,7 +2286,7 @@ class AgentBundler {
 				wp_mkdir_p( $dir );
 			}
 
-			file_put_contents( $full_path, $content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			$this->write_journaled_file( $full_path, (string) $content );
 		}
 	}
 
@@ -1875,7 +2311,7 @@ class AgentBundler {
 			wp_mkdir_p( $user_dir );
 		}
 
-		file_put_contents( $path, $content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		$this->write_journaled_file( $path, $content );
 	}
 
 	/**
@@ -1893,12 +2329,12 @@ class AgentBundler {
 		$this->directory_manager->ensure_directory_exists( $pipeline_dir );
 
 		foreach ( $files as $filename => $content ) {
-			$full_path = $pipeline_dir . '/' . $filename;
+			$full_path = BundleRelativePath::contained_join( $pipeline_dir, (string) $filename, 'pipeline memory' );
 			$dir       = dirname( $full_path );
 			if ( ! is_dir( $dir ) ) {
 				wp_mkdir_p( $dir );
 			}
-			file_put_contents( $full_path, $content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			$this->write_journaled_file( $full_path, (string) $content );
 		}
 	}
 
@@ -1918,6 +2354,8 @@ class AgentBundler {
 		$this->directory_manager->ensure_directory_exists( $flow_dir );
 
 		foreach ( $files as $relative_path => $content ) {
+			$relative_path = (string) $relative_path;
+			BundleRelativePath::validate( $relative_path, 'flow memory' );
 			// Handle files/ prefix for flow files directory.
 			if ( str_starts_with( $relative_path, 'files/' ) ) {
 				$flow_files_dir = $this->directory_manager->get_flow_files_directory( $pipeline_id, $flow_id );
@@ -1925,16 +2363,16 @@ class AgentBundler {
 					wp_mkdir_p( $flow_files_dir );
 				}
 				$filename  = substr( $relative_path, 6 ); // Strip 'files/' prefix.
-				$full_path = $flow_files_dir . '/' . $filename;
+				$full_path = BundleRelativePath::contained_join( $flow_files_dir, $filename, 'flow memory' );
 			} else {
-				$full_path = $flow_dir . '/' . $relative_path;
+				$full_path = BundleRelativePath::contained_join( $flow_dir, $relative_path, 'flow memory' );
 			}
 
 			$dir = dirname( $full_path );
 			if ( ! is_dir( $dir ) ) {
 				wp_mkdir_p( $dir );
 			}
-			file_put_contents( $full_path, $content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			$this->write_journaled_file( $full_path, (string) $content );
 		}
 	}
 

--- a/inc/Engine/Agents/AgentSubagentGraph.php
+++ b/inc/Engine/Agents/AgentSubagentGraph.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Portable, persisted Agents API subagent graph contract.
+ *
+ * @package DataMachine\Engine\Agents
+ */
+
+namespace DataMachine\Engine\Agents;
+
+use DataMachine\Engine\Bundle\BundleValidationException;
+use DataMachine\Engine\Bundle\PortableSlug;
+
+defined( 'ABSPATH' ) || exit;
+
+final class AgentSubagentGraph {
+
+	/** @return string[] */
+	public static function edges_from_config( mixed $edges, string $slug = '' ): array {
+		if ( ! is_array( $edges ) || ! array_is_list( $edges ) ) {
+			throw new BundleValidationException( 'Subagent edges must be a list.' );
+		}
+		$normalized = array();
+		foreach ( $edges as $edge ) {
+			if ( ! is_string( $edge ) || '' === trim( $edge ) ) {
+				throw new BundleValidationException( 'Subagent edges must contain non-empty slugs.' );
+			}
+			$edge_slug = PortableSlug::normalize( $edge, 'subagent' );
+			if ( $edge_slug !== trim( $edge ) ) {
+				throw new BundleValidationException( sprintf( 'Invalid subagent edge slug: %s.', esc_html( $edge ) ) );
+			}
+			if ( '' !== $slug && $edge_slug === PortableSlug::normalize( $slug, 'agent' ) ) {
+				throw new BundleValidationException( sprintf( 'Subagent %s cannot reference itself.', esc_html( $slug ) ) );
+			}
+			if ( in_array( $edge_slug, $normalized, true ) ) {
+				throw new BundleValidationException( sprintf( 'Duplicate subagent edge: %s.', esc_html( $edge_slug ) ) );
+			}
+			$normalized[] = $edge_slug;
+		}
+		sort( $normalized, SORT_STRING );
+		return $normalized;
+	}
+
+	/**
+	 * Normalize and validate a coordinator plus its bundled child definitions.
+	 *
+	 * @return array<int,array<string,mixed>> Deterministically slug-sorted children.
+	 */
+	public static function normalize( mixed $children, string $coordinator_slug = '' ): array {
+		if ( null === $children || array() === $children ) {
+			return array();
+		}
+		if ( ! is_array( $children ) || ! array_is_list( $children ) ) {
+			throw new BundleValidationException( 'manifest.json subagents must be a list.' );
+		}
+
+		$nodes = array();
+		foreach ( $children as $child ) {
+			if ( ! is_array( $child ) ) {
+				throw new BundleValidationException( 'Each subagent definition must be an object.' );
+			}
+			foreach ( array( 'slug', 'label', 'description', 'agent_config', 'memory', 'tool_policy', 'skills', 'references', 'subagents' ) as $field ) {
+				if ( ! array_key_exists( $field, $child ) ) {
+					throw new BundleValidationException( sprintf( 'Subagent is missing required field %s.', esc_html( $field ) ) );
+				}
+			}
+			if ( ! is_string( $child['slug'] ) || '' === $child['slug'] ) {
+				throw new BundleValidationException( 'Subagent slug must be a non-empty string.' );
+			}
+			$slug = PortableSlug::normalize( $child['slug'], 'subagent' );
+			if ( $slug !== $child['slug'] ) {
+				throw new BundleValidationException( sprintf( 'Subagent slug must be canonical: %s.', esc_html( $child['slug'] ) ) );
+			}
+			if ( '' !== $coordinator_slug && $slug === PortableSlug::normalize( $coordinator_slug, 'agent' ) ) {
+				throw new BundleValidationException( 'A coordinator cannot declare itself as a subagent.' );
+			}
+			if ( isset( $nodes[ $slug ] ) ) {
+				throw new BundleValidationException( sprintf( 'Duplicate subagent slug: %s.', esc_html( $slug ) ) );
+			}
+			if ( ! is_array( $child['agent_config'] ) || ! is_array( $child['memory'] ) || ! is_array( $child['tool_policy'] ) || ! is_array( $child['skills'] ) || ! is_array( $child['references'] ) || ! is_array( $child['subagents'] ) ) {
+				throw new BundleValidationException( sprintf( 'Subagent %s has an invalid object field.', esc_html( $slug ) ) );
+			}
+			if ( array_key_exists( 'skill_policy', $child ) && ( ! is_array( $child['skill_policy'] ) || array_is_list( $child['skill_policy'] ) ) ) {
+				throw new BundleValidationException( sprintf( 'Subagent %s has an invalid skill policy.', esc_html( $slug ) ) );
+			}
+			$memory = array();
+			foreach ( $child['memory'] as $path => $contents ) {
+				$path = ltrim( str_replace( '\\', '/', (string) $path ), '/' );
+				if ( '' === $path || str_contains( $path, '..' ) || ! is_string( $contents ) ) {
+					throw new BundleValidationException( sprintf( 'Subagent %s has an invalid memory file.', esc_html( $slug ) ) );
+				}
+				$memory[ $path ] = $contents;
+			}
+			ksort( $memory, SORT_STRING );
+			$edges = self::edges_from_config( $child['subagents'], $slug );
+			$nodes[ $slug ] = array(
+				'slug'         => $slug,
+				'label'        => (string) $child['label'],
+				'description'  => (string) $child['description'],
+				'agent_config' => $child['agent_config'],
+				'memory'       => $memory,
+				'tool_policy'  => $child['tool_policy'],
+				'skill_policy' => is_array( $child['skill_policy'] ?? null ) ? $child['skill_policy'] : array(),
+				'skills'       => self::normalize_file_map( $child['skills'], $slug, 'skill' ),
+				'references'   => self::normalize_file_map( $child['references'], $slug, 'reference' ),
+				'subagents'    => $edges,
+			);
+		}
+		ksort( $nodes, SORT_STRING );
+		foreach ( $nodes as $node ) {
+			foreach ( $node['subagents'] as $edge ) {
+				if ( ! isset( $nodes[ $edge ] ) ) {
+					throw new BundleValidationException( sprintf( 'Subagent edge %s -> %s does not resolve within the bundle.', esc_html( $node['slug'] ), esc_html( $edge ) ) );
+				}
+			}
+		}
+		self::assert_acyclic( $nodes );
+		return array_values( $nodes );
+	}
+
+	/** @param string[] $edges @param array<int,array<string,mixed>> $children @return string[] */
+	public static function coordinator_edges( mixed $edges, array $children, string $coordinator_slug ): array {
+		$normalized = self::edges_from_config( $edges, $coordinator_slug );
+		$available  = array_fill_keys( array_column( $children, 'slug' ), true );
+		foreach ( $normalized as $edge ) {
+			if ( ! isset( $available[ $edge ] ) ) {
+				throw new BundleValidationException( sprintf( 'Coordinator edge %s does not resolve within the bundle.', esc_html( $edge ) ) );
+			}
+		}
+		return $normalized;
+	}
+
+	private static function assert_acyclic( array $nodes ): void {
+		$visiting = array();
+		$visited  = array();
+		$visit    = static function ( string $slug ) use ( &$visit, &$visiting, &$visited, $nodes ): void {
+			if ( isset( $visiting[ $slug ] ) ) {
+				throw new BundleValidationException( sprintf( 'Subagent graph contains a cycle at %s.', esc_html( $slug ) ) );
+			}
+			if ( isset( $visited[ $slug ] ) ) {
+				return;
+			}
+			$visiting[ $slug ] = true;
+			foreach ( $nodes[ $slug ]['subagents'] as $child ) {
+				$visit( $child );
+			}
+			unset( $visiting[ $slug ] );
+			$visited[ $slug ] = true;
+		};
+		foreach ( array_keys( $nodes ) as $slug ) {
+			$visit( $slug );
+		}
+	}
+
+	private static function sorted_value( array $value ): array {
+		foreach ( $value as $key => $child ) {
+			$value[ $key ] = is_array( $child ) ? self::sorted_value( $child ) : $child;
+		}
+		if ( ! array_is_list( $value ) ) {
+			ksort( $value, SORT_STRING );
+		}
+		return $value;
+	}
+
+	/** @return array<string,string> */
+	private static function normalize_file_map( array $files, string $slug, string $kind ): array {
+		if ( array_is_list( $files ) ) {
+			throw new BundleValidationException( sprintf( 'Subagent %s %s artifacts must be a path-to-bytes object.', esc_html( $slug ), esc_html( $kind ) ) );
+		}
+		$normalized = array();
+		foreach ( $files as $path => $contents ) {
+			$path = str_replace( '\\', '/', (string) $path );
+			if ( '' === $path || str_starts_with( $path, '/' ) || str_contains( $path, '..' ) || str_contains( $path, '//' ) || in_array( $path, array( '.', '..' ), true ) || ! is_string( $contents ) ) {
+				throw new BundleValidationException( sprintf( 'Subagent %s has an invalid %s artifact.', esc_html( $slug ), esc_html( $kind ) ) );
+			}
+			$normalized[ $path ] = $contents;
+		}
+		ksort( $normalized, SORT_STRING );
+		return $normalized;
+	}
+}

--- a/inc/Engine/Agents/PersistedAgentGraphProjector.php
+++ b/inc/Engine/Agents/PersistedAgentGraphProjector.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Read-only persisted agent graph projection for generic runtime adapters.
+ *
+ * @package DataMachine\Engine\Agents
+ */
+
+namespace DataMachine\Engine\Agents;
+
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Engine\Bundle\AgentBundleArtifactState;
+use DataMachine\Engine\Bundle\BundleRelativePath;
+use DataMachine\Engine\Bundle\BundleValidationException;
+
+defined( 'ABSPATH' ) || exit;
+
+final class PersistedAgentGraphProjector {
+
+	/** @return array<string,mixed> */
+	public static function project( string $slug, ?Agents $repository = null ): array {
+		$repository = $repository ?? new Agents();
+		$root       = $repository->get_by_slug( sanitize_title( $slug ) );
+		if ( ! $root ) {
+			return array( 'success' => false, 'error' => 'Agent not found.' );
+		}
+
+		try {
+		$nodes   = array();
+		$pending = array( $root );
+		while ( ! empty( $pending ) ) {
+			$row  = array_shift( $pending );
+			$slug = (string) $row['agent_slug'];
+			if ( isset( $nodes[ $slug ] ) ) {
+				continue;
+			}
+			$config = is_array( $row['agent_config'] ?? null ) ? $row['agent_config'] : array();
+			$edges  = AgentSubagentGraph::edges_from_config( $config['subagents'] ?? array(), $slug );
+			$paths  = array();
+			$artifact_paths = array( 'skills' => array(), 'references' => array() );
+			if ( class_exists( DirectoryManager::class ) ) {
+				$directory = ( new DirectoryManager() )->get_agent_identity_directory( $slug );
+				$identity_hashes = self::identity_hashes( $row );
+				foreach ( array( 'SOUL.md', 'MEMORY.md' ) as $filename ) {
+					if ( isset( $identity_hashes[ $filename ] ) || is_file( $directory . '/' . $filename ) ) {
+						$paths[ $filename ] = self::verified_source_path( $directory, $filename, $identity_hashes[ $filename ] ?? null, 'instruction' );
+					}
+				}
+				$stored_subagent = is_array( $config['datamachine_subagent'] ?? null ) ? $config['datamachine_subagent'] : array();
+				foreach ( array( 'skills', 'references' ) as $kind ) {
+					foreach ( is_array( $stored_subagent[ $kind ] ?? null ) ? $stored_subagent[ $kind ] : array() as $relative => $sha256 ) {
+						if ( ! is_string( $relative ) || ! is_string( $sha256 ) || ! preg_match( '/^[a-f0-9]{64}$/', $sha256 ) ) {
+							continue;
+						}
+						$artifact_paths[ $kind ][ (string) $relative ] = self::verified_source_path( $directory . '/' . $kind, $relative, $sha256, $kind );
+					}
+				}
+			}
+			$subagent = is_array( $config['datamachine_subagent'] ?? null ) ? $config['datamachine_subagent'] : array();
+			$nodes[ $slug ] = array(
+				'slug'              => $slug,
+				'label'             => (string) ( $row['agent_name'] ?? $slug ),
+				'description'       => (string) ( $config['description'] ?? '' ),
+				'subagents'         => $edges,
+				'model'             => (string) ( $config['model'] ?? $config['default_model'] ?? '' ),
+				'sources'           => array( 'instructions' => $paths, 'skills' => $artifact_paths['skills'], 'references' => $artifact_paths['references'] ),
+				'tool_policy'       => is_array( $subagent['tool_policy'] ?? null ) ? $subagent['tool_policy'] : array(),
+				'skill_policy'      => array_merge( is_array( $subagent['skill_policy'] ?? null ) ? $subagent['skill_policy'] : array(), array( 'paths' => array_keys( $artifact_paths['skills'] ) ) ),
+			);
+			foreach ( $edges as $edge ) {
+				$child = $repository->get_by_slug( $edge );
+				if ( ! $child ) {
+					return array( 'success' => false, 'coordinator' => (string) $root['agent_slug'], 'error' => sprintf( 'Persisted subagent is missing: %s.', $edge ) );
+				}
+				$pending[] = $child;
+			}
+		}
+		ksort( $nodes, SORT_STRING );
+		return array( 'success' => true, 'coordinator' => (string) $root['agent_slug'], 'nodes' => array_values( $nodes ) );
+		} catch ( BundleValidationException $e ) {
+			return array( 'success' => false, 'coordinator' => (string) $root['agent_slug'], 'error' => 'Graph projection failed: ' . $e->getMessage() );
+		}
+	}
+
+	/** @return array<string,string> */
+	private static function identity_hashes( array $row ): array {
+		$hashes = array();
+		foreach ( AgentBundleArtifactState::installed_for_agent( $row ) as $artifact ) {
+			if ( 'memory' !== (string) ( $artifact['artifact_type'] ?? '' ) ) {
+				continue;
+			}
+			$id = (string) ( $artifact['artifact_id'] ?? '' );
+			if ( str_starts_with( $id, 'agent/' ) && preg_match( '/^[a-f0-9]{64}$/', (string) ( $artifact['installed_hash'] ?? '' ) ) ) {
+				$hashes[ substr( $id, 6 ) ] = (string) $artifact['installed_hash'];
+			}
+		}
+		return $hashes;
+	}
+
+	private static function verified_source_path( string $root, string $relative, ?string $sha256, string $label ): string {
+		BundleRelativePath::validate( $relative, $label );
+		$root_real = realpath( $root );
+		if ( false === $root_real || ! is_dir( $root_real ) ) {
+			throw new BundleValidationException( sprintf( 'Graph %s root is missing: %s', $label, $root ) );
+		}
+		$path = BundleRelativePath::contained_join( $root_real, $relative, $label );
+		$cursor = $root_real;
+		foreach ( explode( '/', $relative ) as $segment ) {
+			$cursor .= '/' . $segment;
+			if ( is_link( $cursor ) ) {
+				throw new BundleValidationException( sprintf( 'Graph %s source is a symlink: %s', $label, $relative ) );
+			}
+		}
+		$real = realpath( $path );
+		if ( false === $real || ! is_file( $real ) || ! str_starts_with( $real, $root_real . DIRECTORY_SEPARATOR ) ) {
+			throw new BundleValidationException( sprintf( 'Graph %s source is missing or escapes its root: %s', $label, $relative ) );
+		}
+		$contents = file_get_contents( $real );
+		if ( ! is_string( $contents ) ) {
+			throw new BundleValidationException( sprintf( 'Graph %s source is unreadable: %s', $label, $relative ) );
+		}
+		if ( null !== $sha256 && ! hash_equals( $sha256, hash( 'sha256', $contents ) ) ) {
+			throw new BundleValidationException( sprintf( 'Graph %s source hash does not match: %s', $label, $relative ) );
+		}
+		return $real;
+	}
+}

--- a/inc/Engine/Agents/PersistedAgentProjector.php
+++ b/inc/Engine/Agents/PersistedAgentProjector.php
@@ -69,6 +69,7 @@ class PersistedAgentProjector {
 			'description'    => self::description_from_row( $row, $config ),
 			'owner_resolver' => static fn(): int => $owner_id,
 			'default_config' => $config,
+			'subagents'      => AgentSubagentGraph::edges_from_config( $config['subagents'] ?? array(), (string) ( $row['agent_slug'] ?? '' ) ),
 			'meta'           => self::meta_from_row( $row, $config ),
 		);
 	}

--- a/inc/Engine/Bundle/AgentBundleArrayAdapter.php
+++ b/inc/Engine/Bundle/AgentBundleArrayAdapter.php
@@ -42,7 +42,8 @@ final class AgentBundleArrayAdapter {
 				'handler_auth' => 'refs',
 			),
 			BundleSchema::normalize_run_artifact_egress_policy( $bundle['run_artifacts'] ?? array() ),
-			is_array( $bundle['capabilities'] ?? null ) ? $bundle['capabilities'] : array()
+			is_array( $bundle['capabilities'] ?? null ) ? $bundle['capabilities'] : array(),
+			is_array( $bundle['subagents'] ?? null ) ? $bundle['subagents'] : array()
 		);
 
 		return new AgentBundleDirectory(
@@ -171,6 +172,9 @@ final class AgentBundleArrayAdapter {
 		if ( ! empty( $manifest['capabilities'] ) && is_array( $manifest['capabilities'] ) ) {
 			$bundle['capabilities'] = $manifest['capabilities'];
 		}
+		if ( ! empty( $manifest['subagents'] ) && is_array( $manifest['subagents'] ) ) {
+			$bundle['subagents'] = $manifest['subagents'];
+		}
 
 		return $bundle;
 	}
@@ -253,6 +257,14 @@ final class AgentBundleArrayAdapter {
 			'description'  => (string) ( $agent['description'] ?? '' ),
 			'agent_config' => is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array(),
 		);
+		if ( array_key_exists( 'subagents', $agent ) ) {
+			$block['subagents'] = $agent['subagents'];
+		}
+		foreach ( array( 'skills', 'references', 'skill_policy', 'tool_policy' ) as $field ) {
+			if ( array_key_exists( $field, $agent ) ) {
+				$block[ $field ] = $agent[ $field ];
+			}
+		}
 
 		if ( array_key_exists( 'site_scope', $agent ) ) {
 			$scope = BundleSchema::normalize_agent_site_scope( $agent['site_scope'] );
@@ -281,6 +293,14 @@ final class AgentBundleArrayAdapter {
 			'agent_name'   => $agent['label'] ?? ( $agent['slug'] ?? 'Agent' ),
 			'agent_config' => is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array(),
 		);
+		if ( array_key_exists( 'subagents', $agent ) ) {
+			$block['subagents'] = $agent['subagents'];
+		}
+		foreach ( array( 'skills', 'references', 'skill_policy', 'tool_policy' ) as $field ) {
+			if ( array_key_exists( $field, $agent ) ) {
+				$block[ $field ] = $agent[ $field ];
+			}
+		}
 
 		if ( array_key_exists( 'site_scope', $agent ) ) {
 			$scope = BundleSchema::normalize_agent_site_scope( $agent['site_scope'] );

--- a/inc/Engine/Bundle/AgentBundleDirectory.php
+++ b/inc/Engine/Bundle/AgentBundleDirectory.php
@@ -60,9 +60,10 @@ final class AgentBundleDirectory {
 			throw new BundleValidationException( 'Bundle directory is missing manifest.json.' );
 		}
 
-		$manifest = AgentBundleManifest::from_array(
-			BundleSchema::decode_json( self::read_file( $manifest_path ), 'manifest.json' )
-		);
+		$manifest_data = BundleSchema::decode_json( self::read_file( $manifest_path ), 'manifest.json' );
+		self::hydrate_agent_artifacts( $manifest_data, $directory );
+		self::hydrate_subagent_artifacts( $manifest_data, $directory );
+		$manifest = AgentBundleManifest::from_array( $manifest_data );
 
 		return new self(
 			$manifest,
@@ -85,8 +86,14 @@ final class AgentBundleDirectory {
 			self::ensure_directory( $directory . '/' . $artifact_directory );
 		}
 		self::ensure_directory( $directory . '/' . BundleSchema::EXTENSIONS_DIR );
+		self::ensure_directory( $directory . '/' . BundleSchema::SUBAGENTS_DIR );
+		self::ensure_directory( $directory . '/' . BundleSchema::SKILLS_DIR );
+		self::ensure_directory( $directory . '/' . BundleSchema::REFERENCES_DIR );
 
-		self::write_file( $directory . '/' . BundleSchema::MANIFEST_FILE, BundleSchema::encode_json( $this->manifest->to_array() ) );
+		$manifest = $this->manifest->to_array();
+		self::write_agent_artifacts( $directory, $manifest );
+		self::write_subagent_artifacts( $directory, $manifest );
+		self::write_file( $directory . '/' . BundleSchema::MANIFEST_FILE, BundleSchema::encode_json( $manifest ) );
 
 		foreach ( $this->memory_files as $relative_path => $contents ) {
 			$path = $directory . '/' . BundleSchema::MEMORY_DIR . '/' . $relative_path;
@@ -197,11 +204,8 @@ final class AgentBundleDirectory {
 	private static function normalize_memory_files( array $memory_files ): array {
 		$normalized = array();
 		foreach ( $memory_files as $relative_path => $contents ) {
-			$relative_path = str_replace( '\\', '/', (string) $relative_path );
-			$relative_path = ltrim( $relative_path, '/' );
-			if ( str_contains( $relative_path, '..' ) || '' === $relative_path ) {
-				throw new BundleValidationException( sprintf( 'Invalid memory file path: %s', esc_html( $relative_path ) ) );
-			}
+			$relative_path = (string) $relative_path;
+			BundleRelativePath::validate( $relative_path, 'memory' );
 			$normalized[ $relative_path ] = (string) $contents;
 		}
 		ksort( $normalized, SORT_STRING );
@@ -525,12 +529,7 @@ final class AgentBundleDirectory {
 	}
 
 	private static function normalize_relative_path( string $relative_path, string $label ): string {
-		$relative_path = str_replace( '\\', '/', $relative_path );
-		$relative_path = ltrim( $relative_path, '/' );
-		if ( str_contains( $relative_path, '..' ) || '' === $relative_path ) {
-			throw new BundleValidationException( sprintf( 'Invalid %s file path: %s', esc_html( $label ), esc_html( $relative_path ) ) );
-		}
-
+		BundleRelativePath::validate( $relative_path, $label );
 		return $relative_path;
 	}
 
@@ -540,6 +539,114 @@ final class AgentBundleDirectory {
 	}
 
 	private static function write_file( string $path, string $contents ): void {
-		file_put_contents( $path, $contents );
+		if ( false === file_put_contents( $path, $contents ) ) {
+			throw new BundleValidationException( sprintf( 'Unable to write bundle file: %s', esc_html( $path ) ) );
+		}
+	}
+
+	private static function write_subagent_artifacts( string $directory, array &$manifest ): void {
+		foreach ( $manifest['subagents'] ?? array() as $index => $child ) {
+			if ( ! is_array( $child ) || ! is_string( $child['slug'] ?? null ) || PortableSlug::normalize( $child['slug'], 'subagent' ) !== $child['slug'] ) {
+				throw new BundleValidationException( 'Subagent artifact owner slug must be canonical.' );
+			}
+			foreach ( array( 'skills', 'references' ) as $kind ) {
+				$entries = array();
+				foreach ( $child[ $kind ] ?? array() as $path => $contents ) {
+					$path = self::normalize_relative_path( (string) $path, 'subagent ' . $kind );
+					if ( ! is_string( $contents ) ) {
+						throw new BundleValidationException( 'Subagent artifact contents must be bytes.' );
+					}
+					$stored = BundleSchema::SUBAGENTS_DIR . '/' . $child['slug'] . '/' . $kind . '/' . $path;
+					self::ensure_directory( dirname( $directory . '/' . $stored ) );
+					self::write_file( $directory . '/' . $stored, $contents );
+					$entries[] = array( 'path' => $path, 'sha256' => hash( 'sha256', $contents ) );
+				}
+				$manifest['subagents'][ $index ][ $kind ] = $entries;
+			}
+		}
+	}
+
+	private static function write_agent_artifacts( string $directory, array &$manifest ): void {
+		foreach ( array( 'skills' => BundleSchema::SKILLS_DIR, 'references' => BundleSchema::REFERENCES_DIR ) as $kind => $root ) {
+			if ( ! array_key_exists( $kind, $manifest['agent'] ?? array() ) ) {
+				continue;
+			}
+			$entries = array();
+			foreach ( $manifest['agent'][ $kind ] as $path => $contents ) {
+				$path = self::normalize_relative_path( (string) $path, 'agent ' . $kind );
+				if ( ! is_string( $contents ) ) {
+					throw new BundleValidationException( 'Agent artifact contents must be bytes.' );
+				}
+				self::ensure_directory( dirname( $directory . '/' . $root . '/' . $path ) );
+				self::write_file( $directory . '/' . $root . '/' . $path, $contents );
+				$entries[] = array( 'path' => $path, 'sha256' => hash( 'sha256', $contents ) );
+			}
+			$manifest['agent'][ $kind ] = $entries;
+		}
+	}
+
+	private static function hydrate_subagent_artifacts( array &$manifest, string $directory ): void {
+		$bundle_real = realpath( $directory );
+		if ( false === $bundle_real ) {
+			throw new BundleValidationException( 'Bundle directory cannot be resolved.' );
+		}
+		foreach ( $manifest['subagents'] ?? array() as $index => $child ) {
+			foreach ( array( 'skills', 'references' ) as $kind ) {
+				if ( ! is_array( $child[ $kind ] ?? null ) || ! array_is_list( $child[ $kind ] ) ) {
+					throw new BundleValidationException( sprintf( 'Subagent %s artifacts must be a list.', esc_html( $kind ) ) );
+				}
+				$files = array();
+				foreach ( $child[ $kind ] as $entry ) {
+					if ( ! is_array( $entry ) || ! is_string( $entry['path'] ?? null ) || ! preg_match( '/^[a-f0-9]{64}$/', (string) ( $entry['sha256'] ?? '' ) ) ) {
+						throw new BundleValidationException( sprintf( 'Subagent %s artifact metadata is invalid.', esc_html( $kind ) ) );
+					}
+					$path = self::normalize_relative_path( $entry['path'], 'subagent ' . $kind );
+					$candidate = $directory . '/' . BundleSchema::SUBAGENTS_DIR . '/' . $child['slug'] . '/' . $kind . '/' . $path;
+					$file_real = realpath( $candidate );
+					if ( false === $file_real || ! is_file( $file_real ) || ! str_starts_with( $file_real, $bundle_real . DIRECTORY_SEPARATOR ) ) {
+						throw new BundleValidationException( sprintf( 'Subagent %s artifact is missing or escapes the package: %s', esc_html( $kind ), esc_html( $path ) ) );
+					}
+					$contents = self::read_file( $file_real );
+					if ( ! hash_equals( $entry['sha256'], hash( 'sha256', $contents ) ) ) {
+						throw new BundleValidationException( sprintf( 'Subagent %s artifact hash does not match: %s', esc_html( $kind ), esc_html( $path ) ) );
+					}
+					$files[ $path ] = $contents;
+				}
+				$manifest['subagents'][ $index ][ $kind ] = $files;
+			}
+		}
+	}
+
+	private static function hydrate_agent_artifacts( array &$manifest, string $directory ): void {
+		$bundle_real = realpath( $directory );
+		if ( false === $bundle_real ) {
+			throw new BundleValidationException( 'Bundle directory cannot be resolved.' );
+		}
+		foreach ( array( 'skills' => BundleSchema::SKILLS_DIR, 'references' => BundleSchema::REFERENCES_DIR ) as $kind => $root ) {
+			if ( ! array_key_exists( $kind, $manifest['agent'] ?? array() ) ) {
+				continue;
+			}
+			if ( ! is_array( $manifest['agent'][ $kind ] ) || ! array_is_list( $manifest['agent'][ $kind ] ) ) {
+				throw new BundleValidationException( sprintf( 'Agent %s artifacts must be a list.', esc_html( $kind ) ) );
+			}
+			$files = array();
+			foreach ( $manifest['agent'][ $kind ] as $entry ) {
+				if ( ! is_array( $entry ) || ! is_string( $entry['path'] ?? null ) || ! preg_match( '/^[a-f0-9]{64}$/', (string) ( $entry['sha256'] ?? '' ) ) ) {
+					throw new BundleValidationException( sprintf( 'Agent %s artifact metadata is invalid.', esc_html( $kind ) ) );
+				}
+				$path = self::normalize_relative_path( $entry['path'], 'agent ' . $kind );
+				$candidate = $directory . '/' . $root . '/' . $path;
+				$file_real = realpath( $candidate );
+				if ( false === $file_real || ! is_file( $file_real ) || ! str_starts_with( $file_real, $bundle_real . DIRECTORY_SEPARATOR ) ) {
+					throw new BundleValidationException( sprintf( 'Agent %s artifact is missing or escapes the package: %s', esc_html( $kind ), esc_html( $path ) ) );
+				}
+				$contents = self::read_file( $file_real );
+				if ( ! hash_equals( $entry['sha256'], hash( 'sha256', $contents ) ) ) {
+					throw new BundleValidationException( sprintf( 'Agent %s artifact hash does not match: %s', esc_html( $kind ), esc_html( $path ) ) );
+				}
+				$files[ $path ] = $contents;
+			}
+			$manifest['agent'][ $kind ] = $files;
+		}
 	}
 }

--- a/inc/Engine/Bundle/AgentBundleManifest.php
+++ b/inc/Engine/Bundle/AgentBundleManifest.php
@@ -7,6 +7,8 @@
 
 namespace DataMachine\Engine\Bundle;
 
+use DataMachine\Engine\Agents\AgentSubagentGraph;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -24,8 +26,9 @@ final class AgentBundleManifest {
 	private array $included;
 	private array $run_artifacts;
 	private array $capabilities;
+	private array $subagents;
 
-	public function __construct( string $exported_at, string $exported_by, string $bundle_slug, string $bundle_version, string $source_ref, string $source_revision, array $agent, array $included, array $run_artifacts = array(), array $capabilities = array() ) {
+	public function __construct( string $exported_at, string $exported_by, string $bundle_slug, string $bundle_version, string $source_ref, string $source_revision, array $agent, array $included, array $run_artifacts = array(), array $capabilities = array(), array $subagents = array() ) {
 		$this->exported_at     = $exported_at;
 		$this->exported_by     = $exported_by;
 		$this->bundle_slug     = PortableSlug::normalize( $bundle_slug, 'bundle' );
@@ -36,6 +39,10 @@ final class AgentBundleManifest {
 		$this->included        = self::validate_included( $included );
 		$this->run_artifacts   = BundleSchema::normalize_run_artifact_egress_policy( $run_artifacts );
 		$this->capabilities    = self::validate_string_list( $capabilities, 'capabilities' );
+		$this->subagents       = AgentSubagentGraph::normalize( $subagents, (string) $this->agent['slug'] );
+		if ( ! empty( $this->subagents ) ) {
+			$this->agent['subagents'] = AgentSubagentGraph::coordinator_edges( $this->agent['subagents'] ?? array(), $this->subagents, (string) $this->agent['slug'] );
+		}
 	}
 
 	/**
@@ -67,7 +74,8 @@ final class AgentBundleManifest {
 			$data['agent'],
 			$data['included'],
 			is_array( $data['run_artifacts'] ?? null ) ? $data['run_artifacts'] : array(),
-			is_array( $data['capabilities'] ?? null ) ? $data['capabilities'] : array()
+			is_array( $data['capabilities'] ?? null ) ? $data['capabilities'] : array(),
+			is_array( $data['subagents'] ?? null ) ? $data['subagents'] : array()
 		);
 	}
 
@@ -94,6 +102,9 @@ final class AgentBundleManifest {
 		}
 		if ( ! empty( $this->capabilities ) ) {
 			$data['capabilities'] = $this->capabilities;
+		}
+		if ( ! empty( $this->subagents ) ) {
+			$data['subagents'] = $this->subagents;
 		}
 
 		return $data;
@@ -136,6 +147,11 @@ final class AgentBundleManifest {
 		return $this->capabilities;
 	}
 
+	/** @return array<int,array<string,mixed>> */
+	public function subagents(): array {
+		return $this->subagents;
+	}
+
 	private static function validate_agent( array $agent ): array {
 		foreach ( array( 'slug', 'label', 'description', 'agent_config' ) as $field ) {
 			if ( ! array_key_exists( $field, $agent ) ) {
@@ -156,6 +172,42 @@ final class AgentBundleManifest {
 			'description'  => $agent['description'],
 			'agent_config' => $agent['agent_config'],
 		);
+		if ( array_key_exists( 'subagents', $agent ) ) {
+			if ( ! is_array( $agent['subagents'] ) || ! array_is_list( $agent['subagents'] ) ) {
+				throw new BundleValidationException( 'manifest.json agent.subagents must be a list.' );
+			}
+			$validated['subagents'] = AgentSubagentGraph::edges_from_config( $agent['subagents'], $agent['slug'] );
+		}
+		foreach ( array( 'skills', 'references' ) as $kind ) {
+			if ( ! array_key_exists( $kind, $agent ) ) {
+				continue;
+			}
+			if ( ! is_array( $agent[ $kind ] ) || array_is_list( $agent[ $kind ] ) ) {
+				throw new BundleValidationException( sprintf( 'manifest.json agent.%s must be a path-to-bytes object after hydration.', esc_html( $kind ) ) );
+			}
+			$files = array();
+			foreach ( $agent[ $kind ] as $path => $contents ) {
+				$path = str_replace( '\\', '/', (string) $path );
+				if ( '' === $path || str_starts_with( $path, '/' ) || str_contains( $path, '..' ) || str_contains( $path, '//' ) || ! is_string( $contents ) ) {
+					throw new BundleValidationException( sprintf( 'manifest.json agent.%s has an invalid artifact path.', esc_html( $kind ) ) );
+				}
+				$files[ $path ] = $contents;
+			}
+			ksort( $files, SORT_STRING );
+			$validated[ $kind ] = $files;
+		}
+		if ( array_key_exists( 'skill_policy', $agent ) ) {
+			if ( ! is_array( $agent['skill_policy'] ) || array_is_list( $agent['skill_policy'] ) ) {
+				throw new BundleValidationException( 'manifest.json agent.skill_policy must be an object.' );
+			}
+			$validated['skill_policy'] = $agent['skill_policy'];
+		}
+		if ( array_key_exists( 'tool_policy', $agent ) ) {
+			if ( ! is_array( $agent['tool_policy'] ) || array_is_list( $agent['tool_policy'] ) ) {
+				throw new BundleValidationException( 'manifest.json agent.tool_policy must be an object.' );
+			}
+			$validated['tool_policy'] = $agent['tool_policy'];
+		}
 
 		// Carry the agent's site scope through the round-trip. `null` means
 		// network-wide; a positive integer means a specific blog. Anything else

--- a/inc/Engine/Bundle/AgentBundleMemoryArtifact.php
+++ b/inc/Engine/Bundle/AgentBundleMemoryArtifact.php
@@ -170,6 +170,32 @@ final class AgentBundleMemoryArtifact {
 		);
 	}
 
+	/** @return array{artifact_id:string,exists:bool,content:?string}|null */
+	public static function snapshot( int $agent_id, string $artifact_id ): ?array {
+		$filename = self::filename_from_artifact_id( $artifact_id );
+		if ( $agent_id <= 0 || '' === $filename || ! self::is_authored_identity( $filename ) ) {
+			return null;
+		}
+		$memory = new AgentMemory( 0, $agent_id, $filename );
+		$result = $memory->read();
+		return array( 'artifact_id' => $artifact_id, 'exists' => $result->exists, 'content' => $result->exists ? (string) $result->content : null );
+	}
+
+	/** @param array{artifact_id:string,exists:bool,content:?string} $snapshot */
+	public static function restore( int $agent_id, array $snapshot ): void {
+		$filename = self::filename_from_artifact_id( (string) ( $snapshot['artifact_id'] ?? '' ) );
+		if ( $agent_id <= 0 || '' === $filename ) {
+			return;
+		}
+		$memory = new AgentMemory( 0, $agent_id, $filename );
+		$result = ! empty( $snapshot['exists'] )
+			? $memory->replace_all( (string) ( $snapshot['content'] ?? '' ) )
+			: $memory->delete();
+		if ( empty( $result['success'] ) ) {
+			throw new \RuntimeException( sprintf( 'Failed to restore agent memory file "%s".', $filename ) );
+		}
+	}
+
 	/**
 	 * Whether a bundle-carried agent-layer file may be materialized on upgrade.
 	 *

--- a/inc/Engine/Bundle/BundleRelativePath.php
+++ b/inc/Engine/Bundle/BundleRelativePath.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Strict relative paths for bundle file maps.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+defined( 'ABSPATH' ) || exit;
+
+final class BundleRelativePath {
+
+	/**
+	 * Join a validated bundle-relative path to a trusted filesystem root.
+	 */
+	public static function contained_join( string $root, string $relative_path, string $label = 'bundle' ): string {
+		self::validate( $relative_path, $label );
+
+		return rtrim( $root, '/\\' ) . '/' . $relative_path;
+	}
+
+	/** Validate one portable bundle path without normalizing unsafe input. */
+	public static function validate( string $relative_path, string $label = 'bundle' ): void {
+		if (
+			'' === $relative_path
+			|| str_contains( $relative_path, "\0" )
+			|| str_contains( $relative_path, '\\' )
+			|| str_starts_with( $relative_path, '/' )
+			|| preg_match( '/^[A-Za-z]:/', $relative_path )
+			|| str_contains( $relative_path, '//' )
+		) {
+			throw new BundleValidationException( sprintf( 'Invalid %s file path: %s', esc_html( $label ), esc_html( $relative_path ) ) );
+		}
+
+		foreach ( explode( '/', $relative_path ) as $segment ) {
+			if ( '' === $segment || '.' === $segment || '..' === $segment ) {
+				throw new BundleValidationException( sprintf( 'Invalid %s file path: %s', esc_html( $label ), esc_html( $relative_path ) ) );
+			}
+		}
+	}
+}

--- a/inc/Engine/Bundle/BundleSchema.php
+++ b/inc/Engine/Bundle/BundleSchema.php
@@ -45,6 +45,12 @@ final class BundleSchema {
 
 	public const EXTENSIONS_DIR = 'extensions';
 
+	public const SUBAGENTS_DIR = 'subagents';
+
+	public const SKILLS_DIR = 'skills';
+
+	public const REFERENCES_DIR = 'references';
+
 	/**
 	 * Top-level bundle entries that Data Machine owns by name.
 	 *
@@ -69,6 +75,9 @@ final class BundleSchema {
 		self::AUTH_REFS_DIR,
 		self::SEED_QUEUES_DIR,
 		self::EXTENSIONS_DIR,
+		self::SUBAGENTS_DIR,
+		self::SKILLS_DIR,
+		self::REFERENCES_DIR,
 		// Legacy export paths produced by AgentBundler::to_directory():
 		'agent',
 		'USER.md',
@@ -91,6 +100,9 @@ final class BundleSchema {
 		self::AUTH_REFS_DIR,
 		self::SEED_QUEUES_DIR,
 		self::EXTENSIONS_DIR,
+		self::SUBAGENTS_DIR,
+		self::SKILLS_DIR,
+		self::REFERENCES_DIR,
 		'agent',
 	);
 

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -45,6 +45,7 @@ use DataMachine\Engine\Bundle\AgentBundleDirectory;
 use DataMachine\Engine\Bundle\AgentBundleInstalledArtifact;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
 use DataMachine\Engine\Bundle\BundleSchema;
+use DataMachine\Engine\Agents\PersistedAgentGraphProjector;
 use WP_UnitTestCase;
 
 final class DailyMemoryImportFakeStore implements WP_Agent_Memory_Store {
@@ -123,6 +124,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 	private int $owner_id;
 	private $memory_store_filter = null;
 	private $agent_config_projection_filter = null;
+	private $transaction_available_filter = null;
 
 	public function set_up(): void {
 		parent::set_up();
@@ -162,6 +164,10 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		if ( null !== $this->agent_config_projection_filter ) {
 			remove_filter( 'datamachine_agent_config_artifact_projection_policies', $this->agent_config_projection_filter, 10 );
 			$this->agent_config_projection_filter = null;
+		}
+		if ( null !== $this->transaction_available_filter ) {
+			remove_filter( 'datamachine_bundle_import_transaction_available', $this->transaction_available_filter, 10 );
+			$this->transaction_available_filter = null;
 		}
 		PermissionHelper::clear_agent_context();
 
@@ -919,6 +925,66 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 
 		$this->assertSame( 0, $pipeline_count, 'No orphan pipeline rows.' );
 		$this->assertSame( 0, $flow_count, 'No orphan flow rows.' );
+	}
+
+	public function test_legacy_file_maps_reject_unsafe_paths_before_mutation(): void {
+		$maps = array(
+			'agent'    => static function ( array &$bundle ): void { $bundle['files'] = array( '../escape.md' => 'x' ); },
+			'pipeline' => static function ( array &$bundle ): void { $bundle['pipelines'][0]['memory_file_contents'] = array( 'dir//file.md' => 'x' ); },
+			'flow'     => static function ( array &$bundle ): void { $bundle['flows'][0]['memory_file_contents'] = array( '/escape.md' => 'x' ); },
+		);
+
+		foreach ( $maps as $label => $mutate ) {
+			$bundle = $this->fixture_bundle( 'unsafe-' . $label );
+			$mutate( $bundle );
+			$result = $this->bundler->import( $bundle, null, $this->owner_id );
+
+			$this->assertFalse( (bool) $result['success'], "Unsafe {$label} map is rejected." );
+			$this->assertSame( 'install_invalid_bundle', $result['error_code'] ?? null );
+			$this->assertNull( $this->agents_repo->get_by_slug( 'unsafe-' . $label ), "Unsafe {$label} map creates no agent." );
+		}
+	}
+
+	public function test_transaction_unavailable_fails_before_normal_import_mutates(): void {
+		$this->transaction_available_filter = static fn(): bool => false;
+		add_filter( 'datamachine_bundle_import_transaction_available', $this->transaction_available_filter, 10 );
+
+		$result = $this->bundler->import( $this->fixture_bundle( 'transaction-unavailable-agent' ), null, $this->owner_id );
+
+		$this->assertFalse( (bool) $result['success'] );
+		$this->assertSame( 'install_transaction_unavailable', $result['error_code'] ?? null );
+		$this->assertNull( $this->agents_repo->get_by_slug( 'transaction-unavailable-agent' ), 'No agent row is created without an atomic transaction.' );
+	}
+
+	public function test_subagent_skill_policy_survives_persisted_graph_projection(): void {
+		$bundle                              = $this->fixture_bundle( 'policy-coordinator' );
+		$bundle['agent']['subagents']        = array( 'policy-writer' );
+		$bundle['subagents']                 = array(
+			array(
+				'slug'         => 'policy-writer',
+				'label'        => 'Policy Writer',
+				'description'  => 'Writes with an explicit skill policy.',
+				'agent_config' => array(),
+				'memory'       => array( 'SOUL.md' => "# Policy Writer\n" ),
+				'tool_policy'  => array(),
+				'skill_policy' => array( 'mode' => 'explicit', 'allowed' => array( 'write.md' ) ),
+				'skills'       => array( 'write.md' => "# Write\n" ),
+				'references'   => array(),
+				'subagents'    => array(),
+			),
+		);
+
+		$result = $this->bundler->import( $bundle, null, $this->owner_id );
+		$this->assertTrue( (bool) $result['success'] );
+
+		$projection = PersistedAgentGraphProjector::project( 'policy-coordinator' );
+		$this->assertTrue( (bool) $projection['success'] );
+		$nodes = array_column( $projection['nodes'] ?? array(), null, 'slug' );
+		$this->assertSame(
+			array( 'mode' => 'explicit', 'allowed' => array( 'write.md' ), 'paths' => array( 'write.md' ) ),
+			$nodes['policy-writer']['skill_policy'] ?? null,
+			'Persisted graph projection retains the child policy and installed skill paths.'
+		);
 	}
 
 	/**

--- a/tests/agent-bundle-subagent-graph-smoke.php
+++ b/tests/agent-bundle-subagent-graph-smoke.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Pure-PHP contract smoke for schema-v1 coordinator subagent graphs (#3169).
+ *
+ * Run with: php tests/agent-bundle-subagent-graph-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $value ) { return (string) $value; }
+}
+
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleValidationException.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/PortableSlug.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Agents/AgentSubagentGraph.php';
+
+use DataMachine\Engine\Agents\AgentSubagentGraph;
+use DataMachine\Engine\Bundle\BundleValidationException;
+
+$failures = 0;
+function subagent_graph_assert( bool $condition, string $label ): void {
+	global $failures;
+	echo ( $condition ? 'PASS' : 'FAIL' ) . ": {$label}\n";
+	if ( ! $condition ) { ++$failures; }
+}
+function subagent_graph_node( string $slug, array $edges = array() ): array {
+	return array(
+		'slug' => $slug, 'label' => ucfirst( $slug ), 'description' => $slug,
+		'agent_config' => array( 'default_model' => 'generic-model' ),
+		'memory' => array( 'SOUL.md' => "# {$slug}\n", 'MEMORY.md' => '' ),
+		'tool_policy' => array( 'allow' => array( 'generic/tool' ) ),
+		'skill_policy' => array( 'mode' => 'explicit' ),
+		'skills' => array( 'skill.md' => "generic-skill\n" ), 'references' => array( 'reference.md' => "generic-ref\n" ), 'subagents' => $edges,
+	);
+}
+
+$nodes = AgentSubagentGraph::normalize( array(
+	subagent_graph_node( 'writer', array( 'researcher' ) ),
+	subagent_graph_node( 'reviewer' ),
+	subagent_graph_node( 'researcher' ),
+), 'coordinator' );
+subagent_graph_assert( array( 'researcher', 'reviewer', 'writer' ) === array_column( $nodes, 'slug' ), 'children have deterministic slug order' );
+subagent_graph_assert( array( 'researcher' ) === $nodes[2]['subagents'], 'child edges preserve normalized exact target' );
+subagent_graph_assert( '# writer' . "\n" === $nodes[2]['memory']['SOUL.md'], 'identity bytes round-trip' );
+subagent_graph_assert( "generic-skill\n" === $nodes[2]['skills']['skill.md'] && "generic-ref\n" === $nodes[2]['references']['reference.md'], 'generic skills and references round-trip as bytes' );
+subagent_graph_assert( array( 'mode' => 'explicit' ) === $nodes[2]['skill_policy'], 'child skill policy round-trips' );
+subagent_graph_assert( array( 'writer' ) === AgentSubagentGraph::coordinator_edges( array( 'writer' ), $nodes, 'coordinator' ), 'coordinator edges resolve within bundled children' );
+
+foreach ( array(
+	array( subagent_graph_node( 'coordinator' ) ),
+	array( subagent_graph_node( 'writer', array( 'missing' ) ) ),
+	array( subagent_graph_node( 'writer', array( 'reviewer' ) ), subagent_graph_node( 'reviewer', array( 'writer' ) ) ),
+	array( subagent_graph_node( 'writer', array( 'writer' ) ) ),
+	array( subagent_graph_node( 'writer' ), subagent_graph_node( 'writer' ) ),
+	array( subagent_graph_node( 'writer' ) ),
+) as $index => $invalid ) {
+	$rejected = false;
+	try {
+		$invalid_nodes = AgentSubagentGraph::normalize( $invalid, 'coordinator' );
+		if ( 5 === $index ) {
+			AgentSubagentGraph::coordinator_edges( array( 'missing' ), $invalid_nodes, 'coordinator' );
+		}
+	} catch ( BundleValidationException $e ) { $rejected = true; }
+	subagent_graph_assert( $rejected, 'invalid graph is rejected before materialization' );
+}
+
+$rejected = false;
+try {
+	$invalid = subagent_graph_node( 'writer' );
+	$invalid['skills'] = array( 'legacy-list' );
+	AgentSubagentGraph::normalize( array( $invalid ), 'coordinator' );
+} catch ( BundleValidationException $e ) { $rejected = true; }
+subagent_graph_assert( $rejected, 'legacy list-form skills are rejected rather than normalized away' );
+
+foreach ( array( 'Writer', '../writer' ) as $invalid_slug ) {
+	$rejected = false;
+	try {
+		$invalid = subagent_graph_node( $invalid_slug );
+		AgentSubagentGraph::normalize( array( $invalid ), 'coordinator' );
+	} catch ( BundleValidationException $e ) { $rejected = true; }
+	subagent_graph_assert( $rejected, 'noncanonical or traversal child slugs are rejected before path construction' );
+}
+
+$rejected = false;
+try {
+	$invalid = subagent_graph_node( 'writer' );
+	$invalid['skills'] = array( '../escape.md' => 'escape' );
+	AgentSubagentGraph::normalize( array( $invalid ), 'coordinator' );
+} catch ( BundleValidationException $e ) { $rejected = true; }
+subagent_graph_assert( $rejected, 'traversal skill artifact paths are rejected before package path construction' );
+
+if ( $failures ) {
+	exit( 1 );
+}
+echo "All subagent graph assertions passed.\n";

--- a/tests/agent-bundler-directory-adapter-smoke.php
+++ b/tests/agent-bundler-directory-adapter-smoke.php
@@ -311,6 +311,53 @@ assert_adapter_equals( 'round-trip preserves system task settings', 'wiki_graph_
 assert_adapter_equals( 'round-trip preserves system task params', 'wordpress-com', $round_steps[2]['flow_step_settings']['params']['root'] ?? null );
 assert_adapter_equals( 'round-trip preserves scheduling interval', 'hourly', $round_flow['scheduling_config']['interval'] );
 
+echo "\n[2b] Subagent artifacts are file-backed and byte-exact\n";
+$graph_bundle = array(
+	'bundle_version' => 1,
+	'bundle_schema_version' => 1,
+	'agent' => array(
+		'agent_slug' => 'coordinator', 'agent_name' => 'Coordinator',
+		'agent_config' => array( 'model' => 'gpt-5', 'subagents' => array( 'writer' ) ),
+		'subagents' => array( 'writer' ),
+		'tool_policy' => array( 'allow' => array( 'datamachine/read-file' ) ),
+		'skill_policy' => array( 'mode' => 'explicit' ),
+		'skills' => array( 'root.md' => "root \0\xFF" ),
+		'references' => array( 'root-ref.md' => "root reference \xC3\xA9" ),
+	),
+	'files' => array(), 'pipelines' => array(), 'flows' => array(),
+	'subagents' => array(
+		array(
+			'slug' => 'writer', 'label' => 'Writer', 'description' => 'Writes.',
+			'agent_config' => array( 'model' => 'gpt-5-mini' ), 'memory' => array( 'SOUL.md' => "Writer\n" ),
+			'tool_policy' => array( 'allow' => array( 'datamachine/read-file' ) ),
+			'skill_policy' => array( 'mode' => 'explicit', 'allowed' => array( 'compose.md' ) ),
+			'skills' => array( 'compose.md' => "cafe \xC3\xA9\0skill" ),
+			'references' => array( 'guide.bin' => "\0reference\xFF" ),
+			'subagents' => array(),
+		),
+	),
+);
+$graph_directory = AgentBundleArrayAdapter::from_array_bundle( $graph_bundle );
+$graph_tmp = sys_get_temp_dir() . '/datamachine-subagent-package-' . getmypid();
+rm_adapter_tree( $graph_tmp );
+$graph_directory->write( $graph_tmp );
+$graph_manifest = json_decode( file_get_contents( $graph_tmp . '/manifest.json' ), true );
+assert_adapter( 'manifest contains skill artifact path and hash, not bytes', isset( $graph_manifest['subagents'][0]['skills'][0]['path'], $graph_manifest['subagents'][0]['skills'][0]['sha256'] ) && ! isset( $graph_manifest['subagents'][0]['skills']['compose.md'] ) );
+assert_adapter( 'root manifest contains skill path and hash, not bytes', isset( $graph_manifest['agent']['skills'][0]['path'], $graph_manifest['agent']['skills'][0]['sha256'] ) && ! isset( $graph_manifest['agent']['skills']['root.md'] ) );
+assert_adapter_equals( 'root skill bytes use dedicated package directory', "root \0\xFF", file_get_contents( $graph_tmp . '/skills/root.md' ) );
+assert_adapter_equals( 'root reference bytes use dedicated package directory', "root reference \xC3\xA9", file_get_contents( $graph_tmp . '/references/root-ref.md' ) );
+assert_adapter_equals( 'skill bytes written without JSON transport', "cafe \xC3\xA9\0skill", file_get_contents( $graph_tmp . '/subagents/writer/skills/compose.md' ) );
+assert_adapter_equals( 'reference bytes written without JSON transport', "\0reference\xFF", file_get_contents( $graph_tmp . '/subagents/writer/references/guide.bin' ) );
+$graph_round_trip = AgentBundleArrayAdapter::to_import_payload( AgentBundleDirectory::read( $graph_tmp ) );
+assert_adapter_equals( 'skill bytes survive directory package read', "cafe \xC3\xA9\0skill", $graph_round_trip['subagents'][0]['skills']['compose.md'] ?? null );
+assert_adapter_equals( 'reference bytes survive directory package read', "\0reference\xFF", $graph_round_trip['subagents'][0]['references']['guide.bin'] ?? null );
+assert_adapter_equals( 'root skill bytes survive directory package read', "root \0\xFF", $graph_round_trip['agent']['skills']['root.md'] ?? null );
+assert_adapter_equals( 'root reference bytes survive directory package read', "root reference \xC3\xA9", $graph_round_trip['agent']['references']['root-ref.md'] ?? null );
+assert_adapter_equals( 'root skill policy survives directory package read', array( 'mode' => 'explicit' ), $graph_round_trip['agent']['skill_policy'] ?? null );
+assert_adapter_equals( 'root tool policy survives directory package read', array( 'allow' => array( 'datamachine/read-file' ) ), $graph_round_trip['agent']['tool_policy'] ?? null );
+assert_adapter_equals( 'child skill policy survives directory package read', array( 'mode' => 'explicit', 'allowed' => array( 'compose.md' ) ), $graph_round_trip['subagents'][0]['skill_policy'] ?? null );
+rm_adapter_tree( $graph_tmp );
+
 echo "\n[3] Directory read resolves prompt file references relative to bundle root\n";
 if ( ! is_dir( $tmp . '/prompts' ) ) {
 	mkdir( $tmp . '/prompts', 0775, true );

--- a/tests/agent-bundler-transaction-durability-smoke.php
+++ b/tests/agent-bundler-transaction-durability-smoke.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Source contract smoke for bundle transaction durability.
+ *
+ * Run with: php tests/agent-bundler-transaction-durability-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Agents/AgentBundler.php' );
+if ( ! is_string( $source ) ) {
+	exit( 1 );
+}
+
+$checks = array(
+	'COMMIT failure throws rather than returning success' => str_contains( $source, "if ( false === \$wpdb->query( 'COMMIT' ) )" ) && str_contains( $source, 'Database COMMIT failed:' ),
+	'normal import surfaces rollback diagnostics' => str_contains( $source, 'Agent install rolled back: %s' ) && str_contains( $source, 'Rollback also failed: %s' ),
+	'graph import surfaces rollback diagnostics' => str_contains( $source, 'Subagent graph install rolled back: %s' ) && str_contains( $source, 'commit_transaction( $transaction_started );' ),
+);
+
+$failed = 0;
+foreach ( $checks as $label => $passed ) {
+	echo ( $passed ? 'PASS' : 'FAIL' ) . ": {$label}\n";
+	if ( ! $passed ) {
+		++$failed;
+	}
+}
+
+exit( $failed ? 1 : 0 );

--- a/tests/agents-api-persisted-agent-registry-smoke.php
+++ b/tests/agents-api-persisted-agent-registry-smoke.php
@@ -13,6 +13,9 @@ agents_api_smoke_require_module();
 require_once dirname( __DIR__ ) . '/inc/Core/Database/BaseRepository.php';
 require_once dirname( __DIR__ ) . '/inc/Core/Agents/AgentConfigFactory.php';
 require_once dirname( __DIR__ ) . '/inc/Core/Database/Agents/Agents.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleValidationException.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/PortableSlug.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Agents/AgentSubagentGraph.php';
 require_once dirname( __DIR__ ) . '/inc/Engine/Agents/PersistedAgentProjector.php';
 
 use DataMachine\Core\Agents\AgentConfigFactory;
@@ -113,6 +116,10 @@ $repository = new DataMachinePersistedAgentProjectorFakeRepository(
 			),
 		),
 		array(
+			'agent_id' => 104, 'agent_slug' => 'coordinator', 'agent_name' => 'Coordinator', 'owner_id' => 7,
+			'agent_config' => array( 'subagents' => array( 'researcher', 'writer' ) ),
+		),
+		array(
 			'agent_id'     => 102,
 			'agent_slug'   => 'woocommerce-wiki',
 			'agent_name'   => 'WooCommerce Wiki',
@@ -142,7 +149,7 @@ do_action( 'init' );
 $agents       = wp_get_agents();
 $agent        = wp_get_agent( 'wordpress-com-wiki' );
 $roadie_agent = wp_get_agent( 'roadie' );
-agents_api_smoke_assert_equals( array( 'wordpress-com-wiki', 'woocommerce-wiki', 'roadie' ), array_keys( $agents ), 'persisted rows are visible through wp_get_agents()', $failures, $passes );
+	agents_api_smoke_assert_equals( array( 'wordpress-com-wiki', 'woocommerce-wiki', 'roadie', 'coordinator' ), array_keys( $agents ), 'persisted rows are visible through wp_get_agents()', $failures, $passes );
 agents_api_smoke_assert_equals( true, $agent instanceof WP_Agent, 'persisted row resolves through wp_get_agent()', $failures, $passes );
 agents_api_smoke_assert_equals( 'WordPress.com Wiki', $agent ? $agent->get_label() : '', 'row agent_name becomes label', $failures, $passes );
 agents_api_smoke_assert_equals( 'Maintains the WordPress.com wiki brain.', $agent ? $agent->get_description() : '', 'extension description source is surfaced', $failures, $passes );
@@ -151,6 +158,7 @@ agents_api_smoke_assert_equals( 7, $agent && is_callable( $agent->get_owner_reso
 agents_api_smoke_assert_equals( 'gpt-5.5', $agent ? $agent->get_default_config()['default_model'] ?? '' : '', 'agent_config becomes default_config', $failures, $passes );
 agents_api_smoke_assert_equals( 'wordpress-com-wiki', $agent ? $agent->get_meta()['source_package'] ?? '' : '', 'bundle slug is exposed as source package', $failures, $passes );
 agents_api_smoke_assert_equals( 'wordpress-com', $agent ? $agent->get_meta()['intelligence_wiki_brain_wiki_slug'] ?? '' : '', 'extension metadata projector is exposed', $failures, $passes );
+agents_api_smoke_assert_equals( array( 'researcher', 'writer' ), wp_get_agent( 'coordinator' ) ? wp_get_agent( 'coordinator' )->get_subagents() : array(), 'persisted config projects exact normalized subagent edges', $failures, $passes );
 
 echo "\n[1b] persisted agent config normalizes legacy model aliases:\n";
 $legacy_config = AgentConfigFactory::normalize(
@@ -183,7 +191,7 @@ add_action(
 do_action( 'init' );
 
 $agents = wp_get_agents();
-agents_api_smoke_assert_equals( array( 'wordpress-com-wiki', 'woocommerce-wiki', 'roadie' ), array_keys( $agents ), 'projection skips duplicate slugs without dropping other rows', $failures, $passes );
+	agents_api_smoke_assert_equals( array( 'wordpress-com-wiki', 'woocommerce-wiki', 'roadie', 'coordinator' ), array_keys( $agents ), 'projection skips duplicate slugs without dropping other rows', $failures, $passes );
 agents_api_smoke_assert_equals( 'Declarative Definition', $agents['wordpress-com-wiki']->get_label(), 'first registered definition wins', $failures, $passes );
 agents_api_smoke_assert_equals( array(), $GLOBALS['__agents_api_smoke_wrong'], 'duplicate skip avoids doing-it-wrong notices', $failures, $passes );
 

--- a/tests/persisted-agent-graph-projector-paths-smoke.php
+++ b/tests/persisted-agent-graph-projector-paths-smoke.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Pure path-integrity smoke for persisted graph projection.
+ *
+ * Run with: php tests/persisted-agent-graph-projector-paths-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $value ) { return (string) $value; }
+}
+
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleValidationException.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/BundleRelativePath.php';
+require_once dirname( __DIR__ ) . '/inc/Engine/Agents/PersistedAgentGraphProjector.php';
+
+use DataMachine\Engine\Agents\PersistedAgentGraphProjector;
+use DataMachine\Engine\Bundle\BundleValidationException;
+
+$method = new ReflectionMethod( PersistedAgentGraphProjector::class, 'verified_source_path' );
+$tmp = sys_get_temp_dir() . '/datamachine-graph-paths-' . getmypid();
+@mkdir( $tmp, 0775, true );
+file_put_contents( $tmp . '/valid.md', "valid\0bytes" );
+
+$assert = static function ( bool $condition, string $label ): void {
+	echo ( $condition ? 'PASS' : 'FAIL' ) . ": {$label}\n";
+	if ( ! $condition ) { exit( 1 ); }
+};
+
+$hash = hash_file( 'sha256', $tmp . '/valid.md' );
+$assert( realpath( $tmp . '/valid.md' ) === $method->invoke( null, $tmp, 'valid.md', $hash, 'skill' ), 'valid regular file with matching hash resolves' );
+
+foreach ( array(
+	array( '../escape.md', $hash, 'traversal key' ),
+	array( 'valid.md', str_repeat( '0', 64 ), 'modified hash' ),
+) as $case ) {
+	list( $path, $expected_hash, $label ) = $case;
+	$rejected = false;
+	try { $method->invoke( null, $tmp, $path, $expected_hash, 'skill' ); } catch ( Throwable $e ) { $rejected = true; }
+	$assert( $rejected, $label . ' is rejected' );
+}
+
+if ( function_exists( 'symlink' ) && @symlink( $tmp . '/valid.md', $tmp . '/linked.md' ) ) {
+	$rejected = false;
+	try { $method->invoke( null, $tmp, 'linked.md', $hash, 'skill' ); } catch ( Throwable $e ) { $rejected = true; }
+	$assert( $rejected, 'symlink source is rejected' );
+	@unlink( $tmp . '/linked.md' );
+}
+
+@unlink( $tmp . '/valid.md' );
+@rmdir( $tmp );


### PR DESCRIPTION
## Summary

Adds first-class portable coordinator/subagent graphs to schema-v1 agent bundles. Data Machine can now install, persist, export, upgrade, and project a coordinator with referenced child agents while keeping runtime-specific adapter behavior outside core.

- validates exact graph edges, canonical slugs, duplicates, unresolved nodes, and cycles
- transports root and child identities, native skills, and references as hashed package files
- persists models, tool policies, skill policies, and child edges
- installs graph packages atomically and fails closed when transactions or commits fail
- preserves locally modified artifacts during upgrades
- journals filesystem and identity mutations for rollback
- exposes an access-controlled `wp datamachine agent graph <slug> --format=json` projection
- validates projected source containment, symlinks, regular files, and persisted hashes
- preserves existing single-agent schema-v1 package behavior

Closes #3169.

## Verification

- `php tests/agent-bundle-subagent-graph-smoke.php`
- `php tests/agent-bundler-transaction-durability-smoke.php`
- `php tests/persisted-agent-graph-projector-paths-smoke.php`
- PHP syntax checks for changed files
- `git diff --check`

Composer-backed directory adapter, Agents API registry, and WordPress database integration tests remain environment gates because this isolated worktree does not have its vendor dependencies installed.

## AI assistance

OpenAI gpt-5.6-sol via OpenCode inspected the Agents API and Data Machine bundle/import contracts; it helped implement and review graph validation, atomic import behavior, artifact integrity, runtime projection, and tests. Chris Huber reviewed and is responsible for every line.