### PR TITLE
fix: preserve successful child scheduler ownership

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -668,6 +668,23 @@ class ExecuteStepAbility {
 			);
 		}
 
+		// Only terminal overrides may short-circuit normal continuation routing.
+		// A stale processing/pending marker must not consume the current action
+		// without either scheduling the next step or completing the job.
+		if ( $status_override && ! JobStatus::isStatusFinal( $status_override ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Ignoring non-terminal job status override after successful step execution',
+				array(
+					'job_id'          => $job_id,
+					'flow_step_id'    => $flow_step_id,
+					'status_override' => $status_override,
+				)
+			);
+			$status_override = null;
+		}
+
 		// Status override: complete with override status and clean up.
 		if ( $status_override ) {
 			if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
@@ -683,7 +700,16 @@ class ExecuteStepAbility {
 				$context = datamachine_get_file_context( $flow_id );
 				$cleanup->cleanup_job_data_packets( $job_id, $context );
 			}
-			if ( JobStatus::isStatusSuccess( $status_override ) && ( ! $transition['success'] || ! JobStatus::isStatusSuccess( $transition['status'] ) ) ) {
+			if ( ! $transition['success'] || ! JobStatus::isStatusFinal( $transition['status'] ) ) {
+				return array(
+					'success'      => false,
+					'step_success' => false,
+					'outcome'      => 'terminal_transition_failed',
+					'reason'       => 'terminal_transition_failed',
+					'status'       => $transition['status'],
+				);
+			}
+			if ( JobStatus::isStatusSuccess( $status_override ) && ! JobStatus::isStatusSuccess( $transition['status'] ) ) {
 				return array(
 					'success'      => false,
 					'step_success' => false,

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -66,7 +66,7 @@ function datamachine_flow_exists( int $flow_id ): bool {
 function datamachine_execute_step_action( $job_id, string $flow_step_id, $operation_generation = 0, $operation_claim_token = '', $ai_resume_generation = 0, $recovery_generation = 0, $recovery_claim_token = '' ): void {
 	$ability = wp_get_ability( 'datamachine/execute-step' );
 	if ( $ability ) {
-		$ability->execute(
+		$result = $ability->execute(
 			array(
 				'job_id'                => (int) $job_id,
 				'flow_step_id'          => $flow_step_id,
@@ -77,6 +77,9 @@ function datamachine_execute_step_action( $job_id, string $flow_step_id, $operat
 				'recovery_claim_token'  => is_string( $recovery_claim_token ) ? $recovery_claim_token : '',
 			)
 		);
+		if ( in_array( (string) ( $result['outcome'] ?? '' ), array( 'claim_completion_failed', 'terminal_transition_failed' ), true ) ) {
+			throw new \RuntimeException( 'Data Machine terminal transition failed.' );
+		}
 	}
 }
 

--- a/tests/successful-child-routing-smoke.php
+++ b/tests/successful-child-routing-smoke.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Pure-PHP regression for successful child lifecycle routing.
+ *
+ * Run with: php tests/successful-child-routing-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+if ( ! defined( 'WPINC' ) ) {
+	define( 'WPINC', 'wp-includes' );
+}
+
+$datamachine_successful_child_logs = array();
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$GLOBALS['datamachine_successful_child_logs'][] = array(
+			'hook' => $hook,
+			'args' => $args,
+		);
+	}
+}
+
+if ( ! function_exists( 'datamachine_get_engine_data' ) ) {
+	function datamachine_get_engine_data( int $job_id ): array {
+		unset( $job_id );
+		return array();
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( string $key ): string {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $key ) );
+	}
+}
+
+require_once __DIR__ . '/../inc/Core/JobStatus.php';
+require_once __DIR__ . '/../inc/Core/StepExecutionResult.php';
+require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
+require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
+require_once __DIR__ . '/../inc/Engine/ExecutionPlan.php';
+require_once __DIR__ . '/../inc/Engine/StepNavigator.php';
+require_once __DIR__ . '/../inc/Abilities/Engine/EngineHelpers.php';
+require_once __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php';
+
+use DataMachine\Abilities\Engine\ExecuteStepAbility;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\JobStatus;
+
+class DataMachine_Successful_Child_Jobs extends Jobs {
+	public array $transitions = array();
+
+	public function __construct() {}
+
+	public function transition_job_status_result( int $job_id, string $status, bool $require_final = false ): array {
+		$this->transitions[] = array( $job_id, $status, $require_final );
+		return array(
+			'success'        => true,
+			'changed'        => false,
+			'current_status' => JobStatus::PROCESSING,
+			'status'         => $status,
+		);
+	}
+}
+
+$reflection = new ReflectionClass( ExecuteStepAbility::class );
+$ability    = $reflection->newInstanceWithoutConstructor();
+$jobs       = new DataMachine_Successful_Child_Jobs();
+$reflection->getProperty( 'db_jobs' )->setValue( $ability, $jobs );
+$route = $reflection->getMethod( 'routeAfterExecution' );
+
+$result = $route->invoke(
+	$ability,
+	2930,
+	'handler_step',
+	9,
+	array(
+		'pipeline_id' => 3,
+		'step_type'   => 'upsert',
+	),
+	'upsert',
+	'DataMachine\\Core\\Steps\\Upsert\\UpsertStep',
+	array( array( 'type' => 'handler_complete' ) ),
+	array(
+		'job_id' => 2930,
+		'data'   => array( array( 'type' => 'handler_complete' ) ),
+	),
+	true,
+	JobStatus::PROCESSING
+);
+
+$failures = 0;
+$assert   = static function ( string $label, bool $condition ) use ( &$failures ): void {
+	if ( $condition ) {
+		echo "  [PASS] {$label}\n";
+		return;
+	}
+
+	++$failures;
+	echo "  [FAIL] {$label}\n";
+};
+
+echo "=== successful-child-routing-smoke ===\n";
+$assert( 'successful child completes normally', 'completed' === ( $result['outcome'] ?? '' ) );
+$assert( 'stale processing override is not reported as completion', 'completed_override' !== ( $result['outcome'] ?? '' ) );
+$assert( 'normal terminal transition is committed', array( 2930, JobStatus::COMPLETED, true ) === ( $jobs->transitions[0] ?? array() ) );
+$assert(
+	'non-terminal override is diagnosed',
+	1 === count(
+		array_filter(
+			$GLOBALS['datamachine_successful_child_logs'],
+			static fn( array $entry ): bool => 'datamachine_log' === ( $entry['hook'] ?? '' )
+				&& 'Ignoring non-terminal job status override after successful step execution' === ( $entry['args'][1] ?? '' )
+		)
+	)
+);
+
+echo "\nSuccessful child routing smoke complete: {$failures} failures.\n";
+exit( $failures > 0 ? 1 : 0 );

--- a/tests/successful-child-routing-smoke.php
+++ b/tests/successful-child-routing-smoke.php
@@ -15,6 +15,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 $datamachine_successful_child_logs = array();
+$datamachine_execute_step_result   = array();
 
 if ( ! function_exists( 'do_action' ) ) {
 	function do_action( string $hook, ...$args ): void {
@@ -38,12 +39,25 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	function wp_get_ability( string $name ): object {
+		unset( $name );
+		return new class() {
+			public function execute( array $input ): array {
+				unset( $input );
+				return $GLOBALS['datamachine_execute_step_result'];
+			}
+		};
+	}
+}
+
 require_once __DIR__ . '/../inc/Core/JobStatus.php';
 require_once __DIR__ . '/../inc/Core/StepExecutionResult.php';
 require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
 require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
 require_once __DIR__ . '/../inc/Engine/ExecutionPlan.php';
 require_once __DIR__ . '/../inc/Engine/StepNavigator.php';
+require_once __DIR__ . '/../inc/Engine/Actions/Engine.php';
 require_once __DIR__ . '/../inc/Abilities/Engine/EngineHelpers.php';
 require_once __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php';
 
@@ -118,6 +132,32 @@ $assert(
 		)
 	)
 );
+
+$GLOBALS['datamachine_execute_step_result'] = array(
+	'success' => false,
+	'outcome' => 'terminal_transition_failed',
+	'reason'  => 'terminal_transition_failed',
+);
+$terminal_failure_surfaced = false;
+try {
+	datamachine_execute_step_action( 2930, 'handler_step' );
+} catch ( RuntimeException $exception ) {
+	$terminal_failure_surfaced = 'Data Machine terminal transition failed.' === $exception->getMessage();
+}
+$assert( 'terminal commit failure keeps the scheduler action failed and recoverable', $terminal_failure_surfaced );
+
+$GLOBALS['datamachine_execute_step_result'] = array(
+	'success'          => false,
+	'stale_generation' => true,
+	'outcome'          => 'stale_generation',
+);
+$stale_generation_noop = true;
+try {
+	datamachine_execute_step_action( 2930, 'handler_step' );
+} catch ( RuntimeException ) {
+	$stale_generation_noop = false;
+}
+$assert( 'stale generation remains a non-failing scheduler no-op', $stale_generation_noop );
 
 echo "\nSuccessful child routing smoke complete: {$failures} failures.\n";
 exit( $failures > 0 ? 1 : 0 );


### PR DESCRIPTION
## Summary
- reject non-terminal `engine_data.job_status` values as terminal overrides so successful steps continue through normal next-step or completion routing
- surface failed terminal commits through the Action Scheduler bridge so the canonical failed action remains available to generation-aware child recovery
- add a regression covering successful child completion, failed terminal handoff retention, and stale-generation no-op behavior

Closes #2930.

## Root cause
`ExecuteStepAbility::routeAfterExecution()` treated every truthy `engine_data.job_status` as a terminal override (`inc/Abilities/Engine/ExecuteStepAbility.php`). A stale non-terminal marker such as `processing` therefore called the final-only transition primitive, ignored its rejection, returned `completed_override`, and allowed the current scheduler action to finish while the child remained processing.

A second handoff gap existed after legitimate terminal routing: `datamachine_execute_step_action()` discarded the ability result (`inc/Engine/Actions/Engine.php`). When claim preparation or the terminal database commit returned `claim_completion_failed` or `terminal_transition_failed`, Action Scheduler still marked the canonical execute action complete. The child then had neither a terminal row nor the failed action evidence that `ChildJobRecoveryPolicy` requires for replay-safe recovery.

The restored invariant is: a successful child step either schedules its normal continuation or commits a terminal status. If the terminal commit fails, the canonical Action Scheduler action fails durably instead of being falsely completed, preserving its exact job/step and generation ownership for the existing #2965 recovery policy. Stale operation generations remain non-failing no-ops, and no new scheduler or replay path is introduced.

## Why prior protections missed it
The #2180-era fix in #2187 handled explicit next-step enqueue failures inside `ScheduleNextStepAbility`, but it did not validate stale non-terminal overrides or observe terminal commit results at the Action Scheduler bridge. #2965 added fenced recovery for failed canonical actions and missing histories, but the bridge converted these terminal handoff failures into completed actions before that recovery policy could see a failed action.

## Production evidence
On 2026-08-14, Events liveness reported 293 affected rows: 168 `no_scheduler_path` children and 125 `waiting_children` parents, with no active processing, queued next step, scheduler starvation, or stale in-progress action. A bounded recovery preview found 63 pathless children eligible for terminalization plus 26 timeouts; reconciliation separately found eight processing parents whose children were terminal. A recent Ticketmaster child briefly showed successful AI runtime/tool provenance while its base job remained processing before settling naturally, matching the successful-step/terminal-handoff window addressed here. No private content was inspected or included.

Issue #3023 remains separate: this PR does not change exact operator recovery limits or CLI behavior.

## Tests
Passed:
- `php tests/successful-child-routing-smoke.php`
- `php tests/schedule-next-step-failure-smoke.php`
- `php tests/job-status-accounting-smoke.php`
- `php tests/child-job-recovery-policy-smoke.php`
- `php tests/job-liveness-cli-smoke.php`
- `php tests/recover-stuck-bounded-apply-smoke.php`
- `php tests/recover-stuck-active-action-guard-smoke.php`
- `php tests/transition-fanout-policy-smoke.php`
- `php tests/parallel-map-fanout-adapter-smoke.php`
- `php tests/ai-step-backpressure-smoke.php`
- `php -l inc/Abilities/Engine/ExecuteStepAbility.php`
- `php -l inc/Engine/Actions/Engine.php`
- `php -l tests/successful-child-routing-smoke.php`
- `homeboy review lint data-machine --path /var/lib/datamachine/workspace/data-machine@fix-2930-scheduler-path-regression --extension wordpress --changed-only --placement local` (PHPCS and PHPStan passed with no findings; run `938027dc-de15-47cf-bf25-00cf11aac741`)

Managed PHPUnit was attempted both focused and unfiltered, but the Homeboy adapter reported zero executed tests in runs `2059d9c1-9c50-4973-a9c7-b055c688d543` and `814a2308-092a-4972-b972-043abf07587c`. One unrelated standalone AI smoke also stops in its existing bootstrap because `wp_json_encode()` is not defined outside WordPress. The new pure-PHP regression and all runnable focused lifecycle suites passed.

## AI assistance
- **AI assistance:** Yes
- **Tool:** OpenCode (GPT-5.6)
- **Used for:** issue/history review, lifecycle tracing, implementation, regression coverage, and verification. Chris remains responsible for review and merge.