### PR TITLE
fix: reconcile stale job scheduler ownership

### DIFF
--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -1202,11 +1202,20 @@ class RecoverStuckJobsAbility {
 
 		$batch = PathlessBatchRecovery::diagnoseActiveWork( $job_id, $engine_data, $timeout_hours );
 		if ( ! empty( $batch['owned'] ) ) {
+			$type = 'fresh_child_rows';
+			if ( empty( $batch['evidence_complete'] ) ) {
+				$type = 'child_action_evidence_incomplete';
+			} elseif ( ! empty( $batch['chunk_action'] ) ) {
+				$type = 'batch_chunk_action';
+			} elseif ( ! empty( $batch['child_action_ids'] ) ) {
+				$type = 'child_step_action';
+			}
 			return array(
 				'owned'      => true,
-				'type'       => ! empty( $batch['chunk_action'] ) ? 'batch_chunk_action' : 'fresh_child_rows',
-				'action_ids' => array(),
+				'type'       => $type,
+				'action_ids' => array_map( 'intval', $batch['child_action_ids'] ?? array() ),
 				'job_ids'    => array_map( 'intval', $batch['active_child_job_ids'] ?? array() ),
+				'evidence_complete' => ! empty( $batch['evidence_complete'] ),
 			);
 		}
 

--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -526,7 +526,8 @@ class RecoverStuckJobsAbility {
 					continue;
 				}
 
-				if ( $this->hasActiveSchedulerWork( $job_id, $engine_data, $timeout_hours ) ) {
+				$scheduler_ownership = $this->getActiveSchedulerWork( $job_id, $engine_data, $timeout_hours );
+				if ( ! empty( $scheduler_ownership['owned'] ) ) {
 					++$skipped;
 					$this->appendJobDetail(
 						$jobs,
@@ -536,6 +537,7 @@ class RecoverStuckJobsAbility {
 							'flow_id' => $job_flow_id,
 							'status'  => 'skipped',
 							'reason'  => 'Pending or in-progress scheduler work exists',
+							'scheduler_ownership' => $scheduler_ownership,
 						)
 					);
 					continue;
@@ -1185,18 +1187,34 @@ class RecoverStuckJobsAbility {
 	 * @param int                  $job_id Job ID.
 	 * @param array<string, mixed> $engine_data Job engine data.
 	 * @param int                  $timeout_hours Hours before in-progress actions are considered stale.
-	 * @return bool True when pending or fresh in-progress work exists.
+	 * @return array<string,mixed> Scheduler ownership evidence.
 	 */
-	private function hasActiveSchedulerWork( int $job_id, array $engine_data, int $timeout_hours ): bool {
-		if ( $this->hasActiveStepAction( $job_id, $timeout_hours ) ) {
-			return true;
+	private function getActiveSchedulerWork( int $job_id, array $engine_data, int $timeout_hours ): array {
+		$action_ids = $this->getActiveStepActionIds( $job_id, $timeout_hours );
+		if ( ! empty( $action_ids ) ) {
+			return array(
+				'owned'      => true,
+				'type'       => 'step_action',
+				'action_ids' => $action_ids,
+				'job_ids'    => array( $job_id ),
+			);
 		}
 
-		if ( PathlessBatchRecovery::hasActiveWork( $job_id, $engine_data, $timeout_hours ) ) {
-			return true;
+		$batch = PathlessBatchRecovery::diagnoseActiveWork( $job_id, $engine_data, $timeout_hours );
+		if ( ! empty( $batch['owned'] ) ) {
+			return array(
+				'owned'      => true,
+				'type'       => ! empty( $batch['chunk_action'] ) ? 'batch_chunk_action' : 'fresh_child_rows',
+				'action_ids' => array(),
+				'job_ids'    => array_map( 'intval', $batch['active_child_job_ids'] ?? array() ),
+			);
 		}
 
-		return false;
+		return array(
+			'owned'      => false,
+			'action_ids' => array(),
+			'job_ids'    => array(),
+		);
 	}
 
 	/**
@@ -1209,13 +1227,13 @@ class RecoverStuckJobsAbility {
 	 *
 	 * @param int $job_id Job ID.
 	 * @param int $timeout_hours Hours before in-progress actions are considered stale.
-	 * @return bool True when a pending or fresh in-progress step action exists.
+	 * @return array<int,int> Pending or fresh in-progress action IDs.
 	 */
-	private function hasActiveStepAction( int $job_id, int $timeout_hours ): bool {
+	private function getActiveStepActionIds( int $job_id, int $timeout_hours ): array {
 		global $wpdb;
 
 		if ( $job_id <= 0 ) {
-			return false;
+			return array();
 		}
 
 		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
@@ -1241,10 +1259,12 @@ class RecoverStuckJobsAbility {
 		$timeout_seconds = max( 1, $timeout_hours ) * HOUR_IN_SECONDS;
 		$now_gmt         = strtotime( current_time( 'mysql', true ) );
 
+		$active_action_ids = array();
 		foreach ( $actions as $action ) {
 			if ( $job_id === $this->extractActionJobId( (string) ( $action->args ?? '' ) ) ) {
 				if ( 'pending' === (string) $action->status ) {
-					return true;
+					$active_action_ids[] = (int) $action->action_id;
+					continue;
 				}
 
 				$last_attempt = (string) ( $action->last_attempt_gmt ?? '' );
@@ -1253,16 +1273,17 @@ class RecoverStuckJobsAbility {
 				$started_at   = $reference ? strtotime( $reference ) : false;
 
 				if ( false === $started_at || false === $now_gmt ) {
-					return true;
+					$active_action_ids[] = (int) $action->action_id;
+					continue;
 				}
 
 				if ( ( $now_gmt - $started_at ) < $timeout_seconds ) {
-					return true;
+					$active_action_ids[] = (int) $action->action_id;
 				}
 			}
 		}
 
-		return false;
+		return $active_action_ids;
 	}
 
 	/**

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -30,6 +30,7 @@ use DataMachine\Core\AbilityResult;
 use DataMachine\Core\ExecutionQuery;
 use DataMachine\Core\JobArtifacts;
 use DataMachine\Core\RunMetrics;
+use DataMachine\Core\ActionScheduler\PathlessBatchRecovery;
 use DataMachine\Core\Database\Chat\Chat;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Core\Database\Jobs\Jobs;
@@ -106,7 +107,7 @@ class JobsCommand extends BaseCommand {
 	 *
 	 * @var array
 	 */
-	private array $liveness_fields = array( 'id', 'flow_id', 'classification', 'age_hours', 'defer_count', 'defer_age_seconds', 'pending_actions', 'in_progress_actions', 'oldest_pending', 'latest_attempt' );
+	private array $liveness_fields = array( 'id', 'flow_id', 'classification', 'age_hours', 'defer_count', 'defer_age_seconds', 'pending_actions', 'in_progress_actions', 'owner_action_ids', 'owner_job_ids', 'oldest_pending', 'latest_attempt' );
 
 	/**
 	 * Recover stuck jobs that have job_status in engine_data but status is 'processing'.
@@ -1172,7 +1173,7 @@ class JobsCommand extends BaseCommand {
 		}
 
 		$job['engine_data'] = $engine_data;
-		$child_counts       = ! empty( $engine_data['batch'] ) ? $this->get_child_status_counts( $job_id ) : array();
+		$child_counts       = ! empty( $engine_data['batch'] ) ? $this->get_child_status_counts( $job_id, $overdue_minutes ) : array();
 
 		return JobLivenessClassifier::diagnose( $job, $actions, $child_counts, $overdue_minutes, time() );
 	}
@@ -1236,7 +1237,7 @@ class JobsCommand extends BaseCommand {
 	 * @param int $parent_job_id Parent job ID.
 	 * @return array<string,int>
 	 */
-	private function get_child_status_counts( int $parent_job_id ): array {
+	private function get_child_status_counts( int $parent_job_id, int $overdue_minutes ): array {
 		global $wpdb;
 
 		if ( $parent_job_id <= 0 ) {
@@ -1246,11 +1247,9 @@ class JobsCommand extends BaseCommand {
 		$jobs_table = $wpdb->prefix . 'datamachine_jobs';
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
-		$row = $wpdb->get_row(
+		$rows = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT
-					COUNT(*) as total,
-					SUM(CASE WHEN status = 'processing' OR status = 'pending' THEN 1 ELSE 0 END) as active
+				"SELECT job_id, status, created_at
 				 FROM {$jobs_table}
 				 WHERE parent_job_id = %d",
 				$parent_job_id
@@ -1258,10 +1257,13 @@ class JobsCommand extends BaseCommand {
 			ARRAY_A
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$diagnosis = PathlessBatchRecovery::diagnoseChildRows( is_array( $rows ) ? $rows : array(), max( 1, $overdue_minutes ) * MINUTE_IN_SECONDS, time() );
 
 		return array(
-			'total'  => (int) ( $row['total'] ?? 0 ),
-			'active' => (int) ( $row['active'] ?? 0 ),
+			'total'         => is_array( $rows ) ? count( $rows ) : 0,
+			'active'        => count( $diagnosis['active_job_ids'] ),
+			'active_ids'    => $diagnosis['active_job_ids'],
+			'stale_ids'     => $diagnosis['stale_job_ids'],
 		);
 	}
 

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -1238,32 +1238,19 @@ class JobsCommand extends BaseCommand {
 	 * @return array<string,int>
 	 */
 	private function get_child_status_counts( int $parent_job_id, int $overdue_minutes ): array {
-		global $wpdb;
-
 		if ( $parent_job_id <= 0 ) {
 			return array();
 		}
 
-		$jobs_table = $wpdb->prefix . 'datamachine_jobs';
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WP prefix.
-		$rows = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT job_id, status, created_at
-				 FROM {$jobs_table}
-				 WHERE parent_job_id = %d",
-				$parent_job_id
-			),
-			ARRAY_A
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$diagnosis = PathlessBatchRecovery::diagnoseChildRows( is_array( $rows ) ? $rows : array(), max( 1, $overdue_minutes ) * MINUTE_IN_SECONDS, time() );
+		$diagnosis = PathlessBatchRecovery::diagnoseChildWork( $parent_job_id, max( 1, $overdue_minutes ) * MINUTE_IN_SECONDS, time() );
 
 		return array(
-			'total'         => is_array( $rows ) ? count( $rows ) : 0,
+			'total'         => (int) $diagnosis['total_children'],
 			'active'        => count( $diagnosis['active_job_ids'] ),
 			'active_ids'    => $diagnosis['active_job_ids'],
 			'stale_ids'     => $diagnosis['stale_job_ids'],
+			'action_ids'    => $diagnosis['active_action_ids'],
+			'evidence_complete' => $diagnosis['evidence_complete'],
 		);
 	}
 

--- a/inc/Cli/JobLivenessClassifier.php
+++ b/inc/Cli/JobLivenessClassifier.php
@@ -68,6 +68,8 @@ class JobLivenessClassifier {
 			$classification = 'ai_concurrency_deferred';
 		} elseif ( ! empty( $pending ) ) {
 			$classification = 'queued_next_step';
+		} elseif ( array_key_exists( 'evidence_complete', $child_counts ) && false === $child_counts['evidence_complete'] ) {
+			$classification = 'waiting_children';
 		} elseif ( $active_children > 0 || ( $batch_total > 0 && $total_children < $batch_total ) ) {
 			$classification = 'waiting_children';
 		} else {
@@ -93,9 +95,10 @@ class JobLivenessClassifier {
 			'in_progress_actions' => count( $in_progress ),
 			'complete_actions'    => count( $complete ),
 			'failed_actions'      => count( $failed ),
-			'owner_action_ids'     => array_values( array_map( 'intval', array_column( $owner_actions, 'action_id' ) ) ),
+			'owner_action_ids'     => array_values( array_unique( array_merge( array_map( 'intval', array_column( $owner_actions, 'action_id' ) ), array_map( 'intval', $child_counts['action_ids'] ?? array() ) ) ) ),
 			'owner_job_ids'        => array_values( array_map( 'intval', $child_counts['active_ids'] ?? array() ) ),
 			'stale_child_job_ids'  => array_values( array_map( 'intval', $child_counts['stale_ids'] ?? array() ) ),
+			'child_evidence_complete' => ! array_key_exists( 'evidence_complete', $child_counts ) || true === $child_counts['evidence_complete'],
 			'child_jobs'          => $total_children,
 			'active_children'     => $active_children,
 			'batch_total'         => $batch_total,

--- a/inc/Cli/JobLivenessClassifier.php
+++ b/inc/Cli/JobLivenessClassifier.php
@@ -36,12 +36,19 @@ class JobLivenessClassifier {
 		$in_progress = array_values( array_filter( $actions, fn( $action ) => 'in-progress' === ( $action['status'] ?? '' ) ) );
 		$complete    = array_values( array_filter( $actions, fn( $action ) => 'complete' === ( $action['status'] ?? '' ) ) );
 		$failed      = array_values( array_filter( $actions, fn( $action ) => 'failed' === ( $action['status'] ?? '' ) ) );
+		$fresh_progress = array_values(
+			array_filter(
+				$in_progress,
+				static fn( array $action ): bool => self::minutesSince( self::actionReference( $action ), $now ) <= $overdue_minutes
+			)
+		);
 
 		$oldest_pending      = self::actionDatetime( $pending, 'scheduled_date_gmt', false );
 		$oldest_in_progress  = self::actionDatetime( $in_progress, 'scheduled_date_gmt', false );
 		$latest_attempt      = self::actionDatetime( $actions, 'last_attempt_gmt', true );
 		$oldest_pending_age  = self::minutesSince( $oldest_pending, $now );
 		$oldest_progress_age = self::minutesSince( $oldest_in_progress, $now );
+		$owner_actions       = array_merge( $pending, $fresh_progress );
 
 		$job_id          = (int) ( $job['job_id'] ?? 0 );
 		$active_children = (int) ( $child_counts['active'] ?? 0 );
@@ -51,10 +58,10 @@ class JobLivenessClassifier {
 		$first_deferred  = strtotime( (string) ( $throttle['first_deferred_at'] ?? '' ) );
 		$defer_age       = false === $first_deferred ? (int) ( $throttle['defer_age_seconds'] ?? 0 ) : max( 0, $now - $first_deferred );
 
-		if ( ! empty( $in_progress ) && $oldest_progress_age > $overdue_minutes ) {
-			$classification = 'stale_in_progress';
-		} elseif ( ! empty( $in_progress ) ) {
+		if ( ! empty( $fresh_progress ) ) {
 			$classification = 'active_processing';
+		} elseif ( ! empty( $in_progress ) ) {
+			$classification = 'stale_in_progress';
 		} elseif ( ! empty( $pending ) && $oldest_pending_age > $overdue_minutes ) {
 			$classification = 'scheduler_starved';
 		} elseif ( ! empty( $throttle ) && 'deferred' === ( $throttle['state'] ?? 'deferred' ) && ! empty( $pending ) ) {
@@ -86,6 +93,9 @@ class JobLivenessClassifier {
 			'in_progress_actions' => count( $in_progress ),
 			'complete_actions'    => count( $complete ),
 			'failed_actions'      => count( $failed ),
+			'owner_action_ids'     => array_values( array_map( 'intval', array_column( $owner_actions, 'action_id' ) ) ),
+			'owner_job_ids'        => array_values( array_map( 'intval', $child_counts['active_ids'] ?? array() ) ),
+			'stale_child_job_ids'  => array_values( array_map( 'intval', $child_counts['stale_ids'] ?? array() ) ),
 			'child_jobs'          => $total_children,
 			'active_children'     => $active_children,
 			'batch_total'         => $batch_total,
@@ -109,6 +119,14 @@ class JobLivenessClassifier {
 
 		sort( $values );
 		return $latest ? (string) end( $values ) : $values[0];
+	}
+
+	/** Use the same in-progress heartbeat preference as timeout recovery. */
+	private static function actionReference( array $action ): string {
+		$last_attempt = (string) ( $action['last_attempt_gmt'] ?? '' );
+		return '' !== $last_attempt && '0000-00-00 00:00:00' !== $last_attempt
+			? $last_attempt
+			: (string) ( $action['scheduled_date_gmt'] ?? '' );
 	}
 
 	private static function minutesSince( string $datetime, int $now ): int {

--- a/inc/Cli/JobLivenessClassifier.php
+++ b/inc/Cli/JobLivenessClassifier.php
@@ -21,8 +21,8 @@ class JobLivenessClassifier {
 	 * @return array<string,mixed>
 	 */
 	public static function diagnose( array $job, array $actions, array $child_counts, int $overdue_minutes, int $now ): array {
-		$engine_data = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
-		$actions     = array_values(
+		$engine_data    = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$actions        = array_values(
 			array_filter(
 				$actions,
 				static function ( array $action ) use ( $job, $engine_data ): bool {
@@ -32,10 +32,10 @@ class JobLivenessClassifier {
 				}
 			)
 		);
-		$pending     = array_values( array_filter( $actions, fn( $action ) => 'pending' === ( $action['status'] ?? '' ) ) );
-		$in_progress = array_values( array_filter( $actions, fn( $action ) => 'in-progress' === ( $action['status'] ?? '' ) ) );
-		$complete    = array_values( array_filter( $actions, fn( $action ) => 'complete' === ( $action['status'] ?? '' ) ) );
-		$failed      = array_values( array_filter( $actions, fn( $action ) => 'failed' === ( $action['status'] ?? '' ) ) );
+		$pending        = array_values( array_filter( $actions, fn( $action ) => 'pending' === ( $action['status'] ?? '' ) ) );
+		$in_progress    = array_values( array_filter( $actions, fn( $action ) => 'in-progress' === ( $action['status'] ?? '' ) ) );
+		$complete       = array_values( array_filter( $actions, fn( $action ) => 'complete' === ( $action['status'] ?? '' ) ) );
+		$failed         = array_values( array_filter( $actions, fn( $action ) => 'failed' === ( $action['status'] ?? '' ) ) );
 		$fresh_progress = array_values(
 			array_filter(
 				$in_progress,
@@ -79,32 +79,32 @@ class JobLivenessClassifier {
 		$last_activity = $engine_data['run_metrics']['last_activity_at'] ?? null;
 
 		return array(
-			'id'                  => $job_id,
-			'flow_id'             => (string) ( $job['flow_id'] ?? '' ),
-			'pipeline_id'         => (string) ( $job['pipeline_id'] ?? '' ),
-			'agent_id'            => isset( $job['agent_id'] ) ? (int) $job['agent_id'] : null,
-			'classification'      => $classification,
-			'created_at'          => (string) ( $job['created_at'] ?? '' ),
-			'age_hours'           => round( self::minutesSince( (string) ( $job['created_at'] ?? '' ), $now ) / 60, 1 ),
-			'last_activity_at'    => is_string( $last_activity ) ? $last_activity : '',
-			'defer_count'         => max( 0, (int) ( $throttle['attempts'] ?? 0 ) ),
-			'defer_age_seconds'   => $defer_age,
-			'contention_active'   => ! empty( $throttle ) && 'deferred' === ( $throttle['state'] ?? 'deferred' ),
-			'contention_provider' => (string) ( $throttle['provider'] ?? '' ),
-			'pending_actions'     => count( $pending ),
-			'in_progress_actions' => count( $in_progress ),
-			'complete_actions'    => count( $complete ),
-			'failed_actions'      => count( $failed ),
-			'owner_action_ids'     => array_values( array_unique( array_merge( array_map( 'intval', array_column( $owner_actions, 'action_id' ) ), array_map( 'intval', $child_counts['action_ids'] ?? array() ) ) ) ),
-			'owner_job_ids'        => array_values( array_map( 'intval', $child_counts['active_ids'] ?? array() ) ),
-			'stale_child_job_ids'  => array_values( array_map( 'intval', $child_counts['stale_ids'] ?? array() ) ),
+			'id'                      => $job_id,
+			'flow_id'                 => (string) ( $job['flow_id'] ?? '' ),
+			'pipeline_id'             => (string) ( $job['pipeline_id'] ?? '' ),
+			'agent_id'                => isset( $job['agent_id'] ) ? (int) $job['agent_id'] : null,
+			'classification'          => $classification,
+			'created_at'              => (string) ( $job['created_at'] ?? '' ),
+			'age_hours'               => round( self::minutesSince( (string) ( $job['created_at'] ?? '' ), $now ) / 60, 1 ),
+			'last_activity_at'        => is_string( $last_activity ) ? $last_activity : '',
+			'defer_count'             => max( 0, (int) ( $throttle['attempts'] ?? 0 ) ),
+			'defer_age_seconds'       => $defer_age,
+			'contention_active'       => ! empty( $throttle ) && 'deferred' === ( $throttle['state'] ?? 'deferred' ),
+			'contention_provider'     => (string) ( $throttle['provider'] ?? '' ),
+			'pending_actions'         => count( $pending ),
+			'in_progress_actions'     => count( $in_progress ),
+			'complete_actions'        => count( $complete ),
+			'failed_actions'          => count( $failed ),
+			'owner_action_ids'        => array_values( array_unique( array_merge( array_map( 'intval', array_column( $owner_actions, 'action_id' ) ), array_map( 'intval', $child_counts['action_ids'] ?? array() ) ) ) ),
+			'owner_job_ids'           => array_values( array_map( 'intval', $child_counts['active_ids'] ?? array() ) ),
+			'stale_child_job_ids'     => array_values( array_map( 'intval', $child_counts['stale_ids'] ?? array() ) ),
 			'child_evidence_complete' => ! array_key_exists( 'evidence_complete', $child_counts ) || true === $child_counts['evidence_complete'],
-			'child_jobs'          => $total_children,
-			'active_children'     => $active_children,
-			'batch_total'         => $batch_total,
-			'oldest_pending'      => $oldest_pending,
-			'oldest_in_progress'  => $oldest_in_progress,
-			'latest_attempt'      => $latest_attempt,
+			'child_jobs'              => $total_children,
+			'active_children'         => $active_children,
+			'batch_total'             => $batch_total,
+			'oldest_pending'          => $oldest_pending,
+			'oldest_in_progress'      => $oldest_in_progress,
+			'latest_attempt'          => $latest_attempt,
 		);
 	}
 

--- a/inc/Core/ActionScheduler/PathlessBatchRecovery.php
+++ b/inc/Core/ActionScheduler/PathlessBatchRecovery.php
@@ -26,21 +26,72 @@ class PathlessBatchRecovery {
 
 	/** Check whether a batch parent still has scheduled chunk or child work. */
 	public static function hasActiveWork( int $parent_job_id, array $engine_data, int $timeout_hours ): bool {
+		return ! empty( self::diagnoseActiveWork( $parent_job_id, $engine_data, $timeout_hours )['owned'] );
+	}
+
+	/** Describe the scheduler action or fresh child rows that currently own a batch. */
+	public static function diagnoseActiveWork( int $parent_job_id, array $engine_data, int $timeout_hours ): array {
 		if ( $parent_job_id <= 0 || empty( $engine_data['batch'] ) ) {
-			return false;
+			return array(
+				'owned'                => false,
+				'chunk_action'         => false,
+				'active_child_job_ids' => array(),
+				'stale_child_job_ids'  => array(),
+			);
 		}
 		if ( self::hasActiveAction( $parent_job_id, $engine_data, $timeout_hours ) ) {
-			return true;
+			return array(
+				'owned'                => true,
+				'chunk_action'         => true,
+				'active_child_job_ids' => array(),
+				'stale_child_job_ids'  => array(),
+			);
 		}
 
 		global $wpdb;
 		$jobs_table = $wpdb->prefix . Jobs::TABLE_NAME;
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WordPress prefix.
-		$active_children = (int) $wpdb->get_var(
-			$wpdb->prepare( "SELECT COUNT(*) FROM {$jobs_table} WHERE parent_job_id = %d AND status IN ( %s, %s )", $parent_job_id, 'pending', 'processing' )
+		$children = $wpdb->get_results(
+			$wpdb->prepare( "SELECT job_id, status, created_at FROM {$jobs_table} WHERE parent_job_id = %d AND status IN ( %s, %s )", $parent_job_id, 'pending', 'processing' ),
+			ARRAY_A
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		return $active_children > 0;
+		$diagnosis = self::diagnoseChildRows( is_array( $children ) ? $children : array(), max( 1, $timeout_hours ) * HOUR_IN_SECONDS, time() );
+
+		return array(
+			'owned'                => ! empty( $diagnosis['active_job_ids'] ),
+			'chunk_action'         => false,
+			'active_child_job_ids' => $diagnosis['active_job_ids'],
+			'stale_child_job_ids'  => $diagnosis['stale_job_ids'],
+		);
+	}
+
+	/**
+	 * Apply the shared child-row ownership grace used by recovery and liveness.
+	 *
+	 * A fresh pending/processing row protects the create-and-schedule race. Once
+	 * the timeout passes, only actual scheduler action evidence may own work.
+	 */
+	public static function diagnoseChildRows( array $children, int $timeout_seconds, int $now ): array {
+		$active_job_ids = array();
+		$stale_job_ids  = array();
+		foreach ( $children as $child ) {
+			$job_id     = (int) ( $child['job_id'] ?? 0 );
+			$created_at = strtotime( (string) ( $child['created_at'] ?? '' ) . ' UTC' );
+			if ( $job_id <= 0 || ! in_array( (string) ( $child['status'] ?? '' ), array( 'pending', 'processing' ), true ) ) {
+				continue;
+			}
+			if ( false === $created_at || ( $now - $created_at ) < max( 1, $timeout_seconds ) ) {
+				$active_job_ids[] = $job_id;
+			} else {
+				$stale_job_ids[] = $job_id;
+			}
+		}
+
+		return array(
+			'active_job_ids' => $active_job_ids,
+			'stale_job_ids'  => $stale_job_ids,
+		);
 	}
 
 	/** Re-establish one scheduler path for a durable pathless v2 batch. */

--- a/inc/Core/ActionScheduler/PathlessBatchRecovery.php
+++ b/inc/Core/ActionScheduler/PathlessBatchRecovery.php
@@ -10,7 +10,9 @@ namespace DataMachine\Core\ActionScheduler;
 
 use DataMachine\Core\Database\BatchItems\BatchItems;
 use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\DirectJobEnqueuer;
 use DataMachine\Core\EngineData;
+use DataMachine\Engine\AI\AIConcurrencyBackpressure;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -32,25 +34,21 @@ class PathlessBatchRecovery {
 
 	/** Describe the scheduler action or fresh child rows that currently own a batch. */
 	public static function diagnoseActiveWork( int $parent_job_id, array $engine_data, int $timeout_hours ): array {
+		$diagnosis = array(
+			'owned'                => false,
+			'chunk_action'         => false,
+			'active_child_job_ids' => array(),
+			'stale_child_job_ids'  => array(),
+			'child_action_ids'      => array(),
+			'evidence_complete'     => true,
+		);
 		if ( $parent_job_id <= 0 || empty( $engine_data['batch'] ) ) {
-			return array(
-				'owned'                => false,
-				'chunk_action'         => false,
-				'active_child_job_ids' => array(),
-				'stale_child_job_ids'  => array(),
-				'child_action_ids'      => array(),
-				'evidence_complete'     => true,
-			);
+			return $diagnosis;
 		}
 		if ( self::hasActiveAction( $parent_job_id, $engine_data, $timeout_hours ) ) {
-			return array(
-				'owned'                => true,
-				'chunk_action'         => true,
-				'active_child_job_ids' => array(),
-				'stale_child_job_ids'  => array(),
-				'child_action_ids'      => array(),
-				'evidence_complete'     => true,
-			);
+			$diagnosis['owned']        = true;
+			$diagnosis['chunk_action'] = true;
+			return $diagnosis;
 		}
 
 		$diagnosis = self::diagnoseChildWork( $parent_job_id, max( 1, $timeout_hours ) * HOUR_IN_SECONDS, time() );
@@ -70,27 +68,45 @@ class PathlessBatchRecovery {
 		global $wpdb;
 		$jobs_table = $wpdb->prefix . Jobs::TABLE_NAME;
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WordPress prefix.
+		$total_children = $wpdb->get_var(
+			$wpdb->prepare( "SELECT COUNT(*) FROM {$jobs_table} WHERE parent_job_id = %d", $parent_job_id )
+		);
+		$count_complete = null !== $total_children && '' === (string) $wpdb->last_error;
 		$children = $wpdb->get_results(
-			$wpdb->prepare( "SELECT job_id, status, created_at FROM {$jobs_table} WHERE parent_job_id = %d", $parent_job_id ),
+			$wpdb->prepare(
+				"SELECT job_id, status, created_at
+				 FROM {$jobs_table}
+				 WHERE parent_job_id = %d AND status IN ( %s, %s )
+				 ORDER BY job_id ASC
+				 LIMIT %d",
+				$parent_job_id,
+				'pending',
+				'processing',
+				self::CHILD_QUERY_LIMIT + 1
+			),
 			ARRAY_A
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		if ( ! is_array( $children ) || '' !== (string) $wpdb->last_error ) {
-			return self::diagnoseChildRows( array(), $timeout_seconds, $now, array(), false );
+		$children_complete = is_array( $children )
+			&& '' === (string) $wpdb->last_error
+			&& count( $children ) <= self::CHILD_QUERY_LIMIT;
+		$children          = is_array( $children ) ? array_slice( $children, 0, self::CHILD_QUERY_LIMIT ) : array();
+		if ( ! $count_complete || ! $children_complete ) {
+			$diagnosis                   = self::diagnoseChildRows( $children, $timeout_seconds, $now, array(), false );
+			$diagnosis['total_children'] = $count_complete ? (int) $total_children : count( $children );
+			return $diagnosis;
 		}
 
 		$initial       = self::diagnoseChildRows( $children, $timeout_seconds, $now );
+		$initial['total_children'] = (int) $total_children;
 		$stale_job_ids = $initial['stale_job_ids'];
 		if ( empty( $stale_job_ids ) ) {
 			return $initial;
 		}
-		if ( count( $stale_job_ids ) > self::CHILD_QUERY_LIMIT ) {
-			return self::diagnoseChildRows( $children, $timeout_seconds, $now, array(), false );
-		}
 
 		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
 		$clauses       = array();
-		$query_args    = array( 'datamachine_execute_step', 'datamachine_resume_ai_step', 'pending', 'in-progress' );
+		$query_args    = array( DirectJobEnqueuer::HOOK, AIConcurrencyBackpressure::RESUME_HOOK, 'pending', 'in-progress' );
 		foreach ( $stale_job_ids as $job_id ) {
 			$clauses[]    = '(args LIKE %s OR args LIKE %s)';
 			$query_args[] = '%"job_id":' . $wpdb->esc_like( (string) $job_id ) . ',%';
@@ -117,13 +133,15 @@ class PathlessBatchRecovery {
 			&& '' === (string) $wpdb->last_error
 			&& count( $actions ) <= self::ACTION_QUERY_LIMIT;
 
-		return self::diagnoseChildRows(
+		$diagnosis = self::diagnoseChildRows(
 			$children,
 			$timeout_seconds,
 			$now,
 			is_array( $actions ) ? array_slice( $actions, 0, self::ACTION_QUERY_LIMIT ) : array(),
 			$complete
 		);
+		$diagnosis['total_children'] = (int) $total_children;
+		return $diagnosis;
 	}
 
 	/**

--- a/inc/Core/ActionScheduler/PathlessBatchRecovery.php
+++ b/inc/Core/ActionScheduler/PathlessBatchRecovery.php
@@ -39,8 +39,8 @@ class PathlessBatchRecovery {
 			'chunk_action'         => false,
 			'active_child_job_ids' => array(),
 			'stale_child_job_ids'  => array(),
-			'child_action_ids'      => array(),
-			'evidence_complete'     => true,
+			'child_action_ids'     => array(),
+			'evidence_complete'    => true,
 		);
 		if ( $parent_job_id <= 0 || empty( $engine_data['batch'] ) ) {
 			return $diagnosis;
@@ -58,8 +58,8 @@ class PathlessBatchRecovery {
 			'chunk_action'         => false,
 			'active_child_job_ids' => $diagnosis['active_job_ids'],
 			'stale_child_job_ids'  => $diagnosis['stale_job_ids'],
-			'child_action_ids'      => $diagnosis['active_action_ids'],
-			'evidence_complete'     => $diagnosis['evidence_complete'],
+			'child_action_ids'     => $diagnosis['active_action_ids'],
+			'evidence_complete'    => $diagnosis['evidence_complete'],
 		);
 	}
 
@@ -72,7 +72,7 @@ class PathlessBatchRecovery {
 			$wpdb->prepare( "SELECT COUNT(*) FROM {$jobs_table} WHERE parent_job_id = %d", $parent_job_id )
 		);
 		$count_complete = null !== $total_children && '' === (string) $wpdb->last_error;
-		$children = $wpdb->get_results(
+		$children       = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT job_id, status, created_at
 				 FROM {$jobs_table}
@@ -97,9 +97,9 @@ class PathlessBatchRecovery {
 			return $diagnosis;
 		}
 
-		$initial       = self::diagnoseChildRows( $children, $timeout_seconds, $now );
+		$initial                   = self::diagnoseChildRows( $children, $timeout_seconds, $now );
 		$initial['total_children'] = (int) $total_children;
-		$stale_job_ids = $initial['stale_job_ids'];
+		$stale_job_ids             = $initial['stale_job_ids'];
 		if ( empty( $stale_job_ids ) ) {
 			return $initial;
 		}
@@ -114,26 +114,24 @@ class PathlessBatchRecovery {
 		}
 		$query_args[] = self::ACTION_QUERY_LIMIT + 1;
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name and placeholder clauses are generated above.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Table name and placeholder clauses are generated above; values remain prepared.
 		$actions = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT action_id, args, status, scheduled_date_gmt, last_attempt_gmt
 				 FROM {$actions_table}
 				 WHERE hook IN ( %s, %s )
 				 AND status IN ( %s, %s )
-				 AND (" . implode( ' OR ', $clauses ) . ")
-				 ORDER BY action_id DESC
-				 LIMIT %d",
+				 AND (" . implode( ' OR ', $clauses ) . ') ORDER BY action_id DESC LIMIT %d',
 				$query_args
 			),
 			ARRAY_A
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 		$complete = is_array( $actions )
 			&& '' === (string) $wpdb->last_error
 			&& count( $actions ) <= self::ACTION_QUERY_LIMIT;
 
-		$diagnosis = self::diagnoseChildRows(
+		$diagnosis                   = self::diagnoseChildRows(
 			$children,
 			$timeout_seconds,
 			$now,

--- a/inc/Core/ActionScheduler/PathlessBatchRecovery.php
+++ b/inc/Core/ActionScheduler/PathlessBatchRecovery.php
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class PathlessBatchRecovery {
 	private const CLAIM_TTL          = 300;
 	private const ACTION_QUERY_LIMIT = 100;
+	private const CHILD_QUERY_LIMIT  = 100;
 
 	/** Whether a v2 batch still has work that can be requeued. */
 	public static function isRecoverable( array $engine_data ): bool {
@@ -37,6 +38,8 @@ class PathlessBatchRecovery {
 				'chunk_action'         => false,
 				'active_child_job_ids' => array(),
 				'stale_child_job_ids'  => array(),
+				'child_action_ids'      => array(),
+				'evidence_complete'     => true,
 			);
 		}
 		if ( self::hasActiveAction( $parent_job_id, $engine_data, $timeout_hours ) ) {
@@ -45,24 +48,81 @@ class PathlessBatchRecovery {
 				'chunk_action'         => true,
 				'active_child_job_ids' => array(),
 				'stale_child_job_ids'  => array(),
+				'child_action_ids'      => array(),
+				'evidence_complete'     => true,
 			);
 		}
 
+		$diagnosis = self::diagnoseChildWork( $parent_job_id, max( 1, $timeout_hours ) * HOUR_IN_SECONDS, time() );
+
+		return array(
+			'owned'                => ! $diagnosis['evidence_complete'] || ! empty( $diagnosis['active_job_ids'] ),
+			'chunk_action'         => false,
+			'active_child_job_ids' => $diagnosis['active_job_ids'],
+			'stale_child_job_ids'  => $diagnosis['stale_job_ids'],
+			'child_action_ids'      => $diagnosis['active_action_ids'],
+			'evidence_complete'     => $diagnosis['evidence_complete'],
+		);
+	}
+
+	/** Query child rows and their active scheduler actions without N+1 scans. */
+	public static function diagnoseChildWork( int $parent_job_id, int $timeout_seconds, int $now ): array {
 		global $wpdb;
 		$jobs_table = $wpdb->prefix . Jobs::TABLE_NAME;
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated from the WordPress prefix.
 		$children = $wpdb->get_results(
-			$wpdb->prepare( "SELECT job_id, status, created_at FROM {$jobs_table} WHERE parent_job_id = %d AND status IN ( %s, %s )", $parent_job_id, 'pending', 'processing' ),
+			$wpdb->prepare( "SELECT job_id, status, created_at FROM {$jobs_table} WHERE parent_job_id = %d", $parent_job_id ),
 			ARRAY_A
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$diagnosis = self::diagnoseChildRows( is_array( $children ) ? $children : array(), max( 1, $timeout_hours ) * HOUR_IN_SECONDS, time() );
+		if ( ! is_array( $children ) || '' !== (string) $wpdb->last_error ) {
+			return self::diagnoseChildRows( array(), $timeout_seconds, $now, array(), false );
+		}
 
-		return array(
-			'owned'                => ! empty( $diagnosis['active_job_ids'] ),
-			'chunk_action'         => false,
-			'active_child_job_ids' => $diagnosis['active_job_ids'],
-			'stale_child_job_ids'  => $diagnosis['stale_job_ids'],
+		$initial       = self::diagnoseChildRows( $children, $timeout_seconds, $now );
+		$stale_job_ids = $initial['stale_job_ids'];
+		if ( empty( $stale_job_ids ) ) {
+			return $initial;
+		}
+		if ( count( $stale_job_ids ) > self::CHILD_QUERY_LIMIT ) {
+			return self::diagnoseChildRows( $children, $timeout_seconds, $now, array(), false );
+		}
+
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$clauses       = array();
+		$query_args    = array( 'datamachine_execute_step', 'datamachine_resume_ai_step', 'pending', 'in-progress' );
+		foreach ( $stale_job_ids as $job_id ) {
+			$clauses[]    = '(args LIKE %s OR args LIKE %s)';
+			$query_args[] = '%"job_id":' . $wpdb->esc_like( (string) $job_id ) . ',%';
+			$query_args[] = '%"job_id":' . $wpdb->esc_like( (string) $job_id ) . '}%';
+		}
+		$query_args[] = self::ACTION_QUERY_LIMIT + 1;
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name and placeholder clauses are generated above.
+		$actions = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT action_id, args, status, scheduled_date_gmt, last_attempt_gmt
+				 FROM {$actions_table}
+				 WHERE hook IN ( %s, %s )
+				 AND status IN ( %s, %s )
+				 AND (" . implode( ' OR ', $clauses ) . ")
+				 ORDER BY action_id DESC
+				 LIMIT %d",
+				$query_args
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$complete = is_array( $actions )
+			&& '' === (string) $wpdb->last_error
+			&& count( $actions ) <= self::ACTION_QUERY_LIMIT;
+
+		return self::diagnoseChildRows(
+			$children,
+			$timeout_seconds,
+			$now,
+			is_array( $actions ) ? array_slice( $actions, 0, self::ACTION_QUERY_LIMIT ) : array(),
+			$complete
 		);
 	}
 
@@ -72,7 +132,7 @@ class PathlessBatchRecovery {
 	 * A fresh pending/processing row protects the create-and-schedule race. Once
 	 * the timeout passes, only actual scheduler action evidence may own work.
 	 */
-	public static function diagnoseChildRows( array $children, int $timeout_seconds, int $now ): array {
+	public static function diagnoseChildRows( array $children, int $timeout_seconds, int $now, array $actions = array(), bool $evidence_complete = true ): array {
 		$active_job_ids = array();
 		$stale_job_ids  = array();
 		foreach ( $children as $child ) {
@@ -87,10 +147,42 @@ class PathlessBatchRecovery {
 				$stale_job_ids[] = $job_id;
 			}
 		}
+		$active_action_ids = array();
+		$action_job_ids    = array();
+		foreach ( $actions as $action ) {
+			$action = is_object( $action ) ? get_object_vars( $action ) : $action;
+			$args   = json_decode( (string) ( $action['args'] ?? '' ), true );
+			$job_id = is_array( $args ) && isset( $args['job_id'] ) && is_numeric( $args['job_id'] ) ? (int) $args['job_id'] : 0;
+			if ( $job_id <= 0 || ! in_array( $job_id, $stale_job_ids, true ) ) {
+				$evidence_complete = false;
+				continue;
+			}
+			$status = (string) ( $action['status'] ?? '' );
+			if ( 'pending' !== $status && 'in-progress' !== $status ) {
+				continue;
+			}
+			$last_attempt = (string) ( $action['last_attempt_gmt'] ?? '' );
+			$scheduled    = (string) ( $action['scheduled_date_gmt'] ?? '' );
+			$reference    = '' !== $last_attempt && '0000-00-00 00:00:00' !== $last_attempt ? $last_attempt : $scheduled;
+			$started_at   = strtotime( $reference . ' UTC' );
+			if ( 'pending' === $status || false === $started_at || ( $now - $started_at ) < max( 1, $timeout_seconds ) ) {
+				$active_action_ids[] = (int) ( $action['action_id'] ?? 0 );
+				$action_job_ids[]    = $job_id;
+			}
+		}
+
+		if ( ! $evidence_complete ) {
+			$action_job_ids = $stale_job_ids;
+		}
+		$active_job_ids = array_values( array_unique( array_merge( $active_job_ids, $action_job_ids ) ) );
+		$stale_job_ids  = array_values( array_diff( $stale_job_ids, $action_job_ids ) );
 
 		return array(
-			'active_job_ids' => $active_job_ids,
-			'stale_job_ids'  => $stale_job_ids,
+			'total_children'    => count( $children ),
+			'active_job_ids'   => $active_job_ids,
+			'stale_job_ids'    => $stale_job_ids,
+			'active_action_ids' => array_values( array_filter( array_unique( $active_action_ids ) ) ),
+			'evidence_complete' => $evidence_complete,
 		);
 	}
 

--- a/tests/job-liveness-cli-smoke.php
+++ b/tests/job-liveness-cli-smoke.php
@@ -44,9 +44,13 @@ $classify = static function ( array $job_row, array $actions = array(), array $c
 echo "=== job-liveness-cli-smoke ===\n";
 $active = $classify( $job(), array( $action( 'in-progress', '2026-07-22 11:30:00' ) ) );
 $assert( 'fresh running action is active processing', 'active_processing' === $active['classification'] );
+$assert( 'active diagnostics expose owning action ID', array( 91 ) === $classify( $job(), array( $action( 'in-progress', '2026-07-22 11:30:00', array(), 'datamachine_execute_step', 91 ) ) )['owner_action_ids'] );
 
 $stale = $classify( $job(), array( $action( 'in-progress', '2026-07-22 09:00:00' ) ) );
 $assert( 'overdue running action is stale in progress', 'stale_in_progress' === $stale['classification'] );
+
+$mixed_progress = $classify( $job(), array( $action( 'in-progress', '2026-07-22 09:00:00', array(), 'datamachine_execute_step', 90 ), $action( 'in-progress', '2026-07-22 11:30:00', array(), 'datamachine_execute_step', 91 ) ) );
+$assert( 'fresh action owns work alongside stale history', 'active_processing' === $mixed_progress['classification'] && array( 91 ) === $mixed_progress['owner_action_ids'] );
 
 $starved = $classify( $job(), array( $action( 'pending', '2026-07-22 09:00:00' ) ) );
 $assert( 'overdue pending action is scheduler starved', 'scheduler_starved' === $starved['classification'] );
@@ -75,8 +79,13 @@ $assert( 'deferred contention is active', true === $deferred['contention_active'
 $queued = $classify( $job(), array( $action( 'pending', '2026-07-22 11:50:00' ) ) );
 $assert( 'fresh pending action without throttle is queued', 'queued_next_step' === $queued['classification'] );
 
-$waiting = $classify( $job( array( 'batch' => true, 'batch_total' => 3 ) ), array(), array( 'active' => 1, 'total' => 2 ) );
+$waiting = $classify( $job( array( 'batch' => true, 'batch_total' => 3 ) ), array(), array( 'active' => 1, 'total' => 2, 'active_ids' => array( 43 ) ) );
 $assert( 'active batch children classify as waiting', 'waiting_children' === $waiting['classification'] );
+$assert( 'waiting diagnostics expose owning child ID', array( 43 ) === $waiting['owner_job_ids'] );
+
+$stale_children = $classify( $job( array( 'batch' => true, 'batch_total' => 2 ) ), array(), array( 'active' => 0, 'total' => 2, 'stale_ids' => array( 43, 44 ) ) );
+$assert( 'old pathless children do not own the parent', 'no_scheduler_path' === $stale_children['classification'] );
+$assert( 'old pathless child IDs remain diagnostic evidence', array( 43, 44 ) === $stale_children['stale_child_job_ids'] );
 
 $resolved = $classify( $job( array( 'ai_concurrency_history' => array( array( 'state' => 'resolved' ) ) ) ) );
 $assert( 'resolved history does not report active contention', false === $resolved['contention_active'] );
@@ -105,6 +114,9 @@ $invalid_receipt_engine = $recovery_engine;
 $invalid_receipt_engine['scheduler_recovery']['receipt']['action_id'] = 0;
 $invalid_receipt = $classify( $job( $invalid_receipt_engine ), array( $action( 'pending', '2026-07-22 11:50:00', array( 'recovery_generation' => 8, 'recovery_claim_token' => 'current-recovery' ), 'datamachine_execute_step', 108 ) ) );
 $assert( 'zero action receipt is not a liveness path', 'no_scheduler_path' === $invalid_receipt['classification'] );
+
+$historical = $classify( $job(), array( $action( 'complete', '2026-07-01 00:00:00', array(), 'datamachine_execute_step', 55 ) ) );
+$assert( 'old historical action is not scheduler ownership', 'no_scheduler_path' === $historical['classification'] && array() === $historical['owner_action_ids'] );
 
 echo "\nJob liveness CLI smoke complete: {$total} assertions, {$failed} failures.\n";
 exit( $failed > 0 ? 1 : 0 );

--- a/tests/job-liveness-cli-smoke.php
+++ b/tests/job-liveness-cli-smoke.php
@@ -87,6 +87,13 @@ $stale_children = $classify( $job( array( 'batch' => true, 'batch_total' => 2 ) 
 $assert( 'old pathless children do not own the parent', 'no_scheduler_path' === $stale_children['classification'] );
 $assert( 'old pathless child IDs remain diagnostic evidence', array( 43, 44 ) === $stale_children['stale_child_job_ids'] );
 
+$owned_child_action = $classify( $job( array( 'batch' => true, 'batch_total' => 2 ) ), array(), array( 'active' => 1, 'total' => 2, 'active_ids' => array( 43 ), 'stale_ids' => array( 44 ), 'action_ids' => array( 109 ), 'evidence_complete' => true ) );
+$assert( 'old child action keeps parent waiting', 'waiting_children' === $owned_child_action['classification'] );
+$assert( 'child scheduler action and job IDs are exposed', array( 109 ) === $owned_child_action['owner_action_ids'] && array( 43 ) === $owned_child_action['owner_job_ids'] );
+
+$incomplete_children = $classify( $job( array( 'batch' => true, 'batch_total' => 2 ) ), array(), array( 'active' => 1, 'total' => 2, 'active_ids' => array( 43 ), 'stale_ids' => array(), 'action_ids' => array(), 'evidence_complete' => false ) );
+$assert( 'incomplete child evidence fails closed as waiting', 'waiting_children' === $incomplete_children['classification'] && false === $incomplete_children['child_evidence_complete'] );
+
 $resolved = $classify( $job( array( 'ai_concurrency_history' => array( array( 'state' => 'resolved' ) ) ) ) );
 $assert( 'resolved history does not report active contention', false === $resolved['contention_active'] );
 $assert( 'job without active scheduler path is classified directly', 'no_scheduler_path' === $resolved['classification'] );

--- a/tests/pathless-batch-recovery-bounds-smoke.php
+++ b/tests/pathless-batch-recovery-bounds-smoke.php
@@ -122,5 +122,17 @@ $wpdb->responses = array( array(), array(), array() );
 pathless_assert( false === $lookup->invoke( null, 7, $engine, 1 ), 'exhausted exact and compatibility evidence proves absence' );
 pathless_assert( 3 === count( $wpdb->queries ), 'absence requires every bounded status query to be exhausted' );
 
+$children = \DataMachine\Core\ActionScheduler\PathlessBatchRecovery::diagnoseChildRows(
+	array(
+		array( 'job_id' => 70, 'status' => 'pending', 'created_at' => '2026-08-09 11:30:00' ),
+		array( 'job_id' => 71, 'status' => 'processing', 'created_at' => '2026-08-09 09:00:00' ),
+		array( 'job_id' => 72, 'status' => 'completed', 'created_at' => '2026-08-09 11:30:00' ),
+	),
+	HOUR_IN_SECONDS,
+	strtotime( '2026-08-09 12:00:00 UTC' )
+);
+pathless_assert( array( 70 ) === $children['active_job_ids'], 'fresh child row protects the scheduling race' );
+pathless_assert( array( 71 ) === $children['stale_job_ids'], 'old child row ages out of scheduler ownership' );
+
 echo "Pathless batch recovery bounds: {$passes} passed, {$failures} failed.\n";
 exit( $failures > 0 ? 1 : 0 );

--- a/tests/pathless-batch-recovery-bounds-smoke.php
+++ b/tests/pathless-batch-recovery-bounds-smoke.php
@@ -165,7 +165,8 @@ pathless_assert( false === $incomplete['evidence_complete'], 'bounded evidence f
 pathless_assert( array( 71 ) === $incomplete['active_job_ids'], 'bounded evidence failure preserves ownership' );
 
 $source = file_get_contents( __DIR__ . '/../inc/Core/ActionScheduler/PathlessBatchRecovery.php' ) ?: '';
-pathless_assert( str_contains( $source, 'count( $stale_job_ids ) > self::CHILD_QUERY_LIMIT' ), 'child ID scope is bounded before scheduler query' );
+pathless_assert( str_contains( $source, 'self::CHILD_QUERY_LIMIT + 1' ), 'active child query uses a truncation sentinel' );
+pathless_assert( str_contains( $source, 'count( $children ) <= self::CHILD_QUERY_LIMIT' ), 'child evidence fails closed when truncated' );
 pathless_assert( str_contains( $source, 'count( $actions ) <= self::ACTION_QUERY_LIMIT' ), 'child action result uses truncation sentinel' );
 
 echo "Pathless batch recovery bounds: {$passes} passed, {$failures} failed.\n";

--- a/tests/pathless-batch-recovery-bounds-smoke.php
+++ b/tests/pathless-batch-recovery-bounds-smoke.php
@@ -134,5 +134,39 @@ $children = \DataMachine\Core\ActionScheduler\PathlessBatchRecovery::diagnoseChi
 pathless_assert( array( 70 ) === $children['active_job_ids'], 'fresh child row protects the scheduling race' );
 pathless_assert( array( 71 ) === $children['stale_job_ids'], 'old child row ages out of scheduler ownership' );
 
+$old_child = array( array( 'job_id' => 71, 'status' => 'pending', 'created_at' => '2026-08-09 09:00:00' ) );
+$current_action = array(
+	array(
+		'action_id'          => 901,
+		'args'               => '{"job_id":71,"flow_step_id":"step"}',
+		'status'             => 'pending',
+		'scheduled_date_gmt' => '2026-08-09 11:59:00',
+		'last_attempt_gmt'   => '0000-00-00 00:00:00',
+	),
+);
+$owned = \DataMachine\Core\ActionScheduler\PathlessBatchRecovery::diagnoseChildRows( $old_child, HOUR_IN_SECONDS, strtotime( '2026-08-09 12:00:00 UTC' ), $current_action );
+pathless_assert( array( 71 ) === $owned['active_job_ids'], 'old child with current action still owns parent' );
+pathless_assert( array( 901 ) === $owned['active_action_ids'], 'current child action ID is exposed' );
+
+$stale_action = $current_action;
+$stale_action[0]['status'] = 'in-progress';
+$stale_action[0]['last_attempt_gmt'] = '2026-08-09 09:00:00';
+$historical = \DataMachine\Core\ActionScheduler\PathlessBatchRecovery::diagnoseChildRows( $old_child, HOUR_IN_SECONDS, strtotime( '2026-08-09 12:00:00 UTC' ), $stale_action );
+pathless_assert( array( 71 ) === $historical['stale_job_ids'], 'old child with only stale action ages out' );
+pathless_assert( array() === $historical['active_action_ids'], 'stale child action is not ownership' );
+
+$completed_action = $current_action;
+$completed_action[0]['status'] = 'complete';
+$completed = \DataMachine\Core\ActionScheduler\PathlessBatchRecovery::diagnoseChildRows( $old_child, HOUR_IN_SECONDS, strtotime( '2026-08-09 12:00:00 UTC' ), $completed_action );
+pathless_assert( array( 71 ) === $completed['stale_job_ids'], 'old child with only historical action ages out' );
+
+$incomplete = \DataMachine\Core\ActionScheduler\PathlessBatchRecovery::diagnoseChildRows( $old_child, HOUR_IN_SECONDS, strtotime( '2026-08-09 12:00:00 UTC' ), array(), false );
+pathless_assert( false === $incomplete['evidence_complete'], 'bounded evidence failure is explicit' );
+pathless_assert( array( 71 ) === $incomplete['active_job_ids'], 'bounded evidence failure preserves ownership' );
+
+$source = file_get_contents( __DIR__ . '/../inc/Core/ActionScheduler/PathlessBatchRecovery.php' ) ?: '';
+pathless_assert( str_contains( $source, 'count( $stale_job_ids ) > self::CHILD_QUERY_LIMIT' ), 'child ID scope is bounded before scheduler query' );
+pathless_assert( str_contains( $source, 'count( $actions ) <= self::ACTION_QUERY_LIMIT' ), 'child action result uses truncation sentinel' );
+
 echo "Pathless batch recovery bounds: {$passes} passed, {$failures} failed.\n";
 exit( $failures > 0 ? 1 : 0 );

--- a/tests/recover-stuck-active-action-guard-smoke.php
+++ b/tests/recover-stuck-active-action-guard-smoke.php
@@ -28,8 +28,8 @@ $batch_source = file_get_contents( __DIR__ . '/../inc/Core/ActionScheduler/Pathl
 $timeout_loop = strstr( $source, 'foreach ( $timed_out_jobs as $job )' ) ?: '';
 
 echo "Case 1: timed-out recovery skips jobs with active scheduler work\n";
-assert_recover_stuck_guard_smoke( 'active scheduler work method exists', str_contains( $source, 'private function hasActiveSchedulerWork' ) );
-assert_recover_stuck_guard_smoke( 'active step guard method exists', str_contains( $source, 'private function hasActiveStepAction' ) );
+assert_recover_stuck_guard_smoke( 'active scheduler work evidence method exists', str_contains( $source, 'private function getActiveSchedulerWork' ) );
+assert_recover_stuck_guard_smoke( 'active step guard exposes action IDs', str_contains( $source, 'private function getActiveStepActionIds' ) );
 assert_recover_stuck_guard_smoke( 'timeout loop diagnoses child ownership before dry-run recovery', strpos( $timeout_loop, 'ChildJobRecoveryPolicy::diagnose' ) < strpos( $timeout_loop, 'if ( $dry_run )' ) );
 assert_recover_stuck_guard_smoke( 'guard records skipped status', str_contains( $source, "'status'  => 'skipped'") && str_contains( $source, 'Pending or in-progress scheduler work exists' ) );
 
@@ -39,7 +39,7 @@ assert_recover_stuck_guard_smoke( 'guard checks pending and in-progress actions'
 assert_recover_stuck_guard_smoke( 'guard confirms exact job id from action args', str_contains( $source, '$this->extractActionJobId' ) );
 
 echo "Case 3: stale in-progress step actions do not block timeout recovery forever\n";
-assert_recover_stuck_guard_smoke( 'guard receives timeout window', str_contains( $source, 'private function hasActiveStepAction( int $job_id, int $timeout_hours )' ) );
+assert_recover_stuck_guard_smoke( 'guard receives timeout window', str_contains( $source, 'private function getActiveStepActionIds( int $job_id, int $timeout_hours )' ) );
 assert_recover_stuck_guard_smoke( 'guard reads action attempt timestamps', str_contains( $source, 'last_attempt_gmt' ) && str_contains( $source, 'scheduled_date_gmt' ) );
 assert_recover_stuck_guard_smoke( 'pending actions remain guarded unconditionally', str_contains( $source, 'if ( \'pending\' === (string) $action->status )' ) );
 assert_recover_stuck_guard_smoke( 'old in-progress actions can fall through', str_contains( $source, '( $now_gmt - $started_at ) < $timeout_seconds' ) );
@@ -52,6 +52,7 @@ assert_recover_stuck_guard_smoke( 'batch guard confirms exact parent id', str_co
 assert_recover_stuck_guard_smoke( 'batch guard uses indexed canonical args', str_contains( $batch_source, 'WHERE args = %s AND hook = %s' ) );
 assert_recover_stuck_guard_smoke( 'batch compatibility queries are bounded', str_contains( $batch_source, 'ACTION_QUERY_LIMIT + 1' ) && str_contains( $batch_source, 'LIMIT %d' ) );
 assert_recover_stuck_guard_smoke( 'batch guard fails closed on incomplete evidence', str_contains( $batch_source, 'count( $actions ) > self::ACTION_QUERY_LIMIT' ) && str_contains( $batch_source, "last_error" ) );
+assert_recover_stuck_guard_smoke( 'old child rows age out through shared policy', str_contains( $batch_source, 'public static function diagnoseChildRows' ) && str_contains( $batch_source, "'stale_job_ids'") );
 
 echo "\nRecover-stuck active action guard smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {

--- a/tests/recover-stuck-active-action-guard-smoke.php
+++ b/tests/recover-stuck-active-action-guard-smoke.php
@@ -53,6 +53,8 @@ assert_recover_stuck_guard_smoke( 'batch guard uses indexed canonical args', str
 assert_recover_stuck_guard_smoke( 'batch compatibility queries are bounded', str_contains( $batch_source, 'ACTION_QUERY_LIMIT + 1' ) && str_contains( $batch_source, 'LIMIT %d' ) );
 assert_recover_stuck_guard_smoke( 'batch guard fails closed on incomplete evidence', str_contains( $batch_source, 'count( $actions ) > self::ACTION_QUERY_LIMIT' ) && str_contains( $batch_source, "last_error" ) );
 assert_recover_stuck_guard_smoke( 'old child rows age out through shared policy', str_contains( $batch_source, 'public static function diagnoseChildRows' ) && str_contains( $batch_source, "'stale_job_ids'") );
+assert_recover_stuck_guard_smoke( 'stale child candidates receive one bounded bulk action query', str_contains( $batch_source, 'public static function diagnoseChildWork' ) && str_contains( $batch_source, 'CHILD_QUERY_LIMIT' ) );
+assert_recover_stuck_guard_smoke( 'child action and job ownership evidence is returned', str_contains( $source, "'child_step_action'") && str_contains( $batch_source, "'child_action_ids'") );
 
 echo "\nRecover-stuck active action guard smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary

- age stale `pending`/`processing` child rows out of batch-parent scheduler ownership through one child-row policy shared by recovery and liveness
- expose owning Action Scheduler IDs, owning child job IDs, and stale child IDs in liveness, plus scheduler ownership evidence in recovery skip details
- classify mixed in-progress history by fresh ownership so one stale action cannot hide a genuinely fresh action

## Production Evidence

On Events with Data Machine v0.172.29, bounded recovery left 79 rows:

```text
recover-stuck: skipped=79, actionable=0
reason: Pending or in-progress scheduler work exists
```

The corresponding expanded liveness scope reported:

```text
total=166, active=0, queued=0, waiting_children=79, no_scheduler_path=87
```

Read-only SQL showed that the 79 guarded parents were owned solely by 129 child rows still marked `pending`, aged 272-665 hours. Sampled parents had no pending/in-progress `datamachine_execute_step`, `datamachine_resume_ai_step`, or `datamachine_pipeline_batch_chunk` actions.

## Root Cause

`PathlessBatchRecovery::hasActiveWork()` treated any child row with `pending` or `processing` status as permanent scheduler ownership. Liveness used the same status count to call those parents `waiting_children`, but neither surface exposed the child IDs or distinguished a fresh create/schedule race from stale historical rows. Separately, liveness classified all in-progress evidence from the oldest action, while recovery correctly guarded any fresh action.

## Ownership Contract

A pending Action Scheduler action remains ownership regardless of age because it can still execute. An in-progress action owns work while its attempt/scheduled heartbeat is inside the configured timeout; unknown timestamps fail closed. A fresh child row owns the parent during the same timeout window to protect the create-and-schedule race. Once that grace expires, a bare child status is historical state rather than executable scheduler ownership.

This is intentionally the smallest owning-layer correction: `PathlessBatchRecovery::diagnoseChildRows()` defines child-row ownership, and both recovery and liveness consume it. It does not weaken Action Scheduler guards or change child recovery generation/claim fences.

## Before / After Diagnostics

Before, the production evidence classified 79 parents as `waiting_children` and recovery skipped the same 79 indefinitely despite zero actions. Under the new default 120-minute contract, their 272-665-hour child rows become `stale_child_job_ids`; those parents classify as `no_scheduler_path` and become eligible for bounded recovery.

Fresh queued/running actions continue to expose `owner_action_ids`. Fresh child rows continue to classify as `waiting_children` and expose `owner_job_ids`. Recovery skip details now include the ownership type and owning IDs.

## Race Safety

- pending scheduler actions remain guarded unconditionally
- fresh in-progress actions remain guarded, including when stale history also exists
- invalid/unknown action timestamps fail closed as active
- fresh child rows retain a timeout-sized scheduling grace
- generation filtering for operation, AI resume, and recovery actions is unchanged
- bounded batch action queries still fail closed on query errors or truncated evidence
- child recovery claims, receipts, and compare-and-swap transitions are unchanged

## Tests

Passed:

```text
php -l inc/Core/ActionScheduler/PathlessBatchRecovery.php
php -l inc/Abilities/Job/RecoverStuckJobsAbility.php
php -l inc/Cli/Commands/JobsCommand.php
php -l inc/Cli/JobLivenessClassifier.php
php tests/job-liveness-cli-smoke.php
php tests/recover-stuck-active-action-guard-smoke.php
php tests/pathless-batch-recovery-bounds-smoke.php
php tests/child-job-recovery-policy-smoke.php
vendor/bin/phpcs <all changed PHP files>
composer lint
git diff --check
```

The repository-wide `tests/*-smoke.php` loop also found three unrelated baseline failures, tracked separately as #3201, #3202, and #3203. No unrelated source or test was changed here.

Closes #3200