### PR TITLE
fix: honor pathless recovery policy in dry runs

### DIFF
--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -429,6 +429,12 @@ class RecoverStuckJobsAbility {
 
 				if ( is_array( $child_diagnosis ) ) {
 					$planned_status = ! empty( $child_diagnosis['retry_eligible'] ) ? 'would_requeue_pathless_child' : 'would_transition_pathless_child';
+					if ( ! $recover_pathless_children ) {
+						++$skipped;
+						++$pathless_policy_skipped;
+						$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, 'skipped', $recovery_trigger, 'pathless_child_apply_policy_required' ) );
+						continue;
+					}
 					if ( $dry_run ) {
 						if ( ! empty( $child_diagnosis['retry_eligible'] ) ) {
 							++$requeued;
@@ -437,12 +443,6 @@ class RecoverStuckJobsAbility {
 							++$pathless_terminal;
 						}
 						$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, $planned_status, $recovery_trigger ) );
-						continue;
-					}
-					if ( ! $recover_pathless_children ) {
-						++$skipped;
-						++$pathless_policy_skipped;
-						$this->appendJobDetail( $jobs, $jobs_omitted, $this->childRecoveryEvidence( $job_row, $child_diagnosis, 'skipped', $recovery_trigger, 'pathless_child_apply_policy_required' ) );
 						continue;
 					}
 					// Diagnosis can change after claiming, so reserve claim + rollback/requeue + finish/terminal.
