### PR TITLE
chore: update bundled Agents API authorization

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -794,12 +794,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "6da93fc05b1d2282ed335447e898e67cd314e0cc"
+                "reference": "78906489fb430083800e7afdd19bf2641ea452ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/6da93fc05b1d2282ed335447e898e67cd314e0cc",
-                "reference": "6da93fc05b1d2282ed335447e898e67cd314e0cc",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/78906489fb430083800e7afdd19bf2641ea452ea",
+                "reference": "78906489fb430083800e7afdd19bf2641ea452ea",
                 "shasum": ""
             },
             "require": {
@@ -893,6 +893,7 @@
                     "php tests/provider-turn-adapter-smoke.php",
                     "php tests/default-provider-turn-adapter-smoke.php",
                     "php tests/agents-chat-ability-smoke.php",
+                    "php tests/chat-permission-parity-smoke.php",
                     "php tests/default-agents-chat-handler-smoke.php",
                     "php tests/tool-observability-smoke.php",
                     "php tests/ability-tool-executor-smoke.php",
@@ -963,7 +964,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-08-01T19:15:31+00:00"
+            "time": "2026-08-15T00:32:13+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## Summary
- update the bundled `wordpress/agents-api` lock from `6da93fc0` to merged authorization commit `78906489`
- consume canonical direct, REST, and JSON-RPC chat authorization parity before the native Roadie proof
- include the upstream authorization parity smoke in the locked package test script

## Verification
- `composer validate --strict` (passes with existing version-field warning and host Composer deprecations)
- `php vendor/wordpress/agents-api/tests/chat-permission-parity-smoke.php`
- `php tests/chat-explicit-workspace-smoke.php`
- `php tests/chat-transcript-owner-smoke.php`
- `php tests/agents-api-transcript-store-smoke.php`
- `php tests/pending-action-scope-smoke.php`
- `php tests/pending-action-store-durable-required-smoke.php`
- `php tests/agents-api-package-contract-smoke.php`
- `php tests/release-bundled-agents-api-smoke.php`
- `git diff --check`

## Baseline test debt
- `tests/chat-caller-context-smoke.php` fails unchanged on `main`: #3195
- `tests/pending-actions-agents-api-contract-smoke.php` has three unchanged registration failures on `main`: #3196

No production release or deployment is included.