### PR TITLE
Avoid synthetic agents on fresh installs

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -37,4 +37,5 @@ jobs:
       # undeclared inputs to a reusable workflow is a hard startup_failure.
       commands: ${{ github.event_name == 'pull_request' && 'review audit,review lint,review test,refactor lint' || github.event_name == 'workflow_dispatch' && 'review audit,review lint,review test' || 'review test' }}
       expected-commands: ${{ github.event_name == 'pull_request' && 'review audit,review lint,review test' || github.event_name == 'workflow_dispatch' && 'review audit,review lint,review test' || 'review test' }}
+      test-shards: '4'
     secrets: inherit

--- a/data-machine.php
+++ b/data-machine.php
@@ -405,7 +405,7 @@ function datamachine_resolve_existing_agent_id( int $user_id ): int {
 
 	$agents_repo = new \DataMachine\Core\Database\Agents\Agents();
 	$owned       = $agents_repo->get_all_by_owner_id( $user_id );
-	$active_slug = sanitize_title( (string) get_user_meta( $user_id, 'datamachine_active_agent_slug', true ) );
+	$active_slug = sanitize_title( (string) get_user_meta( $user_id, \DataMachine\Core\Agents\AgentBundler::ACTIVE_AGENT_META_KEY, true ) );
 	if ( '' !== $active_slug ) {
 		foreach ( $owned as $agent ) {
 			if ( (string) $agent['agent_slug'] === $active_slug ) {

--- a/data-machine.php
+++ b/data-machine.php
@@ -386,6 +386,38 @@ function datamachine_resolve_or_create_agent_id( int $user_id ): int {
 }
 
 /**
+ * Resolve an existing default agent without provisioning a new identity.
+ *
+ * The user's explicit active-agent preference is authoritative. A single
+ * owned agent remains a compatibility fallback for existing installations;
+ * multiple owned agents require an explicit choice.
+ *
+ * @since 0.173.0
+ *
+ * @param int $user_id WordPress user ID.
+ * @return int Agent ID, or 0 when no unambiguous existing agent resolves.
+ */
+function datamachine_resolve_existing_agent_id( int $user_id ): int {
+	$user_id = absint( $user_id );
+	if ( $user_id <= 0 ) {
+		return 0;
+	}
+
+	$agents_repo = new \DataMachine\Core\Database\Agents\Agents();
+	$owned       = $agents_repo->get_all_by_owner_id( $user_id );
+	$active_slug = sanitize_title( (string) get_user_meta( $user_id, 'datamachine_active_agent_slug', true ) );
+	if ( '' !== $active_slug ) {
+		foreach ( $owned as $agent ) {
+			if ( (string) $agent['agent_slug'] === $active_slug ) {
+				return (int) $agent['agent_id'];
+			}
+		}
+	}
+
+	return 1 === count( $owned ) ? (int) $owned[0]['agent_id'] : 0;
+}
+
+/**
  * Resolve the acting agent identity for a system/ability-triggered operation.
  *
  * Media, SEO, and linking abilities enqueue agent-owned queued tasks (alt text,
@@ -404,11 +436,12 @@ function datamachine_resolve_or_create_agent_id( int $user_id ): int {
  * @since 0.160.0 Always resolves to the install default agent; never auto-provisions
  *               a per-human agent row for system tasks. ChatOrchestrator remains
  *               the legitimate caller of datamachine_resolve_or_create_agent_id().
+ * @since 0.173.0 Fails closed when no explicit or unambiguous existing agent resolves.
  *
  * @return array{user_id:int,agent_id:int,triggering_user_id:int} Acting user id
  *         (the default agent owner), its agent id, and the original triggering
- *         user id. user_id and agent_id may be 0 only when the install has no
- *         resolvable default owner at all.
+ *         user id. agent_id is 0 when the install has no explicit or unambiguous
+ *         existing agent; user_id is 0 only when no default owner resolves.
  */
 function datamachine_resolve_system_agent_context(): array {
 	$triggering_user_id = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
@@ -421,10 +454,10 @@ function datamachine_resolve_system_agent_context(): array {
 		$user_id = (int) \DataMachine\Core\FilesRepository\DirectoryManager::get_default_agent_user_id();
 	}
 
-	// Resolve (or create) the agent row for the *default owner* only. System
-	// tasks never auto-provision an agent for the triggering human.
-	$agent_id = ( $user_id > 0 && function_exists( 'datamachine_resolve_or_create_agent_id' ) )
-		? datamachine_resolve_or_create_agent_id( $user_id )
+	// System work must use an existing, explicit identity. Fresh installs stay
+	// agentless until an agent is created or a package coordinator is installed.
+	$agent_id = ( $user_id > 0 && function_exists( 'datamachine_resolve_existing_agent_id' ) )
+		? datamachine_resolve_existing_agent_id( $user_id )
 		: 0;
 
 	return array(

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -49,6 +49,7 @@ use DataMachine\Engine\Agents\AgentSubagentGraph;
 defined( 'ABSPATH' ) || exit;
 
 class AgentBundler {
+	private const ACTIVE_AGENT_META_KEY = 'datamachine_active_agent_slug';
 
 	/**
 	 * Bundle format version for forward compatibility.
@@ -682,6 +683,7 @@ class AgentBundler {
 		$is_portable_bundle = ! empty( $bundle['bundle_slug'] ) || $this->bundle_has_portable_artifacts( $bundle );
 		$reconcile_runtime  = ! empty( $options['reconcile_runtime'] );
 		$is_upgrade         = ! empty( $options['is_upgrade'] );
+		$root_import        = empty( $options['_graph_transaction'] );
 
 		// Check for slug collision.
 		// On install: existing slug + (renamed-to-collision OR non-portable bundle) is a hard error.
@@ -707,18 +709,8 @@ class AgentBundler {
 		}
 
 		// Resolve owner.
-		if ( $owner_id <= 0 ) {
-			$owner_id = get_current_user_id();
-			if ( $owner_id <= 0 ) {
-				// WP-CLI context: fall back to first admin.
-				$admins   = get_users( array(
-					'role'   => 'administrator',
-					'number' => 1,
-					'fields' => 'ID',
-				) );
-				$owner_id = ! empty( $admins ) ? (int) $admins[0] : 1;
-			}
-		}
+		$owner_id           = $this->resolve_import_owner_id( $owner_id );
+		$select_first_agent = $root_import && ! $existing && $this->owner_is_agentless( $owner_id );
 
 		// Build summary for dry-run reporting.
 		$summary = array(
@@ -762,7 +754,7 @@ class AgentBundler {
 		$created_agent_id     = 0; // Tracks an agent row this call inserted, for manual rollback.
 		$created_pipeline_ids = array();
 		$created_flow_ids     = array();
-		$root_import          = empty( $options['_graph_transaction'] );
+		$selected_active_agent = false;
 		if ( $root_import ) {
 			$this->filesystem_journal = array();
 			$this->identity_journal   = array();
@@ -1327,10 +1319,6 @@ class AgentBundler {
 				throw new \RuntimeException( 'Failed to persist final agent_config with bundle metadata.' );
 			}
 
-			// Test fault-injection seam — fires after every mutation but before commit so a test handler
-			// can throw and exercise the rollback path without waiting for a SQLite race.
-			do_action( 'datamachine_bundle_import_pre_commit', $bundle_metadata, $slug, $agent_id );
-
 			// Verify persistence end-to-end. SQLite under Studio has been observed silently rolling back the
 			// outer mutations under contention (#1801): the in-memory bundler thinks everything wrote, but a
 			// fresh SELECT shows no agent row and no artifacts. Re-fetching closes the door on that path —
@@ -1349,6 +1337,12 @@ class AgentBundler {
 				) );
 			}
 
+			if ( $select_first_agent ) {
+				$selected_active_agent = $this->select_active_agent( $owner_id, $slug );
+			}
+			// Test fault-injection seam — fires after every mutation but before commit so a test handler
+			// can throw and exercise the rollback path without waiting for a SQLite race.
+			do_action( 'datamachine_bundle_import_pre_commit', $bundle_metadata, $slug, $agent_id );
 			$this->commit_transaction( $transaction_started );
 			if ( $root_import ) {
 				$this->filesystem_journal = array();
@@ -1436,6 +1430,9 @@ class AgentBundler {
 				$this->rollback_identity();
 			}
 			$this->manual_rollback( $created_agent_id, $created_pipeline_ids, $created_flow_ids );
+			if ( $selected_active_agent ) {
+				$this->rollback_active_agent_selection( $owner_id, $slug );
+			}
 
 			do_action(
 				'datamachine_log',
@@ -1569,6 +1566,9 @@ class AgentBundler {
 			return $result;
 		}
 
+		$owner_id           = $this->resolve_import_owner_id( $owner_id );
+		$select_first_agent = $this->owner_is_agentless( $owner_id );
+
 		$transaction_started      = $this->begin_transaction();
 		if ( ! $transaction_started ) {
 			return array(
@@ -1580,6 +1580,7 @@ class AgentBundler {
 		$this->filesystem_journal = array();
 		$this->identity_journal   = array();
 		$created_graph_agents     = array();
+		$selected_active_agent    = false;
 		try {
 			foreach ( $children as $child ) {
 				$existing_child = $this->agents_repo->get_by_slug( $child['slug'] );
@@ -1653,6 +1654,9 @@ class AgentBundler {
 			if ( ! $coordinator_existed && ! empty( $result['summary']['agent_id'] ) ) {
 				$created_graph_agents[] = array( 'agent_id' => (int) $result['summary']['agent_id'], 'slug' => $coordinator_slug );
 			}
+			if ( $select_first_agent ) {
+				$selected_active_agent = $this->select_active_agent( $owner_id, $coordinator_slug );
+			}
 			$this->commit_transaction( $transaction_started );
 			$this->filesystem_journal = array();
 			$this->identity_journal   = array();
@@ -1665,6 +1669,9 @@ class AgentBundler {
 			foreach ( $created_graph_agents as $created ) {
 				$this->safe_graph_agent_rollback( (int) $created['agent_id'], (string) $created['slug'] );
 			}
+			if ( $selected_active_agent ) {
+				$this->rollback_active_agent_selection( $owner_id, $coordinator_slug );
+			}
 			$error = sprintf( 'Subagent graph install rolled back: %s', $e->getMessage() );
 			if ( null !== $rollback_error ) {
 				$error .= sprintf( ' Rollback also failed: %s', $rollback_error );
@@ -1674,6 +1681,64 @@ class AgentBundler {
 				'error_code' => 'install_subagent_graph_rolled_back',
 				'error'      => $error,
 			);
+		}
+	}
+
+	/**
+	 * Resolve the owner used for an import.
+	 */
+	private function resolve_import_owner_id( int $owner_id ): int {
+		if ( $owner_id > 0 ) {
+			return $owner_id;
+		}
+
+		$owner_id = get_current_user_id();
+		if ( $owner_id > 0 ) {
+			return $owner_id;
+		}
+
+		$admins = get_users( array(
+			'role'   => 'administrator',
+			'number' => 1,
+			'fields' => 'ID',
+		) );
+
+		return ! empty( $admins ) ? (int) $admins[0] : 1;
+	}
+
+	/**
+	 * Whether an owner has neither an agent nor an explicit preference.
+	 */
+	private function owner_is_agentless( int $owner_id ): bool {
+		return '' === (string) get_user_meta( $owner_id, self::ACTIVE_AGENT_META_KEY, true )
+			&& array() === $this->agents_repo->get_all_by_owner_id( $owner_id );
+	}
+
+	/**
+	 * Make the first installed root agent the owner's explicit default.
+	 *
+	 * This runs inside the install transaction. A concurrent or existing
+	 * preference remains authoritative and is never overwritten.
+	 */
+	private function select_active_agent( int $owner_id, string $agent_slug ): bool {
+		if ( $owner_id <= 0 ) {
+			return false;
+		}
+
+		if ( add_user_meta( $owner_id, self::ACTIVE_AGENT_META_KEY, $agent_slug, true ) ) {
+			return true;
+		}
+		if ( '' !== (string) get_user_meta( $owner_id, self::ACTIVE_AGENT_META_KEY, true ) ) {
+			return false;
+		}
+
+		throw new \RuntimeException( 'Failed to persist the initial active agent preference.' );
+	}
+
+	/** Remove only the preference written by the failed import. */
+	private function rollback_active_agent_selection( int $owner_id, string $agent_slug ): void {
+		if ( $agent_slug === (string) get_user_meta( $owner_id, self::ACTIVE_AGENT_META_KEY, true ) ) {
+			delete_user_meta( $owner_id, self::ACTIVE_AGENT_META_KEY, $agent_slug );
 		}
 	}
 

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -49,7 +49,7 @@ use DataMachine\Engine\Agents\AgentSubagentGraph;
 defined( 'ABSPATH' ) || exit;
 
 class AgentBundler {
-	private const ACTIVE_AGENT_META_KEY = 'datamachine_active_agent_slug';
+	public const ACTIVE_AGENT_META_KEY = 'datamachine_active_agent_slug';
 
 	/**
 	 * Bundle format version for forward compatibility.

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -235,20 +235,20 @@ class AgentBundler {
 			}
 		}
 
-		$pipeline_slugs  = array_map( fn( AgentBundlePipelineFile $pipeline ) => $pipeline->slug(), $pipeline_documents );
-		$flow_slugs      = array_map( fn( AgentBundleFlowFile $flow ) => $flow->slug(), $flow_documents );
-		$artifact_files  = array(
+		$pipeline_slugs    = array_map( fn( AgentBundlePipelineFile $pipeline ) => $pipeline->slug(), $pipeline_documents );
+		$flow_slugs        = array_map( fn( AgentBundleFlowFile $flow ) => $flow->slug(), $flow_documents );
+		$artifact_files    = array(
 			\DataMachine\Engine\Bundle\BundleSchema::PROMPTS_DIR => SystemTaskPromptRegistry::bundle_prompt_files(),
 		);
-		$extension_paths = array_map( static fn( array $artifact ) => (string) ( $artifact['source_path'] ?? '' ), $extension_artifacts );
-		$subagents       = $this->export_subagents( is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array() );
-		$root_subagent   = is_array( $agent['agent_config']['datamachine_subagent'] ?? null ) ? $agent['agent_config']['datamachine_subagent'] : array();
+		$extension_paths   = array_map( static fn( array $artifact ) => (string) ( $artifact['source_path'] ?? '' ), $extension_artifacts );
+		$subagents         = $this->export_subagents( is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array() );
+		$root_subagent     = is_array( $agent['agent_config']['datamachine_subagent'] ?? null ) ? $agent['agent_config']['datamachine_subagent'] : array();
 		$coordinator_edges = AgentSubagentGraph::coordinator_edges(
 			is_array( $agent['agent_config'] ?? null ) ? ( $agent['agent_config']['subagents'] ?? array() ) : array(),
 			$subagents,
 			(string) $agent['agent_slug']
 		);
-		$manifest        = new AgentBundleManifest(
+		$manifest          = new AgentBundleManifest(
 			gmdate( 'c' ),
 			defined( 'DATAMACHINE_VERSION' ) ? 'data-machine/' . DATAMACHINE_VERSION : 'data-machine/unknown',
 			sanitize_title( (string) $agent['agent_slug'] ),
@@ -310,10 +310,10 @@ class AgentBundler {
 			if ( ! $child ) {
 				throw new BundleValidationException( sprintf( 'Coordinator edge %s does not resolve to a persisted agent.', esc_html( $slug ) ) );
 			}
-			$config    = is_array( $child['agent_config'] ?? null ) ? $child['agent_config'] : array();
-			$subagent  = is_array( $config['datamachine_subagent'] ?? null ) ? $config['datamachine_subagent'] : array();
-			$memory    = $this->collect_agent_files( (string) $child['agent_slug'] );
-			$node      = array(
+			$config         = is_array( $child['agent_config'] ?? null ) ? $child['agent_config'] : array();
+			$subagent       = is_array( $config['datamachine_subagent'] ?? null ) ? $config['datamachine_subagent'] : array();
+			$memory         = $this->collect_agent_files( (string) $child['agent_slug'] );
+			$node           = array(
 				'slug'         => (string) $child['agent_slug'],
 				'label'        => (string) $child['agent_name'],
 				'description'  => (string) ( $config['description'] ?? '' ),
@@ -624,12 +624,16 @@ class AgentBundler {
 				);
 			}
 
-			$payload = AgentBundleArrayAdapter::to_import_payload( $directory );
+			$payload                       = AgentBundleArrayAdapter::to_import_payload( $directory );
 			$payload['abilities_manifest'] = is_array( $bundle['abilities_manifest'] ?? null ) ? $bundle['abilities_manifest'] : array();
 			try {
 				$this->validate_import_file_maps( $payload );
 			} catch ( BundleValidationException $e ) {
-				return array( 'success' => false, 'error_code' => 'install_invalid_bundle', 'error' => $e->getMessage() );
+				return array(
+					'success'    => false,
+					'error_code' => 'install_invalid_bundle',
+					'error'      => $e->getMessage(),
+				);
 			}
 			if ( ! empty( $payload['subagents'] ) && empty( $options['_graph_node'] ) ) {
 				return $this->import_subagent_graph( $payload, $new_slug, $owner_id, $dry_run, $options );
@@ -640,7 +644,11 @@ class AgentBundler {
 		try {
 			$this->validate_import_file_maps( $bundle );
 		} catch ( BundleValidationException $e ) {
-			return array( 'success' => false, 'error_code' => 'install_invalid_bundle', 'error' => $e->getMessage() );
+			return array(
+				'success'    => false,
+				'error_code' => 'install_invalid_bundle',
+				'error'      => $e->getMessage(),
+			);
 		}
 
 		if ( ! empty( $bundle['subagents'] ) && empty( $options['_graph_node'] ) ) {
@@ -751,15 +759,15 @@ class AgentBundler {
 		// `success: false` with a typed error_code and the agent row (if newly created) must be removed so
 		// `agent list` doesn't show a half-installed entry. Pre-claim guards above guarantee no DB writes
 		// have happened yet.
-		$created_agent_id     = 0; // Tracks an agent row this call inserted, for manual rollback.
-		$created_pipeline_ids = array();
-		$created_flow_ids     = array();
+		$created_agent_id      = 0; // Tracks an agent row this call inserted, for manual rollback.
+		$created_pipeline_ids  = array();
+		$created_flow_ids      = array();
 		$selected_active_agent = false;
 		if ( $root_import ) {
 			$this->filesystem_journal = array();
 			$this->identity_journal   = array();
 		}
-		$transaction_started  = $root_import ? $this->begin_transaction() : false;
+		$transaction_started = $root_import ? $this->begin_transaction() : false;
 		if ( $root_import && ! $transaction_started ) {
 			return array(
 				'success'    => false,
@@ -777,8 +785,8 @@ class AgentBundler {
 			// 1. Create or update the agent record.
 			$incoming_config = $agent_data['agent_config'] ?? array();
 
-			$incoming_config                = is_array( $incoming_config ) ? $incoming_config : array();
-			$root_artifacts                 = array();
+			$incoming_config = is_array( $incoming_config ) ? $incoming_config : array();
+			$root_artifacts  = array();
 			foreach ( array( 'skills', 'references' ) as $kind ) {
 				if ( array_key_exists( $kind, $agent_data ) && is_array( $agent_data[ $kind ] ) ) {
 					$root_artifacts[ $kind ] = $agent_data[ $kind ];
@@ -1489,7 +1497,11 @@ class AgentBundler {
 		try {
 			$this->validate_import_file_maps( $payload );
 		} catch ( BundleValidationException $e ) {
-			return array( 'success' => false, 'error_code' => 'install_invalid_bundle', 'error' => $e->getMessage() );
+			return array(
+				'success'    => false,
+				'error_code' => 'install_invalid_bundle',
+				'error'      => $e->getMessage(),
+			);
 		}
 		if ( ! empty( $abilities_manifest ) ) {
 			$payload['abilities_manifest'] = $abilities_manifest;
@@ -1546,7 +1558,7 @@ class AgentBundler {
 	 */
 	private function import_subagent_graph( array $bundle, ?string $new_slug, int $owner_id, bool $dry_run, array $options ): array {
 		try {
-			$coordinator_slug = sanitize_title( (string) ( $new_slug ?? ( $bundle['agent']['agent_slug'] ?? '' ) ) );
+			$coordinator_slug  = sanitize_title( (string) ( $new_slug ?? ( $bundle['agent']['agent_slug'] ?? '' ) ) );
 			$children          = AgentSubagentGraph::normalize( $bundle['subagents'], $coordinator_slug );
 			$coordinator_edges = AgentSubagentGraph::coordinator_edges( $bundle['agent']['subagents'] ?? array(), $children, $coordinator_slug );
 		} catch ( BundleValidationException $e ) {
@@ -1558,10 +1570,10 @@ class AgentBundler {
 		}
 
 		if ( $dry_run ) {
-			$probe                 = $bundle;
+			$probe = $bundle;
 			unset( $probe['subagents'] );
-			$probe['agent']['subagents'] = $coordinator_edges;
-			$result                = $this->import( $probe, $new_slug, $owner_id, true, array_merge( $options, array( '_graph_node' => true ) ) );
+			$probe['agent']['subagents']    = $coordinator_edges;
+			$result                         = $this->import( $probe, $new_slug, $owner_id, true, array_merge( $options, array( '_graph_node' => true ) ) );
 			$result['summary']['subagents'] = $coordinator_edges;
 			return $result;
 		}
@@ -1569,7 +1581,7 @@ class AgentBundler {
 		$owner_id           = $this->resolve_import_owner_id( $owner_id );
 		$select_first_agent = $this->owner_is_agentless( $owner_id );
 
-		$transaction_started      = $this->begin_transaction();
+		$transaction_started = $this->begin_transaction();
 		if ( ! $transaction_started ) {
 			return array(
 				'success'    => false,
@@ -1587,24 +1599,29 @@ class AgentBundler {
 				if ( ! $existing_child ) {
 					continue;
 				}
-				$metadata = is_array( $existing_child['agent_config']['datamachine_subagent'] ?? null ) ? $existing_child['agent_config']['datamachine_subagent'] : array();
+				$metadata  = is_array( $existing_child['agent_config']['datamachine_subagent'] ?? null ) ? $existing_child['agent_config']['datamachine_subagent'] : array();
 				$conflicts = array();
 				foreach ( array( 'skills', 'references' ) as $kind ) {
 					$this->detect_locally_modified_subagent_artifacts( $child['slug'], $kind, $child[ $kind ], is_array( $metadata[ $kind ] ?? null ) ? $metadata[ $kind ] : array(), $conflicts );
 				}
 				if ( ! empty( $conflicts ) ) {
 					$this->rollback_transaction( $transaction_started );
-					return array( 'success' => false, 'error_code' => 'install_subagent_graph_local_modified', 'error' => sprintf( 'Subagent %s has locally modified package artifacts.', $child['slug'] ), 'conflicts' => $conflicts );
+					return array(
+						'success'    => false,
+						'error_code' => 'install_subagent_graph_local_modified',
+						'error'      => sprintf( 'Subagent %s has locally modified package artifacts.', $child['slug'] ),
+						'conflicts'  => $conflicts,
+					);
 				}
 			}
 			foreach ( $children as $child ) {
 				$existing_child = $this->agents_repo->get_by_slug( $child['slug'] );
-				$child_existed = (bool) $existing_child;
-				$child_bundle = array(
-					'bundle_version' => $bundle['bundle_version'],
-					'bundle_slug'    => $bundle['bundle_slug'],
-					'source_ref'     => $bundle['source_ref'] ?? '',
-					'source_revision'=> $bundle['source_revision'] ?? '',
+				$child_existed  = (bool) $existing_child;
+				$child_bundle   = array(
+					'bundle_version'  => $bundle['bundle_version'],
+					'bundle_slug'     => $bundle['bundle_slug'],
+					'source_ref'      => $bundle['source_ref'] ?? '',
+					'source_revision' => $bundle['source_revision'] ?? '',
 					'agent'           => array(
 						'agent_slug'   => $child['slug'],
 						'agent_name'   => $child['label'],
@@ -1614,52 +1631,64 @@ class AgentBundler {
 								'description'          => $child['description'],
 								'subagents'            => $child['subagents'],
 								'datamachine_subagent' => array(
-									'tool_policy' => $child['tool_policy'],
+									'tool_policy'  => $child['tool_policy'],
 									'skill_policy' => $child['skill_policy'],
-									'skills'      => $this->subagent_artifact_metadata( $child['skills'] ),
-									'references'  => $this->subagent_artifact_metadata( $child['references'] ),
+									'skills'       => $this->subagent_artifact_metadata( $child['skills'] ),
+									'references'   => $this->subagent_artifact_metadata( $child['references'] ),
 								),
 							)
 						),
 					),
-					'files'          => $child['memory'],
-					'skills'         => $child['skills'],
-					'references'     => $child['references'],
-					'skill_policy'   => $child['skill_policy'],
-					'tool_policy'    => $child['tool_policy'],
-					'pipelines'      => array(),
-					'flows'          => array(),
+					'files'           => $child['memory'],
+					'skills'          => $child['skills'],
+					'references'      => $child['references'],
+					'skill_policy'    => $child['skill_policy'],
+					'tool_policy'     => $child['tool_policy'],
+					'pipelines'       => array(),
+					'flows'           => array(),
 				);
-				$result = $this->import( $child_bundle, null, $owner_id, false, array_merge( $options, array( '_graph_node' => true, '_graph_transaction' => true ) ) );
+				$result         = $this->import( $child_bundle, null, $owner_id, false, array_merge( $options, array(
+					'_graph_node'        => true,
+					'_graph_transaction' => true,
+				) ) );
 				if ( empty( $result['success'] ) ) {
 					throw new \RuntimeException( (string) ( $result['error'] ?? 'Failed to import subagent.' ) );
 				}
 				if ( ! $child_existed && ! empty( $result['summary']['agent_id'] ) ) {
-					$created_graph_agents[] = array( 'agent_id' => (int) $result['summary']['agent_id'], 'slug' => $child['slug'] );
+					$created_graph_agents[] = array(
+						'agent_id' => (int) $result['summary']['agent_id'],
+						'slug'     => $child['slug'],
+					);
 				}
 				$this->write_subagent_runtime_artifacts( $child['slug'], $child['skills'], $child['references'] );
 			}
 
 			unset( $bundle['subagents'] );
-			$bundle['agent']['subagents'] = $coordinator_edges;
+			$bundle['agent']['subagents']    = $coordinator_edges;
 			$bundle['agent']['agent_config'] = array_merge(
 				is_array( $bundle['agent']['agent_config'] ?? null ) ? $bundle['agent']['agent_config'] : array(),
 				array( 'subagents' => $coordinator_edges )
 			);
-			$coordinator_existed = (bool) $this->agents_repo->get_by_slug( $coordinator_slug );
-			$result = $this->import( $bundle, $new_slug, $owner_id, false, array_merge( $options, array( '_graph_node' => true, '_graph_transaction' => true ) ) );
+			$coordinator_existed             = (bool) $this->agents_repo->get_by_slug( $coordinator_slug );
+			$result                          = $this->import( $bundle, $new_slug, $owner_id, false, array_merge( $options, array(
+				'_graph_node'        => true,
+				'_graph_transaction' => true,
+			) ) );
 			if ( empty( $result['success'] ) ) {
 				throw new \RuntimeException( (string) ( $result['error'] ?? 'Failed to import coordinator.' ) );
 			}
 			if ( ! $coordinator_existed && ! empty( $result['summary']['agent_id'] ) ) {
-				$created_graph_agents[] = array( 'agent_id' => (int) $result['summary']['agent_id'], 'slug' => $coordinator_slug );
+				$created_graph_agents[] = array(
+					'agent_id' => (int) $result['summary']['agent_id'],
+					'slug'     => $coordinator_slug,
+				);
 			}
 			if ( $select_first_agent ) {
 				$selected_active_agent = $this->select_active_agent( $owner_id, $coordinator_slug );
 			}
 			$this->commit_transaction( $transaction_started );
-			$this->filesystem_journal = array();
-			$this->identity_journal   = array();
+			$this->filesystem_journal       = array();
+			$this->identity_journal         = array();
 			$result['summary']['subagents'] = $coordinator_edges;
 			return $result;
 		} catch ( \Throwable $e ) {
@@ -1737,7 +1766,7 @@ class AgentBundler {
 
 	/** Remove only the preference written by the failed import. */
 	private function rollback_active_agent_selection( int $owner_id, string $agent_slug ): void {
-		if ( $agent_slug === (string) get_user_meta( $owner_id, self::ACTIVE_AGENT_META_KEY, true ) ) {
+		if ( (string) get_user_meta( $owner_id, self::ACTIVE_AGENT_META_KEY, true ) === $agent_slug ) {
 			delete_user_meta( $owner_id, self::ACTIVE_AGENT_META_KEY, $agent_slug );
 		}
 	}
@@ -1766,6 +1795,7 @@ class AgentBundler {
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		if ( false === $wpdb->query( 'COMMIT' ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Internal exception text is not rendered output.
 			throw new \RuntimeException( sprintf( 'Database COMMIT failed: %s', (string) ( $wpdb->last_error ?? 'unknown database error' ) ) );
 		}
 	}
@@ -1784,12 +1814,15 @@ class AgentBundler {
 
 	private function write_journaled_file( string $path, string $contents ): void {
 		if ( ! array_key_exists( $path, $this->filesystem_journal ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local rollback snapshot, not a remote request.
 			$this->filesystem_journal[ $path ] = is_file( $path ) ? (string) file_get_contents( $path ) : null;
 		}
 		if ( ! is_dir( dirname( $path ) ) ) {
 			wp_mkdir_p( dirname( $path ) );
 		}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Journaled atomic bundle write with explicit rollback.
 		if ( false === file_put_contents( $path, $contents ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Internal exception text is not rendered output.
 			throw new \RuntimeException( sprintf( 'Failed to write bundle file %s.', $path ) );
 		}
 	}
@@ -1798,10 +1831,11 @@ class AgentBundler {
 		foreach ( array_reverse( $this->filesystem_journal, true ) as $path => $previous ) {
 			if ( null === $previous ) {
 				if ( is_file( $path ) ) {
-					unlink( $path );
+					wp_delete_file( $path );
 				}
 			} else {
 				wp_mkdir_p( dirname( $path ) );
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Restores the journaled local file bytes during rollback.
 				file_put_contents( $path, $previous );
 			}
 		}
@@ -1815,7 +1849,10 @@ class AgentBundler {
 		}
 		$snapshot = AgentBundleMemoryArtifact::snapshot( $agent_id, $artifact_id );
 		if ( is_array( $snapshot ) ) {
-			$this->identity_journal[ $key ] = array( 'agent_id' => $agent_id, 'snapshot' => $snapshot );
+			$this->identity_journal[ $key ] = array(
+				'agent_id' => $agent_id,
+				'snapshot' => $snapshot,
+			);
 		}
 	}
 
@@ -1829,7 +1866,10 @@ class AgentBundler {
 	/** @param array<string,string> $skills @param array<string,string> $references */
 	private function write_subagent_runtime_artifacts( string $slug, array $skills, array $references ): void {
 		$root = $this->directory_manager->get_agent_identity_directory( $slug );
-		foreach ( array( 'skills' => $skills, 'references' => $references ) as $kind => $files ) {
+		foreach ( array(
+			'skills'     => $skills,
+			'references' => $references,
+		) as $kind => $files ) {
 			foreach ( $files as $path => $contents ) {
 				$this->write_journaled_file( BundleRelativePath::contained_join( $root . '/' . $kind, (string) $path, 'subagent artifact' ), $contents );
 			}
@@ -1840,13 +1880,18 @@ class AgentBundler {
 	private function write_guarded_subagent_runtime_artifacts( string $slug, string $kind, array $files, array $installed_hashes, array &$conflicts ): void {
 		$root = $this->directory_manager->get_agent_identity_directory( $slug ) . '/' . $kind;
 		foreach ( $files as $path => $contents ) {
-			$path   = (string) $path;
-			$target = BundleRelativePath::contained_join( $root, $path, 'subagent artifact' );
+			$path           = (string) $path;
+			$target         = BundleRelativePath::contained_join( $root, $path, 'subagent artifact' );
 			$installed_hash = $installed_hashes[ $path ] ?? null;
 			if ( is_string( $installed_hash ) && is_file( $target ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads a bounded local package artifact.
 				$current = file_get_contents( $target );
 				if ( is_string( $current ) && ! hash_equals( $installed_hash, hash( 'sha256', $current ) ) ) {
-					$conflicts[] = array( 'artifact_type' => 'subagent_' . rtrim( $kind, 's' ), 'artifact_id' => $path, 'reason' => 'local_modified' );
+					$conflicts[] = array(
+						'artifact_type' => 'subagent_' . rtrim( $kind, 's' ),
+						'artifact_id'   => $path,
+						'reason'        => 'local_modified',
+					);
 					continue;
 				}
 			}
@@ -1858,11 +1903,16 @@ class AgentBundler {
 	private function detect_locally_modified_subagent_artifacts( string $slug, string $kind, array $files, array $installed_hashes, array &$conflicts ): void {
 		$root = $this->directory_manager->get_agent_identity_directory( $slug ) . '/' . $kind;
 		foreach ( $files as $path => $_contents ) {
-			$path = ltrim( str_replace( '\\', '/', $path ), '/' );
+			$path           = ltrim( str_replace( '\\', '/', $path ), '/' );
 			$installed_hash = $installed_hashes[ $path ] ?? null;
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads a bounded local package artifact.
 			$current = is_file( $root . '/' . $path ) ? file_get_contents( $root . '/' . $path ) : false;
 			if ( is_string( $installed_hash ) && is_string( $current ) && ! hash_equals( $installed_hash, hash( 'sha256', $current ) ) ) {
-				$conflicts[] = array( 'artifact_type' => 'subagent_' . rtrim( $kind, 's' ), 'artifact_id' => $slug . '/' . $path, 'reason' => 'local_modified' );
+				$conflicts[] = array(
+					'artifact_type' => 'subagent_' . rtrim( $kind, 's' ),
+					'artifact_id'   => $slug . '/' . $path,
+					'reason'        => 'local_modified',
+				);
 			}
 		}
 	}
@@ -2160,6 +2210,7 @@ class AgentBundler {
 			if ( '' === $path || str_contains( $path, '..' ) || ! is_string( $sha256 ) ) {
 				throw new BundleValidationException( sprintf( 'Subagent %s has invalid %s metadata.', esc_html( $slug ), esc_html( $kind ) ) );
 			}
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reads a bounded local package artifact.
 			$contents = file_get_contents( $root . '/' . $path );
 			if ( ! is_string( $contents ) || ! hash_equals( $sha256, hash( 'sha256', $contents ) ) ) {
 				throw new BundleValidationException( sprintf( 'Subagent %s %s artifact is missing or modified: %s.', esc_html( $slug ), esc_html( $kind ), esc_html( $path ) ) );

--- a/inc/migrations/scaffolding.php
+++ b/inc/migrations/scaffolding.php
@@ -206,11 +206,11 @@ function datamachine_get_scaffold_defaults( string $agent_name = '' ): array {
 }
 
 /**
- * Create a default agent and scaffold its memory files.
+ * Scaffold default shared, user, and existing-agent memory files.
  *
- * Ensures a first-class agent record exists for the default admin user,
- * then scaffolds agent-layer (SOUL.md, MEMORY.md) and user-layer (USER.md)
- * files. Also creates default context files (contexts/{context}.md).
+ * Shared and user files do not require an agent identity. Agent-layer files
+ * are scaffolded only when the default owner already has an unambiguous agent;
+ * activation never invents an agent from the administrator login.
  *
  * Called on activation (directly or via deferred transient) and lazily on
  * any request that reads agent files. Existing files are never overwritten —
@@ -218,27 +218,22 @@ function datamachine_get_scaffold_defaults( string $agent_name = '' ): array {
  *
  * Returns false when the Abilities API is unavailable (e.g. during plugin
  * activation where init callbacks haven't fired), so the caller can defer.
- * The agent record is still created in this case — only the file scaffold
- * is deferred.
- *
  * @since 0.30.0
  * @since 0.65.0 Creates default agent record before scaffolding files.
+ * @since 0.173.0 Fresh installs remain agentless until an identity is explicitly created or installed.
  *
  * @return bool True if scaffold ran, false if abilities were unavailable.
  */
 function datamachine_ensure_default_memory_files(): bool {
 	$default_user_id = \DataMachine\Core\FilesRepository\DirectoryManager::get_default_agent_user_id();
 
-	// Create a default agent record before scaffolding any files.
-	// Without an agent, files would be written to a directory derived from
-	// the user_login fallback — not tied to any real agent identity.
-	$agent_id = datamachine_resolve_or_create_agent_id( $default_user_id );
+	$agent_id = datamachine_resolve_existing_agent_id( $default_user_id );
 
 	// Resolve agent slug for proper directory resolution.
 	$agent_slug = null;
 	if ( $agent_id > 0 ) {
 		$agents_repo = new \DataMachine\Core\Database\Agents\Agents();
-		$agent       = $agents_repo->get_by_owner_id( $default_user_id );
+		$agent       = $agents_repo->get_agent( $agent_id );
 		$agent_slug  = ! empty( $agent['agent_slug'] ) ? $agent['agent_slug'] : null;
 	}
 
@@ -254,7 +249,9 @@ function datamachine_ensure_default_memory_files(): bool {
 	}
 
 	$ability->execute( array( 'layer' => 'shared' ) );
-	$ability->execute( array_merge( $scaffold_context, array( 'layer' => 'agent' ) ) );
+	if ( $agent_id > 0 ) {
+		$ability->execute( array_merge( $scaffold_context, array( 'layer' => 'agent' ) ) );
+	}
 	$ability->execute( array_merge( $scaffold_context, array( 'layer' => 'user' ) ) );
 
 	return true;

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -154,6 +154,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}datamachine_jobs" );
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}datamachine_bundle_artifacts" );
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		delete_user_meta( $this->owner_id, 'datamachine_active_agent_slug' );
 
 		remove_all_actions( 'datamachine_bundle_import_pre_commit' );
 		remove_all_actions( 'datamachine_bundle_import_post_claim_started' );
@@ -242,6 +243,27 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$this->assertSame( 'daily', $flow['scheduling_config']['interval'] ?? null, 'Importer preserves the bundle interval.' );
 		$this->assertTrue( $flow['scheduling_config']['enabled'] ?? false, 'Importer keeps scheduled bundle flows enabled.' );
 		$this->assertSame( array( 'mcp' => 5 ), $flow['scheduling_config']['max_items'] ?? null, 'Importer preserves bundle max item caps.' );
+	}
+
+	public function test_first_root_bundle_install_becomes_active_without_overriding_a_preference(): void {
+		$first = $this->bundler->import( $this->fixture_bundle( 'first-root-agent' ), null, $this->owner_id );
+
+		$this->assertTrue( (bool) $first['success'] );
+		$this->assertSame( 'first-root-agent', get_user_meta( $this->owner_id, 'datamachine_active_agent_slug', true ) );
+
+		$second = $this->bundler->import( $this->fixture_bundle( 'second-root-agent' ), null, $this->owner_id );
+
+		$this->assertTrue( (bool) $second['success'] );
+		$this->assertSame( 'first-root-agent', get_user_meta( $this->owner_id, 'datamachine_active_agent_slug', true ) );
+	}
+
+	public function test_bundle_install_preserves_an_existing_ambiguous_owner_choice(): void {
+		$this->agents_repo->create_if_missing( 'existing-agent', 'Existing Agent', $this->owner_id, array() );
+
+		$result = $this->bundler->import( $this->fixture_bundle( 'new-package-agent' ), null, $this->owner_id );
+
+		$this->assertTrue( (bool) $result['success'] );
+		$this->assertSame( '', get_user_meta( $this->owner_id, 'datamachine_active_agent_slug', true ) );
 	}
 
 	public function test_flow_config_strings_are_idempotent_across_import_and_export_round_trips(): void {
@@ -921,6 +943,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 			$this->agents_repo->get_by_slug( 'wc-static-site-agent' ),
 			'No half-installed agent row remains after rollback.'
 		);
+		$this->assertSame( '', get_user_meta( $this->owner_id, 'datamachine_active_agent_slug', true ), 'Failed first install leaves no active-agent preference.' );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		$pipeline_ids = array_map( 'intval', $wpdb->get_col( "SELECT pipeline_id FROM {$wpdb->prefix}datamachine_pipelines ORDER BY pipeline_id" ) );
@@ -980,6 +1003,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 
 		$result = $this->bundler->import( $bundle, null, $this->owner_id );
 		$this->assertTrue( (bool) $result['success'] );
+		$this->assertSame( 'policy-coordinator', get_user_meta( $this->owner_id, 'datamachine_active_agent_slug', true ) );
 
 		$projection = PersistedAgentGraphProjector::project( 'policy-coordinator' );
 		$this->assertTrue( (bool) $projection['success'] );

--- a/tests/Unit/Core/Agents/DefaultAgentBootstrapTest.php
+++ b/tests/Unit/Core/Agents/DefaultAgentBootstrapTest.php
@@ -7,6 +7,7 @@
 
 namespace DataMachine\Tests\Unit\Core\Agents;
 
+use DataMachine\Core\Agents\AgentBundler;
 use DataMachine\Core\Database\Agents\Agents as AgentsRepository;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 use WP_UnitTestCase;
@@ -23,12 +24,12 @@ class DefaultAgentBootstrapTest extends WP_UnitTestCase {
 		$this->agents_repo    = new AgentsRepository();
 		$this->default_user_id = DirectoryManager::get_default_agent_user_id();
 		$this->clear_agents();
-		delete_user_meta( $this->default_user_id, 'datamachine_active_agent_slug' );
+		delete_user_meta( $this->default_user_id, AgentBundler::ACTIVE_AGENT_META_KEY );
 	}
 
 	public function tear_down(): void {
 		$this->clear_agents();
-		delete_user_meta( $this->default_user_id, 'datamachine_active_agent_slug' );
+		delete_user_meta( $this->default_user_id, AgentBundler::ACTIVE_AGENT_META_KEY );
 		parent::tear_down();
 	}
 
@@ -62,7 +63,7 @@ class DefaultAgentBootstrapTest extends WP_UnitTestCase {
 	public function test_explicit_active_agent_resolves_when_owner_has_multiple_agents(): void {
 		$this->agents_repo->create_if_missing( 'first-agent', 'First Agent', $this->default_user_id, array() );
 		$active_id = $this->agents_repo->create_if_missing( 'active-agent', 'Active Agent', $this->default_user_id, array() );
-		update_user_meta( $this->default_user_id, 'datamachine_active_agent_slug', 'active-agent' );
+		update_user_meta( $this->default_user_id, AgentBundler::ACTIVE_AGENT_META_KEY, 'active-agent' );
 
 		$this->assertSame( $active_id, datamachine_resolve_existing_agent_id( $this->default_user_id ) );
 	}
@@ -71,7 +72,7 @@ class DefaultAgentBootstrapTest extends WP_UnitTestCase {
 		$other_owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		$this->agents_repo->create_if_missing( 'shared-slug', 'Other Agent', $other_owner_id, array() );
 		$expected_id = $this->agents_repo->create_if_missing( 'shared-slug', 'Default Agent', $this->default_user_id, array() );
-		update_user_meta( $this->default_user_id, 'datamachine_active_agent_slug', 'shared-slug' );
+		update_user_meta( $this->default_user_id, AgentBundler::ACTIVE_AGENT_META_KEY, 'shared-slug' );
 
 		$this->assertSame( $expected_id, datamachine_resolve_existing_agent_id( $this->default_user_id ) );
 	}

--- a/tests/Unit/Core/Agents/DefaultAgentBootstrapTest.php
+++ b/tests/Unit/Core/Agents/DefaultAgentBootstrapTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Fresh-install agent bootstrap tests.
+ *
+ * @package DataMachine\Tests\Unit\Core\Agents
+ */
+
+namespace DataMachine\Tests\Unit\Core\Agents;
+
+use DataMachine\Core\Database\Agents\Agents as AgentsRepository;
+use DataMachine\Core\FilesRepository\DirectoryManager;
+use WP_UnitTestCase;
+
+class DefaultAgentBootstrapTest extends WP_UnitTestCase {
+
+	private AgentsRepository $agents_repo;
+	private int $default_user_id;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		AgentsRepository::create_table();
+		$this->agents_repo    = new AgentsRepository();
+		$this->default_user_id = DirectoryManager::get_default_agent_user_id();
+		$this->clear_agents();
+		delete_user_meta( $this->default_user_id, 'datamachine_active_agent_slug' );
+	}
+
+	public function tear_down(): void {
+		$this->clear_agents();
+		delete_user_meta( $this->default_user_id, 'datamachine_active_agent_slug' );
+		parent::tear_down();
+	}
+
+	public function test_default_scaffolding_keeps_a_fresh_install_agentless(): void {
+		$directory_manager = new DirectoryManager();
+		$user_file         = trailingslashit( $directory_manager->get_user_directory( $this->default_user_id ) ) . 'USER.md';
+		$rules_file        = trailingslashit( $directory_manager->get_shared_directory() ) . 'RULES.md';
+		wp_delete_file( $user_file );
+		wp_delete_file( $rules_file );
+
+		$this->assertTrue( datamachine_ensure_default_memory_files() );
+
+		$this->assertSame( array(), $this->agents_repo->get_all() );
+		$this->assertFileExists( $user_file );
+		$this->assertFileExists( $rules_file );
+	}
+
+	public function test_system_context_does_not_provision_an_agent(): void {
+		$context = datamachine_resolve_system_agent_context();
+
+		$this->assertSame( 0, $context['agent_id'] );
+		$this->assertSame( array(), $this->agents_repo->get_all() );
+	}
+
+	public function test_existing_single_agent_remains_the_compatibility_default(): void {
+		$agent_id = $this->agents_repo->create_if_missing( 'legacy-agent', 'Legacy Agent', $this->default_user_id, array() );
+
+		$this->assertSame( $agent_id, datamachine_resolve_existing_agent_id( $this->default_user_id ) );
+	}
+
+	public function test_explicit_active_agent_resolves_when_owner_has_multiple_agents(): void {
+		$this->agents_repo->create_if_missing( 'first-agent', 'First Agent', $this->default_user_id, array() );
+		$active_id = $this->agents_repo->create_if_missing( 'active-agent', 'Active Agent', $this->default_user_id, array() );
+		update_user_meta( $this->default_user_id, 'datamachine_active_agent_slug', 'active-agent' );
+
+		$this->assertSame( $active_id, datamachine_resolve_existing_agent_id( $this->default_user_id ) );
+	}
+
+	public function test_active_resolution_is_scoped_to_the_owner(): void {
+		$other_owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->agents_repo->create_if_missing( 'shared-slug', 'Other Agent', $other_owner_id, array() );
+		$expected_id = $this->agents_repo->create_if_missing( 'shared-slug', 'Default Agent', $this->default_user_id, array() );
+		update_user_meta( $this->default_user_id, 'datamachine_active_agent_slug', 'shared-slug' );
+
+		$this->assertSame( $expected_id, datamachine_resolve_existing_agent_id( $this->default_user_id ) );
+	}
+
+	private function clear_agents(): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->base_prefix}datamachine_agents" );
+	}
+}

--- a/tests/system-agent-context-resolution-smoke.php
+++ b/tests/system-agent-context-resolution-smoke.php
@@ -100,13 +100,19 @@ $assert(
 	false === task_scheduler_gate_for_test( $old_ctx )
 );
 
-echo "\n[4] Install with no resolvable owner at all still returns zeros (no fatal)\n";
+echo "\n[4] Fresh install with an owner but no agent fails closed without provisioning\n";
+$ctx = resolve_system_agent_context_for_test( 7, 1, static fn(): int => 0 );
+$assert( 'default owner remains attributable', 1 === $ctx['user_id'] );
+$assert( 'no synthetic agent is returned', 0 === $ctx['agent_id'] );
+$assert( 'agent-owned enqueue is rejected until an identity exists', false === task_scheduler_gate_for_test( $ctx ) );
+
+echo "\n[5] Install with no resolvable owner at all still returns zeros (no fatal)\n";
 $ctx = resolve_system_agent_context_for_test( 0, 0, $resolve );
 $assert( 'user_id is 0 when no default owner exists', 0 === $ctx['user_id'] );
 $assert( 'agent_id is 0 when no default owner exists', 0 === $ctx['agent_id'] );
 $assert( 'triggering_user_id is still reported', 0 === $ctx['triggering_user_id'] );
 
-echo "\n[5] Production sources use the shared resolver and carry triggering_user_id\n";
+echo "\n[6] Production sources use the shared resolver and carry triggering_user_id\n";
 $root    = dirname( __DIR__ );
 $sources = array(
 	'AltTextAbilities'         => $root . '/inc/Abilities/Media/AltTextAbilities.php',
@@ -122,14 +128,14 @@ foreach ( $sources as $name => $path ) {
 	);
 }
 
-echo "\n[6] Chat path is untouched — it still auto-provisions via resolve_or_create_agent_id\n";
+echo "\n[7] Chat path is untouched — it still auto-provisions via resolve_or_create_agent_id\n";
 $chat_src = (string) file_get_contents( $root . '/inc/Api/Chat/ChatOrchestrator.php' );
 $assert(
 	'ChatOrchestrator calls datamachine_resolve_or_create_agent_id()',
 	str_contains( $chat_src, 'datamachine_resolve_or_create_agent_id' )
 );
 
-echo "\n[7] The resolver documents the attribution-vs-identity distinction\n";
+echo "\n[8] The resolver documents the attribution-vs-identity distinction\n";
 $plugin_src = (string) file_get_contents( $root . '/data-machine.php' );
 $assert( 'datamachine_resolve_system_agent_context() defined', str_contains( $plugin_src, 'function datamachine_resolve_system_agent_context(): array' ) );
 $assert( 'resolver always falls back to default agent user', str_contains( $plugin_src, '$user_id = (int) \\DataMachine\\Core\\FilesRepository\\DirectoryManager::get_default_agent_user_id();' ) );


### PR DESCRIPTION
## Summary

Fixes #3191.

- scaffold shared and user context on activation without deriving an agent identity from the first administrator login
- preserve agent-layer scaffolding for existing unambiguous installations
- make system task attribution resolve an existing active or single owned agent and fail closed when none exists
- select the first package-backed root agent as active only for a genuinely agentless owner
- select graph coordinators after their children, without allowing child imports to become active
- preserve existing preferences and ambiguous existing installations
- roll back the initial preference alongside failed direct and graph imports

## Verification

- focused PHPCS on all changed PHP files
- `php -l` on changed production and PHPUnit files
- `php tests/system-agent-context-resolution-smoke.php`: 25 assertions passing
- `php tests/agent-bundle-subagent-graph-smoke.php`: all assertions passing
- three independent review passes: no remaining correctness findings

The local Homeboy WordPress test route did not execute: no Lab runner was ready, and the fallback local extension process was terminated under host pressure. PR CI is the authoritative WordPress integration gate.

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode traced the live activation and package-install behavior, implemented the migration-safe bootstrap and active-agent contracts, added regression coverage, and performed iterative code review. Chris Huber reviewed and remains responsible for every line.