### PR TITLE
ci: cap the changed-scope test selection at 60 files

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -37,4 +37,25 @@ jobs:
       # undeclared inputs to a reusable workflow is a hard startup_failure.
       commands: ${{ github.event_name == 'pull_request' && 'review audit,review lint,review test,refactor lint' || github.event_name == 'workflow_dispatch' && 'review audit,review lint,review test' || 'review test' }}
       expected-commands: ${{ github.event_name == 'pull_request' && 'review audit,review lint,review test' || github.event_name == 'workflow_dispatch' && 'review audit,review lint,review test' || 'review test' }}
+      # Fail an oversized changed-scope selection in seconds instead of burning
+      # the whole 1500s test budget and reporting zero test counts.
+      #
+      # Measured on run 31735416840 (3 changed files -> 161 selected tests):
+      # 93 host smokes started and 90 finished inside the budget, at a mean of
+      # 16.6s each (median 16, p90 17, max 25). Those 90 sum to 1492s, so the
+      # smokes ARE the budget -- throughput is ~90 per phase and there is no
+      # meaningful overhead to reclaim.
+      #
+      # Observed selections and outcomes:
+      #   1 -> passed in 3m39s
+      #   95, 137, 161, 177, 312, 459, 464 -> all timed out at 1500s
+      #
+      # 60 x 16.6s ~= 1000s, about two thirds of the budget, leaving ~500s of
+      # headroom for runner variance. Above ~80 the phase is a coin flip and
+      # above ~90 it cannot finish at all.
+      #
+      # This bounds the symptom. The cause is that a 3-file diff selects 161
+      # tests: the WordPress drift/changed-test mapping is too broad, tracked
+      # in Extra-Chill/homeboy#12365.
+      max-changed-test-files: '60'
     secrets: inherit


### PR DESCRIPTION
Turns the repeated 25-minute Candidate Test timeouts into a ~30-second, actionable failure.

Consumes the guard added in Extra-Chill/homeboy#12385 and exposed as a workflow input in Extra-Chill/homeboy-action#382 (shipped in `v2.12.0`, so `@v2` already declares `max-changed-test-files` — no `startup_failure` risk).

## The problem

Changed-scope resolution maps small diffs onto test selections that physically cannot finish. PR #3173 changed **three files** and selected **161 tests**; the phase burned the full 1,500s budget and reported *zero* test counts — then did it again on the rerun.

## The measurement

From run [31735416840](https://github.com/Extra-Chill/data-machine/actions/runs/31735416840) (161 selected), counting `HOST_SMOKE_BEGIN` and the per-smoke `elapsed=Ns`:

- **93 smokes started, 90 completed** inside the budget
- mean **16.6s** each — median 16, p90 17, max 25 (a very tight distribution)
- those 90 sum to **1492s**

The smokes *are* the budget. There is no setup overhead to reclaim, and throughput is **~90 smokes per phase**.

Observed selections and outcomes across recent PR runs:

| selected | duration | result |
|---|---|---|
| 1 | 3m39s | passed |
| 95 | 27m51s | timeout |
| 137 | 27m45s | timeout |
| 161 | 21m31s | timeout |
| 177 | 27m37s | timeout |
| 312 | 27m15s | timeout |
| 459 | 28m22s | timeout |
| 464 | 27m21s | timeout |

95 already exceeds the ceiling, which is why nothing above it has ever completed.

## Why 60

60 × 16.6s ≈ **1000s**, about two thirds of the 1,500s budget, leaving ~500s of headroom for runner variance. Above ~80 the phase is a coin flip; above ~90 it cannot finish at all.

The trade is deliberate: selections in the 61–90 band would have been marginal and flaky anyway, and this converts them into a deterministic, named failure instead of a 25-minute coin flip.

## What a failure looks like now

Instead of `test phase timed out after 1500s before reporting test counts, suite incomplete`, the phase fails in seconds with a `changed_scope_selection_exceeds_cap` finding (category `test-scope`, severity `error`) naming the selected count, the cap, a bounded preview of the selected files, and the remedies — narrow the mapping, run the full suite explicitly, raise the cap, or shard.

The full selection is preserved on `test_scope`, so `runs.json` still shows exactly which files triggered it.

## This bounds the symptom, not the cause

A 3-file diff selecting 161 tests means the WordPress drift/changed-test mapping is too broad. The cap makes that visible instead of expensive. Tracked in Extra-Chill/homeboy#12365.

## Sequencing note

The guard is merged to `homeboy` `main` but not yet in a published release, and this repo installs `version: latest`. Until a homeboy release ships it, `HOMEBOY_MAX_CHANGED_TEST_FILES` is simply an unread environment variable and CI behaves exactly as it does today — so this is safe to merge now and takes effect automatically on the next homeboy release.
