### PR TITLE
Fix empty agent bundle policies

### DIFF
--- a/inc/Engine/Agents/AgentSubagentGraph.php
+++ b/inc/Engine/Agents/AgentSubagentGraph.php
@@ -79,7 +79,10 @@ final class AgentSubagentGraph {
 			if ( ! is_array( $child['agent_config'] ) || ! is_array( $child['memory'] ) || ! is_array( $child['tool_policy'] ) || ! is_array( $child['skills'] ) || ! is_array( $child['references'] ) || ! is_array( $child['subagents'] ) ) {
 				throw new BundleValidationException( sprintf( 'Subagent %s has an invalid object field.', esc_html( $slug ) ) );
 			}
-			if ( array_key_exists( 'skill_policy', $child ) && ( ! is_array( $child['skill_policy'] ) || array_is_list( $child['skill_policy'] ) ) ) {
+			if ( array() !== $child['tool_policy'] && array_is_list( $child['tool_policy'] ) ) {
+				throw new BundleValidationException( sprintf( 'Subagent %s has an invalid tool policy.', esc_html( $slug ) ) );
+			}
+			if ( array_key_exists( 'skill_policy', $child ) && ( ! is_array( $child['skill_policy'] ) || ( array() !== $child['skill_policy'] && array_is_list( $child['skill_policy'] ) ) ) ) {
 				throw new BundleValidationException( sprintf( 'Subagent %s has an invalid skill policy.', esc_html( $slug ) ) );
 			}
 			$memory = array();

--- a/inc/Engine/Bundle/AgentBundleManifest.php
+++ b/inc/Engine/Bundle/AgentBundleManifest.php
@@ -182,7 +182,7 @@ final class AgentBundleManifest {
 			if ( ! array_key_exists( $kind, $agent ) ) {
 				continue;
 			}
-			if ( ! is_array( $agent[ $kind ] ) || array_is_list( $agent[ $kind ] ) ) {
+			if ( ! is_array( $agent[ $kind ] ) || ( array() !== $agent[ $kind ] && array_is_list( $agent[ $kind ] ) ) ) {
 				throw new BundleValidationException( sprintf( 'manifest.json agent.%s must be a path-to-bytes object after hydration.', esc_html( $kind ) ) );
 			}
 			$files = array();

--- a/inc/Engine/Bundle/AgentBundleManifest.php
+++ b/inc/Engine/Bundle/AgentBundleManifest.php
@@ -197,13 +197,13 @@ final class AgentBundleManifest {
 			$validated[ $kind ] = $files;
 		}
 		if ( array_key_exists( 'skill_policy', $agent ) ) {
-			if ( ! is_array( $agent['skill_policy'] ) || array_is_list( $agent['skill_policy'] ) ) {
+			if ( ! is_array( $agent['skill_policy'] ) || ( array() !== $agent['skill_policy'] && array_is_list( $agent['skill_policy'] ) ) ) {
 				throw new BundleValidationException( 'manifest.json agent.skill_policy must be an object.' );
 			}
 			$validated['skill_policy'] = $agent['skill_policy'];
 		}
 		if ( array_key_exists( 'tool_policy', $agent ) ) {
-			if ( ! is_array( $agent['tool_policy'] ) || array_is_list( $agent['tool_policy'] ) ) {
+			if ( ! is_array( $agent['tool_policy'] ) || ( array() !== $agent['tool_policy'] && array_is_list( $agent['tool_policy'] ) ) ) {
 				throw new BundleValidationException( 'manifest.json agent.tool_policy must be an object.' );
 			}
 			$validated['tool_policy'] = $agent['tool_policy'];

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -895,6 +895,11 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 	 */
 	public function test_post_claim_failure_rolls_back_and_reports_typed_error(): void {
 		$bundle = $this->fixture_bundle();
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$pipeline_ids_before = array_map( 'intval', $wpdb->get_col( "SELECT pipeline_id FROM {$wpdb->prefix}datamachine_pipelines ORDER BY pipeline_id" ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$flow_ids_before = array_map( 'intval', $wpdb->get_col( "SELECT flow_id FROM {$wpdb->prefix}datamachine_flows ORDER BY flow_id" ) );
 
 		$fault_count = 0;
 		add_action(
@@ -917,14 +922,13 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 			'No half-installed agent row remains after rollback.'
 		);
 
-		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
-		$pipeline_count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}datamachine_pipelines" );
+		$pipeline_ids = array_map( 'intval', $wpdb->get_col( "SELECT pipeline_id FROM {$wpdb->prefix}datamachine_pipelines ORDER BY pipeline_id" ) );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
-		$flow_count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}datamachine_flows" );
+		$flow_ids = array_map( 'intval', $wpdb->get_col( "SELECT flow_id FROM {$wpdb->prefix}datamachine_flows ORDER BY flow_id" ) );
 
-		$this->assertSame( 0, $pipeline_count, 'No orphan pipeline rows.' );
-		$this->assertSame( 0, $flow_count, 'No orphan flow rows.' );
+		$this->assertSame( $pipeline_ids_before, $pipeline_ids, 'Failed import leaves the pipeline row set unchanged.' );
+		$this->assertSame( $flow_ids_before, $flow_ids, 'Failed import leaves the flow row set unchanged.' );
 	}
 
 	public function test_legacy_file_maps_reject_unsafe_paths_before_mutation(): void {

--- a/tests/agent-bundler-directory-adapter-smoke.php
+++ b/tests/agent-bundler-directory-adapter-smoke.php
@@ -363,6 +363,8 @@ assert_adapter(
 rm_adapter_tree( $graph_tmp );
 
 $empty_graph_bundle = $graph_bundle;
+$empty_graph_bundle['agent']['skills'] = array();
+$empty_graph_bundle['agent']['references'] = array();
 $empty_graph_bundle['agent']['skill_policy'] = array();
 $empty_graph_bundle['agent']['tool_policy'] = array();
 $empty_graph_bundle['subagents'][0]['skills'] = array();
@@ -374,6 +376,8 @@ $empty_graph_tmp = sys_get_temp_dir() . '/datamachine-empty-subagent-package-' .
 rm_adapter_tree( $empty_graph_tmp );
 $empty_graph_directory->write( $empty_graph_tmp );
 $empty_graph_round_trip = AgentBundleArrayAdapter::to_import_payload( AgentBundleDirectory::read( $empty_graph_tmp ) );
+assert_adapter_equals( 'empty root skills survive directory package read', array(), $empty_graph_round_trip['agent']['skills'] ?? null );
+assert_adapter_equals( 'empty root references survive directory package read', array(), $empty_graph_round_trip['agent']['references'] ?? null );
 assert_adapter_equals( 'empty subagent skills survive directory package read', array(), $empty_graph_round_trip['subagents'][0]['skills'] ?? null );
 assert_adapter_equals( 'empty subagent references survive directory package read', array(), $empty_graph_round_trip['subagents'][0]['references'] ?? null );
 assert_adapter_equals( 'empty root skill policy survives directory package read', array(), $empty_graph_round_trip['agent']['skill_policy'] ?? null );
@@ -381,6 +385,17 @@ assert_adapter_equals( 'empty root tool policy survives directory package read',
 assert_adapter_equals( 'omitted subagent skill policy survives directory package read as empty', array(), $empty_graph_round_trip['subagents'][0]['skill_policy'] ?? null );
 assert_adapter_equals( 'empty subagent tool policy survives directory package read', array(), $empty_graph_round_trip['subagents'][0]['tool_policy'] ?? null );
 rm_adapter_tree( $empty_graph_tmp );
+
+foreach ( array( 'skills', 'references' ) as $invalid_artifact_kind ) {
+	$invalid_artifact_bundle = $graph_bundle;
+	$invalid_artifact_bundle['agent'][ $invalid_artifact_kind ] = array( 'root.md' );
+	try {
+		AgentBundleArrayAdapter::from_array_bundle( $invalid_artifact_bundle );
+		assert_adapter( "non-empty root {$invalid_artifact_kind} list is rejected", false );
+	} catch ( BundleValidationException $e ) {
+		assert_adapter( "non-empty root {$invalid_artifact_kind} list is rejected", str_contains( $e->getMessage(), 'path-to-bytes object' ) );
+	}
+}
 
 foreach ( array( 'root skill', 'root tool', 'subagent skill', 'subagent tool' ) as $invalid_policy ) {
 	$invalid_policy_bundle = $graph_bundle;

--- a/tests/agent-bundler-directory-adapter-smoke.php
+++ b/tests/agent-bundler-directory-adapter-smoke.php
@@ -363,8 +363,12 @@ assert_adapter(
 rm_adapter_tree( $graph_tmp );
 
 $empty_graph_bundle = $graph_bundle;
+$empty_graph_bundle['agent']['skill_policy'] = array();
+$empty_graph_bundle['agent']['tool_policy'] = array();
 $empty_graph_bundle['subagents'][0]['skills'] = array();
 $empty_graph_bundle['subagents'][0]['references'] = array();
+unset( $empty_graph_bundle['subagents'][0]['skill_policy'] );
+$empty_graph_bundle['subagents'][0]['tool_policy'] = array();
 $empty_graph_directory = AgentBundleArrayAdapter::from_array_bundle( $empty_graph_bundle );
 $empty_graph_tmp = sys_get_temp_dir() . '/datamachine-empty-subagent-package-' . getmypid();
 rm_adapter_tree( $empty_graph_tmp );
@@ -372,7 +376,30 @@ $empty_graph_directory->write( $empty_graph_tmp );
 $empty_graph_round_trip = AgentBundleArrayAdapter::to_import_payload( AgentBundleDirectory::read( $empty_graph_tmp ) );
 assert_adapter_equals( 'empty subagent skills survive directory package read', array(), $empty_graph_round_trip['subagents'][0]['skills'] ?? null );
 assert_adapter_equals( 'empty subagent references survive directory package read', array(), $empty_graph_round_trip['subagents'][0]['references'] ?? null );
+assert_adapter_equals( 'empty root skill policy survives directory package read', array(), $empty_graph_round_trip['agent']['skill_policy'] ?? null );
+assert_adapter_equals( 'empty root tool policy survives directory package read', array(), $empty_graph_round_trip['agent']['tool_policy'] ?? null );
+assert_adapter_equals( 'omitted subagent skill policy survives directory package read as empty', array(), $empty_graph_round_trip['subagents'][0]['skill_policy'] ?? null );
+assert_adapter_equals( 'empty subagent tool policy survives directory package read', array(), $empty_graph_round_trip['subagents'][0]['tool_policy'] ?? null );
 rm_adapter_tree( $empty_graph_tmp );
+
+foreach ( array( 'root skill', 'root tool', 'subagent skill', 'subagent tool' ) as $invalid_policy ) {
+	$invalid_policy_bundle = $graph_bundle;
+	if ( 'root skill' === $invalid_policy ) {
+		$invalid_policy_bundle['agent']['skill_policy'] = array( 'explicit' );
+	} elseif ( 'root tool' === $invalid_policy ) {
+		$invalid_policy_bundle['agent']['tool_policy'] = array( 'datamachine/read-file' );
+	} elseif ( 'subagent skill' === $invalid_policy ) {
+		$invalid_policy_bundle['subagents'][0]['skill_policy'] = array( 'compose.md' );
+	} else {
+		$invalid_policy_bundle['subagents'][0]['tool_policy'] = array( 'datamachine/read-file' );
+	}
+	try {
+		AgentBundleArrayAdapter::from_array_bundle( $invalid_policy_bundle );
+		assert_adapter( "non-empty {$invalid_policy} policy list is rejected", false );
+	} catch ( BundleValidationException $exception ) {
+		assert_adapter( "non-empty {$invalid_policy} policy list is rejected", str_contains( $exception->getMessage(), 'policy' ) );
+	}
+}
 
 echo "\n[3] Directory read resolves prompt file references relative to bundle root\n";
 if ( ! is_dir( $tmp . '/prompts' ) ) {


### PR DESCRIPTION
## Summary

- accept PHP's empty-array representation for empty root and subagent policy objects
- continue rejecting non-empty policy lists at every root/subagent skill/tool boundary
- cover omitted and empty policies through directory write, read, hydration, and import projection

## Verification

- `php tests/agent-bundler-directory-adapter-smoke.php` (70 assertions)
- `php tests/agent-bundle-subagent-graph-smoke.php`
- `vendor/bin/phpunit --filter AgentBundlerImportTest`
- focused PHPCS for all changed files
- independent review found no remaining findings

Closes #3189.

## AI Assistance

OpenAI GPT-5.6 Sol through OpenCode was used to reproduce the live North bundle failure, trace the directory round-trip contradiction, implement the schema-boundary repair, add regression coverage, and review the final diff. Chris Huber reviewed and remains responsible for every line.