@@ -673,7 +673,7 @@ class RecoverStuckJobsAbility {
 		$jobs_truncated = $jobs_omitted > 0;
 
 		$message = $dry_run
-			? sprintf( 'Dry run complete. Would recover %d jobs, timeout %d jobs, requeue %d pathless children, terminalize %d pathless children, and reconcile %d terminal-backed actions.', $recovered, $timed_out, $pathless_requeued, $pathless_terminal, $stale_actions )
+			? sprintf( 'Dry run complete. Would recover %d jobs, timeout %d jobs, requeue %d pathless children, terminalize %d pathless children, reconcile %d terminal-backed actions, and guard %d pathless children requiring explicit authorization.', $recovered, $timed_out, $pathless_requeued, $pathless_terminal, $stale_actions, $pathless_policy_skipped )
 			: sprintf( 'Recovery complete. Attempted/touched/mutated: %d/%d/%d (limit %d), outcomes: %d, recovered: %d, timed out: %d, pathless requeued: %d, pathless terminal: %d, reconciled actions: %d, policy-skipped: %d', $attempted, $touched, $mutated, $apply_limit, $mutations, $recovered, $timed_out, $pathless_requeued, $pathless_terminal, $stale_actions, $pathless_policy_skipped );
 
 		if ( ! $dry_run && ( $mutations > 0 || $claimed_elsewhere > 0 || $pathless_policy_skipped > 0 ) ) {

--- a/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
+++ b/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
@@ -17,6 +17,7 @@ use DataMachine\Engine\AI\AIConcurrencyBackpressure;
 use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
 use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
 use DataMachine\Abilities\Engine\ExecuteStepAbility;
+use DataMachine\Cli\Commands\JobsCommand;
 use WP_UnitTestCase;
 
 class JobLifecycleTransitionTest extends WP_UnitTestCase {
@@ -164,6 +165,62 @@ class JobLifecycleTransitionTest extends WP_UnitTestCase {
 		$this->assertSame( 'get_jobs_failed', $result->get_error_code() );
 		$this->assertSame( 'job_id must be a positive integer.', $result->get_error_message() );
 		$this->assertSame( 500, $result->get_error_data()['status'] );
+	}
+
+	public function test_pathless_dry_run_summaries_honor_apply_authorization(): void {
+		global $wpdb;
+		$parent_id = $this->db_jobs->create_job( array( 'label' => 'Dry-run policy parent' ) );
+		$child_id  = $this->db_jobs->create_job( array( 'label' => 'Dry-run policy child', 'parent_job_id' => $parent_id ) );
+		$this->assertTrue( $this->db_jobs->start_job( $child_id ) );
+		$wpdb->update(
+			$wpdb->prefix . 'datamachine_jobs',
+			array( 'created_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ) ),
+			array( 'job_id' => $child_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		$guarded = ( new RecoverStuckJobsAbility() )->execute(
+			array(
+				'dry_run'       => true,
+				'job_id'        => $child_id,
+				'timeout_hours' => 1,
+			)
+		);
+		$summary_method = new \ReflectionMethod( JobsCommand::class, 'summarize_recover_stuck_result' );
+		$guarded_summary = $summary_method->invoke( new JobsCommand(), $guarded );
+
+		$this->assertFalse( $guarded['scope']['recover_pathless_children'] );
+		$this->assertSame( 0, $guarded['pathless_terminal'] );
+		$this->assertSame( 0, $guarded['pathless_requeued'] );
+		$this->assertSame( 1, $guarded['pathless_policy_skipped'] );
+		$this->assertSame( 1, $guarded['skipped'] );
+		$this->assertSame( 'skipped', $guarded['jobs'][0]['status'] );
+		$this->assertSame( 'pathless_child_apply_policy_required', $guarded['jobs'][0]['reason'] );
+		$this->assertStringContainsString( 'guard 1 pathless children requiring explicit authorization', $guarded['message'] );
+		$this->assertSame( 0, $guarded_summary['actionable'] );
+		$this->assertSame( 1, $guarded_summary['skipped'] );
+		$this->assertSame( 1, $guarded_summary['total'] );
+
+		$authorized = ( new RecoverStuckJobsAbility() )->execute(
+			array(
+				'dry_run'                    => true,
+				'job_id'                     => $child_id,
+				'timeout_hours'               => 1,
+				'recover_pathless_children' => true,
+			)
+		);
+		$authorized_summary = $summary_method->invoke( new JobsCommand(), $authorized );
+
+		$this->assertTrue( $authorized['scope']['recover_pathless_children'] );
+		$this->assertSame( 1, $authorized['pathless_terminal'] );
+		$this->assertSame( 0, $authorized['pathless_policy_skipped'] );
+		$this->assertSame( 0, $authorized['skipped'] );
+		$this->assertSame( 'would_transition_pathless_child', $authorized['jobs'][0]['status'] );
+		$this->assertStringContainsString( 'terminalize 1 pathless children', $authorized['message'] );
+		$this->assertSame( 1, $authorized_summary['actionable'] );
+		$this->assertSame( 0, $authorized_summary['skipped'] );
+		$this->assertSame( 1, $authorized_summary['total'] );
 	}
 
 	public function test_touch_limit_stops_before_partial_pathless_claim(): void {

--- a/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
+++ b/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
@@ -17,7 +17,6 @@ use DataMachine\Engine\AI\AIConcurrencyBackpressure;
 use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
 use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
 use DataMachine\Abilities\Engine\ExecuteStepAbility;
-use DataMachine\Cli\Commands\JobsCommand;
 use WP_UnitTestCase;
 
 class JobLifecycleTransitionTest extends WP_UnitTestCase {
@@ -165,62 +164,6 @@ class JobLifecycleTransitionTest extends WP_UnitTestCase {
 		$this->assertSame( 'get_jobs_failed', $result->get_error_code() );
 		$this->assertSame( 'job_id must be a positive integer.', $result->get_error_message() );
 		$this->assertSame( 500, $result->get_error_data()['status'] );
-	}
-
-	public function test_pathless_dry_run_summaries_honor_apply_authorization(): void {
-		global $wpdb;
-		$parent_id = $this->db_jobs->create_job( array( 'label' => 'Dry-run policy parent' ) );
-		$child_id  = $this->db_jobs->create_job( array( 'label' => 'Dry-run policy child', 'parent_job_id' => $parent_id ) );
-		$this->assertTrue( $this->db_jobs->start_job( $child_id ) );
-		$wpdb->update(
-			$wpdb->prefix . 'datamachine_jobs',
-			array( 'created_at' => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ) ),
-			array( 'job_id' => $child_id ),
-			array( '%s' ),
-			array( '%d' )
-		);
-
-		$guarded = ( new RecoverStuckJobsAbility() )->execute(
-			array(
-				'dry_run'       => true,
-				'job_id'        => $child_id,
-				'timeout_hours' => 1,
-			)
-		);
-		$summary_method = new \ReflectionMethod( JobsCommand::class, 'summarize_recover_stuck_result' );
-		$guarded_summary = $summary_method->invoke( new JobsCommand(), $guarded );
-
-		$this->assertFalse( $guarded['scope']['recover_pathless_children'] );
-		$this->assertSame( 0, $guarded['pathless_terminal'] );
-		$this->assertSame( 0, $guarded['pathless_requeued'] );
-		$this->assertSame( 1, $guarded['pathless_policy_skipped'] );
-		$this->assertSame( 1, $guarded['skipped'] );
-		$this->assertSame( 'skipped', $guarded['jobs'][0]['status'] );
-		$this->assertSame( 'pathless_child_apply_policy_required', $guarded['jobs'][0]['reason'] );
-		$this->assertStringContainsString( 'guard 1 pathless children requiring explicit authorization', $guarded['message'] );
-		$this->assertSame( 0, $guarded_summary['actionable'] );
-		$this->assertSame( 1, $guarded_summary['skipped'] );
-		$this->assertSame( 1, $guarded_summary['total'] );
-
-		$authorized = ( new RecoverStuckJobsAbility() )->execute(
-			array(
-				'dry_run'                    => true,
-				'job_id'                     => $child_id,
-				'timeout_hours'               => 1,
-				'recover_pathless_children' => true,
-			)
-		);
-		$authorized_summary = $summary_method->invoke( new JobsCommand(), $authorized );
-
-		$this->assertTrue( $authorized['scope']['recover_pathless_children'] );
-		$this->assertSame( 1, $authorized['pathless_terminal'] );
-		$this->assertSame( 0, $authorized['pathless_policy_skipped'] );
-		$this->assertSame( 0, $authorized['skipped'] );
-		$this->assertSame( 'would_transition_pathless_child', $authorized['jobs'][0]['status'] );
-		$this->assertStringContainsString( 'terminalize 1 pathless children', $authorized['message'] );
-		$this->assertSame( 1, $authorized_summary['actionable'] );
-		$this->assertSame( 0, $authorized_summary['skipped'] );
-		$this->assertSame( 1, $authorized_summary['total'] );
 	}
 
 	public function test_touch_limit_stops_before_partial_pathless_claim(): void {

--- a/tests/recover-stuck-cli-output-smoke.php
+++ b/tests/recover-stuck-cli-output-smoke.php
@@ -23,20 +23,32 @@ function assert_recover_stuck_cli_output_smoke( string $name, bool $condition, s
 	++$failed;
 }
 
-$source = file_get_contents( __DIR__ . '/../inc/Cli/Commands/JobsCommand.php' ) ?: '';
+$cli_source     = file_get_contents( __DIR__ . '/../inc/Cli/Commands/JobsCommand.php' ) ?: '';
+$ability_source = file_get_contents( __DIR__ . '/../inc/Abilities/Job/RecoverStuckJobsAbility.php' ) ?: '';
 
 echo "Case 1: recover-stuck exposes structured output\n";
-assert_recover_stuck_cli_output_smoke( 'recover-stuck documents format option', str_contains( $source, '[--format=<format>]' ) );
-assert_recover_stuck_cli_output_smoke( 'recover-stuck supports json examples', str_contains( $source, 'recover-stuck --dry-run --format=json' ) );
-assert_recover_stuck_cli_output_smoke( 'non-table output uses WP_CLI print_value', str_contains( $source, "if ( 'table' !== \$format )" ) && str_contains( $source, 'WP_CLI::print_value' ) );
-assert_recover_stuck_cli_output_smoke( 'structured output includes summary and jobs', str_contains( $source, "'summary'        => \$summary" ) && str_contains( $source, "'jobs'           => \$jobs" ) );
-assert_recover_stuck_cli_output_smoke( 'structured output includes truncation metadata', str_contains( $source, "'jobs_omitted'" ) && str_contains( $source, "'jobs_truncated'" ) );
+assert_recover_stuck_cli_output_smoke( 'recover-stuck documents format option', str_contains( $cli_source, '[--format=<format>]' ) );
+assert_recover_stuck_cli_output_smoke( 'recover-stuck supports json examples', str_contains( $cli_source, 'recover-stuck --dry-run --format=json' ) );
+assert_recover_stuck_cli_output_smoke( 'non-table output uses WP_CLI print_value', str_contains( $cli_source, "if ( 'table' !== \$format )" ) && str_contains( $cli_source, 'WP_CLI::print_value' ) );
+assert_recover_stuck_cli_output_smoke( 'structured output includes summary and jobs', str_contains( $cli_source, "'summary'        => \$summary" ) && str_contains( $cli_source, "'jobs'           => \$jobs" ) );
+assert_recover_stuck_cli_output_smoke( 'structured output includes truncation metadata', str_contains( $cli_source, "'jobs_omitted'" ) && str_contains( $cli_source, "'jobs_truncated'" ) );
 
 echo "Case 2: recover-stuck separates actionable and guarded jobs\n";
-assert_recover_stuck_cli_output_smoke( 'summary helper exists', str_contains( $source, 'private function summarize_recover_stuck_result' ) );
-assert_recover_stuck_cli_output_smoke( 'summary computes actionable total', str_contains( $source, "'actionable'    => \$recovered + \$timed_out + \$stale_actions" ) );
-assert_recover_stuck_cli_output_smoke( 'table headline reports guarded jobs separately', str_contains( $source, 'Found %d recoverable jobs/actions and %d guarded jobs.' ) );
-assert_recover_stuck_cli_output_smoke( 'table output reports truncated details', str_contains( $source, 'Output truncated; %d additional job/action details omitted.' ) );
+assert_recover_stuck_cli_output_smoke( 'summary helper exists', str_contains( $cli_source, 'private function summarize_recover_stuck_result' ) );
+assert_recover_stuck_cli_output_smoke( 'summary computes actionable total', str_contains( $cli_source, "'actionable'    => \$recovered + \$timed_out + \$stale_actions" ) );
+assert_recover_stuck_cli_output_smoke( 'table headline reports guarded jobs separately', str_contains( $cli_source, 'Found %d recoverable jobs/actions and %d guarded jobs.' ) );
+assert_recover_stuck_cli_output_smoke( 'table output reports truncated details', str_contains( $cli_source, 'Output truncated; %d additional job/action details omitted.' ) );
+
+$pathless_branch = strstr( $ability_source, 'if ( is_array( $child_diagnosis ) ) {' ) ?: '';
+$pathless_branch = strstr( $pathless_branch, '// Diagnosis can change after claiming', true ) ?: '';
+$policy_guard    = strpos( $pathless_branch, 'if ( ! $recover_pathless_children ) {' );
+$dry_run_preview = strpos( $pathless_branch, 'if ( $dry_run ) {' );
+
+echo "Case 3: pathless dry-run reporting honors apply authorization\n";
+assert_recover_stuck_cli_output_smoke( 'pathless policy guard precedes actionable preview', false !== $policy_guard && false !== $dry_run_preview && $policy_guard < $dry_run_preview );
+assert_recover_stuck_cli_output_smoke( 'unauthorized preview is policy-skipped', str_contains( $pathless_branch, '++$skipped;' ) && str_contains( $pathless_branch, '++$pathless_policy_skipped;' ) && str_contains( $pathless_branch, 'pathless_child_apply_policy_required' ) );
+assert_recover_stuck_cli_output_smoke( 'authorized preview preserves actionable dispositions', str_contains( $pathless_branch, 'would_requeue_pathless_child' ) && str_contains( $pathless_branch, 'would_transition_pathless_child' ) && str_contains( $pathless_branch, '++$pathless_requeued;' ) && str_contains( $pathless_branch, '++$pathless_terminal;' ) );
+assert_recover_stuck_cli_output_smoke( 'dry-run message reports guarded pathless candidates', str_contains( $ability_source, 'guard %d pathless children requiring explicit authorization' ) );
 
 echo "\nRecover-stuck CLI output smoke complete: {$total} assertions, {$failed} failures.\n";
 if ( $failed > 0 ) {


### PR DESCRIPTION
## Summary

- evaluate pathless-child apply authorization before dry-run mutation preview accounting
- report unauthorized pathless candidates as guarded via `skipped` and `pathless_policy_skipped`, including coherent detail and human-readable output
- preserve the existing actionable preview when `--recover-pathless-children` is explicitly supplied
- add regression coverage for disabled and enabled authorization, including CLI summary totals used by JSON and table output

## Production reproduction

Production Data Machine v0.172.29 returned misleading dry-run output for:

```sh
wp --url=https://events.extrachill.com datamachine jobs recover-stuck --dry-run --limit=100 --format=json
```

Although `scope.recover_pathless_children=false`, the response counted `pathless_terminal: 63`, included those jobs in `actionable: 89`, and said it would terminalize 63 pathless children.

## Root cause

`RecoverStuckJobsAbility::execute()` handled the dry-run branch before checking `recover_pathless_children`. It incremented actionable pathless counters and emitted `would_transition_pathless_child` or `would_requeue_pathless_child`, while the apply branch correctly checked authorization before mutation.

## Behavior before/after

Before: an unauthorized dry run diagnosed pathless candidates as actionable mutations even though apply would policy-skip them.

After: an unauthorized dry run records those candidates as `skipped` and `pathless_policy_skipped`, emits `pathless_child_apply_policy_required`, excludes them from actionable counters, and reports the guarded count in the message. An authorized dry run retains the existing actionable pathless preview.

## Tests

Passed:

- `php -l inc/Abilities/Job/RecoverStuckJobsAbility.php`
- `php -l tests/Unit/Core/Database/JobLifecycleTransitionTest.php`
- `php tests/recover-stuck-cli-output-smoke.php`
- `php tests/recover-stuck-bounded-apply-smoke.php`
- `composer lint -- inc/Abilities/Job/RecoverStuckJobsAbility.php tests/Unit/Core/Database/JobLifecycleTransitionTest.php`
- `homeboy review lint data-machine --path /var/lib/datamachine/workspace/data-machine@fix-3199-recovery-dry-run-summary --changed-only --placement local --summary`
- `homeboy review audit data-machine --path /var/lib/datamachine/workspace/data-machine@fix-3199-recovery-dry-run-summary --changed-since origin/main --placement local --summary` (no introduced findings)
- `git diff --check`

The added WordPress integration regression was selected by Homeboy, but the local repository test gate executed zero tests because this checkout has no PHPUnit suite configuration. A direct focused attempt reached the WordPress test bootstrap but could not authenticate the local `wptests` database as the current OS user. Configured CI should execute the added test.

## Race and safety implications

This changes reporting order only. Unauthorized dry runs now follow the same policy boundary as apply without touching storage. Authorized dry runs remain read-only and unchanged. Apply claim ownership, touch budgeting, post-claim re-diagnosis, scheduler race handling, and mutation paths are untouched.

Closes #3199