### PR TITLE
Fix empty subagent artifact maps

### DIFF
--- a/inc/Engine/Agents/AgentSubagentGraph.php
+++ b/inc/Engine/Agents/AgentSubagentGraph.php
@@ -25,10 +25,10 @@ final class AgentSubagentGraph {
 				throw new BundleValidationException( 'Subagent edges must contain non-empty slugs.' );
 			}
 			$edge_slug = PortableSlug::normalize( $edge, 'subagent' );
-			if ( $edge_slug !== trim( $edge ) ) {
+			if ( trim( $edge ) !== $edge_slug ) {
 				throw new BundleValidationException( sprintf( 'Invalid subagent edge slug: %s.', esc_html( $edge ) ) );
 			}
-			if ( '' !== $slug && $edge_slug === PortableSlug::normalize( $slug, 'agent' ) ) {
+			if ( '' !== $slug && PortableSlug::normalize( $slug, 'agent' ) === $edge_slug ) {
 				throw new BundleValidationException( sprintf( 'Subagent %s cannot reference itself.', esc_html( $slug ) ) );
 			}
 			if ( in_array( $edge_slug, $normalized, true ) ) {
@@ -70,7 +70,7 @@ final class AgentSubagentGraph {
 			if ( $slug !== $child['slug'] ) {
 				throw new BundleValidationException( sprintf( 'Subagent slug must be canonical: %s.', esc_html( $child['slug'] ) ) );
 			}
-			if ( '' !== $coordinator_slug && $slug === PortableSlug::normalize( $coordinator_slug, 'agent' ) ) {
+			if ( '' !== $coordinator_slug && PortableSlug::normalize( $coordinator_slug, 'agent' ) === $slug ) {
 				throw new BundleValidationException( 'A coordinator cannot declare itself as a subagent.' );
 			}
 			if ( isset( $nodes[ $slug ] ) ) {
@@ -91,7 +91,7 @@ final class AgentSubagentGraph {
 				$memory[ $path ] = $contents;
 			}
 			ksort( $memory, SORT_STRING );
-			$edges = self::edges_from_config( $child['subagents'], $slug );
+			$edges          = self::edges_from_config( $child['subagents'], $slug );
 			$nodes[ $slug ] = array(
 				'slug'         => $slug,
 				'label'        => (string) $child['label'],
@@ -163,7 +163,7 @@ final class AgentSubagentGraph {
 
 	/** @return array<string,string> */
 	private static function normalize_file_map( array $files, string $slug, string $kind ): array {
-		if ( array_is_list( $files ) ) {
+		if ( array() !== $files && array_is_list( $files ) ) {
 			throw new BundleValidationException( sprintf( 'Subagent %s %s artifacts must be a path-to-bytes object.', esc_html( $slug ), esc_html( $kind ) ) );
 		}
 		$normalized = array();

--- a/tests/agent-bundler-directory-adapter-smoke.php
+++ b/tests/agent-bundler-directory-adapter-smoke.php
@@ -362,6 +362,18 @@ assert_adapter(
 );
 rm_adapter_tree( $graph_tmp );
 
+$empty_graph_bundle = $graph_bundle;
+$empty_graph_bundle['subagents'][0]['skills'] = array();
+$empty_graph_bundle['subagents'][0]['references'] = array();
+$empty_graph_directory = AgentBundleArrayAdapter::from_array_bundle( $empty_graph_bundle );
+$empty_graph_tmp = sys_get_temp_dir() . '/datamachine-empty-subagent-package-' . getmypid();
+rm_adapter_tree( $empty_graph_tmp );
+$empty_graph_directory->write( $empty_graph_tmp );
+$empty_graph_round_trip = AgentBundleArrayAdapter::to_import_payload( AgentBundleDirectory::read( $empty_graph_tmp ) );
+assert_adapter_equals( 'empty subagent skills survive directory package read', array(), $empty_graph_round_trip['subagents'][0]['skills'] ?? null );
+assert_adapter_equals( 'empty subagent references survive directory package read', array(), $empty_graph_round_trip['subagents'][0]['references'] ?? null );
+rm_adapter_tree( $empty_graph_tmp );
+
 echo "\n[3] Directory read resolves prompt file references relative to bundle root\n";
 if ( ! is_dir( $tmp . '/prompts' ) ) {
 	mkdir( $tmp . '/prompts', 0775, true );


### PR DESCRIPTION
## Summary

- accept PHP's empty-array representation for hydrated empty subagent artifact maps
- continue rejecting every non-empty list-form skill or reference payload
- cover empty skills and references through the full directory write/read round trip
- clean existing coding-standard findings in the touched graph validator

## Verification

- `php tests/agent-bundler-directory-adapter-smoke.php`
- `php tests/agent-bundle-subagent-graph-smoke.php`
- `homeboy review lint data-machine --path /Users/chubes/Developer/data-machine@fix-3187-empty-subagent-artifacts --changed-only --placement local`
- independent review found no findings

Closes #3187.

## AI Assistance

OpenAI GPT-5.6 Sol through OpenCode was used to reproduce the real package-validation failure, trace the hydration/normalization boundary, implement the minimal correction, run verification, and review the final diff. Chris Huber reviewed and remains responsible for every line.
