### PR TITLE
fix: defer fetch acknowledgement until packet disposition

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -22,9 +22,11 @@ use DataMachine\Core\FilesRepository\FileRetrieval;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\RunMetrics;
 use DataMachine\Core\RecoveryExecutionFence;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\StepExecutionResult;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\Step;
+use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
 use DataMachine\Engine\StepNavigator;
 
 defined( 'ABSPATH' ) || exit;
@@ -647,9 +649,27 @@ class ExecuteStepAbility {
 		string $recovery_claim_token = ''
 	): array {
 		$pipeline_id = $flow_step_config['pipeline_id'] ?? null;
-
-		// Waiting status: pipeline is parked at a webhook gate.
+		$transfer_recovery = array( 'success' => true, 'stale' => false );
+		$transfer_snapshot = datamachine_get_engine_data( $job_id );
+		if ( is_array( $transfer_snapshot['packet_fanout_transfer'] ?? null ) ) {
+			$transfer_recovery = StepLifecycleHandler::recoverPreparedFanoutTransfer( $job_id, $recovery_generation, $recovery_claim_token );
+		}
+		if ( ! $transfer_recovery['success'] ) {
+			return ! empty( $transfer_recovery['stale'] )
+				? $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'lost ownership while recovering prepared fanout transfer' )
+				: $this->claimReconciliationFailure( $job_id, $flow_step_id, $step_type );
+		}
+		// Waiting is not a disposition boundary; retain every claim for resume.
 		if ( $status_override && JobStatus::isStatusWaiting( $status_override ) ) {
+			$parked_snapshot = datamachine_get_engine_data( $job_id );
+			$renewed = ProcessedItems::has_claim_metadata( $parked_snapshot )
+				? StepLifecycleHandler::renewParkedClaims( $job_id, $recovery_generation, $recovery_claim_token )
+				: array( 'success' => true, 'stale' => false );
+			if ( ! $renewed['success'] ) {
+				return ! empty( $renewed['stale'] )
+					? $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'lost ownership while renewing waiting packet claims' )
+					: $this->claimReconciliationFailure( $job_id, $flow_step_id, $step_type );
+			}
 			do_action(
 				'datamachine_log',
 				'info',
@@ -667,6 +687,63 @@ class ExecuteStepAbility {
 				'outcome'      => 'waiting',
 			);
 		}
+		$retry_owns_work = 'blocked' === ( $execution_result['status'] ?? '' ) || $this->retryOwnsCurrentWork( $job_id );
+		if ( $retry_owns_work ) {
+			$parked_snapshot = datamachine_get_engine_data( $job_id );
+			$renewed = ProcessedItems::has_claim_metadata( $parked_snapshot )
+				? StepLifecycleHandler::renewParkedClaims( $job_id, $recovery_generation, $recovery_claim_token )
+				: array( 'success' => true, 'stale' => false );
+			if ( ! $renewed['success'] ) {
+				return ! empty( $renewed['stale'] )
+					? $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'lost ownership while renewing parked packet claims' )
+					: $this->claimReconciliationFailure( $job_id, $flow_step_id, $step_type );
+			}
+		}
+		$reconciled  = array(
+			'success'   => true,
+			'handled'   => false,
+			'retained'  => 0,
+			'completed' => 0,
+			'released'  => 0,
+			'omitted'   => 0,
+			'explicit'  => 0,
+		);
+		if ( ! $retry_owns_work && ! in_array( $step_type, array( 'fetch', 'event_import' ), true ) ) {
+			$reconciled = StepLifecycleHandler::reconcileStepOutput(
+				$job_id,
+				array_merge( $flow_step_config, array( 'flow_step_id' => $flow_step_id ) ),
+				$dataPackets,
+				$step_success,
+				$recovery_generation,
+				$recovery_claim_token
+			);
+		}
+		if ( ! $reconciled['success'] ) {
+			if ( ! empty( $reconciled['stale'] ) ) {
+				return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'lost ownership before packet claim reconciliation' );
+			}
+			do_action(
+				'datamachine_fail_job',
+				$job_id,
+				'packet_claim_reconciliation_failed',
+				array(
+					'flow_step_id' => $flow_step_id,
+					'step_type'    => $step_type,
+					'reconciliation' => $reconciled,
+				)
+			);
+			return array(
+				'success'      => false,
+				'step_success' => false,
+				'outcome'      => 'claim_reconciliation_failed',
+				'reason'       => 'packet_claim_reconciliation_failed',
+			);
+		}
+
+		$explicitly_dispositioned = $step_success
+			&& $reconciled['handled']
+			&& 0 === $reconciled['retained']
+			&& 0 < $reconciled['explicit'];
 
 		// Status override: complete with override status and clean up.
 		if ( $status_override ) {
@@ -724,6 +801,20 @@ class ExecuteStepAbility {
 			);
 		}
 
+		if ( $explicitly_dispositioned ) {
+			$transition       = $this->transitionTerminalWithRecoveryFence( $job_id, JobStatus::COMPLETED_NO_ITEMS, $recovery_generation, $recovery_claim_token );
+			$stale_transition = $this->staleRejectedTerminalTransition( $job_id, $recovery_generation, $recovery_claim_token, $transition );
+			if ( null !== $stale_transition ) {
+				return $stale_transition;
+			}
+			return array(
+				'success'      => $transition['success'] && JobStatus::isStatusSuccess( $transition['status'] ),
+				'step_success' => true,
+				'outcome'      => 'packets_dispositioned',
+				'status'       => $transition['status'],
+			);
+		}
+
 		// Success: advance to next step or complete.
 		if ( $step_success ) {
 			$navigator         = new StepNavigator();
@@ -776,7 +867,12 @@ class ExecuteStepAbility {
 					if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
 						return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before inline lifecycle routing' );
 					}
-					$this->handleStepLifecycleInlineContinuation( $job_id, $flow_step_config, $routed_packets );
+					$inline_reconciliation = $this->handleStepLifecycleInlineContinuation( $job_id, $flow_step_config, $routed_packets, $recovery_generation, $recovery_claim_token );
+					if ( ! $inline_reconciliation['success'] ) {
+						return ! empty( $inline_reconciliation['stale'] )
+							? $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'lost ownership during inline claim reconciliation' )
+							: $this->claimReconciliationFailure( $job_id, $flow_step_id, $step_type );
+					}
 
 					if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
 						return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before next-step scheduling' );
@@ -816,12 +912,59 @@ class ExecuteStepAbility {
 				if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
 					return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before fan-out routing' );
 				}
-				$parallel_result = $adapter->dispatch(
+				$should_fanout = ParallelMapFanoutAdapter::shouldFanOut(
 					$parallel_step,
-					$job_id,
-					$next_flow_step_id,
-					$engine_snapshot
+					array( 'job_id' => $job_id, 'next_flow_step_id' => $next_flow_step_id, 'item_count' => $packet_count, 'step_id' => $next_flow_step_id )
 				);
+				$fanout_transfer = $should_fanout
+					? StepLifecycleHandler::transferClaimsToFanout( $job_id, $routed_packets, $recovery_generation, $recovery_claim_token )
+					: array( 'success' => true, 'stale' => false );
+				if ( ! $fanout_transfer['success'] ) {
+					return ! empty( $fanout_transfer['stale'] )
+						? $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'lost ownership during fanout claim transfer' )
+						: $this->claimReconciliationFailure( $job_id, $flow_step_id, $step_type );
+				}
+				if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
+					$transfer_id = (string) ( $fanout_transfer['transfer_id'] ?? '' );
+					$restored    = '' === $transfer_id || StepLifecycleHandler::restorePreparedFanoutTransfer( $job_id, $transfer_id, $recovery_generation, $recovery_claim_token );
+					if ( ! $restored ) {
+						return $this->claimReconciliationFailure( $job_id, $flow_step_id, $step_type );
+					}
+					return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded after fanout claim transfer and before durable batch dispatch' );
+				}
+				try {
+					$parallel_result = $adapter->dispatch(
+						$parallel_step,
+						$job_id,
+						$next_flow_step_id,
+						$engine_snapshot,
+						$should_fanout
+					);
+				} catch ( \Throwable $exception ) {
+					$transfer_id = (string) ( $fanout_transfer['transfer_id'] ?? '' );
+					$recovered = '' === $transfer_id
+						? array( 'success' => true )
+						: StepLifecycleHandler::recoverPreparedFanoutTransfer( $job_id, $recovery_generation, $recovery_claim_token );
+					if ( empty( $recovered['success'] ) ) {
+						do_action( 'datamachine_log', 'error', 'Fanout dispatch threw and its durable transfer state could not be recovered.', array( 'job_id' => $job_id ) );
+					}
+					throw $exception;
+				}
+				$transfer_id = (string) ( $fanout_transfer['transfer_id'] ?? '' );
+				$batch_adopted = ! empty( $parallel_result['batch']['adopted'] );
+				if ( $should_fanout && '' !== $transfer_id && ! $batch_adopted ) {
+					if ( ! StepLifecycleHandler::restorePreparedFanoutTransfer( $job_id, $transfer_id, $recovery_generation, $recovery_claim_token ) ) {
+						return $this->claimReconciliationFailure( $job_id, $flow_step_id, $step_type );
+					}
+					return $this->claimReconciliationFailure( $job_id, $flow_step_id, $step_type );
+				}
+				if ( $should_fanout && '' !== $transfer_id ) {
+					$adopted = StepLifecycleHandler::adoptPreparedFanoutTransfer( $job_id, $transfer_id, $recovery_generation, $recovery_claim_token );
+					$finalized = $adopted && StepLifecycleHandler::finalizePreparedFanoutTransfer( $job_id, $transfer_id, $recovery_generation, $recovery_claim_token );
+					if ( ! $finalized ) {
+						return $this->claimReconciliationFailure( $job_id, $flow_step_id, $step_type );
+					}
+				}
 
 				// Gate declined (shape:'inline'): collapse to inline
 				// continuation — the routed packets continue on this job
@@ -830,7 +973,12 @@ class ExecuteStepAbility {
 					if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
 						return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before gated inline lifecycle routing' );
 					}
-					$this->handleStepLifecycleInlineContinuation( $job_id, $flow_step_config, $routed_packets );
+					$inline_reconciliation = $this->handleStepLifecycleInlineContinuation( $job_id, $flow_step_config, $routed_packets, $recovery_generation, $recovery_claim_token );
+					if ( ! $inline_reconciliation['success'] ) {
+						return ! empty( $inline_reconciliation['stale'] )
+							? $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'lost ownership during gated inline claim reconciliation' )
+							: $this->claimReconciliationFailure( $job_id, $flow_step_id, $step_type );
+					}
 
 					if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
 						return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before gated next-step scheduling' );
@@ -861,6 +1009,27 @@ class ExecuteStepAbility {
 
 			if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
 				return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before successful terminal routing' );
+			}
+			if ( in_array( $step_type, array( 'fetch', 'event_import' ), true ) ) {
+				$source_reconciliation = StepLifecycleHandler::reconcileStepOutput(
+					$job_id,
+					array_merge( $flow_step_config, array( 'flow_step_id' => $flow_step_id ) ),
+					$dataPackets,
+					true,
+					$recovery_generation,
+					$recovery_claim_token
+				);
+				if ( ! $source_reconciliation['success'] ) {
+					if ( ! empty( $source_reconciliation['stale'] ) ) {
+						return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'lost ownership during terminal source claim reconciliation' );
+					}
+					return array(
+						'success'      => false,
+						'step_success' => false,
+						'outcome'      => 'claim_reconciliation_failed',
+						'reason'       => 'packet_claim_reconciliation_failed',
+					);
+				}
 			}
 			$transition       = $this->transitionTerminalWithRecoveryFence( $job_id, JobStatus::COMPLETED, $recovery_generation, $recovery_claim_token );
 			$stale_transition = $this->staleRejectedTerminalTransition( $job_id, $recovery_generation, $recovery_claim_token, $transition );
@@ -1123,6 +1292,16 @@ class ExecuteStepAbility {
 		return ! empty( $throttle['next_retry_at'] );
 	}
 
+	/** Whether a durable pending retry owns this job's current packet claims. */
+	private function retryOwnsCurrentWork( int $job_id ): bool {
+		$job = $this->db_jobs->get_job( $job_id );
+		if ( ! is_array( $job ) || JobStatus::PENDING !== JobStatus::fromString( (string) ( $job['status'] ?? '' ) )->getBaseStatus() ) {
+			return false;
+		}
+
+		return $this->hasPendingRetry( $job_id ) || $this->hasPendingAIConcurrencyThrottle( $job_id );
+	}
+
 	/**
 	 * Notify step lifecycle handlers that a step is continuing inline.
 	 *
@@ -1130,8 +1309,20 @@ class ExecuteStepAbility {
 	 * @param array $flow_step_config Current flow step configuration.
 	 * @param array $routed_packets   Packets routed to the next step.
 	 */
-	private function handleStepLifecycleInlineContinuation( int $job_id, array $flow_step_config, array $routed_packets ): void {
+	private function handleStepLifecycleInlineContinuation( int $job_id, array $flow_step_config, array $routed_packets, int $recovery_generation = 0, string $recovery_claim_token = '' ): array {
+		if ( in_array( (string) ( $flow_step_config['step_type'] ?? '' ), array( 'fetch', 'event_import' ), true ) ) {
+			$result = StepLifecycleHandler::reconcileStepOutput( $job_id, $flow_step_config, $routed_packets, true, $recovery_generation, $recovery_claim_token );
+			if ( ! $result['success'] ) {
+				return $result;
+			}
+		}
 		do_action( 'datamachine_step_lifecycle_inline_continuation', $job_id, $flow_step_config, $routed_packets );
+		return array( 'success' => true, 'stale' => false );
+	}
+
+	private function claimReconciliationFailure( int $job_id, string $flow_step_id, string $step_type ): array {
+		do_action( 'datamachine_fail_job', $job_id, 'packet_claim_reconciliation_failed', compact( 'flow_step_id', 'step_type' ) );
+		return array( 'success' => false, 'step_success' => false, 'outcome' => 'claim_reconciliation_failed', 'reason' => 'packet_claim_reconciliation_failed' );
 	}
 
 	/**
@@ -1234,18 +1425,18 @@ class ExecuteStepAbility {
 			return array();
 		}
 
-		// Deduplicate handler packets by tool_name. When the AI calls
+		// Deduplicate handler packets by tool_name and packet identity. When the AI calls
 		// the same handler tool multiple times (e.g. upsert_event called
 		// on consecutive turns because the conversation didn't terminate),
-		// each call produces a separate ai_handler_complete packet with
-		// the same tool_name but possibly varied parameters. Only the
-		// first invocation per tool_name is kept — subsequent duplicates
-		// would create child jobs processing identical data.
+		// each call produces a separate ai_handler_complete packet. Calls for
+		// different packet identities must remain distinct; only repeated calls
+		// for the same tool and disposition identity are collapsed.
 		$seen_tools = array();
 		$deduped    = array();
 
 		foreach ( $handler_packets as $packet ) {
-			$tool_name = $packet['metadata']['tool_name'] ?? '';
+			$tool_name      = $packet['metadata']['tool_name'] ?? '';
+			$disposition_id = $packet['metadata']['disposition_id'] ?? '';
 
 			if ( '' === $tool_name ) {
 				// No tool_name — keep unconditionally.
@@ -1253,12 +1444,13 @@ class ExecuteStepAbility {
 				continue;
 			}
 
-			if ( isset( $seen_tools[ $tool_name ] ) ) {
+			$dedupe_key = '' !== $disposition_id ? $tool_name . ':' . $disposition_id : $tool_name;
+			if ( isset( $seen_tools[ $dedupe_key ] ) ) {
 				continue;
 			}
 
-			$seen_tools[ $tool_name ] = true;
-			$deduped[]                = $packet;
+			$seen_tools[ $dedupe_key ] = true;
+			$deduped[]                 = $packet;
 		}
 
 		return $deduped;

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -648,8 +648,11 @@ class ExecuteStepAbility {
 		int $recovery_generation = 0,
 		string $recovery_claim_token = ''
 	): array {
-		$pipeline_id = $flow_step_config['pipeline_id'] ?? null;
-		$transfer_recovery = array( 'success' => true, 'stale' => false );
+		$pipeline_id       = $flow_step_config['pipeline_id'] ?? null;
+		$transfer_recovery = array(
+			'success' => true,
+			'stale'   => false,
+		);
 		$transfer_snapshot = datamachine_get_engine_data( $job_id );
 		if ( is_array( $transfer_snapshot['packet_fanout_transfer'] ?? null ) ) {
 			$transfer_recovery = StepLifecycleHandler::recoverPreparedFanoutTransfer( $job_id, $recovery_generation, $recovery_claim_token );
@@ -662,9 +665,12 @@ class ExecuteStepAbility {
 		// Waiting is not a disposition boundary; retain every claim for resume.
 		if ( $status_override && JobStatus::isStatusWaiting( $status_override ) ) {
 			$parked_snapshot = datamachine_get_engine_data( $job_id );
-			$renewed = ProcessedItems::has_claim_metadata( $parked_snapshot )
+			$renewed         = ProcessedItems::has_claim_metadata( $parked_snapshot )
 				? StepLifecycleHandler::renewParkedClaims( $job_id, $recovery_generation, $recovery_claim_token )
-				: array( 'success' => true, 'stale' => false );
+				: array(
+					'success' => true,
+					'stale'   => false,
+				);
 			if ( ! $renewed['success'] ) {
 				return ! empty( $renewed['stale'] )
 					? $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'lost ownership while renewing waiting packet claims' )
@@ -690,16 +696,19 @@ class ExecuteStepAbility {
 		$retry_owns_work = 'blocked' === ( $execution_result['status'] ?? '' ) || $this->retryOwnsCurrentWork( $job_id );
 		if ( $retry_owns_work ) {
 			$parked_snapshot = datamachine_get_engine_data( $job_id );
-			$renewed = ProcessedItems::has_claim_metadata( $parked_snapshot )
+			$renewed         = ProcessedItems::has_claim_metadata( $parked_snapshot )
 				? StepLifecycleHandler::renewParkedClaims( $job_id, $recovery_generation, $recovery_claim_token )
-				: array( 'success' => true, 'stale' => false );
+				: array(
+					'success' => true,
+					'stale'   => false,
+				);
 			if ( ! $renewed['success'] ) {
 				return ! empty( $renewed['stale'] )
 					? $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'lost ownership while renewing parked packet claims' )
 					: $this->claimReconciliationFailure( $job_id, $flow_step_id, $step_type );
 			}
 		}
-		$reconciled  = array(
+		$reconciled = array(
 			'success'   => true,
 			'handled'   => false,
 			'retained'  => 0,
@@ -727,8 +736,8 @@ class ExecuteStepAbility {
 				$job_id,
 				'packet_claim_reconciliation_failed',
 				array(
-					'flow_step_id' => $flow_step_id,
-					'step_type'    => $step_type,
+					'flow_step_id'   => $flow_step_id,
+					'step_type'      => $step_type,
 					'reconciliation' => $reconciled,
 				)
 			);
@@ -912,13 +921,21 @@ class ExecuteStepAbility {
 				if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
 					return $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'was superseded before fan-out routing' );
 				}
-				$should_fanout = ParallelMapFanoutAdapter::shouldFanOut(
+				$should_fanout   = ParallelMapFanoutAdapter::shouldFanOut(
 					$parallel_step,
-					array( 'job_id' => $job_id, 'next_flow_step_id' => $next_flow_step_id, 'item_count' => $packet_count, 'step_id' => $next_flow_step_id )
+					array(
+						'job_id'            => $job_id,
+						'next_flow_step_id' => $next_flow_step_id,
+						'item_count'        => $packet_count,
+						'step_id'           => $next_flow_step_id,
+					)
 				);
 				$fanout_transfer = $should_fanout
 					? StepLifecycleHandler::transferClaimsToFanout( $job_id, $routed_packets, $recovery_generation, $recovery_claim_token )
-					: array( 'success' => true, 'stale' => false );
+					: array(
+						'success' => true,
+						'stale'   => false,
+					);
 				if ( ! $fanout_transfer['success'] ) {
 					return ! empty( $fanout_transfer['stale'] )
 						? $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'lost ownership during fanout claim transfer' )
@@ -942,7 +959,7 @@ class ExecuteStepAbility {
 					);
 				} catch ( \Throwable $exception ) {
 					$transfer_id = (string) ( $fanout_transfer['transfer_id'] ?? '' );
-					$recovered = '' === $transfer_id
+					$recovered   = '' === $transfer_id
 						? array( 'success' => true )
 						: StepLifecycleHandler::recoverPreparedFanoutTransfer( $job_id, $recovery_generation, $recovery_claim_token );
 					if ( empty( $recovered['success'] ) ) {
@@ -950,7 +967,7 @@ class ExecuteStepAbility {
 					}
 					throw $exception;
 				}
-				$transfer_id = (string) ( $fanout_transfer['transfer_id'] ?? '' );
+				$transfer_id   = (string) ( $fanout_transfer['transfer_id'] ?? '' );
 				$batch_adopted = ! empty( $parallel_result['batch']['adopted'] );
 				if ( $should_fanout && '' !== $transfer_id && ! $batch_adopted ) {
 					if ( ! StepLifecycleHandler::restorePreparedFanoutTransfer( $job_id, $transfer_id, $recovery_generation, $recovery_claim_token ) ) {
@@ -959,7 +976,7 @@ class ExecuteStepAbility {
 					return $this->claimReconciliationFailure( $job_id, $flow_step_id, $step_type );
 				}
 				if ( $should_fanout && '' !== $transfer_id ) {
-					$adopted = StepLifecycleHandler::adoptPreparedFanoutTransfer( $job_id, $transfer_id, $recovery_generation, $recovery_claim_token );
+					$adopted   = StepLifecycleHandler::adoptPreparedFanoutTransfer( $job_id, $transfer_id, $recovery_generation, $recovery_claim_token );
 					$finalized = $adopted && StepLifecycleHandler::finalizePreparedFanoutTransfer( $job_id, $transfer_id, $recovery_generation, $recovery_claim_token );
 					if ( ! $finalized ) {
 						return $this->claimReconciliationFailure( $job_id, $flow_step_id, $step_type );
@@ -1317,12 +1334,28 @@ class ExecuteStepAbility {
 			}
 		}
 		do_action( 'datamachine_step_lifecycle_inline_continuation', $job_id, $flow_step_config, $routed_packets );
-		return array( 'success' => true, 'stale' => false );
+		return array(
+			'success' => true,
+			'stale'   => false,
+		);
 	}
 
 	private function claimReconciliationFailure( int $job_id, string $flow_step_id, string $step_type ): array {
-		do_action( 'datamachine_fail_job', $job_id, 'packet_claim_reconciliation_failed', compact( 'flow_step_id', 'step_type' ) );
-		return array( 'success' => false, 'step_success' => false, 'outcome' => 'claim_reconciliation_failed', 'reason' => 'packet_claim_reconciliation_failed' );
+		do_action(
+			'datamachine_fail_job',
+			$job_id,
+			'packet_claim_reconciliation_failed',
+			array(
+				'flow_step_id' => $flow_step_id,
+				'step_type'    => $step_type,
+			)
+		);
+		return array(
+			'success'      => false,
+			'step_success' => false,
+			'outcome'      => 'claim_reconciliation_failed',
+			'reason'       => 'packet_claim_reconciliation_failed',
+		);
 	}
 
 	/**

--- a/inc/Abilities/Engine/ParallelMapFanoutAdapter.php
+++ b/inc/Abilities/Engine/ParallelMapFanoutAdapter.php
@@ -203,7 +203,8 @@ class ParallelMapFanoutAdapter {
 		array $step,
 		int $parent_job_id,
 		string $next_flow_step_id,
-		array $engine_snapshot
+		array $engine_snapshot,
+		?bool $should_fanout = null
 	): array {
 		self::assertSubstrateAvailable();
 
@@ -217,7 +218,8 @@ class ParallelMapFanoutAdapter {
 			'step_id'           => (string) ( $step['id'] ?? '' ),
 		);
 
-		if ( ! self::shouldFanOut( $step, $context ) ) {
+		$should_fanout = null === $should_fanout ? self::shouldFanOut( $step, $context ) : $should_fanout;
+		if ( ! $should_fanout ) {
 			return array(
 				'shape'    => self::SHAPE_INLINE,
 				'count'    => $count,

--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -290,9 +290,9 @@ class PipelineBatchScheduler {
 		int $item_index = 0,
 		string $payload_checksum = ''
 	): int|false {
-		$pipeline_id = $engine_snapshot['job']['pipeline_id'] ?? null;
-		$flow_id     = $engine_snapshot['job']['flow_id'] ?? null;
-		$item_title  = $single_packet['data']['title'] ?? 'Untitled';
+		$pipeline_id     = $engine_snapshot['job']['pipeline_id'] ?? null;
+		$flow_id         = $engine_snapshot['job']['flow_id'] ?? null;
+		$item_title      = $single_packet['data']['title'] ?? 'Untitled';
 		$packet_metadata = is_array( $single_packet['metadata'] ?? null ) ? $single_packet['metadata'] : array();
 		if ( ProcessedItems::has_claim_metadata( $packet_metadata ) && ! ProcessedItems::has_valid_claim_metadata( $packet_metadata ) ) {
 			return false;
@@ -358,7 +358,7 @@ class PipelineBatchScheduler {
 		// like CoreMemoryFilesDirective resolve the correct agent's
 		// MEMORY.md / SOUL.md instead of falling back to the user_id
 		// default-agent lookup.
-		$child_engine        = $this->stripBatchRuntimeState( \DataMachine\Core\EngineData::stripFlowRuntimeQueuePayloads( $engine_snapshot ) );
+		$child_engine = $this->stripBatchRuntimeState( \DataMachine\Core\EngineData::stripFlowRuntimeQueuePayloads( $engine_snapshot ) );
 		unset( $child_engine[ ProcessedItems::CLAIM_METADATA_KEY ], $child_engine[ ProcessedItems::CLAIMS_METADATA_KEY ] );
 		$child_engine['job'] = array(
 			'job_id'        => $child_job_id,

--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -99,16 +99,17 @@ class PipelineBatchScheduler {
 		// Surface next_flow_step_id at the top level for legacy consumers
 		// that read it without descending into batch_state. Parity with
 		// the pre-extraction shape.
-		EngineData::mutate(
-			$parent_job_id,
-			static function ( array $current ) use ( $next_flow_step_id ): array {
-				$current['next_flow_step_id'] = $next_flow_step_id;
-				return $current;
-			},
-			'pipeline_batch_metadata'
-		);
+		try {
+			EngineData::mutate(
+				$parent_job_id,
+				static function ( array $current ) use ( $next_flow_step_id ): array {
+					$current['next_flow_step_id'] = $next_flow_step_id;
+					return $current;
+				},
+				'pipeline_batch_metadata'
+			);
 
-		do_action(
+			do_action(
 			'datamachine_log',
 			'info',
 			sprintf( 'Pipeline batch: fanning out %d items for flow "%s"', $total, $flow_name ),
@@ -119,7 +120,14 @@ class PipelineBatchScheduler {
 				'total'             => $total,
 				'next_flow_step_id' => $next_flow_step_id,
 			)
-		);
+			);
+		} catch ( \Throwable $exception ) {
+			if ( empty( $result['adopted'] ) ) {
+				throw $exception;
+			}
+			// The durable worklist is authoritative once adopted; observer failures
+			// must not send ownership back to the parent.
+		}
 
 		return $result;
 	}
@@ -285,6 +293,15 @@ class PipelineBatchScheduler {
 		$pipeline_id = $engine_snapshot['job']['pipeline_id'] ?? null;
 		$flow_id     = $engine_snapshot['job']['flow_id'] ?? null;
 		$item_title  = $single_packet['data']['title'] ?? 'Untitled';
+		$packet_metadata = is_array( $single_packet['metadata'] ?? null ) ? $single_packet['metadata'] : array();
+		if ( ProcessedItems::has_claim_metadata( $packet_metadata ) && ! ProcessedItems::has_valid_claim_metadata( $packet_metadata ) ) {
+			return false;
+		}
+		$packet_claims = ProcessedItems::disposition_claims( $packet_metadata );
+		if ( count( $packet_claims ) > 1 ) {
+			return false;
+		}
+		$item_claim = 1 === count( $packet_claims ) ? reset( $packet_claims ) : null;
 
 		// Normalize: 0 → null when no pipeline/flow context.
 		$pipeline_id = ( empty( $pipeline_id ) && ! is_string( $pipeline_id ) ) ? null : $pipeline_id;
@@ -342,6 +359,7 @@ class PipelineBatchScheduler {
 		// MEMORY.md / SOUL.md instead of falling back to the user_id
 		// default-agent lookup.
 		$child_engine        = $this->stripBatchRuntimeState( \DataMachine\Core\EngineData::stripFlowRuntimeQueuePayloads( $engine_snapshot ) );
+		unset( $child_engine[ ProcessedItems::CLAIM_METADATA_KEY ], $child_engine[ ProcessedItems::CLAIMS_METADATA_KEY ] );
 		$child_engine['job'] = array(
 			'job_id'        => $child_job_id,
 			'flow_id'       => $flow_id,
@@ -362,6 +380,7 @@ class PipelineBatchScheduler {
 			$item_engine_data = PacketEngineData::sanitize( $item_engine_data, $parent_job_id );
 			$child_engine     = array_merge( $child_engine, $item_engine_data );
 		}
+		unset( $child_engine[ ProcessedItems::CLAIM_METADATA_KEY ], $child_engine[ ProcessedItems::CLAIMS_METADATA_KEY ] );
 
 		// Seed dedup context (item_identifier + source_type) from DataPacket metadata.
 		// This enables deferred mark-as-processed: when the child job completes
@@ -370,7 +389,6 @@ class PipelineBatchScheduler {
 		// parent, but now the fetch step no longer marks items eagerly.
 		$item_identifier = $single_packet['metadata']['item_identifier'] ?? null;
 		$source_type     = $single_packet['metadata']['source_type'] ?? null;
-		$item_claim      = $single_packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] ?? null;
 		if ( ! empty( $item_identifier ) ) {
 			$child_engine['item_identifier'] = $item_identifier;
 		}
@@ -414,6 +432,7 @@ class PipelineBatchScheduler {
 			$engine_snapshot['batch_schedule_failed'],
 			$engine_snapshot['batch_results'],
 			$engine_snapshot['next_flow_step_id'],
+			$engine_snapshot['packet_fanout_transfer'],
 			$engine_snapshot['cancelled'],
 			$engine_snapshot['cancelled_at']
 		);

--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -147,7 +147,7 @@ class BatchScheduler {
 	 * @param array  $extra         Lightweight per-batch state cloned to chunks.
 	 * @param string $context       Consumer context, used for chunk-size/delay filter dispatch.
 	 * @param string $completion_strategy Declared parent-completion strategy.
-	 * @return array{parent_job_id:int,total:int,chunk_size:int,action_id:int,scheduled:bool} Batch summary.
+	 * @return array{parent_job_id:int,total:int,chunk_size:int,action_id:int,scheduled:bool,adopted:bool} Batch summary.
 	 */
 	public static function start(
 		int $parent_job_id,
@@ -213,15 +213,15 @@ class BatchScheduler {
 		$mutation = EngineData::mutate(
 			$parent_job_id,
 			static function ( array $current ) use ( $total, $chunk_size, $context, $completion_strategy, $extra, $hook, $worklist_checksum ): ?array {
-				if ( self::STORAGE_VERSION === (int) ( $current['batch_storage_version'] ?? 0 ) ) {
+				if ( self::STORAGE_VERSION === (int) ( $current['batch_storage_version'] ?? 0 ) && is_array( $current['batch_state'] ?? null ) ) {
 					$current_checksum = (string) ( $current['batch_state']['checksum'] ?? '' );
 					if ( ! hash_equals( $worklist_checksum, $current_checksum ) ) {
 						return null;
 					}
 					unset( $current['batch_schedule_failed'] );
-					return $current;
+					return (array) apply_filters( 'datamachine_batch_engine_adoption_state', $current, $context, $worklist_checksum );
 				}
-				return array_merge(
+				$next = array_merge(
 					$current,
 					array(
 						'batch'                     => true,
@@ -242,6 +242,7 @@ class BatchScheduler {
 						),
 					)
 				);
+				return (array) apply_filters( 'datamachine_batch_engine_adoption_state', $next, $context, $worklist_checksum );
 			},
 			'batch_start_v2'
 		);
@@ -256,31 +257,63 @@ class BatchScheduler {
 			}
 			return self::startResult( $parent_job_id, $total, $chunk_size );
 		}
-		if ( ! empty( $insert['existing'] ) ) {
-			return self::startResult( $parent_job_id, $total, $chunk_size, 0, true );
+		if ( ! empty( $insert['created'] ) ) {
+			\DataMachine\Core\RunMetrics::start(
+				$parent_job_id,
+				array(
+					'batch_context'             => $context,
+					'batch_total'               => $total,
+					'batch_completion_strategy' => $completion_strategy,
+				)
+			);
 		}
 
-		\DataMachine\Core\RunMetrics::start(
-			$parent_job_id,
-			array(
-				'batch_context'             => $context,
-				'batch_total'               => $total,
-				'batch_completion_strategy' => $completion_strategy,
-			)
-		);
+		$action_id = self::ensureInitialChunkScheduled( $hook, $parent_job_id );
 
-		try {
-			$action_id = as_schedule_single_action(
-				time(),
-				$hook,
-				array(
-					'parent_job_id' => $parent_job_id,
-					'offset'        => 0,
-				),
-				'data-machine'
+		if ( ! $action_id ) {
+			$ownership_restored = false;
+			$rollback           = EngineData::mutate(
+				$parent_job_id,
+				static function ( array $current ) use ( $context, $worklist_checksum, &$ownership_restored ): array {
+					$had_transfer = is_array( $current['packet_fanout_transfer'] ?? null );
+					$current      = (array) apply_filters( 'datamachine_batch_engine_adoption_rollback_state', $current, $context, $worklist_checksum );
+					$ownership_restored = $had_transfer && ! isset( $current['packet_fanout_transfer'] );
+					unset( $current['batch_state'] );
+					$current['batch_schedule_failed'] = true;
+					return $current;
+				},
+				'batch_initial_schedule_failure'
 			);
+			if ( ! empty( $rollback['success'] ) && ! empty( $insert['created'] ) && $ownership_restored ) {
+				$repository->delete_owned_batch( $parent_job_id, (string) $insert['ownership_token'] );
+			} elseif ( ! empty( $rollback['success'] ) && ! empty( $insert['created'] ) ) {
+				if ( self::discardOwnedWorklist( $repository, $parent_job_id, (string) $insert['ownership_token'], $context ) ) {
+					$repository->delete_owned_batch( $parent_job_id, (string) $insert['ownership_token'] );
+				}
+			}
+		}
+
+		return self::startResult( $parent_job_id, $total, $chunk_size, (int) $action_id, null, (bool) $action_id );
+	}
+
+	/** Find or idempotently create the initial chunk action. */
+	private static function ensureInitialChunkScheduled( string $hook, int $parent_job_id ): int {
+		$args = array(
+			'parent_job_id' => $parent_job_id,
+			'offset'        => 0,
+		);
+		if ( function_exists( 'as_has_scheduled_action' ) ) {
+			$existing = (int) as_has_scheduled_action( $hook, $args, GroupRegistrar::GROUP );
+			if ( $existing > 0 ) {
+				return $existing;
+			}
+		}
+		try {
+			$action_id = (int) as_schedule_single_action( time(), $hook, $args, GroupRegistrar::GROUP );
+			if ( $action_id > 0 ) {
+				return $action_id;
+			}
 		} catch ( \Throwable $exception ) {
-			$action_id = 0;
 			do_action(
 				'datamachine_log',
 				'error',
@@ -291,47 +324,20 @@ class BatchScheduler {
 				)
 			);
 		}
-		if ( ! $action_id && function_exists( 'as_has_scheduled_action' ) ) {
-			$action_id = (int) as_has_scheduled_action(
-				$hook,
-				array(
-					'parent_job_id' => $parent_job_id,
-					'offset'        => 0,
-				),
-				GroupRegistrar::GROUP
-			);
-		}
-
-		if ( ! $action_id ) {
-			if ( ! empty( $insert['created'] ) ) {
-				if ( self::discardOwnedWorklist( $repository, $parent_job_id, (string) $insert['ownership_token'], $context ) ) {
-					$repository->delete_owned_batch( $parent_job_id, (string) $insert['ownership_token'] );
-				}
-			}
-			EngineData::mutate(
-				$parent_job_id,
-				static function ( array $current ) use ( $insert ): array {
-					if ( ! empty( $insert['created'] ) ) {
-						unset( $current['batch_state'] );
-					}
-					$current['batch_schedule_failed'] = true;
-					return $current;
-				},
-				'batch_initial_schedule_failure'
-			);
-		}
-
-		return self::startResult( $parent_job_id, $total, $chunk_size, (int) $action_id );
+		return function_exists( 'as_has_scheduled_action' )
+			? (int) as_has_scheduled_action( $hook, $args, GroupRegistrar::GROUP )
+			: 0;
 	}
 
 	/** Build the stable public start result. */
-	private static function startResult( int $parent_job_id, int $total, int $chunk_size, int $action_id = 0, ?bool $scheduled = null ): array {
+	private static function startResult( int $parent_job_id, int $total, int $chunk_size, int $action_id = 0, ?bool $scheduled = null, bool $adopted = false ): array {
 		return array(
 			'parent_job_id' => $parent_job_id,
 			'total'         => $total,
 			'chunk_size'    => $chunk_size,
 			'action_id'     => $action_id,
 			'scheduled'     => null === $scheduled ? (bool) $action_id : $scheduled,
+			'adopted'       => $adopted,
 		);
 	}
 

--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -275,8 +275,8 @@ class BatchScheduler {
 			$rollback           = EngineData::mutate(
 				$parent_job_id,
 				static function ( array $current ) use ( $context, $worklist_checksum, &$ownership_restored ): array {
-					$had_transfer = is_array( $current['packet_fanout_transfer'] ?? null );
-					$current      = (array) apply_filters( 'datamachine_batch_engine_adoption_rollback_state', $current, $context, $worklist_checksum );
+					$had_transfer       = is_array( $current['packet_fanout_transfer'] ?? null );
+					$current            = (array) apply_filters( 'datamachine_batch_engine_adoption_rollback_state', $current, $context, $worklist_checksum );
 					$ownership_restored = $had_transfer && ! isset( $current['packet_fanout_transfer'] );
 					unset( $current['batch_state'] );
 					$current['batch_schedule_failed'] = true;

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -1944,6 +1944,53 @@ class Jobs extends BaseRepository {
 	}
 
 	/**
+	 * Store engine data inside a caller-owned transaction without publishing cache state.
+	 *
+	 * The caller must hold the job row lock and must call
+	 * publish_committed_engine_data() only after COMMIT succeeds.
+	 */
+	public function store_engine_data_in_transaction( int $job_id, array $data ): bool {
+		if ( $job_id <= 0 ) {
+			return false;
+		}
+
+		$encoded = wp_json_encode( $data );
+		if ( ! is_string( $encoded ) ) {
+			$this->log_engine_data_write_rejection( $job_id, 'json_encode_failed', '', null, $data );
+			return false;
+		}
+		if ( $this->estimate_engine_data_query_bytes( strlen( $encoded ) ) > $this->engine_data_query_budget() ) {
+			$this->log_engine_data_write_rejection( $job_id, 'engine_data_query_oversize', $encoded, null, $data );
+			return false;
+		}
+
+		$storage_envelope = $this->engine_data_storage_envelope( $data, $encoded );
+		$result           = $this->wpdb->update(
+			$this->table_name,
+			$storage_envelope['data'],
+			array( 'job_id' => $job_id ),
+			$storage_envelope['format'],
+			array( '%d' )
+		);
+		if ( false === $result ) {
+			return false;
+		}
+
+		return ( new RunMetadata() )->replace_for_engine_data( $job_id, $data );
+	}
+
+	/** Invalidate cache after commit so an older writer cannot publish over a newer snapshot. */
+	public function publish_committed_engine_data( int $job_id, array $data ): void {
+		unset( $data );
+		wp_cache_delete( $job_id, 'datamachine_engine_data' );
+	}
+
+	/** Whether the current wpdb error requires restarting the complete transaction. */
+	public function has_retryable_transaction_error(): bool {
+		return $this->is_retryable_db_error( (string) $this->wpdb->last_error );
+	}
+
+	/**
 	 * Store engine data only when the persisted snapshot still matches the caller's baseline.
 	 *
 	 * @param int   $job_id        Job ID.
@@ -2801,6 +2848,7 @@ class Jobs extends BaseRepository {
 		);
 		$update_formats = array( '%s', '%s', '%d', null, null, '%d' );
 		$engine = $this->engine_data_with_status_reason( is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array(), $prepared_job_status );
+		$engine = (array) apply_filters( 'datamachine_job_terminal_engine_data', $engine, $job_id, $status );
 		$update_data['engine_data'] = wp_json_encode( $engine );
 		$update_formats[] = '%s';
 		$operation_recovery = is_array( $recovery_owner ) && 'operation' === (string) ( $recovery_owner['mode'] ?? '' );

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -25,9 +25,115 @@ class ProcessedItems extends BaseRepository {
 	const STATUS_CLAIMED            = 'claimed';
 	const STATUS_PROCESSED          = 'processed';
 	const DEFAULT_CLAIM_TTL_SECONDS = 3600;
-	const CLAIM_METADATA_KEY        = '_datamachine_item_claim';
-	const CLAIMS_METADATA_KEY       = '_datamachine_item_claims';
+	const CLAIM_METADATA_KEY          = '_datamachine_item_claim';
+	const CLAIMS_METADATA_KEY         = '_datamachine_item_claims';
+	const DISPOSITION_ID_METADATA_KEY = '_datamachine_packet_disposition_id';
 	private const READ_CHUNK_SIZE   = 500;
+
+	/** Return a stable, non-secret packet disposition identity. */
+	public static function disposition_identity( string $identity_scope, string $source_type, string $item_identifier ): string {
+		return hash( 'sha256', implode( "\0", array( $identity_scope, $source_type, $item_identifier ) ) );
+	}
+
+	/**
+	 * Return valid owned claims keyed by their non-secret disposition identity.
+	 *
+	 * @param array $container Engine data or packet metadata.
+	 * @return array<string,array<string,mixed>>
+	 */
+	public static function disposition_claims( array $container ): array {
+		$candidates = array();
+		if ( is_array( $container[ self::CLAIM_METADATA_KEY ] ?? null ) ) {
+			$candidates[] = $container[ self::CLAIM_METADATA_KEY ];
+		}
+		if ( is_array( $container[ self::CLAIMS_METADATA_KEY ] ?? null ) ) {
+			$candidates = array_merge( $candidates, $container[ self::CLAIMS_METADATA_KEY ] );
+		}
+
+		$claims = array();
+		foreach ( $candidates as $claim ) {
+			if ( ! is_array( $claim ) || false === ( $claim['persisted'] ?? true ) ) {
+				continue;
+			}
+			foreach ( array( 'identity_scope', 'source_type', 'item_identifier', 'ownership_token' ) as $key ) {
+				if ( ! is_string( $claim[ $key ] ?? null ) || '' === $claim[ $key ] ) {
+					continue 2;
+				}
+			}
+
+			$disposition_id = self::disposition_identity( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] );
+			if ( isset( $claim['disposition_id'] ) && ( ! is_string( $claim['disposition_id'] ) || ! hash_equals( $disposition_id, $claim['disposition_id'] ) ) ) {
+				continue;
+			}
+			$claim['disposition_id']     = $disposition_id;
+			$claims[ $disposition_id ] = $claim;
+		}
+
+		return $claims;
+	}
+
+	/** Resolve an explicit ID, or infer it only when exactly one claim exists. */
+	public static function resolve_disposition_claim( array $container, string $disposition_id = '', bool $infer_single = true ): ?array {
+		$claims = self::disposition_claims( $container );
+		if ( '' !== $disposition_id ) {
+			foreach ( $claims as $claim_id => $claim ) {
+				if ( hash_equals( $claim_id, $disposition_id ) ) {
+					return $claim;
+				}
+			}
+			return null;
+		}
+
+		return $infer_single && 1 === count( $claims ) ? reset( $claims ) : null;
+	}
+
+	/** Whether a container explicitly carries singular or collection claim metadata. */
+	public static function has_claim_metadata( array $container ): bool {
+		return array_key_exists( self::CLAIM_METADATA_KEY, $container )
+			|| array_key_exists( self::CLAIMS_METADATA_KEY, $container );
+	}
+
+	/** Whether every explicitly supplied claim descriptor is valid and uniquely identified. */
+	public static function has_valid_claim_metadata( array $container ): bool {
+		if ( ! self::has_claim_metadata( $container ) ) {
+			return true;
+		}
+
+		$candidates = array();
+		if ( array_key_exists( self::CLAIM_METADATA_KEY, $container ) ) {
+			if ( ! is_array( $container[ self::CLAIM_METADATA_KEY ] ) ) {
+				return false;
+			}
+			$candidates[] = $container[ self::CLAIM_METADATA_KEY ];
+		}
+		if ( array_key_exists( self::CLAIMS_METADATA_KEY, $container ) ) {
+			if ( ! is_array( $container[ self::CLAIMS_METADATA_KEY ] ) ) {
+				return false;
+			}
+			$candidates = array_merge( $candidates, $container[ self::CLAIMS_METADATA_KEY ] );
+		}
+
+		if ( empty( $candidates ) ) {
+			return false;
+		}
+		foreach ( $candidates as $candidate ) {
+			if ( ! is_array( $candidate ) ) {
+				return false;
+			}
+		}
+
+		$persisted = array_values(
+			array_filter(
+				$candidates,
+				static fn( mixed $claim ): bool => is_array( $claim ) && false !== ( $claim['persisted'] ?? true )
+			)
+		);
+		if ( empty( $persisted ) ) {
+			return true;
+		}
+
+		return count( $persisted ) === count( self::disposition_claims( $container ) );
+	}
 
 
 	/**
@@ -532,6 +638,58 @@ class ProcessedItems extends BaseRepository {
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		return is_string( $owned ) && hash_equals( $token, $owned );
+	}
+
+	/** Lock and validate one token-owned claim inside a caller-managed transaction. */
+	public function lock_owned_claim_in_transaction( array $claim ): bool {
+		$identity_scope  = (string) ( $claim['identity_scope'] ?? '' );
+		$source_type     = (string) ( $claim['source_type'] ?? '' );
+		$item_identifier = (string) ( $claim['item_identifier'] ?? '' );
+		$token           = (string) ( $claim['ownership_token'] ?? '' );
+		if ( '' === $identity_scope || '' === $source_type || '' === $item_identifier || '' === $token ) {
+			return false;
+		}
+
+		$query = $this->wpdb->prepare(
+			'SELECT claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s FOR UPDATE',
+			$this->table_name,
+			$identity_scope,
+			$source_type,
+			$item_identifier,
+			$token,
+			self::STATUS_CLAIMED
+		);
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Fully prepared lock query on the plugin table.
+		$owned = $this->wpdb->get_var( $query );
+		return is_string( $owned ) && hash_equals( $token, $owned );
+	}
+
+	/** Renew one locked token-owned claim inside a caller-managed transaction. */
+	public function renew_owned_claim_in_transaction( array $claim, int $job_id, int $ttl_seconds = self::DEFAULT_CLAIM_TTL_SECONDS ): bool {
+		if ( $job_id <= 0 || ! $this->lock_owned_claim_in_transaction( $claim ) ) {
+			return false;
+		}
+
+		$ttl_seconds = max( 1, $ttl_seconds );
+		$updated     = $this->wpdb->update(
+			$this->table_name,
+			array(
+				'job_id'           => $job_id,
+				'claim_expires_at' => gmdate( 'Y-m-d H:i:s', time() + $ttl_seconds ),
+			),
+			array(
+				'flow_step_id'    => $claim['identity_scope'],
+				'source_type'     => $claim['source_type'],
+				'item_identifier' => $claim['item_identifier'],
+				'claim_token'     => $claim['ownership_token'],
+				'status'          => self::STATUS_CLAIMED,
+			),
+			array( '%d', '%s' ),
+			array( '%s', '%s', '%s', '%s', '%s' )
+		);
+
+		// A renewal in the same second may be a no-op after the ownership lock.
+		return false !== $updated;
 	}
 
 	/**

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -21,14 +21,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class ProcessedItems extends BaseRepository {
 
-	const TABLE_NAME                = 'datamachine_processed_items';
-	const STATUS_CLAIMED            = 'claimed';
-	const STATUS_PROCESSED          = 'processed';
-	const DEFAULT_CLAIM_TTL_SECONDS = 3600;
+	const TABLE_NAME                  = 'datamachine_processed_items';
+	const STATUS_CLAIMED              = 'claimed';
+	const STATUS_PROCESSED            = 'processed';
+	const DEFAULT_CLAIM_TTL_SECONDS   = 3600;
 	const CLAIM_METADATA_KEY          = '_datamachine_item_claim';
 	const CLAIMS_METADATA_KEY         = '_datamachine_item_claims';
 	const DISPOSITION_ID_METADATA_KEY = '_datamachine_packet_disposition_id';
-	private const READ_CHUNK_SIZE   = 500;
+	private const READ_CHUNK_SIZE     = 500;
 
 	/** Return a stable, non-secret packet disposition identity. */
 	public static function disposition_identity( string $identity_scope, string $source_type, string $item_identifier ): string {
@@ -65,7 +65,7 @@ class ProcessedItems extends BaseRepository {
 			if ( isset( $claim['disposition_id'] ) && ( ! is_string( $claim['disposition_id'] ) || ! hash_equals( $disposition_id, $claim['disposition_id'] ) ) ) {
 				continue;
 			}
-			$claim['disposition_id']     = $disposition_id;
+			$claim['disposition_id']   = $disposition_id;
 			$claims[ $disposition_id ] = $claim;
 		}
 
@@ -659,8 +659,10 @@ class ProcessedItems extends BaseRepository {
 			$token,
 			self::STATUS_CLAIMED
 		);
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Fully prepared lock query on the plugin table.
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Query is fully prepared above with an escaped identifier and typed values.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Transactional ownership lock on the plugin table.
 		$owned = $this->wpdb->get_var( $query );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		return is_string( $owned ) && hash_equals( $token, $owned );
 	}
 

--- a/inc/Core/ExecutionContext.php
+++ b/inc/Core/ExecutionContext.php
@@ -486,6 +486,7 @@ class ExecutionContext {
 			'source_type'     => $this->handler_type,
 			'item_identifier' => $item_identifier,
 			'ownership_token' => $token,
+			'disposition_id'  => ProcessedItems::disposition_identity( $identity_scope, $this->handler_type, $item_identifier ),
 			'completion'      => $completion,
 		);
 	}

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -1235,8 +1235,8 @@ class AIStep extends Step {
 		$tool_execution_results = $loop_result['tool_execution_results'] ?? array();
 		$loop_metadata          = datamachine_conversation_metadata( $loop_result );
 		$assertions_satisfied   = ! empty( $loop_metadata['completion_assertions_satisfied'] ) && empty( $loop_metadata['completion_assertions_missing'] );
-		$engine_data           = is_array( $payload['engine_data'] ?? null ) ? $payload['engine_data'] : array();
-		$active_claims         = class_exists( ProcessedItems::class ) ? ProcessedItems::disposition_claims( $engine_data ) : array();
+		$engine_data            = is_array( $payload['engine_data'] ?? null ) ? $payload['engine_data'] : array();
+		$active_claims          = class_exists( ProcessedItems::class ) ? ProcessedItems::disposition_claims( $engine_data ) : array();
 
 		// Start with an empty output array — input packets are NOT carried forward.
 		$outputPackets = array();
@@ -1288,9 +1288,9 @@ class AIStep extends Step {
 			$projected_tool_result_data = ToolResultFinder::projectEnvelopeData( $tool_result );
 			$packet_claim_metadata      = null !== $matched_claim
 				? array(
-					ProcessedItems::CLAIM_METADATA_KEY          => $matched_claim,
+					ProcessedItems::CLAIM_METADATA_KEY => $matched_claim,
 					ProcessedItems::DISPOSITION_ID_METADATA_KEY => $matched_claim['disposition_id'],
-					'disposition_id'                            => $matched_claim['disposition_id'],
+					'disposition_id'                   => $matched_claim['disposition_id'],
 				)
 				: array();
 			$packet_disposition         = (string) ( $tool_result['disposition'] ?? ( ! empty( $tool_result['success'] ) ? 'succeeded' : 'failed' ) );

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -7,6 +7,7 @@ use DataMachine\Core\Agents\AgentIdentity;
 use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\DataPacket;
 use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Core\RunMetrics;
 use DataMachine\Core\Steps\Step;
@@ -1234,6 +1235,8 @@ class AIStep extends Step {
 		$tool_execution_results = $loop_result['tool_execution_results'] ?? array();
 		$loop_metadata          = datamachine_conversation_metadata( $loop_result );
 		$assertions_satisfied   = ! empty( $loop_metadata['completion_assertions_satisfied'] ) && empty( $loop_metadata['completion_assertions_missing'] );
+		$engine_data           = is_array( $payload['engine_data'] ?? null ) ? $payload['engine_data'] : array();
+		$active_claims         = class_exists( ProcessedItems::class ) ? ProcessedItems::disposition_claims( $engine_data ) : array();
 
 		// Start with an empty output array — input packets are NOT carried forward.
 		$outputPackets = array();
@@ -1272,7 +1275,25 @@ class AIStep extends Step {
 
 			$tool_def = $available_tools[ $tool_name ] ?? null;
 
+			$disposition_id = (string) ( $tool_result['disposition_id'] ?? $tool_parameters['disposition_id'] ?? '' );
+			$matched_claim  = '' !== $disposition_id && class_exists( ProcessedItems::class ) ? ProcessedItems::resolve_disposition_claim( $engine_data, $disposition_id, false ) : null;
+			if ( $is_handler_tool && ! empty( $active_claims ) && null === $matched_claim ) {
+				$tool_result = array(
+					'success'   => false,
+					'error'     => 'Successful handler output did not identify an active packet claim.',
+					'code'      => 'invalid_packet_disposition',
+					'tool_name' => $tool_name,
+				);
+			}
 			$projected_tool_result_data = ToolResultFinder::projectEnvelopeData( $tool_result );
+			$packet_claim_metadata      = null !== $matched_claim
+				? array(
+					ProcessedItems::CLAIM_METADATA_KEY          => $matched_claim,
+					ProcessedItems::DISPOSITION_ID_METADATA_KEY => $matched_claim['disposition_id'],
+					'disposition_id'                            => $matched_claim['disposition_id'],
+				)
+				: array();
+			$packet_disposition         = (string) ( $tool_result['disposition'] ?? ( ! empty( $tool_result['success'] ) ? 'succeeded' : 'failed' ) );
 
 			if ( $is_handler_tool && ( $tool_result['success'] ?? false ) ) {
 				// Handler tool succeeded - mark completion
@@ -1289,17 +1310,21 @@ class AIStep extends Step {
 						'title' => 'Handler Tool Executed: ' . $tool_name,
 						'body'  => 'Tool executed successfully by AI agent in ' . $result_turn_count . ' conversation turns',
 					),
-					array(
-						'tool_name'              => $tool_name,
-						'handler_tool'           => $tool_def['handler'] ?? null,
-						'tool_parameters'        => $clean_tool_parameters,
-						'handler_config'         => $handler_config,
-						'source_type'            => $input_source_type,
-						'flow_step_id'           => $flow_step_id,
-						'conversation_turn'      => $result_turn_count,
-						'tool_result_envelope'   => $tool_result,
-						'tool_result_data'       => $projected_tool_result_data,
-						'step_execution_success' => true,
+					array_merge(
+						array(
+							'tool_name'              => $tool_name,
+							'handler_tool'           => $tool_def['handler'] ?? null,
+							'tool_parameters'        => $clean_tool_parameters,
+							'handler_config'         => $handler_config,
+							'source_type'            => $input_source_type,
+							'flow_step_id'           => $flow_step_id,
+							'conversation_turn'      => $result_turn_count,
+							'tool_result_envelope'   => $tool_result,
+							'tool_result_data'       => $projected_tool_result_data,
+							'step_execution_success' => true,
+							'packet_disposition'     => $packet_disposition,
+						),
+						$packet_claim_metadata
 					),
 					'ai_handler_complete'
 				);
@@ -1316,15 +1341,19 @@ class AIStep extends Step {
 						'title' => ucwords( str_replace( '_', ' ', $tool_name ) ) . ' Result',
 						'body'  => $success_message,
 					),
-					array(
-						'tool_name'              => $tool_name,
-						'handler_tool'           => $tool_def['handler'] ?? null,
-						'tool_parameters'        => $tool_parameters,
-						'tool_success'           => $tool_success,
-						'tool_failure_non_fatal' => false === (bool) $tool_success && $assertions_satisfied,
-						'tool_result_envelope'   => $tool_result,
-						'tool_result_data'       => $projected_tool_result_data,
-						'source_type'            => $input_source_type,
+					array_merge(
+						array(
+							'tool_name'              => $tool_name,
+							'handler_tool'           => $tool_def['handler'] ?? null,
+							'tool_parameters'        => $tool_parameters,
+							'tool_success'           => $tool_success,
+							'tool_failure_non_fatal' => false === (bool) $tool_success && $assertions_satisfied,
+							'tool_result_envelope'   => $tool_result,
+							'tool_result_data'       => $projected_tool_result_data,
+							'source_type'            => $input_source_type,
+							'packet_disposition'     => $packet_disposition,
+						),
+						$packet_claim_metadata
 					),
 					'tool_result'
 				);

--- a/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
@@ -63,10 +63,10 @@ abstract class FetchHandler {
 	 * @return DataPacket[] Array of DataPackets (empty on failure/no data).
 	 */
 	final public function get_fetch_data( int|string $pipeline_id, array $handler_config, ?string $job_id = null ): array {
-		$config  = $this->extractConfig( $handler_config );
-		$context = ExecutionContext::fromConfig( $handler_config, $job_id, $this->handler_type );
-		$stages  = $this->initialFetchDiagnostics( $config, $context );
-		$max_items = (int) ( $config['max_items'] ?? $this->getDefaultMaxItems() );
+		$config              = $this->extractConfig( $handler_config );
+		$context             = ExecutionContext::fromConfig( $handler_config, $job_id, $this->handler_type );
+		$stages              = $this->initialFetchDiagnostics( $config, $context );
+		$max_items           = (int) ( $config['max_items'] ?? $this->getDefaultMaxItems() );
 		$stages['max_items'] = max( 0, $max_items );
 
 		$result = $this->executeFetch( $config, $context );
@@ -80,7 +80,7 @@ abstract class FetchHandler {
 
 		// Normalize: if handler returned { items: [...] }, use that list.
 		// Otherwise treat the entire result as a single item.
-		$items = ( isset( $result['items'] ) && is_array( $result['items'] ) )
+		$items                         = ( isset( $result['items'] ) && is_array( $result['items'] ) )
 			? $result['items']
 			: array( $result );
 		$stages['source_materialized'] = count( $items );
@@ -97,7 +97,7 @@ abstract class FetchHandler {
 		// Set to 0 for unlimited.
 		if ( $max_items > 0 && count( $items ) > $max_items ) {
 			$stages['eligible_outside_max_items'] = count( $items ) - $max_items;
-			$items = array_slice( $items, 0, $max_items );
+			$items                                = array_slice( $items, 0, $max_items );
 		}
 		$stages['selected_after_max_items'] = count( $items );
 
@@ -167,17 +167,17 @@ abstract class FetchHandler {
 		$result         = array();
 
 		if ( is_array( $diagnostics ) ) {
-			$identifierless_items                        = count( $candidates ) - count( $identifiers );
-			$diagnostics['valid_items']                  = $valid_items;
-			$diagnostics['invalid_items']                = max( 0, (int) $diagnostics['source_materialized'] - $valid_items );
-			$diagnostics['identified_items']             = count( $identifiers );
-			$diagnostics['identifierless_items']         = $identifierless_items;
-			$diagnostics['unique_identifiers']           = (int) ( $counts['unique'] ?? 0 );
-			$diagnostics['duplicate_identifiers']        = (int) ( $counts['duplicates'] ?? 0 );
-			$diagnostics['eligible_before_max_items']    = (int) ( $counts['eligible'] ?? 0 ) + $identifierless_items;
-			$diagnostics['processed_skipped']            = (int) ( $counts['processed_skipped'] ?? 0 );
-			$diagnostics['reprocess_eligible']           = (int) ( $counts['processed_reprocess_eligible'] ?? 0 );
-			$diagnostics['actively_claimed']             = (int) ( $counts['actively_claimed'] ?? 0 );
+			$identifierless_items                     = count( $candidates ) - count( $identifiers );
+			$diagnostics['valid_items']               = $valid_items;
+			$diagnostics['invalid_items']             = max( 0, (int) $diagnostics['source_materialized'] - $valid_items );
+			$diagnostics['identified_items']          = count( $identifiers );
+			$diagnostics['identifierless_items']      = $identifierless_items;
+			$diagnostics['unique_identifiers']        = (int) ( $counts['unique'] ?? 0 );
+			$diagnostics['duplicate_identifiers']     = (int) ( $counts['duplicates'] ?? 0 );
+			$diagnostics['eligible_before_max_items'] = (int) ( $counts['eligible'] ?? 0 ) + $identifierless_items;
+			$diagnostics['processed_skipped']         = (int) ( $counts['processed_skipped'] ?? 0 );
+			$diagnostics['reprocess_eligible']        = (int) ( $counts['processed_reprocess_eligible'] ?? 0 );
+			$diagnostics['actively_claimed']          = (int) ( $counts['actively_claimed'] ?? 0 );
 		}
 
 		foreach ( $candidates as $candidate ) {
@@ -234,7 +234,7 @@ abstract class FetchHandler {
 			if ( is_array( $diagnostics ) ) {
 				++$diagnostics['claim_attempts'];
 			}
-			$is_duplicate                            = isset( $attempted_identifiers[ (string) $item_identifier ] );
+			$is_duplicate                                       = isset( $attempted_identifiers[ (string) $item_identifier ] );
 			$attempted_identifiers[ (string) $item_identifier ] = true;
 			$claim = $context->claimItemOwnership( (string) $context->getFlowStepId(), (string) $item_identifier );
 			if ( false === $claim ) {
@@ -251,7 +251,7 @@ abstract class FetchHandler {
 				++$diagnostics['claims_acquired'];
 			}
 
-			$item['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] = $claim;
+			$item['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ]          = $claim;
 			$item['metadata'][ ProcessedItems::DISPOSITION_ID_METADATA_KEY ] = $claim['disposition_id'];
 
 			$result[] = $item;
@@ -269,29 +269,29 @@ abstract class FetchHandler {
 	 */
 	private function initialFetchDiagnostics( array $config, ExecutionContext $context ): array {
 		return array(
-			'schema_version'                 => 'datamachine.fetch_stages.v1',
-			'handler_type'                   => $this->handler_type,
-			'execution_mode'                 => $context->getMode(),
-			'config_hash'                    => $this->configHash( $config ),
-			'source_materialized'            => 0,
-			'valid_items'                    => 0,
-			'invalid_items'                  => 0,
-			'identified_items'               => 0,
-			'identifierless_items'            => 0,
-			'unique_identifiers'             => 0,
-			'duplicate_identifiers'          => 0,
-			'eligible_before_max_items'      => 0,
-			'processed_skipped'              => 0,
-			'reprocess_eligible'             => 0,
-			'actively_claimed'               => 0,
-			'max_items'                      => 0,
-			'eligible_outside_max_items'     => 0,
-			'selected_after_max_items'       => 0,
-			'claim_attempts'                 => 0,
-			'claims_acquired'                => 0,
-			'claim_conflicts'                => 0,
-			'duplicate_claim_conflicts'      => 0,
-			'final_packets'                  => 0,
+			'schema_version'             => 'datamachine.fetch_stages.v1',
+			'handler_type'               => $this->handler_type,
+			'execution_mode'             => $context->getMode(),
+			'config_hash'                => $this->configHash( $config ),
+			'source_materialized'        => 0,
+			'valid_items'                => 0,
+			'invalid_items'              => 0,
+			'identified_items'           => 0,
+			'identifierless_items'       => 0,
+			'unique_identifiers'         => 0,
+			'duplicate_identifiers'      => 0,
+			'eligible_before_max_items'  => 0,
+			'processed_skipped'          => 0,
+			'reprocess_eligible'         => 0,
+			'actively_claimed'           => 0,
+			'max_items'                  => 0,
+			'eligible_outside_max_items' => 0,
+			'selected_after_max_items'   => 0,
+			'claim_attempts'             => 0,
+			'claims_acquired'            => 0,
+			'claim_conflicts'            => 0,
+			'duplicate_claim_conflicts'  => 0,
+			'final_packets'              => 0,
 		);
 	}
 
@@ -345,7 +345,7 @@ abstract class FetchHandler {
 		}
 		--$remaining;
 
-		$segmented_key = preg_replace( '/([a-z0-9])([A-Z])/', '$1_$2', $key ) ?? $key;
+		$segmented_key  = preg_replace( '/([a-z0-9])([A-Z])/', '$1_$2', $key ) ?? $key;
 		$normalized_key = strtolower( str_replace( '-', '_', $segmented_key ) );
 		if ( '' !== $normalized_key && ( 'key' === $normalized_key || str_ends_with( $normalized_key, '_key' ) || preg_match( '/(?:^|_)(?:auth|authentication|authorization|oauth|api_?key|private_key|signing_key|secret_key|access_key|bearer|cookie|passwd|password|passphrase|pat|secret|tokens?|credentials?)(?:_|$)/', $normalized_key ) ) ) {
 			return '[redacted]';

--- a/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
@@ -252,6 +252,7 @@ abstract class FetchHandler {
 			}
 
 			$item['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] = $claim;
+			$item['metadata'][ ProcessedItems::DISPOSITION_ID_METADATA_KEY ] = $claim['disposition_id'];
 
 			$result[] = $item;
 		}

--- a/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
+++ b/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
@@ -3,8 +3,8 @@
  * Fetch Item Disposition Tool
  *
  * Handler tool that allows the pipeline agent to explicitly reject or defer
- * a fetched source item. The terminal job lifecycle completes rejected claims
- * or releases deferred claims after the disposition status is committed.
+	 * a fetched source item. The step lifecycle completes or releases only the
+	 * exact packet claim identified by the successful tool result.
  *
  * This provides a safety net when keyword exclusions or other filters
  * miss items that shouldn't be processed (e.g., non-music events).
@@ -15,9 +15,9 @@
 
 namespace DataMachine\Core\Steps\Fetch\Tools;
 
-use DataMachine\Core\JobStatus;
 use DataMachine\Core\RunMetrics;
 use DataMachine\Core\EngineData;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -73,12 +73,6 @@ class FetchItemDispositionTool {
 			);
 		}
 
-		// Dispositions are first-write-wins: never overwrite an earlier terminal disposition.
-		$existing = $this->existingDisposition( $job_id );
-		if ( null !== $existing ) {
-			return $this->alreadyDispositionedResult( $tool_name, $existing, $job_id );
-		}
-
 		// Get engine data for item identification.
 		$engine = $this->resolveEngineData( $parameters, $job_id );
 		if ( ! $engine ) {
@@ -90,27 +84,34 @@ class FetchItemDispositionTool {
 		}
 
 		// Get item identifier and source type from engine data (set by fetch handler)
-		$item_identifier = $engine->get( 'item_identifier' );
-		$source_type     = $engine->get( 'source_type' );
+		$target          = $this->resolveTargetClaim( $engine, $parameters );
+		$item_identifier = $target['item_identifier'] ?? null;
+		$source_type     = $target['source_type'] ?? null;
+		$disposition_id  = $target['disposition_id'] ?? null;
+		if ( ! $target ) {
+			return array( 'success' => false, 'error' => 'packet disposition identity is required', 'tool_name' => $tool_name );
+		}
 		$flow_step_id    = $this->resolveFetchFlowStepId( $engine ) ?? ( $parameters['flow_step_id'] ?? $engine->get( 'flow_step_id' ) );
 		$diagnostic      = $this->buildDispositionDiagnostic( self::DISPOSITION_REJECT_SOURCE, $tool_name, $reason, $flow_step_id, $item_identifier, $source_type, $parameters );
 
-		// Set job status override for engine to use at completion
-		$status = JobStatus::agentSkipped( 'source-rejected' );
-		datamachine_merge_engine_data(
+		$persisted = $this->persistDisposition(
 			$job_id,
+			(string) $disposition_id,
 			array(
-				'job_status'             => $status->toString(),
-				'disposition_diagnostic' => $diagnostic,
-				'source_rejection'       => array(
-					'reason'          => $reason,
-					'flow_step_id'    => $flow_step_id,
-					'item_identifier' => $item_identifier,
-					'source_type'     => $source_type,
-					'diagnostic'      => $diagnostic,
-				),
+				'disposition'     => self::DISPOSITION_REJECT_SOURCE,
+				'reason'          => $reason,
+				'flow_step_id'    => $flow_step_id,
+				'item_identifier' => $item_identifier,
+				'source_type'     => $source_type,
+				'diagnostic'      => $diagnostic,
 			)
 		);
+		if ( empty( $persisted['success'] ) ) {
+			return array( 'success' => false, 'error' => 'packet rejection could not be persisted', 'tool_name' => $tool_name, 'disposition_id' => $disposition_id );
+		}
+		if ( empty( $persisted['created'] ) ) {
+			return $this->alreadyDispositionedResult( $tool_name, $persisted['record'], $job_id, (string) $disposition_id );
+		}
 
 		if ( $flow_step_id && class_exists( RunMetrics::class ) ) {
 			RunMetrics::recordStepResult(
@@ -130,10 +131,9 @@ class FetchItemDispositionTool {
 		do_action(
 			'datamachine_log',
 			'info',
-			'FetchItemDispositionTool: Job status set to source rejected',
+			'FetchItemDispositionTool: Packet rejection persisted',
 			array(
 				'job_id' => $job_id,
-				'status' => $status->toString(),
 				'reason' => $reason,
 			)
 		);
@@ -141,10 +141,10 @@ class FetchItemDispositionTool {
 		return array(
 			'success'         => true,
 			'message'         => "Source rejected: {$reason}",
-			'status'          => $status->toString(),
 			'item_identifier' => $item_identifier,
 			'tool_name'       => $tool_name,
 			'disposition'     => self::DISPOSITION_REJECT_SOURCE,
+			'disposition_id'  => $disposition_id,
 			'reason'          => $reason,
 		);
 	}
@@ -179,13 +179,6 @@ class FetchItemDispositionTool {
 			);
 		}
 
-		// Dispositions are first-write-wins: defer_item must never downgrade an
-		// earlier rejection (agent_skipped - source-rejected) to a failed status.
-		$existing = $this->existingDisposition( $job_id );
-		if ( null !== $existing ) {
-			return $this->alreadyDispositionedResult( $tool_name, $existing, $job_id );
-		}
-
 		$engine = $this->resolveEngineData( $parameters, $job_id );
 		if ( ! $engine ) {
 			return array(
@@ -195,26 +188,34 @@ class FetchItemDispositionTool {
 			);
 		}
 
-		$item_identifier = $engine->get( 'item_identifier' );
-		$source_type     = $engine->get( 'source_type' );
+		$target          = $this->resolveTargetClaim( $engine, $parameters );
+		$item_identifier = $target['item_identifier'] ?? null;
+		$source_type     = $target['source_type'] ?? null;
+		$disposition_id  = $target['disposition_id'] ?? null;
+		if ( ! $target ) {
+			return array( 'success' => false, 'error' => 'packet disposition identity is required', 'tool_name' => $tool_name );
+		}
 		$flow_step_id    = $this->resolveFetchFlowStepId( $engine ) ?? ( $parameters['flow_step_id'] ?? $engine->get( 'flow_step_id' ) );
 		$diagnostic      = $this->buildDispositionDiagnostic( self::DISPOSITION_DEFER_ITEM, $tool_name, $reason, $flow_step_id, $item_identifier, $source_type, $parameters );
 
-		$status = JobStatus::failed( 'item-deferred' );
-		datamachine_merge_engine_data(
+		$persisted = $this->persistDisposition(
 			$job_id,
+			(string) $disposition_id,
 			array(
-				'job_status'             => $status->toString(),
-				'disposition_diagnostic' => $diagnostic,
-				'item_deferral'          => array(
-					'reason'          => $reason,
-					'flow_step_id'    => $flow_step_id,
-					'item_identifier' => $item_identifier,
-					'source_type'     => $source_type,
-					'diagnostic'      => $diagnostic,
-				),
+				'disposition'     => self::DISPOSITION_DEFER_ITEM,
+				'reason'          => $reason,
+				'flow_step_id'    => $flow_step_id,
+				'item_identifier' => $item_identifier,
+				'source_type'     => $source_type,
+				'diagnostic'      => $diagnostic,
 			)
 		);
+		if ( empty( $persisted['success'] ) ) {
+			return array( 'success' => false, 'error' => 'packet deferral could not be persisted', 'tool_name' => $tool_name, 'disposition_id' => $disposition_id );
+		}
+		if ( empty( $persisted['created'] ) ) {
+			return $this->alreadyDispositionedResult( $tool_name, $persisted['record'], $job_id, (string) $disposition_id );
+		}
 
 		if ( $flow_step_id && class_exists( RunMetrics::class ) ) {
 			RunMetrics::recordStepResult(
@@ -234,64 +235,60 @@ class FetchItemDispositionTool {
 		do_action(
 			'datamachine_log',
 			'info',
-			'FetchItemDispositionTool: Item deferred for terminal claim release',
+			'FetchItemDispositionTool: Packet deferral persisted',
 			array(
 				'job_id'          => $job_id,
 				'flow_step_id'    => $flow_step_id,
 				'item_identifier' => $item_identifier,
 				'source_type'     => $source_type,
 				'reason'          => $reason,
-				'status'          => $status->toString(),
 			)
 		);
 
 		return array(
 			'success'         => true,
 			'message'         => "Item deferred for retry: {$reason}",
-			'status'          => $status->toString(),
 			'item_identifier' => $item_identifier,
 			'tool_name'       => $tool_name,
 			'disposition'     => self::DISPOSITION_DEFER_ITEM,
+			'disposition_id'  => $disposition_id,
 			'reason'          => $reason,
 		);
 	}
 
 	/**
-	 * Return the disposition already recorded for a job, if any.
+	 * Atomically persist the first disposition recorded for a packet identity.
 	 *
-	 * Reads the persisted engine snapshot rather than the runtime engine object
-	 * because the runtime snapshot may predate an earlier disposition call in
-	 * the same conversation.
-	 *
-	 * @param int $job_id Job ID.
-	 * @return array{disposition:string,job_status:string,reason:string}|null
+	 * @return array{success:bool,created:bool,record:array{disposition:string,reason:string}}
 	 */
-	private function existingDisposition( int $job_id ): ?array {
-		$engine_data = EngineData::retrieve( $job_id );
+	private function persistDisposition( int $job_id, string $disposition_id, array $record ): array {
+		$created  = false;
+		$selected = array();
+		$result   = EngineData::mutate(
+			$job_id,
+			static function ( array $engine ) use ( $disposition_id, $record, &$created, &$selected ): array {
+				$existing = is_array( $engine['packet_dispositions'][ $disposition_id ] ?? null ) ? $engine['packet_dispositions'][ $disposition_id ] : array();
+				if ( '' !== (string) ( $existing['disposition'] ?? '' ) ) {
+					$created  = false;
+					$selected = $existing;
+					return $engine;
+				}
 
-		$diagnostic  = is_array( $engine_data['disposition_diagnostic'] ?? null ) ? $engine_data['disposition_diagnostic'] : array();
-		$disposition = (string) ( $diagnostic['disposition'] ?? '' );
-
-		if ( '' === $disposition && isset( $engine_data['source_rejection'] ) ) {
-			$disposition = self::DISPOSITION_REJECT_SOURCE;
-		}
-
-		if ( '' === $disposition && isset( $engine_data['item_deferral'] ) ) {
-			$disposition = self::DISPOSITION_DEFER_ITEM;
-		}
-
-		if ( '' === $disposition ) {
-			return null;
-		}
-
-		$record = self::DISPOSITION_DEFER_ITEM === $disposition
-			? ( is_array( $engine_data['item_deferral'] ?? null ) ? $engine_data['item_deferral'] : array() )
-			: ( is_array( $engine_data['source_rejection'] ?? null ) ? $engine_data['source_rejection'] : array() );
+				$created  = true;
+				$selected = $record;
+				$engine['packet_dispositions'][ $disposition_id ] = $record;
+				return $engine;
+			},
+			'packet_disposition_first_write'
+		);
 
 		return array(
-			'disposition' => $disposition,
-			'job_status'  => (string) ( $engine_data['job_status'] ?? '' ),
-			'reason'      => (string) ( $record['reason'] ?? $diagnostic['reason'] ?? '' ),
+			'success' => ! empty( $result['success'] ),
+			'created' => $created,
+			'record'  => array(
+				'disposition' => (string) ( $selected['disposition'] ?? '' ),
+				'reason'      => (string) ( $selected['reason'] ?? '' ),
+			),
 		);
 	}
 
@@ -299,14 +296,14 @@ class FetchItemDispositionTool {
 	 * Build the idempotent success result for an already-dispositioned job.
 	 *
 	 * Returned as success so the model is not pushed into error-retry loops;
-	 * the original disposition remains authoritative (first-write-wins).
+	 * the original disposition for this packet remains authoritative.
 	 *
 	 * @param string                                              $tool_name Tool that attempted the second disposition.
-	 * @param array{disposition:string,job_status:string,reason:string} $existing  Existing disposition record.
+	 * @param array{disposition:string,reason:string} $existing  Existing disposition record.
 	 * @param int                                                 $job_id    Job ID.
 	 * @return array Tool result.
 	 */
-	private function alreadyDispositionedResult( string $tool_name, array $existing, int $job_id ): array {
+	private function alreadyDispositionedResult( string $tool_name, array $existing, int $job_id, string $disposition_id ): array {
 		$label = self::DISPOSITION_DEFER_ITEM === $existing['disposition'] ? 'item-deferred' : 'source-rejected';
 
 		do_action(
@@ -317,16 +314,16 @@ class FetchItemDispositionTool {
 				'job_id'               => $job_id,
 				'attempted_tool'       => $tool_name,
 				'existing_disposition' => $existing['disposition'],
-				'existing_job_status'  => $existing['job_status'],
+				'disposition_id'       => $disposition_id,
 			)
 		);
 
 		return array(
 			'success'              => true,
 			'message'              => "Item already dispositioned ({$label}); no further action needed.",
-			'status'               => $existing['job_status'],
 			'tool_name'            => $tool_name,
 			'disposition'          => $existing['disposition'],
+			'disposition_id'       => $disposition_id,
 			'reason'               => $existing['reason'],
 			'already_dispositioned' => true,
 		);
@@ -342,6 +339,15 @@ class FetchItemDispositionTool {
 		$disposition = $tool_def['disposition'] ?? self::DISPOSITION_REJECT_SOURCE;
 
 		return self::DISPOSITION_DEFER_ITEM === $disposition ? self::DISPOSITION_DEFER_ITEM : self::DISPOSITION_REJECT_SOURCE;
+	}
+
+	/** Resolve a stable packet identity against engine-owned claim descriptors. */
+	private function resolveTargetClaim( object $engine, array $parameters ): array {
+		$container = array(
+			ProcessedItems::CLAIM_METADATA_KEY  => $engine->get( ProcessedItems::CLAIM_METADATA_KEY ),
+			ProcessedItems::CLAIMS_METADATA_KEY => $engine->get( ProcessedItems::CLAIMS_METADATA_KEY ),
+		);
+		return ProcessedItems::resolve_disposition_claim( $container, (string) ( $parameters['disposition_id'] ?? '' ), true ) ?? array();
 	}
 
 	/**

--- a/inc/Engine/AI/DataPacketPromptProjector.php
+++ b/inc/Engine/AI/DataPacketPromptProjector.php
@@ -51,7 +51,7 @@ class DataPacketPromptProjector {
 	 * @return array Prompt-facing packet.
 	 */
 	private static function projectPacket( array $packet, array $context ): array {
-		$projected     = $packet;
+		$projected      = $packet;
 		$metadata       = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
 		$packet_claims  = class_exists( ProcessedItems::class ) ? ProcessedItems::disposition_claims( $metadata ) : array();
 		$disposition_id = 1 === count( $packet_claims ) ? (string) array_key_first( $packet_claims ) : '';
@@ -67,7 +67,7 @@ class DataPacketPromptProjector {
 		}
 		$projected = self::redactOwnershipTokens( $projected );
 		if ( '' !== $disposition_id ) {
-			$projected['metadata'] = is_array( $projected['metadata'] ?? null ) ? $projected['metadata'] : array();
+			$projected['metadata']                                       = is_array( $projected['metadata'] ?? null ) ? $projected['metadata'] : array();
 			$projected['metadata']['_datamachine_packet_disposition_id'] = $disposition_id;
 		}
 

--- a/inc/Engine/AI/DataPacketPromptProjector.php
+++ b/inc/Engine/AI/DataPacketPromptProjector.php
@@ -7,6 +7,8 @@
 
 namespace DataMachine\Engine\AI;
 
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -49,7 +51,10 @@ class DataPacketPromptProjector {
 	 * @return array Prompt-facing packet.
 	 */
 	private static function projectPacket( array $packet, array $context ): array {
-		$projected = $packet;
+		$projected     = $packet;
+		$metadata       = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+		$packet_claims  = class_exists( ProcessedItems::class ) ? ProcessedItems::disposition_claims( $metadata ) : array();
+		$disposition_id = 1 === count( $packet_claims ) ? (string) array_key_first( $packet_claims ) : '';
 		if ( isset( $projected['data'] ) && is_array( $projected['data'] ) ) {
 			$projected['data'] = self::sanitizePacketData( $projected['data'] );
 		}
@@ -57,11 +62,30 @@ class DataPacketPromptProjector {
 		if ( function_exists( 'apply_filters' ) ) {
 			$filtered = apply_filters( 'datamachine_ai_project_data_packet', $projected, $packet, $context );
 			if ( is_array( $filtered ) ) {
-				return $filtered;
+				$projected = $filtered;
 			}
+		}
+		$projected = self::redactOwnershipTokens( $projected );
+		if ( '' !== $disposition_id ) {
+			$projected['metadata'] = is_array( $projected['metadata'] ?? null ) ? $projected['metadata'] : array();
+			$projected['metadata']['_datamachine_packet_disposition_id'] = $disposition_id;
 		}
 
 		return $projected;
+	}
+
+	/** Recursively remove opaque ownership credentials from prompt-facing data. */
+	private static function redactOwnershipTokens( array $value ): array {
+		foreach ( $value as $key => $child ) {
+			if ( 'ownership_token' === $key ) {
+				unset( $value[ $key ] );
+				continue;
+			}
+			if ( is_array( $child ) ) {
+				$value[ $key ] = self::redactOwnershipTokens( $child );
+			}
+		}
+		return $value;
 	}
 
 	/**

--- a/inc/Engine/AI/RuntimeToolRunStateStore.php
+++ b/inc/Engine/AI/RuntimeToolRunStateStore.php
@@ -109,8 +109,8 @@ class RuntimeToolRunStateStore {
 
 	/** Build initial state for callers that persist request and run state in one CAS. */
 	public static function initial_state_from_request( array $request ): ?array {
-		$metadata = is_array( $request['metadata']['datamachine'] ?? null ) ? $request['metadata']['datamachine'] : array();
-		$job_id   = max( 0, (int) ( $metadata['job_id'] ?? 0 ) );
+		$metadata   = is_array( $request['metadata']['datamachine'] ?? null ) ? $request['metadata']['datamachine'] : array();
+		$job_id     = max( 0, (int) ( $metadata['job_id'] ?? 0 ) );
 		$request_id = trim( (string) ( $request['request_id'] ?? '' ) );
 		$tool_name  = trim( (string) ( $request['tool_name'] ?? '' ) );
 		if ( $job_id <= 0 || '' === $request_id || '' === $tool_name ) {
@@ -184,7 +184,7 @@ class RuntimeToolRunStateStore {
 	private function transition_once( int $job_id, string $timestamp_key, string $payload_key, array $payload, string $status, bool $return_existing = true ): ?array {
 		$this->assert_job_id( $job_id );
 
-		$state = null;
+		$state        = null;
 		$transitioned = $this->mutate_engine_data(
 			$job_id,
 			function ( array $engine_data ) use ( $timestamp_key, $payload_key, $payload, $status, $return_existing, &$state ): array {

--- a/inc/Engine/AI/RuntimeToolRunStateStore.php
+++ b/inc/Engine/AI/RuntimeToolRunStateStore.php
@@ -107,6 +107,33 @@ class RuntimeToolRunStateStore {
 		);
 	}
 
+	/** Build initial state for callers that persist request and run state in one CAS. */
+	public static function initial_state_from_request( array $request ): ?array {
+		$metadata = is_array( $request['metadata']['datamachine'] ?? null ) ? $request['metadata']['datamachine'] : array();
+		$job_id   = max( 0, (int) ( $metadata['job_id'] ?? 0 ) );
+		$request_id = trim( (string) ( $request['request_id'] ?? '' ) );
+		$tool_name  = trim( (string) ( $request['tool_name'] ?? '' ) );
+		if ( $job_id <= 0 || '' === $request_id || '' === $tool_name ) {
+			return null;
+		}
+
+		$created_at = gmdate( 'c' );
+		return array(
+			'parent_job_id'           => max( 0, (int) ( $metadata['parent_job_id'] ?? 0 ) ),
+			'runtime_tool_request_id' => $request_id,
+			'tool_name'               => $tool_name,
+			'status'                  => self::STATUS_PENDING,
+			'timeout_seconds'         => max( 0, (int) ( $metadata['timeout_seconds'] ?? 0 ) ),
+			'deadline_at'             => (string) ( $request['timeout_at'] ?? $metadata['expires_at'] ?? '' ),
+			'resume_payload'          => null,
+			'finalize_payload'        => null,
+			'created_at'              => $created_at,
+			'updated_at'              => $created_at,
+			'finalized_at'            => null,
+			'resumed_at'              => null,
+		);
+	}
+
 	/**
 	 * Read runtime-tool run state from a request job.
 	 *
@@ -141,7 +168,7 @@ class RuntimeToolRunStateStore {
 	 * @return array<string,mixed>|null
 	 */
 	public function resume( int $job_id, array $payload ): ?array {
-		return $this->transition_once( $job_id, 'resumed_at', 'resume_payload', $payload, self::STATUS_RESUMED );
+		return $this->transition_once( $job_id, 'resumed_at', 'resume_payload', $payload, self::STATUS_RESUMED, false );
 	}
 
 	/**
@@ -154,15 +181,19 @@ class RuntimeToolRunStateStore {
 	 * @param string              $status      New status.
 	 * @return array<string,mixed>|null
 	 */
-	private function transition_once( int $job_id, string $timestamp_key, string $payload_key, array $payload, string $status ): ?array {
+	private function transition_once( int $job_id, string $timestamp_key, string $payload_key, array $payload, string $status, bool $return_existing = true ): ?array {
 		$this->assert_job_id( $job_id );
 
 		$state = null;
-		$this->mutate_engine_data(
+		$transitioned = $this->mutate_engine_data(
 			$job_id,
-			function ( array $engine_data ) use ( $timestamp_key, $payload_key, $payload, $status, &$state ): array {
+			function ( array $engine_data ) use ( $timestamp_key, $payload_key, $payload, $status, $return_existing, &$state ): array {
 				$state = $this->normalize_existing( $engine_data['runtime_tool_run_state'] ?? null );
-				if ( empty( $state ) || ! empty( $state[ $timestamp_key ] ) ) {
+				if ( empty( $state ) ) {
+					return $engine_data;
+				}
+				if ( ! empty( $state[ $timestamp_key ] ) ) {
+					$state = $return_existing ? $state : null;
 					return $engine_data;
 				}
 
@@ -178,7 +209,7 @@ class RuntimeToolRunStateStore {
 			'runtime_tool_run_state_transition'
 		);
 
-		return $state;
+		return $transitioned ? $state : null;
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/ToolExecutor.php
+++ b/inc/Engine/AI/Tools/ToolExecutor.php
@@ -15,6 +15,9 @@ use AgentsAPI\AI\Tools\WP_Agent_Action_Policy;
 use AgentsAPI\AI\Tools\WP_Agent_Tool_Execution_Core;
 use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachine\Core\EngineData;
 use DataMachine\Core\Workspace\WordPressWorkspaceScope;
 use DataMachine\Core\WordPress\PostTracking;
 use DataMachine\Engine\AI\Actions\ActionPolicyResolver;
@@ -61,6 +64,26 @@ class ToolExecutor {
 		int $agent_id = 0,
 		array $client_context = array()
 	): array {
+		$disposition_claim = null;
+		$reservation_token = '';
+		$raw_tool_def      = is_array( $available_tools[ $tool_name ] ?? null ) ? $available_tools[ $tool_name ] : array();
+		if ( ! empty( $raw_tool_def['packet_disposition_bound'] ) ) {
+			$engine_data = is_array( $payload['engine_data'] ?? null ) ? $payload['engine_data'] : array();
+			$provided_id = is_string( $tool_parameters['disposition_id'] ?? null ) ? trim( $tool_parameters['disposition_id'] ) : '';
+			$disposition_claim = ProcessedItems::resolve_disposition_claim( $engine_data, $provided_id, true );
+			if ( null === $disposition_claim ) {
+				return array(
+					'success'   => false,
+					'error'     => '' === $provided_id
+						? 'disposition_id is required when more than one packet claim is active'
+						: 'disposition_id does not identify an active packet claim',
+					'tool_name' => $tool_name,
+					'code'      => 'invalid_packet_disposition',
+				);
+			}
+			$tool_parameters['disposition_id'] = $disposition_claim['disposition_id'];
+		}
+
 		$core                             = new WP_Agent_Tool_Execution_Core();
 		$execution                        = new ToolExecutionCore();
 		$caller_context                   = $payload;
@@ -181,7 +204,34 @@ class ToolExecutor {
 		}
 
 		// Policy is 'direct' — execute the tool normally.
-		$tool_result = $core->executePreparedTool( $tool_call, $tool_def, $execution, $tool_context );
+		if ( is_array( $disposition_claim ) ) {
+			$reservation = self::beginPacketExecution( $tool_name, $disposition_claim['disposition_id'], $payload );
+			if ( empty( $reservation['acquired'] ) ) {
+				return $reservation['result'];
+			}
+			$reservation_token = (string) $reservation['token'];
+		}
+		$reservation_finalized = ! is_array( $disposition_claim );
+		try {
+			$tool_result = $core->executePreparedTool( $tool_call, $tool_def, $execution, $tool_context );
+			if ( is_array( $disposition_claim ) ) {
+				$tool_result['disposition_id'] = $disposition_claim['disposition_id'];
+				$state = ! empty( $tool_result['success'] ) ? 'succeeded' : 'failed';
+				$reservation_finalized = self::finishPacketExecution( $tool_name, $disposition_claim['disposition_id'], $payload, $reservation_token, $state );
+				if ( ! $reservation_finalized ) {
+					return self::ambiguousPacketExecutionResult( $tool_name, $disposition_claim['disposition_id'], 'Handler returned, but its durable execution outcome could not be persisted.' );
+				}
+			}
+		} catch ( \Throwable $exception ) {
+			if ( is_array( $disposition_claim ) ) {
+				$reservation_finalized = self::finishPacketExecution( $tool_name, $disposition_claim['disposition_id'], $payload, $reservation_token, 'ambiguous' );
+			}
+			throw $exception;
+		} finally {
+			if ( is_array( $disposition_claim ) && ! $reservation_finalized ) {
+				self::finishPacketExecution( $tool_name, $disposition_claim['disposition_id'], $payload, $reservation_token, 'ambiguous' );
+			}
+		}
 		$tool_result = self::attachToolAuditContext( $tool_result, array_merge( $audit_context, array( 'result_status' => ! empty( $tool_result['success'] ) ? 'success' : 'error' ) ) );
 		self::dispatchToolAudit( $tool_result['metadata']['datamachine']['audit_context'] ?? array_merge( $audit_context, array( 'result_status' => ! empty( $tool_result['success'] ) ? 'success' : 'error' ) ) );
 
@@ -202,6 +252,204 @@ class ToolExecutor {
 		}
 
 		return $tool_result;
+	}
+
+	/** Return an idempotent success before repeating one handler/disposition side effect. */
+	public static function existingPacketExecutionResult( string $tool_name, string $disposition_id, array $payload ): ?array {
+		foreach ( (array) ( $payload['prior_tool_results'] ?? array() ) as $entry ) {
+			if ( ! is_array( $entry ) || $tool_name !== (string) ( $entry['tool_name'] ?? $entry['name'] ?? '' ) ) {
+				continue;
+			}
+			$result = is_array( $entry['result'] ?? null ) ? $entry['result'] : array();
+			if ( ! empty( $result['success'] ) && empty( $result['staged'] ) && empty( $result['pending'] ) && hash_equals( $disposition_id, (string) ( $result['disposition_id'] ?? '' ) ) ) {
+				return self::duplicatePacketExecutionResult( $tool_name, $disposition_id );
+			}
+		}
+
+		$job_id = (int) ( $payload['job_id'] ?? 0 );
+		$engine = $job_id > 0 ? EngineData::retrieve( $job_id ) : ( is_array( $payload['engine_data'] ?? null ) ? $payload['engine_data'] : array() );
+		$execution = is_array( $engine['packet_tool_executions'][ $tool_name ][ $disposition_id ] ?? null ) ? $engine['packet_tool_executions'][ $tool_name ][ $disposition_id ] : array();
+		if ( 'succeeded' === ( $execution['state'] ?? '' ) || ! empty( $engine['successful_packet_tool_executions'][ $tool_name ][ $disposition_id ] ) ) {
+			return self::duplicatePacketExecutionResult( $tool_name, $disposition_id );
+		}
+		if ( in_array( (string) ( $execution['state'] ?? '' ), array( 'executing', 'pending', 'ambiguous' ), true ) ) {
+			return self::ambiguousPacketExecutionResult( $tool_name, $disposition_id, 'A prior execution may already have applied side effects; automatic replay is blocked.' );
+		}
+		return null;
+	}
+
+	/** Atomically reserve one packet-bound handler execution before side effects. */
+	public static function beginPacketExecution( string $tool_name, string $disposition_id, array $payload ): array {
+		$prior = self::existingPacketExecutionResult( $tool_name, $disposition_id, $payload );
+		if ( null !== $prior ) {
+			return array( 'acquired' => false, 'token' => '', 'result' => $prior );
+		}
+
+		$job_id = (int) ( $payload['job_id'] ?? 0 );
+		if ( $job_id <= 0 ) {
+			return array(
+				'acquired' => false,
+				'token'    => '',
+				'result'   => self::ambiguousPacketExecutionResult( $tool_name, $disposition_id, 'A durable job ID is required before packet-bound side effects.' ),
+			);
+		}
+
+		$token    = bin2hex( random_bytes( 16 ) );
+		$decision = 'error';
+		$result = EngineData::mutate(
+			$job_id,
+			static function ( array $engine ) use ( $tool_name, $disposition_id, $token, &$decision ): array {
+				$current = is_array( $engine['packet_tool_executions'][ $tool_name ][ $disposition_id ] ?? null ) ? $engine['packet_tool_executions'][ $tool_name ][ $disposition_id ] : array();
+				$state   = (string) ( $current['state'] ?? '' );
+				if ( 'succeeded' === $state || ! empty( $engine['successful_packet_tool_executions'][ $tool_name ][ $disposition_id ] ) ) {
+					$decision = 'duplicate';
+					return $engine;
+				}
+				if ( in_array( $state, array( 'executing', 'pending', 'ambiguous' ), true ) ) {
+					$decision = 'ambiguous';
+					return $engine;
+				}
+				$decision = 'acquired';
+				$engine['packet_tool_executions'][ $tool_name ][ $disposition_id ] = array(
+					'state'      => 'executing',
+					'token'      => $token,
+					'started_at' => gmdate( 'c' ),
+				);
+				return $engine;
+			},
+			'packet_tool_reserve'
+		);
+		if ( empty( $result['success'] ) ) {
+			return array( 'acquired' => false, 'token' => '', 'result' => self::ambiguousPacketExecutionResult( $tool_name, $disposition_id, 'The durable execution reservation could not be persisted.' ) );
+		}
+		if ( 'duplicate' === $decision ) {
+			return array( 'acquired' => false, 'token' => '', 'result' => self::duplicatePacketExecutionResult( $tool_name, $disposition_id ) );
+		}
+		if ( 'acquired' !== $decision ) {
+			return array( 'acquired' => false, 'token' => '', 'result' => self::ambiguousPacketExecutionResult( $tool_name, $disposition_id, 'A prior execution may already have applied side effects; automatic replay is blocked.' ) );
+		}
+
+		return array( 'acquired' => true, 'token' => $token, 'result' => array() );
+	}
+
+	/** Durably finalize an execution reservation after the handler returns. */
+	public static function finishPacketExecution( string $tool_name, string $disposition_id, array $payload, string $token, string $state, string $request_id = '' ): bool {
+		$job_id = (int) ( $payload['job_id'] ?? 0 );
+		if ( $job_id <= 0 || '' === $token || ! in_array( $state, array( 'succeeded', 'failed', 'pending', 'ambiguous' ), true ) || ( 'pending' === $state && '' === $request_id ) ) {
+			return false;
+		}
+
+		$owned  = false;
+		$result = EngineData::mutate(
+			$job_id,
+			static function ( array $engine ) use ( $tool_name, $disposition_id, $token, $state, $request_id, &$owned ): array {
+				$owned   = false;
+				$current = is_array( $engine['packet_tool_executions'][ $tool_name ][ $disposition_id ] ?? null ) ? $engine['packet_tool_executions'][ $tool_name ][ $disposition_id ] : array();
+				if ( 'executing' !== ( $current['state'] ?? '' ) || ! hash_equals( $token, (string) ( $current['token'] ?? '' ) ) ) {
+					return $engine;
+				}
+				$owned = true;
+				$engine['packet_tool_executions'][ $tool_name ][ $disposition_id ] = array(
+					'state'       => $state,
+					'token'       => $token,
+					'started_at'  => (string) ( $current['started_at'] ?? '' ),
+					'finished_at' => gmdate( 'c' ),
+				);
+				if ( '' !== $request_id ) {
+					$engine['packet_tool_executions'][ $tool_name ][ $disposition_id ]['request_id'] = $request_id;
+				}
+				return $engine;
+			},
+			'packet_tool_finalize'
+		);
+
+		return $owned && ! empty( $result['success'] );
+	}
+
+	/** Finalize an asynchronously fulfilled external execution from its durable pending state. */
+	public static function finishPendingPacketExecution( string $tool_name, string $disposition_id, int $job_id, string $state, string $token, string $request_id ): bool {
+		if ( $job_id <= 0 || '' === $token || '' === $request_id || ! in_array( $state, array( 'succeeded', 'failed' ), true ) ) {
+			return false;
+		}
+
+		$owned  = false;
+		$result = EngineData::mutate(
+			$job_id,
+			static function ( array $engine ) use ( $tool_name, $disposition_id, $state, $token, $request_id, &$owned ): array {
+				$owned   = false;
+				$current = is_array( $engine['packet_tool_executions'][ $tool_name ][ $disposition_id ] ?? null ) ? $engine['packet_tool_executions'][ $tool_name ][ $disposition_id ] : array();
+				$identity_matches = hash_equals( $token, (string) ( $current['token'] ?? '' ) )
+					&& hash_equals( $request_id, (string) ( $current['request_id'] ?? '' ) );
+				if ( ! $identity_matches ) {
+					return $engine;
+				}
+				if ( $state === ( $current['state'] ?? '' ) ) {
+					$owned = true;
+					return $engine;
+				}
+				if ( 'pending' !== ( $current['state'] ?? '' ) ) {
+					return $engine;
+				}
+				$owned = true;
+				$engine['packet_tool_executions'][ $tool_name ][ $disposition_id ] = array(
+					'state'       => $state,
+					'token'       => (string) ( $current['token'] ?? '' ),
+					'started_at'  => (string) ( $current['started_at'] ?? '' ),
+					'finished_at' => gmdate( 'c' ),
+					'request_id'  => $request_id,
+				);
+				return $engine;
+			},
+			'packet_tool_async_finalize'
+		);
+
+		return $owned && ! empty( $result['success'] );
+	}
+
+	/** Finalize an asynchronous execution using only its server-side reservation. */
+	public static function finishPendingPacketExecutionForRequest( string $tool_name, string $disposition_id, int $job_id, string $state, string $request_id ): bool {
+		if ( $job_id <= 0 || '' === $request_id || ! in_array( $state, array( 'succeeded', 'failed' ), true ) ) {
+			return false;
+		}
+
+		$engine  = ( new Jobs() )->retrieve_engine_data( $job_id );
+		$current = is_array( $engine['packet_tool_executions'][ $tool_name ][ $disposition_id ] ?? null ) ? $engine['packet_tool_executions'][ $tool_name ][ $disposition_id ] : array();
+		$token   = (string) ( $current['token'] ?? '' );
+		if ( '' === $token || ! hash_equals( $request_id, (string) ( $current['request_id'] ?? '' ) ) ) {
+			return false;
+		}
+
+		return self::finishPendingPacketExecution( $tool_name, $disposition_id, $job_id, $state, $token, $request_id );
+	}
+
+	/** Backward-compatible success recorder for callers that already own a reservation. */
+	public static function recordPacketExecutionSuccess( string $tool_name, string $disposition_id, array $payload ): bool {
+		$reservation = self::beginPacketExecution( $tool_name, $disposition_id, $payload );
+		if ( empty( $reservation['acquired'] ) ) {
+			return ! empty( $reservation['result']['success'] );
+		}
+		return self::finishPacketExecution( $tool_name, $disposition_id, $payload, (string) $reservation['token'], 'succeeded' );
+	}
+
+	private static function duplicatePacketExecutionResult( string $tool_name, string $disposition_id ): array {
+		return array(
+			'success'               => true,
+			'tool_name'             => $tool_name,
+			'disposition_id'        => $disposition_id,
+			'already_dispositioned' => true,
+			'message'               => 'This handler already completed successfully for the packet identity.',
+		);
+	}
+
+	private static function ambiguousPacketExecutionResult( string $tool_name, string $disposition_id, string $message ): array {
+		return array(
+			'success'                => false,
+			'tool_name'              => $tool_name,
+			'disposition_id'         => $disposition_id,
+			'code'                   => 'packet_execution_outcome_ambiguous',
+			'automatic_replay_blocked' => true,
+			'error'                  => $message,
+		);
 	}
 
 	/**

--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -15,7 +15,9 @@
 
 namespace DataMachine\Engine\AI\Tools;
 
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\PluginSettings;
+use DataMachine\Engine\AI\ToolSchemaNormalizer;
 use DataMachine\Engine\AI\Tools\Sources\AbilityToolSource;
 
 defined( 'ABSPATH' ) || exit;
@@ -365,7 +367,7 @@ class ToolManager {
 					continue;
 				}
 
-				$tool_def = $this->withHandlerToolContext( $tool_def, $definition, $handler_slug, $handler_config );
+				$tool_def = $this->withHandlerToolContext( $tool_def, $definition, $handler_slug, $handler_config, $engine_data );
 
 				// Apply registry-level meta unless the resolved tool
 				// explicitly overrides.
@@ -397,9 +399,10 @@ class ToolManager {
 	 * @param array  $declaration    Normalized handler-tool declaration.
 	 * @param string $handler_slug   Adjacent step handler slug.
 	 * @param array  $handler_config Handler configuration from flow step.
+	 * @param array  $engine_data    Current engine snapshot.
 	 * @return array<string,mixed> Tool definition with handler context.
 	 */
-	private function withHandlerToolContext( array $tool_def, array $declaration, string $handler_slug, array $handler_config ): array {
+	private function withHandlerToolContext( array $tool_def, array $declaration, string $handler_slug, array $handler_config, array $engine_data ): array {
 		if ( ! isset( $tool_def['handler'] ) ) {
 			$tool_def['handler'] = $handler_slug;
 		}
@@ -419,6 +422,21 @@ class ToolManager {
 		// declaration so ownership is visible before the callback is invoked.
 		if ( 'handle_tool_call' === ( $tool_def['method'] ?? '' ) ) {
 			$tool_def['client_context_bindings'] = self::mergeContextBindings( $tool_def['client_context_bindings'] ?? array(), array( 'job_id' ) );
+		}
+
+		if ( class_exists( ProcessedItems::class ) && ! empty( ProcessedItems::disposition_claims( $engine_data ) ) ) {
+			$parameters                         = ToolSchemaNormalizer::normalize( $tool_def['parameters'] ?? array() );
+			$properties                         = is_array( $parameters['properties'] ?? null ) ? $parameters['properties'] : array();
+			$properties['disposition_id']        = array(
+				'type'        => 'string',
+				'description' => 'Stable packet disposition identity from the input packet. Return the identity for the exact packet this tool call handles.',
+			);
+			$parameters['properties']            = $properties;
+			$required                            = is_array( $parameters['required'] ?? null ) ? $parameters['required'] : array();
+			$required[]                          = 'disposition_id';
+			$parameters['required']              = array_values( array_unique( $required ) );
+			$tool_def['parameters']               = $parameters;
+			$tool_def['packet_disposition_bound'] = true;
 		}
 
 		return $tool_def;
@@ -468,6 +486,7 @@ class ToolManager {
 		$job_id       = (int) ( $engine_data['job_id'] ?? $job_snapshot['job_id'] ?? 0 );
 		$config_json  = wp_json_encode( $handler_config );
 		$config_hash  = md5( false === $config_json ? '' : $config_json );
+		$claim_bound  = class_exists( ProcessedItems::class ) && ! empty( ProcessedItems::disposition_claims( $engine_data ) );
 
 		return implode(
 			'|',
@@ -477,6 +496,7 @@ class ToolManager {
 				$handler_slug,
 				'job:' . $job_id,
 				'config:' . $config_hash,
+				'claims:' . ( $claim_bound ? 'bound' : 'unbound' ),
 			)
 		);
 	}

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -575,14 +575,14 @@ function datamachine_build_loop_tool_executor( array $tools, array $loop_payload
 
 		/** @inheritDoc */
 		public function executeWP_Agent_Tool_Call( array $tool_call, array $tool_definition, array $context = array() ): array {
-			$tool_name      = (string) ( $tool_call['tool_name'] ?? $tool_call['name'] ?? '' );
-			$parameters     = is_array( $tool_call['parameters'] ?? null ) ? $tool_call['parameters'] : array();
-			$prior_results  = is_array( $context['prior_tool_results'] ?? null ) ? $context['prior_tool_results'] : array();
-			$tool_payload   = datamachine_payload_with_inflight_run_artifacts( $this->loop_payload, $prior_results );
+			$tool_name                          = (string) ( $tool_call['tool_name'] ?? $tool_call['name'] ?? '' );
+			$parameters                         = is_array( $tool_call['parameters'] ?? null ) ? $tool_call['parameters'] : array();
+			$prior_results                      = is_array( $context['prior_tool_results'] ?? null ) ? $context['prior_tool_results'] : array();
+			$tool_payload                       = datamachine_payload_with_inflight_run_artifacts( $this->loop_payload, $prior_results );
 			$tool_payload['prior_tool_results'] = $prior_results;
-			$client_context = is_array( $tool_payload['client_context'] ?? null ) ? $tool_payload['client_context'] : array();
-			$disposition_id = '';
-			$reservation_token = '';
+			$client_context                     = is_array( $tool_payload['client_context'] ?? null ) ? $tool_payload['client_context'] : array();
+			$disposition_id                     = '';
+			$reservation_token                  = '';
 			if ( ! empty( $tool_definition['packet_disposition_bound'] ) ) {
 				$engine_data = is_array( $tool_payload['engine_data'] ?? null ) ? $tool_payload['engine_data'] : array();
 				$provided_id = is_string( $parameters['disposition_id'] ?? null ) ? trim( $parameters['disposition_id'] ) : '';
@@ -597,7 +597,7 @@ function datamachine_build_loop_tool_executor( array $tools, array $loop_payload
 						'code'      => 'invalid_packet_disposition',
 					);
 				}
-				$disposition_id              = $claim['disposition_id'];
+				$disposition_id               = $claim['disposition_id'];
 				$parameters['disposition_id'] = $disposition_id;
 			}
 
@@ -607,8 +607,12 @@ function datamachine_build_loop_tool_executor( array $tools, array $loop_payload
 					if ( empty( $reservation['acquired'] ) ) {
 						return $reservation['result'];
 					}
-					$reservation_token = (string) $reservation['token'];
-					$tool_payload['packet_execution_identity'] = array( 'job_id' => (int) ( $tool_payload['job_id'] ?? 0 ), 'tool_name' => $tool_name, 'disposition_id' => $disposition_id );
+					$reservation_token                         = (string) $reservation['token'];
+					$tool_payload['packet_execution_identity'] = array(
+						'job_id'         => (int) ( $tool_payload['job_id'] ?? 0 ),
+						'tool_name'      => $tool_name,
+						'disposition_id' => $disposition_id,
+					);
 				}
 				try {
 					$result = datamachine_fulfill_runtime_tool_call(
@@ -631,7 +635,14 @@ function datamachine_build_loop_tool_executor( array $tools, array $loop_payload
 					if ( '' !== $reservation_token ) {
 						ToolExecutor::finishPacketExecution( $tool_name, $disposition_id, $tool_payload, $reservation_token, 'ambiguous' );
 					}
-					return array( 'success' => false, 'tool_name' => $tool_name, 'disposition_id' => $disposition_id, 'code' => 'packet_execution_outcome_ambiguous', 'automatic_replay_blocked' => true, 'error' => $exception->getMessage() );
+					return array(
+						'success'                  => false,
+						'tool_name'                => $tool_name,
+						'disposition_id'           => $disposition_id,
+						'code'                     => 'packet_execution_outcome_ambiguous',
+						'automatic_replay_blocked' => true,
+						'error'                    => $exception->getMessage(),
+					);
 				}
 			} else {
 				$result = ToolExecutor::executeTool(
@@ -647,16 +658,16 @@ function datamachine_build_loop_tool_executor( array $tools, array $loop_payload
 			if ( '' !== $disposition_id ) {
 				$result['disposition_id'] = $disposition_id;
 				if ( '' !== $reservation_token ) {
-					$state = ! empty( $result['pending'] ) ? 'pending' : ( ! empty( $result['success'] ) ? 'succeeded' : 'failed' );
+					$state      = ! empty( $result['pending'] ) ? 'pending' : ( ! empty( $result['success'] ) ? 'succeeded' : 'failed' );
 					$request_id = is_array( $result['runtime_tool_request'] ?? null ) ? (string) ( $result['runtime_tool_request']['request_id'] ?? '' ) : '';
 					if ( ! ToolExecutor::finishPacketExecution( $tool_name, $disposition_id, $tool_payload, $reservation_token, $state, $request_id ) ) {
 						return array(
-							'success'                => false,
-							'tool_name'              => $tool_name,
-							'disposition_id'         => $disposition_id,
-							'code'                   => 'packet_execution_outcome_ambiguous',
+							'success'                  => false,
+							'tool_name'                => $tool_name,
+							'disposition_id'           => $disposition_id,
+							'code'                     => 'packet_execution_outcome_ambiguous',
 							'automatic_replay_blocked' => true,
-							'error'                  => 'Runtime handler returned, but its durable execution outcome could not be persisted.',
+							'error'                    => 'Runtime handler returned, but its durable execution outcome could not be persisted.',
 						);
 					}
 				}
@@ -740,14 +751,14 @@ function datamachine_build_pre_tool_mediator( array $tools, array $loop_payload,
 		}
 
 		if ( datamachine_is_external_runtime_tool( $tool_def ) ) {
-			$raw_tool_call = is_array( $context['raw_tool_call'] ?? null ) ? $context['raw_tool_call'] : array();
-			$tool_payload  = datamachine_payload_with_inflight_run_artifacts(
+			$raw_tool_call                      = is_array( $context['raw_tool_call'] ?? null ) ? $context['raw_tool_call'] : array();
+			$tool_payload                       = datamachine_payload_with_inflight_run_artifacts(
 				$loop_payload,
 				is_array( $context['prior_tool_results'] ?? null ) ? $context['prior_tool_results'] : array()
 			);
 			$tool_payload['prior_tool_results'] = is_array( $context['prior_tool_results'] ?? null ) ? $context['prior_tool_results'] : array();
-			$disposition_id = '';
-			$reservation_token = '';
+			$disposition_id                     = '';
+			$reservation_token                  = '';
 			if ( ! empty( $tool_def['packet_disposition_bound'] ) ) {
 				$engine_data = is_array( $tool_payload['engine_data'] ?? null ) ? $tool_payload['engine_data'] : array();
 				$provided_id = is_string( $tool_parameters['disposition_id'] ?? null ) ? trim( $tool_parameters['disposition_id'] ) : '';
@@ -755,17 +766,29 @@ function datamachine_build_pre_tool_mediator( array $tools, array $loop_payload,
 				if ( null === $claim ) {
 					return array(
 						'action' => 'replace_result',
-						'result' => array( 'success' => false, 'tool_name' => $tool_name, 'code' => 'invalid_packet_disposition', 'error' => 'disposition_id does not identify an active packet claim' ),
+						'result' => array(
+							'success'   => false,
+							'tool_name' => $tool_name,
+							'code'      => 'invalid_packet_disposition',
+							'error'     => 'disposition_id does not identify an active packet claim',
+						),
 					);
 				}
-				$disposition_id                       = $claim['disposition_id'];
-				$tool_parameters['disposition_id']    = $disposition_id;
-				$reservation = ToolExecutor::beginPacketExecution( $tool_name, $disposition_id, $tool_payload );
+				$disposition_id                    = $claim['disposition_id'];
+				$tool_parameters['disposition_id'] = $disposition_id;
+				$reservation                       = ToolExecutor::beginPacketExecution( $tool_name, $disposition_id, $tool_payload );
 				if ( empty( $reservation['acquired'] ) ) {
-					return array( 'action' => 'replace_result', 'result' => $reservation['result'] );
+					return array(
+						'action' => 'replace_result',
+						'result' => $reservation['result'],
+					);
 				}
-				$reservation_token = (string) $reservation['token'];
-				$tool_payload['packet_execution_identity'] = array( 'job_id' => (int) ( $tool_payload['job_id'] ?? 0 ), 'tool_name' => $tool_name, 'disposition_id' => $disposition_id );
+				$reservation_token                         = (string) $reservation['token'];
+				$tool_payload['packet_execution_identity'] = array(
+					'job_id'         => (int) ( $tool_payload['job_id'] ?? 0 ),
+					'tool_name'      => $tool_name,
+					'disposition_id' => $disposition_id,
+				);
 			}
 			try {
 				$tool_result = datamachine_fulfill_runtime_tool_call(
@@ -788,22 +811,32 @@ function datamachine_build_pre_tool_mediator( array $tools, array $loop_payload,
 				if ( '' !== $reservation_token ) {
 					ToolExecutor::finishPacketExecution( $tool_name, $disposition_id, $tool_payload, $reservation_token, 'ambiguous' );
 				}
-				return array( 'action' => 'replace_result', 'result' => array( 'success' => false, 'tool_name' => $tool_name, 'disposition_id' => $disposition_id, 'code' => 'packet_execution_outcome_ambiguous', 'automatic_replay_blocked' => true, 'error' => $exception->getMessage() ) );
+				return array(
+					'action' => 'replace_result',
+					'result' => array(
+						'success'                  => false,
+						'tool_name'                => $tool_name,
+						'disposition_id'           => $disposition_id,
+						'code'                     => 'packet_execution_outcome_ambiguous',
+						'automatic_replay_blocked' => true,
+						'error'                    => $exception->getMessage(),
+					),
+				);
 			}
 
 			$tool_result['tool_name'] = is_string( $tool_result['tool_name'] ?? null ) && '' !== $tool_result['tool_name'] ? $tool_result['tool_name'] : $tool_name;
 			if ( '' !== $disposition_id ) {
 				$tool_result['disposition_id'] = $disposition_id;
-				$state = ! empty( $tool_result['pending'] ) ? 'pending' : ( ! empty( $tool_result['success'] ) ? 'succeeded' : 'failed' );
-				$request_id = is_array( $tool_result['runtime_tool_request'] ?? null ) ? (string) ( $tool_result['runtime_tool_request']['request_id'] ?? '' ) : '';
+				$state                         = ! empty( $tool_result['pending'] ) ? 'pending' : ( ! empty( $tool_result['success'] ) ? 'succeeded' : 'failed' );
+				$request_id                    = is_array( $tool_result['runtime_tool_request'] ?? null ) ? (string) ( $tool_result['runtime_tool_request']['request_id'] ?? '' ) : '';
 				if ( ! ToolExecutor::finishPacketExecution( $tool_name, $disposition_id, $tool_payload, $reservation_token, $state, $request_id ) ) {
 					$tool_result = array(
-						'success'                => false,
-						'tool_name'              => $tool_name,
-						'disposition_id'         => $disposition_id,
-						'code'                   => 'packet_execution_outcome_ambiguous',
+						'success'                  => false,
+						'tool_name'                => $tool_name,
+						'disposition_id'           => $disposition_id,
+						'code'                     => 'packet_execution_outcome_ambiguous',
 						'automatic_replay_blocked' => true,
-						'error'                  => 'Runtime handler returned, but its durable execution outcome could not be persisted.',
+						'error'                    => 'Runtime handler returned, but its durable execution outcome could not be persisted.',
 					);
 				}
 			}
@@ -1734,34 +1767,34 @@ function datamachine_runtime_tool_request_store(): WP_Agent_Runtime_Tool_Request
 				}
 
 				$transitioned = false;
-				$mutation = \DataMachine\Core\EngineData::mutate(
+				$mutation     = \DataMachine\Core\EngineData::mutate(
 					$job_id,
 					static function ( array $engine ) use ( $request_id, $status, $result, &$transitioned ): array {
 						$request = is_array( $engine['runtime_tool_request'] ?? null ) ? $engine['runtime_tool_request'] : array();
 						if ( ! hash_equals( $request_id, (string) ( $request['request_id'] ?? '' ) ) || WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== (string) ( $request['status'] ?? '' ) ) {
 							return $engine;
 						}
-						$transitioned = true;
+						$transitioned      = true;
 						$request['status'] = $status;
 						if ( is_array( $result ) ) {
 							$request['result'] = $result;
 						}
-						$metadata                       = datamachine_runtime_tool_datamachine_metadata( $request );
-						$metadata['persistence_status'] = ! empty( $result['success'] ) ? 'fulfilled' : 'failed';
-						$metadata['fulfilled_at']       = gmdate( 'c' );
-						$metadata['result']             = $result;
-						$phases                         = is_array( $metadata['completion_phases'] ?? null ) ? $metadata['completion_phases'] : array();
-						$phases['request_terminal_at']  = (string) ( $phases['request_terminal_at'] ?? gmdate( 'c' ) );
-						$metadata['completion_phases']  = $phases;
+						$metadata                           = datamachine_runtime_tool_datamachine_metadata( $request );
+						$metadata['persistence_status']     = ! empty( $result['success'] ) ? 'fulfilled' : 'failed';
+						$metadata['fulfilled_at']           = gmdate( 'c' );
+						$metadata['result']                 = $result;
+						$phases                             = is_array( $metadata['completion_phases'] ?? null ) ? $metadata['completion_phases'] : array();
+						$phases['request_terminal_at']      = (string) ( $phases['request_terminal_at'] ?? gmdate( 'c' ) );
+						$metadata['completion_phases']      = $phases;
 						$request['metadata']['datamachine'] = $metadata;
-						$engine['runtime_tool_request'] = $request;
-						$run_state = is_array( $engine['runtime_tool_run_state'] ?? null ) ? $engine['runtime_tool_run_state'] : array();
+						$engine['runtime_tool_request']     = $request;
+						$run_state                          = is_array( $engine['runtime_tool_run_state'] ?? null ) ? $engine['runtime_tool_run_state'] : array();
 						if ( ! empty( $run_state ) && empty( $run_state['finalized_at'] ) ) {
-							$finalized_at                  = gmdate( 'c' );
-							$run_state['status']           = WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT === $status ? RuntimeToolRunStateStore::STATUS_TIMED_OUT : RuntimeToolRunStateStore::STATUS_FINALIZED;
-							$run_state['finalize_payload'] = array( 'result' => $result );
-							$run_state['finalized_at']     = $finalized_at;
-							$run_state['updated_at']       = $finalized_at;
+							$finalized_at                     = gmdate( 'c' );
+							$run_state['status']              = WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT === $status ? RuntimeToolRunStateStore::STATUS_TIMED_OUT : RuntimeToolRunStateStore::STATUS_FINALIZED;
+							$run_state['finalize_payload']    = array( 'result' => $result );
+							$run_state['finalized_at']        = $finalized_at;
+							$run_state['updated_at']          = $finalized_at;
 							$engine['runtime_tool_run_state'] = $run_state;
 						}
 						return $engine;
@@ -1933,11 +1966,19 @@ function datamachine_continue_runtime_tool_request( array $request, array $canon
 		if ( ! $finalized ) {
 			do_action( 'datamachine_log', 'error', 'Runtime tool result could not finalize its packet execution reservation.', array( 'request_id' => $request_id ) );
 			datamachine_schedule_runtime_tool_continuation_recovery( $request_id );
-			return array( 'scheduled' => false, 'request_id' => $request_id, 'reservation_finalized' => false );
+			return array(
+				'scheduled'             => false,
+				'request_id'            => $request_id,
+				'reservation_finalized' => false,
+			);
 		}
 		if ( ! datamachine_mark_runtime_tool_completion_phase( $job_id, $request_id, 'reservation_finalized_at' ) ) {
 			datamachine_schedule_runtime_tool_continuation_recovery( $request_id );
-			return array( 'scheduled' => false, 'request_id' => $request_id, 'reservation_phase_persisted' => false );
+			return array(
+				'scheduled'                   => false,
+				'request_id'                  => $request_id,
+				'reservation_phase_persisted' => false,
+			);
 		}
 		$phases['reservation_finalized_at'] = gmdate( 'c' );
 	}
@@ -1948,11 +1989,15 @@ function datamachine_continue_runtime_tool_request( array $request, array $canon
 		$completed     = $jobs_db->complete_job( $job_id, $target_status );
 		if ( ! $completed ) {
 			$job       = method_exists( $jobs_db, 'get_job' ) ? $jobs_db->get_job( $job_id ) : null;
-			$completed = is_array( $job ) && $target_status === (string) ( $job['status'] ?? '' );
+			$completed = is_array( $job ) && (string) ( $job['status'] ?? '' ) === $target_status;
 		}
 		if ( ! $completed || ! datamachine_mark_runtime_tool_completion_phase( $job_id, $request_id, 'job_terminalized_at' ) ) {
 			datamachine_schedule_runtime_tool_continuation_recovery( $request_id );
-			return array( 'scheduled' => false, 'request_id' => $request_id, 'job_terminalized' => false );
+			return array(
+				'scheduled'        => false,
+				'request_id'       => $request_id,
+				'job_terminalized' => false,
+			);
 		}
 		$phases['job_terminalized_at'] = gmdate( 'c' );
 	}
@@ -1962,11 +2007,15 @@ function datamachine_continue_runtime_tool_request( array $request, array $canon
 		return array( 'scheduled' => false );
 	}
 
-	$chat_db = \DataMachine\Core\Database\Chat\ConversationStoreFactory::get();
+	$chat_db      = \DataMachine\Core\Database\Chat\ConversationStoreFactory::get();
 	$session_lock = method_exists( $chat_db, 'acquire_session_lock' ) ? $chat_db->acquire_session_lock( $session_id, 60 ) : '';
 	if ( method_exists( $chat_db, 'acquire_session_lock' ) && ! is_string( $session_lock ) ) {
 		datamachine_schedule_runtime_tool_continuation_recovery( $request_id );
-		return array( 'scheduled' => false, 'request_id' => $request_id, 'session_locked' => true );
+		return array(
+			'scheduled'      => false,
+			'request_id'     => $request_id,
+			'session_locked' => true,
+		);
 	}
 	$session = $chat_db->get_session( $session_id );
 	if ( ! is_array( $session ) ) {
@@ -1977,11 +2026,11 @@ function datamachine_continue_runtime_tool_request( array $request, array $canon
 		return array( 'scheduled' => false );
 	}
 
-	$metadata = is_array( $session['metadata'] ?? null ) ? $session['metadata'] : array();
-	$messages = is_array( $session['messages'] ?? null ) ? $session['messages'] : array();
-	$session_request = is_array( $metadata['runtime_tool_requests'][ $request_id ] ?? null ) ? $metadata['runtime_tool_requests'][ $request_id ] : array();
+	$metadata                 = is_array( $session['metadata'] ?? null ) ? $session['metadata'] : array();
+	$messages                 = is_array( $session['messages'] ?? null ) ? $session['messages'] : array();
+	$session_request          = is_array( $metadata['runtime_tool_requests'][ $request_id ] ?? null ) ? $metadata['runtime_tool_requests'][ $request_id ] : array();
 	$session_request_metadata = datamachine_runtime_tool_datamachine_metadata( $session_request );
-	$already_projected = ! empty( $phases['session_projected_at'] ) || ! empty( $session_request_metadata['continuation_projected_at'] );
+	$already_projected        = ! empty( $phases['session_projected_at'] ) || ! empty( $session_request_metadata['continuation_projected_at'] );
 	if ( ! $already_projected ) {
 		$messages[] = ConversationManager::formatToolResultMessage(
 			(string) ( $request['tool_name'] ?? '' ),
@@ -1993,11 +2042,11 @@ function datamachine_continue_runtime_tool_request( array $request, array $canon
 	}
 
 	if ( is_array( $metadata['runtime_tool_requests'] ?? null ) && isset( $metadata['runtime_tool_requests'][ $request_id ] ) ) {
-		$session_request                        = $metadata['runtime_tool_requests'][ $request_id ];
-		$request_metadata                       = datamachine_runtime_tool_datamachine_metadata( $session_request );
-		$request_metadata['persistence_status'] = ! empty( $tool_result['success'] ) ? 'fulfilled' : 'failed';
-		$request_metadata['fulfilled_at']       = gmdate( 'c' );
-		$request_metadata['result']             = $canonical_result;
+		$session_request                               = $metadata['runtime_tool_requests'][ $request_id ];
+		$request_metadata                              = datamachine_runtime_tool_datamachine_metadata( $session_request );
+		$request_metadata['persistence_status']        = ! empty( $tool_result['success'] ) ? 'fulfilled' : 'failed';
+		$request_metadata['fulfilled_at']              = gmdate( 'c' );
+		$request_metadata['result']                    = $canonical_result;
 		$request_metadata['continuation_projected_at'] = (string) ( $request_metadata['continuation_projected_at'] ?? gmdate( 'c' ) );
 
 		$session_request['metadata']['datamachine']       = $request_metadata;
@@ -2025,13 +2074,21 @@ function datamachine_continue_runtime_tool_request( array $request, array $canon
 	}
 	if ( ! $session_updated ) {
 		datamachine_schedule_runtime_tool_continuation_recovery( $request_id );
-		return array( 'scheduled' => false, 'request_id' => $request_id, 'session_projected' => false );
+		return array(
+			'scheduled'         => false,
+			'request_id'        => $request_id,
+			'session_projected' => false,
+		);
 	}
 	if ( empty( $phases['session_projected_at'] ) && ! datamachine_mark_runtime_tool_completion_phase( $job_id, $request_id, 'session_projected_at' ) ) {
 		datamachine_schedule_runtime_tool_continuation_recovery( $request_id );
-		return array( 'scheduled' => false, 'request_id' => $request_id, 'session_phase_persisted' => false );
+		return array(
+			'scheduled'               => false,
+			'request_id'              => $request_id,
+			'session_phase_persisted' => false,
+		);
 	}
-	$session_projected_now = empty( $phases['session_projected_at'] );
+	$session_projected_now          = empty( $phases['session_projected_at'] );
 	$phases['session_projected_at'] = (string) ( $phases['session_projected_at'] ?? gmdate( 'c' ) );
 
 	$scheduled = ! empty( $phases['resume_scheduled_at'] );
@@ -2039,7 +2096,7 @@ function datamachine_continue_runtime_tool_request( array $request, array $canon
 		$existing_action = function_exists( 'as_has_scheduled_action' )
 			? (int) as_has_scheduled_action( 'datamachine_runtime_tool_resume', array( $request_id ), 'datamachine-runtime-tools' )
 			: 0;
-		$scheduled = $existing_action > 0 || (bool) as_enqueue_async_action( 'datamachine_runtime_tool_resume', array( $request_id ), 'datamachine-runtime-tools' );
+		$scheduled       = $existing_action > 0 || (bool) as_enqueue_async_action( 'datamachine_runtime_tool_resume', array( $request_id ), 'datamachine-runtime-tools' );
 	}
 	if ( $scheduled && empty( $phases['resume_scheduled_at'] ) ) {
 		$scheduled = datamachine_mark_runtime_tool_completion_phase( $job_id, $request_id, 'resume_scheduled_at' );
@@ -2074,10 +2131,10 @@ function datamachine_mark_runtime_tool_completion_phase( int $job_id, string $re
 			$metadata = datamachine_runtime_tool_datamachine_metadata( $request );
 			$phases   = is_array( $metadata['completion_phases'] ?? null ) ? $metadata['completion_phases'] : array();
 			if ( empty( $phases[ $phase ] ) ) {
-				$phases[ $phase ] = gmdate( 'c' );
-				$metadata['completion_phases'] = $phases;
+				$phases[ $phase ]                   = gmdate( 'c' );
+				$metadata['completion_phases']      = $phases;
 				$request['metadata']['datamachine'] = $metadata;
-				$engine['runtime_tool_request'] = $request;
+				$engine['runtime_tool_request']     = $request;
 			}
 			$marked = true;
 			return $engine;
@@ -2092,8 +2149,8 @@ function datamachine_schedule_runtime_tool_continuation_recovery( string $reques
 	if ( '' === $request_id || ! function_exists( 'as_schedule_single_action' ) ) {
 		return false;
 	}
-	$request = datamachine_runtime_tool_request_store()->get( $request_id );
-	$metadata = is_array( $request ) ? datamachine_runtime_tool_datamachine_metadata( $request ) : array();
+	$request    = datamachine_runtime_tool_request_store()->get( $request_id );
+	$metadata   = is_array( $request ) ? datamachine_runtime_tool_datamachine_metadata( $request ) : array();
 	$expires_at = strtotime( (string) ( $metadata['expires_at'] ?? '' ) );
 	if ( false !== $expires_at && time() > $expires_at + 86400 ) {
 		return false;

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -579,25 +579,60 @@ function datamachine_build_loop_tool_executor( array $tools, array $loop_payload
 			$parameters     = is_array( $tool_call['parameters'] ?? null ) ? $tool_call['parameters'] : array();
 			$prior_results  = is_array( $context['prior_tool_results'] ?? null ) ? $context['prior_tool_results'] : array();
 			$tool_payload   = datamachine_payload_with_inflight_run_artifacts( $this->loop_payload, $prior_results );
+			$tool_payload['prior_tool_results'] = $prior_results;
 			$client_context = is_array( $tool_payload['client_context'] ?? null ) ? $tool_payload['client_context'] : array();
+			$disposition_id = '';
+			$reservation_token = '';
+			if ( ! empty( $tool_definition['packet_disposition_bound'] ) ) {
+				$engine_data = is_array( $tool_payload['engine_data'] ?? null ) ? $tool_payload['engine_data'] : array();
+				$provided_id = is_string( $parameters['disposition_id'] ?? null ) ? trim( $parameters['disposition_id'] ) : '';
+				$claim       = \DataMachine\Core\Database\ProcessedItems\ProcessedItems::resolve_disposition_claim( $engine_data, $provided_id, true );
+				if ( null === $claim ) {
+					return array(
+						'success'   => false,
+						'error'     => '' === $provided_id
+							? 'disposition_id is required when more than one packet claim is active'
+							: 'disposition_id does not identify an active packet claim',
+						'tool_name' => $tool_name,
+						'code'      => 'invalid_packet_disposition',
+					);
+				}
+				$disposition_id              = $claim['disposition_id'];
+				$parameters['disposition_id'] = $disposition_id;
+			}
 
 			if ( datamachine_is_external_runtime_tool( $tool_definition ) ) {
-				$result = datamachine_fulfill_runtime_tool_call(
-					array_merge(
-						$tool_call,
-						array(
-							'name'       => $tool_name,
-							'parameters' => $parameters,
-						)
-					),
-					$tool_definition,
-					$tool_payload,
-					$this->mode,
-					$this->modes,
-					(int) ( $context['turn'] ?? 0 ),
-					$this->event_sink,
-					$this->base_log_context
-				);
+				if ( '' !== $disposition_id ) {
+					$reservation = ToolExecutor::beginPacketExecution( $tool_name, $disposition_id, $tool_payload );
+					if ( empty( $reservation['acquired'] ) ) {
+						return $reservation['result'];
+					}
+					$reservation_token = (string) $reservation['token'];
+					$tool_payload['packet_execution_identity'] = array( 'job_id' => (int) ( $tool_payload['job_id'] ?? 0 ), 'tool_name' => $tool_name, 'disposition_id' => $disposition_id );
+				}
+				try {
+					$result = datamachine_fulfill_runtime_tool_call(
+						array_merge(
+							$tool_call,
+							array(
+								'name'       => $tool_name,
+								'parameters' => $parameters,
+							)
+						),
+						$tool_definition,
+						$tool_payload,
+						$this->mode,
+						$this->modes,
+						(int) ( $context['turn'] ?? 0 ),
+						$this->event_sink,
+						$this->base_log_context
+					);
+				} catch ( \Throwable $exception ) {
+					if ( '' !== $reservation_token ) {
+						ToolExecutor::finishPacketExecution( $tool_name, $disposition_id, $tool_payload, $reservation_token, 'ambiguous' );
+					}
+					return array( 'success' => false, 'tool_name' => $tool_name, 'disposition_id' => $disposition_id, 'code' => 'packet_execution_outcome_ambiguous', 'automatic_replay_blocked' => true, 'error' => $exception->getMessage() );
+				}
 			} else {
 				$result = ToolExecutor::executeTool(
 					$tool_name,
@@ -608,6 +643,23 @@ function datamachine_build_loop_tool_executor( array $tools, array $loop_payload
 					(int) ( $tool_payload['agent_id'] ?? 0 ),
 					$client_context
 				);
+			}
+			if ( '' !== $disposition_id ) {
+				$result['disposition_id'] = $disposition_id;
+				if ( '' !== $reservation_token ) {
+					$state = ! empty( $result['pending'] ) ? 'pending' : ( ! empty( $result['success'] ) ? 'succeeded' : 'failed' );
+					$request_id = is_array( $result['runtime_tool_request'] ?? null ) ? (string) ( $result['runtime_tool_request']['request_id'] ?? '' ) : '';
+					if ( ! ToolExecutor::finishPacketExecution( $tool_name, $disposition_id, $tool_payload, $reservation_token, $state, $request_id ) ) {
+						return array(
+							'success'                => false,
+							'tool_name'              => $tool_name,
+							'disposition_id'         => $disposition_id,
+							'code'                   => 'packet_execution_outcome_ambiguous',
+							'automatic_replay_blocked' => true,
+							'error'                  => 'Runtime handler returned, but its durable execution outcome could not be persisted.',
+						);
+					}
+				}
 			}
 
 			$metadata                              = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
@@ -693,24 +745,68 @@ function datamachine_build_pre_tool_mediator( array $tools, array $loop_payload,
 				$loop_payload,
 				is_array( $context['prior_tool_results'] ?? null ) ? $context['prior_tool_results'] : array()
 			);
-			$tool_result   = datamachine_fulfill_runtime_tool_call(
-				array_merge(
-					$raw_tool_call,
-					array(
-						'name'       => $tool_name,
-						'parameters' => $tool_parameters,
-					)
-				),
-				$tool_def ?? array(),
-				$tool_payload,
-				$mode,
-				$modes,
-				$turn_count,
-				$event_sink,
-				$base_log_context
-			);
+			$tool_payload['prior_tool_results'] = is_array( $context['prior_tool_results'] ?? null ) ? $context['prior_tool_results'] : array();
+			$disposition_id = '';
+			$reservation_token = '';
+			if ( ! empty( $tool_def['packet_disposition_bound'] ) ) {
+				$engine_data = is_array( $tool_payload['engine_data'] ?? null ) ? $tool_payload['engine_data'] : array();
+				$provided_id = is_string( $tool_parameters['disposition_id'] ?? null ) ? trim( $tool_parameters['disposition_id'] ) : '';
+				$claim       = \DataMachine\Core\Database\ProcessedItems\ProcessedItems::resolve_disposition_claim( $engine_data, $provided_id, true );
+				if ( null === $claim ) {
+					return array(
+						'action' => 'replace_result',
+						'result' => array( 'success' => false, 'tool_name' => $tool_name, 'code' => 'invalid_packet_disposition', 'error' => 'disposition_id does not identify an active packet claim' ),
+					);
+				}
+				$disposition_id                       = $claim['disposition_id'];
+				$tool_parameters['disposition_id']    = $disposition_id;
+				$reservation = ToolExecutor::beginPacketExecution( $tool_name, $disposition_id, $tool_payload );
+				if ( empty( $reservation['acquired'] ) ) {
+					return array( 'action' => 'replace_result', 'result' => $reservation['result'] );
+				}
+				$reservation_token = (string) $reservation['token'];
+				$tool_payload['packet_execution_identity'] = array( 'job_id' => (int) ( $tool_payload['job_id'] ?? 0 ), 'tool_name' => $tool_name, 'disposition_id' => $disposition_id );
+			}
+			try {
+				$tool_result = datamachine_fulfill_runtime_tool_call(
+					array_merge(
+						$raw_tool_call,
+						array(
+							'name'       => $tool_name,
+							'parameters' => $tool_parameters,
+						)
+					),
+					$tool_def ?? array(),
+					$tool_payload,
+					$mode,
+					$modes,
+					$turn_count,
+					$event_sink,
+					$base_log_context
+				);
+			} catch ( \Throwable $exception ) {
+				if ( '' !== $reservation_token ) {
+					ToolExecutor::finishPacketExecution( $tool_name, $disposition_id, $tool_payload, $reservation_token, 'ambiguous' );
+				}
+				return array( 'action' => 'replace_result', 'result' => array( 'success' => false, 'tool_name' => $tool_name, 'disposition_id' => $disposition_id, 'code' => 'packet_execution_outcome_ambiguous', 'automatic_replay_blocked' => true, 'error' => $exception->getMessage() ) );
+			}
 
 			$tool_result['tool_name'] = is_string( $tool_result['tool_name'] ?? null ) && '' !== $tool_result['tool_name'] ? $tool_result['tool_name'] : $tool_name;
+			if ( '' !== $disposition_id ) {
+				$tool_result['disposition_id'] = $disposition_id;
+				$state = ! empty( $tool_result['pending'] ) ? 'pending' : ( ! empty( $tool_result['success'] ) ? 'succeeded' : 'failed' );
+				$request_id = is_array( $tool_result['runtime_tool_request'] ?? null ) ? (string) ( $tool_result['runtime_tool_request']['request_id'] ?? '' ) : '';
+				if ( ! ToolExecutor::finishPacketExecution( $tool_name, $disposition_id, $tool_payload, $reservation_token, $state, $request_id ) ) {
+					$tool_result = array(
+						'success'                => false,
+						'tool_name'              => $tool_name,
+						'disposition_id'         => $disposition_id,
+						'code'                   => 'packet_execution_outcome_ambiguous',
+						'automatic_replay_blocked' => true,
+						'error'                  => 'Runtime handler returned, but its durable execution outcome could not be persisted.',
+					);
+				}
+			}
 			if ( ! array_key_exists( 'result', $tool_result ) ) {
 				$runtime_result_payload = $tool_result;
 				unset( $runtime_result_payload['success'], $runtime_result_payload['tool_name'], $runtime_result_payload['metadata'], $runtime_result_payload['runtime'] );
@@ -1496,6 +1592,14 @@ function datamachine_prepare_runtime_tool_request( array $request, array $payloa
 					'created_at'         => $created_at,
 					'expires_at'         => $expires_at,
 					'timeout_seconds'    => $timeout_seconds,
+					'packet_execution'   => is_array( $payload['packet_execution_identity'] ?? null )
+						? array(
+							'job_id'         => max( 0, (int) ( $payload['packet_execution_identity']['job_id'] ?? 0 ) ),
+							'tool_name'      => (string) ( $payload['packet_execution_identity']['tool_name'] ?? '' ),
+							'disposition_id' => (string) ( $payload['packet_execution_identity']['disposition_id'] ?? '' ),
+							'request_id'     => $request_id,
+						)
+						: array(),
 				),
 			),
 		)
@@ -1552,7 +1656,7 @@ function datamachine_runtime_tool_request_store(): WP_Agent_Runtime_Tool_Request
 	static $store = null;
 
 	if ( ! $store instanceof WP_Agent_Runtime_Tool_Request_Store ) {
-		$store = new class() implements WP_Agent_Runtime_Tool_Request_Store {
+		$store = new class() implements \AgentsAPI\AI\WP_Agent_Runtime_Tool_Request_Atomic_Store {
 			public function create( array $request ): void {
 				$job_id = datamachine_runtime_tool_job_id_from_request( $request );
 				if ( $job_id <= 0 ) {
@@ -1560,15 +1664,25 @@ function datamachine_runtime_tool_request_store(): WP_Agent_Runtime_Tool_Request
 				}
 
 				$jobs_db = new \DataMachine\Core\Database\Jobs\Jobs();
-				$jobs_db->start_job( (int) $job_id, \DataMachine\Core\JobStatus::WAITING );
-				$jobs_db->store_engine_data(
+				if ( ! $jobs_db->start_job( (int) $job_id, \DataMachine\Core\JobStatus::WAITING ) ) {
+					return;
+				}
+				$run_state = RuntimeToolRunStateStore::initial_state_from_request( $request );
+				$mutation  = \DataMachine\Core\EngineData::mutate(
 					$job_id,
-					array(
-						'task_type'              => 'runtime_tool_request',
-						'runtime_tool_request'   => $request,
-						'runtime_tool_run_state' => ( new RuntimeToolRunStateStore( $jobs_db ) )->create_from_request( $request ),
-					)
+					static function ( array $engine ) use ( $request, $run_state ): array {
+						$engine['task_type']            = 'runtime_tool_request';
+						$engine['runtime_tool_request'] = $request;
+						if ( ! is_array( $engine['runtime_tool_run_state'] ?? null ) && is_array( $run_state ) ) {
+							$engine['runtime_tool_run_state'] = $run_state;
+						}
+						return $engine;
+					},
+					'runtime_tool_request_create'
 				);
+				if ( empty( $mutation['success'] ) ) {
+					return;
+				}
 				datamachine_store_runtime_tool_request_on_session( $request );
 				datamachine_schedule_runtime_tool_timeout( $request );
 				do_action( 'datamachine_runtime_tool_request_deferred', $request, array() );
@@ -1581,45 +1695,84 @@ function datamachine_runtime_tool_request_store(): WP_Agent_Runtime_Tool_Request
 				}
 
 				$engine_data = ( new \DataMachine\Core\Database\Jobs\Jobs() )->retrieve_engine_data( $job_id );
-				$request     = is_array( $engine_data['runtime_tool_request'] ?? null )
-					? datamachine_normalize_stored_runtime_tool_request( $engine_data['runtime_tool_request'] )
-					: null;
+				$stored      = is_array( $engine_data['runtime_tool_request'] ?? null ) ? $engine_data['runtime_tool_request'] : array();
+				$request     = ! empty( $stored ) ? datamachine_normalize_stored_runtime_tool_request( $stored ) : null;
 				if ( empty( $request ) ) {
 					return null;
+				}
+				foreach ( array( 'status', 'result' ) as $terminal_key ) {
+					if ( array_key_exists( $terminal_key, $stored ) ) {
+						$request[ $terminal_key ] = $stored[ $terminal_key ];
+					}
 				}
 
 				return $request;
 			}
 
 			public function complete( string $request_id, array $result ): void {
+				$this->transition_pending( $request_id, WP_Agent_Runtime_Tool_Request::STATUS_COMPLETED, $result );
+			}
+
+			public function transition_pending( string $request_id, string $status, ?array $result = null ): bool {
 				$job_id = datamachine_runtime_tool_job_id_from_request_id( $request_id );
 				if ( $job_id <= 0 ) {
-					return;
+					return false;
+				}
+				if ( null === $result && WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT === $status ) {
+					$current = ( new \DataMachine\Core\Database\Jobs\Jobs() )->retrieve_engine_data( $job_id );
+					$request = is_array( $current['runtime_tool_request'] ?? null ) ? $current['runtime_tool_request'] : array();
+					if ( ! empty( $request ) ) {
+						$result = WP_Agent_Runtime_Tool_Result::from_request(
+							$request,
+							array(
+								'success'  => false,
+								'error'    => 'Runtime tool request timed out.',
+								'metadata' => array( 'datamachine' => array( 'code' => WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT ) ),
+							)
+						);
+					}
 				}
 
-				$jobs_db     = new \DataMachine\Core\Database\Jobs\Jobs();
-				$engine_data = $jobs_db->retrieve_engine_data( $job_id );
-				$request     = is_array( $engine_data['runtime_tool_request'] ?? null ) ? $engine_data['runtime_tool_request'] : array();
-				if ( empty( $request ) ) {
-					return;
-				}
-
-				$datamachine_metadata                       = datamachine_runtime_tool_datamachine_metadata( $request );
-				$datamachine_metadata['persistence_status'] = ! empty( $result['success'] ) ? 'fulfilled' : 'failed';
-				$datamachine_metadata['fulfilled_at']       = gmdate( 'c' );
-				$datamachine_metadata['result']             = $result;
-				$request['metadata']['datamachine']         = $datamachine_metadata;
-				$engine_data['runtime_tool_request']        = $request;
-				$engine_data['runtime_tool_run_state']      = ( new RuntimeToolRunStateStore( $jobs_db ) )->finalize(
+				$transitioned = false;
+				$mutation = \DataMachine\Core\EngineData::mutate(
 					$job_id,
-					array( 'result' => $result ),
-					! empty( $result['metadata']['datamachine']['code'] ) && WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT === (string) $result['metadata']['datamachine']['code']
-						? RuntimeToolRunStateStore::STATUS_TIMED_OUT
-						: RuntimeToolRunStateStore::STATUS_FINALIZED
+					static function ( array $engine ) use ( $request_id, $status, $result, &$transitioned ): array {
+						$request = is_array( $engine['runtime_tool_request'] ?? null ) ? $engine['runtime_tool_request'] : array();
+						if ( ! hash_equals( $request_id, (string) ( $request['request_id'] ?? '' ) ) || WP_Agent_Runtime_Tool_Request::STATUS_PENDING !== (string) ( $request['status'] ?? '' ) ) {
+							return $engine;
+						}
+						$transitioned = true;
+						$request['status'] = $status;
+						if ( is_array( $result ) ) {
+							$request['result'] = $result;
+						}
+						$metadata                       = datamachine_runtime_tool_datamachine_metadata( $request );
+						$metadata['persistence_status'] = ! empty( $result['success'] ) ? 'fulfilled' : 'failed';
+						$metadata['fulfilled_at']       = gmdate( 'c' );
+						$metadata['result']             = $result;
+						$phases                         = is_array( $metadata['completion_phases'] ?? null ) ? $metadata['completion_phases'] : array();
+						$phases['request_terminal_at']  = (string) ( $phases['request_terminal_at'] ?? gmdate( 'c' ) );
+						$metadata['completion_phases']  = $phases;
+						$request['metadata']['datamachine'] = $metadata;
+						$engine['runtime_tool_request'] = $request;
+						$run_state = is_array( $engine['runtime_tool_run_state'] ?? null ) ? $engine['runtime_tool_run_state'] : array();
+						if ( ! empty( $run_state ) && empty( $run_state['finalized_at'] ) ) {
+							$finalized_at                  = gmdate( 'c' );
+							$run_state['status']           = WP_Agent_Runtime_Tool_Request::STATUS_TIMEOUT === $status ? RuntimeToolRunStateStore::STATUS_TIMED_OUT : RuntimeToolRunStateStore::STATUS_FINALIZED;
+							$run_state['finalize_payload'] = array( 'result' => $result );
+							$run_state['finalized_at']     = $finalized_at;
+							$run_state['updated_at']       = $finalized_at;
+							$engine['runtime_tool_run_state'] = $run_state;
+						}
+						return $engine;
+					},
+					'runtime_tool_terminal_transition'
 				);
+				if ( ! $transitioned || empty( $mutation['success'] ) ) {
+					return false;
+				}
 
-				$jobs_db->store_engine_data( $job_id, $engine_data );
-				$jobs_db->complete_job( $job_id, ! empty( $result['success'] ) ? 'completed' : 'failed' );
+				return true;
 			}
 
 			public function timeout( string $request_id ): void {
@@ -1628,8 +1781,9 @@ function datamachine_runtime_tool_request_store(): WP_Agent_Runtime_Tool_Request
 					return;
 				}
 
-				$this->complete(
+				$this->transition_pending(
 					$request_id,
+					WP_Agent_Runtime_Tool_Request::STATUS_TIMED_OUT,
 					WP_Agent_Runtime_Tool_Result::normalize(
 						array(
 							'request_id' => $request_id,
@@ -1723,11 +1877,6 @@ function datamachine_submit_runtime_tool_result( string $request_id, $result ): 
 		return new \WP_Error( 'runtime_tool_request_invalid', 'Runtime tool request id is invalid.' );
 	}
 
-	$datamachine_metadata = datamachine_runtime_tool_datamachine_metadata( $request );
-	if ( 'pending' !== (string) ( $datamachine_metadata['persistence_status'] ?? '' ) ) {
-		return new \WP_Error( 'runtime_tool_request_not_pending', 'Runtime tool request is not pending.' );
-	}
-
 	try {
 		$envelope = WP_Agent_Runtime_Tool_Lifecycle::submit_result(
 			$store,
@@ -1740,6 +1889,9 @@ function datamachine_submit_runtime_tool_result( string $request_id, $result ): 
 	}
 
 	$continuation_result = is_array( $envelope['continuation_result'] ?? null ) ? $envelope['continuation_result'] : array();
+	if ( ! empty( $envelope['duplicate'] ) && is_array( $envelope['request'] ?? null ) && is_array( $envelope['result'] ?? null ) ) {
+		$continuation_result = datamachine_continue_runtime_tool_request( $envelope['request'], $envelope['result'], array( 'source' => 'duplicate_recovery' ) );
+	}
 
 	return array(
 		'success'    => true,
@@ -1760,36 +1912,93 @@ function datamachine_submit_runtime_tool_result( string $request_id, $result ): 
 function datamachine_continue_runtime_tool_request( array $request, array $canonical_result, array $context = array() ): array {
 	unset( $context );
 
-	$request_id           = (string) ( $request['request_id'] ?? '' );
+	$request_id = (string) ( $request['request_id'] ?? '' );
+	$job_id     = datamachine_runtime_tool_job_id_from_request_id( $request_id );
+	$stored     = datamachine_runtime_tool_request_store()->get( $request_id );
+	if ( is_array( $stored ) ) {
+		$request = $stored;
+	}
 	$datamachine_metadata = datamachine_runtime_tool_datamachine_metadata( $request );
+	$phases               = is_array( $datamachine_metadata['completion_phases'] ?? null ) ? $datamachine_metadata['completion_phases'] : array();
 	$tool_result          = datamachine_runtime_tool_result_for_transcript( $canonical_result );
-	$session_id           = (string) ( $datamachine_metadata['session_id'] ?? '' );
+	$packet_execution     = is_array( $datamachine_metadata['packet_execution'] ?? null ) ? $datamachine_metadata['packet_execution'] : array();
+	if ( ! empty( $packet_execution ) && empty( $phases['reservation_finalized_at'] ) ) {
+		$finalized = ToolExecutor::finishPendingPacketExecutionForRequest(
+			(string) ( $packet_execution['tool_name'] ?? '' ),
+			(string) ( $packet_execution['disposition_id'] ?? '' ),
+			(int) ( $packet_execution['job_id'] ?? 0 ),
+			! empty( $tool_result['success'] ) ? 'succeeded' : 'failed',
+			$request_id
+		);
+		if ( ! $finalized ) {
+			do_action( 'datamachine_log', 'error', 'Runtime tool result could not finalize its packet execution reservation.', array( 'request_id' => $request_id ) );
+			datamachine_schedule_runtime_tool_continuation_recovery( $request_id );
+			return array( 'scheduled' => false, 'request_id' => $request_id, 'reservation_finalized' => false );
+		}
+		if ( ! datamachine_mark_runtime_tool_completion_phase( $job_id, $request_id, 'reservation_finalized_at' ) ) {
+			datamachine_schedule_runtime_tool_continuation_recovery( $request_id );
+			return array( 'scheduled' => false, 'request_id' => $request_id, 'reservation_phase_persisted' => false );
+		}
+		$phases['reservation_finalized_at'] = gmdate( 'c' );
+	}
+
+	if ( empty( $phases['job_terminalized_at'] ) ) {
+		$target_status = ! empty( $tool_result['success'] ) ? 'completed' : 'failed';
+		$jobs_db       = new \DataMachine\Core\Database\Jobs\Jobs();
+		$completed     = $jobs_db->complete_job( $job_id, $target_status );
+		if ( ! $completed ) {
+			$job       = method_exists( $jobs_db, 'get_job' ) ? $jobs_db->get_job( $job_id ) : null;
+			$completed = is_array( $job ) && $target_status === (string) ( $job['status'] ?? '' );
+		}
+		if ( ! $completed || ! datamachine_mark_runtime_tool_completion_phase( $job_id, $request_id, 'job_terminalized_at' ) ) {
+			datamachine_schedule_runtime_tool_continuation_recovery( $request_id );
+			return array( 'scheduled' => false, 'request_id' => $request_id, 'job_terminalized' => false );
+		}
+		$phases['job_terminalized_at'] = gmdate( 'c' );
+	}
+
+	$session_id = (string) ( $datamachine_metadata['session_id'] ?? '' );
 	if ( '' === $session_id || ! class_exists( \DataMachine\Core\Database\Chat\ConversationStoreFactory::class ) ) {
 		return array( 'scheduled' => false );
 	}
 
 	$chat_db = \DataMachine\Core\Database\Chat\ConversationStoreFactory::get();
+	$session_lock = method_exists( $chat_db, 'acquire_session_lock' ) ? $chat_db->acquire_session_lock( $session_id, 60 ) : '';
+	if ( method_exists( $chat_db, 'acquire_session_lock' ) && ! is_string( $session_lock ) ) {
+		datamachine_schedule_runtime_tool_continuation_recovery( $request_id );
+		return array( 'scheduled' => false, 'request_id' => $request_id, 'session_locked' => true );
+	}
 	$session = $chat_db->get_session( $session_id );
 	if ( ! is_array( $session ) ) {
+		if ( '' !== $session_lock && method_exists( $chat_db, 'release_session_lock' ) ) {
+			$chat_db->release_session_lock( $session_id, $session_lock );
+		}
+		datamachine_schedule_runtime_tool_continuation_recovery( $request_id );
 		return array( 'scheduled' => false );
 	}
 
-	$messages   = is_array( $session['messages'] ?? null ) ? $session['messages'] : array();
-	$messages[] = ConversationManager::formatToolResultMessage(
-		(string) ( $request['tool_name'] ?? '' ),
-		$tool_result,
-		is_array( $request['parameters'] ?? null ) ? $request['parameters'] : array(),
-		false,
-		(int) ( $datamachine_metadata['turn_count'] ?? 0 )
-	);
-
 	$metadata = is_array( $session['metadata'] ?? null ) ? $session['metadata'] : array();
+	$messages = is_array( $session['messages'] ?? null ) ? $session['messages'] : array();
+	$session_request = is_array( $metadata['runtime_tool_requests'][ $request_id ] ?? null ) ? $metadata['runtime_tool_requests'][ $request_id ] : array();
+	$session_request_metadata = datamachine_runtime_tool_datamachine_metadata( $session_request );
+	$already_projected = ! empty( $phases['session_projected_at'] ) || ! empty( $session_request_metadata['continuation_projected_at'] );
+	if ( ! $already_projected ) {
+		$messages[] = ConversationManager::formatToolResultMessage(
+			(string) ( $request['tool_name'] ?? '' ),
+			$tool_result,
+			is_array( $request['parameters'] ?? null ) ? $request['parameters'] : array(),
+			false,
+			(int) ( $datamachine_metadata['turn_count'] ?? 0 )
+		);
+	}
+
 	if ( is_array( $metadata['runtime_tool_requests'] ?? null ) && isset( $metadata['runtime_tool_requests'][ $request_id ] ) ) {
 		$session_request                        = $metadata['runtime_tool_requests'][ $request_id ];
 		$request_metadata                       = datamachine_runtime_tool_datamachine_metadata( $session_request );
 		$request_metadata['persistence_status'] = ! empty( $tool_result['success'] ) ? 'fulfilled' : 'failed';
 		$request_metadata['fulfilled_at']       = gmdate( 'c' );
 		$request_metadata['result']             = $canonical_result;
+		$request_metadata['continuation_projected_at'] = (string) ( $request_metadata['continuation_projected_at'] ?? gmdate( 'c' ) );
 
 		$session_request['metadata']['datamachine']       = $request_metadata;
 		$metadata['runtime_tool_requests'][ $request_id ] = $session_request;
@@ -1804,24 +2013,98 @@ function datamachine_continue_runtime_tool_request( array $request, array $canon
 	$metadata['status']                   = $metadata['has_pending_tools'] ? 'processing' : 'processing';
 	$metadata['last_activity']            = function_exists( 'current_time' ) ? current_time( 'mysql', true ) : gmdate( 'Y-m-d H:i:s' );
 
-	$chat_db->update_session(
+	$session_updated = $chat_db->update_session(
 		$session_id,
 		$messages,
 		$metadata,
 		(string) ( $session['provider'] ?? '' ),
 		(string) ( $session['model'] ?? '' )
 	);
+	if ( '' !== $session_lock && method_exists( $chat_db, 'release_session_lock' ) ) {
+		$chat_db->release_session_lock( $session_id, $session_lock );
+	}
+	if ( ! $session_updated ) {
+		datamachine_schedule_runtime_tool_continuation_recovery( $request_id );
+		return array( 'scheduled' => false, 'request_id' => $request_id, 'session_projected' => false );
+	}
+	if ( empty( $phases['session_projected_at'] ) && ! datamachine_mark_runtime_tool_completion_phase( $job_id, $request_id, 'session_projected_at' ) ) {
+		datamachine_schedule_runtime_tool_continuation_recovery( $request_id );
+		return array( 'scheduled' => false, 'request_id' => $request_id, 'session_phase_persisted' => false );
+	}
+	$session_projected_now = empty( $phases['session_projected_at'] );
+	$phases['session_projected_at'] = (string) ( $phases['session_projected_at'] ?? gmdate( 'c' ) );
 
-	if ( function_exists( 'as_enqueue_async_action' ) ) {
-		as_enqueue_async_action( 'datamachine_runtime_tool_resume', array( $request_id ), 'datamachine-runtime-tools' );
+	$scheduled = ! empty( $phases['resume_scheduled_at'] );
+	if ( ! $scheduled && function_exists( 'as_enqueue_async_action' ) ) {
+		$existing_action = function_exists( 'as_has_scheduled_action' )
+			? (int) as_has_scheduled_action( 'datamachine_runtime_tool_resume', array( $request_id ), 'datamachine-runtime-tools' )
+			: 0;
+		$scheduled = $existing_action > 0 || (bool) as_enqueue_async_action( 'datamachine_runtime_tool_resume', array( $request_id ), 'datamachine-runtime-tools' );
+	}
+	if ( $scheduled && empty( $phases['resume_scheduled_at'] ) ) {
+		$scheduled = datamachine_mark_runtime_tool_completion_phase( $job_id, $request_id, 'resume_scheduled_at' );
+	}
+	if ( ! $scheduled ) {
+		datamachine_schedule_runtime_tool_continuation_recovery( $request_id );
 	}
 
-	do_action( 'datamachine_runtime_tool_result_submitted', $request, $tool_result );
+	if ( $session_projected_now ) {
+		do_action( 'datamachine_runtime_tool_result_submitted', $request, $tool_result );
+	}
 
 	return array(
-		'scheduled'  => function_exists( 'as_enqueue_async_action' ),
+		'scheduled'  => $scheduled,
 		'request_id' => $request_id,
 	);
+}
+
+/** Persist one idempotent runtime-tool completion phase on the canonical request. */
+function datamachine_mark_runtime_tool_completion_phase( int $job_id, string $request_id, string $phase ): bool {
+	if ( $job_id <= 0 || '' === $request_id || ! in_array( $phase, array( 'reservation_finalized_at', 'job_terminalized_at', 'session_projected_at', 'resume_scheduled_at' ), true ) ) {
+		return false;
+	}
+	$marked   = false;
+	$mutation = \DataMachine\Core\EngineData::mutate(
+		$job_id,
+		static function ( array $engine ) use ( $request_id, $phase, &$marked ): array {
+			$request = is_array( $engine['runtime_tool_request'] ?? null ) ? $engine['runtime_tool_request'] : array();
+			if ( ! hash_equals( $request_id, (string) ( $request['request_id'] ?? '' ) ) ) {
+				return $engine;
+			}
+			$metadata = datamachine_runtime_tool_datamachine_metadata( $request );
+			$phases   = is_array( $metadata['completion_phases'] ?? null ) ? $metadata['completion_phases'] : array();
+			if ( empty( $phases[ $phase ] ) ) {
+				$phases[ $phase ] = gmdate( 'c' );
+				$metadata['completion_phases'] = $phases;
+				$request['metadata']['datamachine'] = $metadata;
+				$engine['runtime_tool_request'] = $request;
+			}
+			$marked = true;
+			return $engine;
+		},
+		'runtime_tool_completion_phase'
+	);
+	return $marked && ! empty( $mutation['success'] );
+}
+
+/** Schedule a bounded retry path for a terminal request whose continuation was not projected. */
+function datamachine_schedule_runtime_tool_continuation_recovery( string $request_id ): bool {
+	if ( '' === $request_id || ! function_exists( 'as_schedule_single_action' ) ) {
+		return false;
+	}
+	$request = datamachine_runtime_tool_request_store()->get( $request_id );
+	$metadata = is_array( $request ) ? datamachine_runtime_tool_datamachine_metadata( $request ) : array();
+	$expires_at = strtotime( (string) ( $metadata['expires_at'] ?? '' ) );
+	if ( false !== $expires_at && time() > $expires_at + 86400 ) {
+		return false;
+	}
+	$hook  = 'datamachine_runtime_tool_recover';
+	$args  = array( $request_id );
+	$group = 'datamachine-runtime-tools';
+	if ( function_exists( 'as_has_scheduled_action' ) && as_has_scheduled_action( $hook, $args, $group ) ) {
+		return true;
+	}
+	return (bool) as_schedule_single_action( time() + 30, $hook, $args, $group );
 }
 
 /** Resume a deferred runtime tool conversation. */
@@ -1841,7 +2124,7 @@ function datamachine_resume_runtime_tool_request( string $request_id ): void {
 
 	$job_id = datamachine_runtime_tool_job_id_from_request_id( $request_id );
 	if ( $job_id > 0 ) {
-		( new RuntimeToolRunStateStore() )->resume(
+		$resumed = ( new RuntimeToolRunStateStore() )->resume(
 			$job_id,
 			array(
 				'session_id'      => (string) ( $datamachine_metadata['session_id'] ?? '' ),
@@ -1849,6 +2132,9 @@ function datamachine_resume_runtime_tool_request( string $request_id ): void {
 				'calling_user_id' => array_key_exists( 'calling_user_id', $datamachine_metadata ) ? max( 0, (int) $datamachine_metadata['calling_user_id'] ) : (int) ( $datamachine_metadata['user_id'] ?? 0 ),
 			)
 		);
+		if ( null === $resumed ) {
+			return;
+		}
 	}
 
 	\DataMachine\Api\Chat\ChatOrchestrator::processContinue(
@@ -1867,6 +2153,10 @@ function datamachine_timeout_runtime_tool_request( string $request_id ): void {
 
 	$datamachine_metadata = datamachine_runtime_tool_datamachine_metadata( $request );
 	if ( 'pending' !== (string) ( $datamachine_metadata['persistence_status'] ?? '' ) ) {
+		$stored_result = is_array( $datamachine_metadata['result'] ?? null ) ? $datamachine_metadata['result'] : array();
+		if ( ! empty( $stored_result ) ) {
+			datamachine_continue_runtime_tool_request( $request, $stored_result, array( 'source' => 'timeout_recovery' ) );
+		}
 		return;
 	}
 
@@ -1942,6 +2232,7 @@ function datamachine_runtime_tool_datamachine_metadata( array $payload ): array 
 if ( function_exists( 'add_action' ) ) {
 	add_action( 'datamachine_runtime_tool_resume', __NAMESPACE__ . '\\datamachine_resume_runtime_tool_request' );
 	add_action( 'datamachine_runtime_tool_timeout', __NAMESPACE__ . '\\datamachine_timeout_runtime_tool_request' );
+	add_action( 'datamachine_runtime_tool_recover', __NAMESPACE__ . '\\datamachine_timeout_runtime_tool_request' );
 }
 
 /**

--- a/inc/Engine/Actions/DataMachineActions.php
+++ b/inc/Engine/Actions/DataMachineActions.php
@@ -71,10 +71,12 @@ function datamachine_register_core_actions() {
 	add_action( 'datamachine_mark_item_processed', array( MarkItemProcessedHandler::class, 'handle' ), 10, 4 );
 	add_action( 'datamachine_fail_job', array( FailJobHandler::class, 'handle' ), 10, 3 );
 	add_action( 'datamachine_log', array( LogHandler::class, 'handle' ), 10, 3 );
-	add_action( 'datamachine_step_lifecycle_inline_continuation', array( StepLifecycleHandler::class, 'handleInlineContinuation' ), 10, 3 );
 	add_action( 'datamachine_step_lifecycle_completed', array( StepLifecycleHandler::class, 'handleCompleted' ), 10, 2 );
 	add_action( 'datamachine_step_lifecycle_failed', array( StepLifecycleHandler::class, 'handleFailed' ), 10, 2 );
 	add_filter( 'datamachine_job_terminal_status', array( StepLifecycleHandler::class, 'filterTerminalStatus' ), 10, 3 );
+	add_filter( 'datamachine_job_terminal_engine_data', array( StepLifecycleHandler::class, 'filterTerminalEngineData' ), 10, 3 );
+	add_filter( 'datamachine_batch_engine_adoption_state', array( StepLifecycleHandler::class, 'filterBatchAdoptionState' ), 10, 3 );
+	add_filter( 'datamachine_batch_engine_adoption_rollback_state', array( StepLifecycleHandler::class, 'filterBatchAdoptionRollbackState' ), 10, 3 );
 	add_filter( 'datamachine_job_terminal_accounting_context', array( StepLifecycleHandler::class, 'filterTerminalAccountingContext' ), 10, 3 );
 	add_action( 'datamachine_job_terminal_rolled_back', array( StepLifecycleHandler::class, 'handleTerminalRollback' ) );
 	add_filter(

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -10,6 +10,8 @@ namespace DataMachine\Engine\Actions\Handlers;
 
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\DataPacketStore;
+use DataMachine\Core\ChildJobRecoveryPolicy;
+use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\PacketEngineData;
 use DataMachine\Core\RunMetrics;
@@ -29,34 +31,582 @@ class StepLifecycleHandler {
 	 * @param array $flow_step_config Current flow step configuration.
 	 * @param array $routed_packets   Packets routed to the next step.
 	 */
-	public static function handleInlineContinuation( int $job_id, array $flow_step_config, array $routed_packets ): void {
-		$step_type = $flow_step_config['step_type'] ?? '';
-		if ( ! self::isSourceIngestionStep( (string) $step_type ) || empty( $routed_packets ) ) {
-			return;
+	public static function handleInlineContinuation( int $job_id, array $flow_step_config, array $routed_packets ): bool {
+		if ( self::isSourceIngestionStep( (string) ( $flow_step_config['step_type'] ?? '' ) ) ) {
+			$existing = ProcessedItems::disposition_claims( \datamachine_get_engine_data( $job_id ) );
+			$routed   = array();
+			foreach ( $routed_packets as $packet ) {
+				$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+				$routed   = array_replace( $routed, ProcessedItems::disposition_claims( $metadata ) );
+			}
+			if ( array_keys( $existing ) === array_keys( $routed ) ) {
+				return true;
+			}
+			return self::reconcileStepOutput( $job_id, $flow_step_config, $routed_packets, true )['success'];
+		}
+		return true;
+	}
+
+	/**
+	 * Reconcile engine-owned claims against exact packet dispositions.
+	 *
+	 * @return array{success:bool,handled:bool,retained:int,completed:int,released:int,omitted:int,explicit:int}
+	 */
+	public static function reconcileStepOutput( int $job_id, array $flow_step_config, array $packets, bool $step_success, int $recovery_generation = 0, string $recovery_claim_token = '' ): array {
+		$result = array(
+			'success'   => true,
+			'handled'   => false,
+			'retained'  => 0,
+			'completed' => 0,
+			'released'  => 0,
+			'omitted'   => 0,
+			'explicit'  => 0,
+			'stale'     => false,
+		);
+		if ( $job_id <= 0 ) {
+			return $result;
 		}
 
-		$seed_data = array();
-		$claims    = self::claimsFromEngine( \datamachine_get_engine_data( $job_id ) );
-		foreach ( $routed_packets as $packet ) {
-			$packet_meta = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
-			if ( empty( $seed_data ) && is_array( $packet_meta['_engine_data'] ?? null ) ) {
-				$seed_data = PacketEngineData::sanitize( $packet_meta['_engine_data'], $job_id );
+		$step_type = (string) ( $flow_step_config['step_type'] ?? '' );
+		if ( self::isSourceIngestionStep( $step_type ) ) {
+			$current   = array();
+			$seed_data = array();
+			foreach ( $packets as $packet ) {
+				$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+				if ( ProcessedItems::has_claim_metadata( $metadata ) && ! ProcessedItems::has_valid_claim_metadata( $metadata ) ) {
+					$result['success'] = false;
+					return $result;
+				}
+				$current  = array_replace( $current, ProcessedItems::disposition_claims( $metadata ) );
+				if ( empty( $seed_data ) && is_array( $metadata['_engine_data'] ?? null ) ) {
+					$seed_data = PacketEngineData::sanitize( $metadata['_engine_data'], $job_id );
+				}
+				if ( ! isset( $seed_data['item_identifier'] ) && ! empty( $metadata['item_identifier'] ) ) {
+					$seed_data['item_identifier'] = $metadata['item_identifier'];
+				}
+				if ( ! isset( $seed_data['source_type'] ) && ! empty( $metadata['source_type'] ) ) {
+					$seed_data['source_type'] = $metadata['source_type'];
+				}
 			}
-			if ( ! isset( $seed_data['item_identifier'] ) && ! empty( $packet_meta['item_identifier'] ) ) {
-				$seed_data['item_identifier'] = $packet_meta['item_identifier'];
+			if ( empty( $current ) ) {
+				return $result;
 			}
-			if ( ! isset( $seed_data['source_type'] ) && ! empty( $packet_meta['source_type'] ) ) {
-				$seed_data['source_type'] = $packet_meta['source_type'];
+			$result['handled']  = true;
+			$result['retained'] = count( $current );
+			return self::commitReconciliation( $job_id, $flow_step_config, $current, array(), $seed_data, $result, $recovery_generation, $recovery_claim_token );
+		}
+
+		$engine_data = \datamachine_get_engine_data( $job_id );
+		if ( ProcessedItems::has_claim_metadata( $engine_data ) && ! ProcessedItems::has_valid_claim_metadata( $engine_data ) ) {
+			$result['success'] = false;
+			return $result;
+		}
+		$current     = ProcessedItems::disposition_claims( $engine_data );
+		if ( empty( $current ) ) {
+			return $result;
+		}
+		$result['handled'] = true;
+		$resolved          = array();
+		if ( $step_success ) {
+			foreach ( $packets as $packet ) {
+				$metadata      = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+				if ( ProcessedItems::has_claim_metadata( $metadata ) && ! ProcessedItems::has_valid_claim_metadata( $metadata ) ) {
+					$result['success'] = false;
+					return $result;
+				}
+				$packet_claims = ProcessedItems::disposition_claims( $metadata );
+				if ( empty( $packet_claims ) ) {
+					continue;
+				}
+				if ( 1 !== count( $packet_claims ) ) {
+					$result['success'] = false;
+					return $result;
+				}
+				$disposition_id = (string) array_key_first( $packet_claims );
+				$supplied_id    = (string) ( $metadata[ ProcessedItems::DISPOSITION_ID_METADATA_KEY ] ?? $metadata['disposition_id'] ?? '' );
+				if ( ( '' !== $supplied_id && ! hash_equals( $disposition_id, $supplied_id ) ) || ! isset( $current[ $disposition_id ] ) ) {
+					$result['success'] = false;
+					return $result;
+				}
+				$disposition = (string) ( $metadata['packet_disposition'] ?? 'succeeded' );
+				if ( ! isset( $resolved[ $disposition_id ] ) || 'succeeded' !== $resolved[ $disposition_id ] ) {
+					$resolved[ $disposition_id ] = $disposition;
+				}
 			}
-			$claims = array_merge( $claims, self::normalizeClaims( $packet_meta ) );
 		}
-		if ( ! empty( $claims ) ) {
-			$seed_data[ ProcessedItems::CLAIMS_METADATA_KEY ] = self::uniqueClaims( $claims );
-			unset( $seed_data[ ProcessedItems::CLAIM_METADATA_KEY ] );
+
+		$result = self::commitReconciliation( $job_id, $flow_step_config, array(), $resolved, array(), $result, $recovery_generation, $recovery_claim_token );
+		if ( ! $result['success'] ) {
+			return $result;
 		}
-		if ( ! empty( $seed_data ) ) {
-			\datamachine_merge_engine_data( $job_id, $seed_data );
+		$evidence = $result['evidence'];
+		$omitted  = $evidence['omitted_ids'];
+		if ( ! empty( $omitted ) ) {
+			$flow_step_id = (string) ( $flow_step_config['flow_step_id'] ?? $flow_step_config['step_id'] ?? '' );
+			if ( '' !== $flow_step_id ) {
+				RunMetrics::recordStepResult( $job_id, $flow_step_id, array( 'packet_disposition' => $evidence ) );
+			}
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Pipeline step omitted claimed packets; claims released for retry.',
+				array(
+					'job_id'       => $job_id,
+					'flow_step_id' => $flow_step_id,
+					'omitted_ids'  => array_values( $omitted ),
+				)
+			);
 		}
+
+		unset( $result['evidence'] );
+		return $result;
+	}
+
+	/** Apply every claim mutation and the exact engine replacement in one locked transaction. */
+	private static function commitReconciliation( int $job_id, array $flow_step_config, array $source_claims, array $resolved, array $seed_data, array $result, int $recovery_generation, string $recovery_claim_token ): array {
+		$max_attempts = 3;
+		for ( $attempt = 1; $attempt <= $max_attempts; ++$attempt ) {
+			$attempt_result = self::commitReconciliationAttempt( $job_id, $flow_step_config, $source_claims, $resolved, $seed_data, $result, $recovery_generation, $recovery_claim_token );
+			$retryable      = ! empty( $attempt_result['_retryable'] );
+			unset( $attempt_result['_retryable'] );
+			if ( ! $retryable || $attempt >= $max_attempts ) {
+				return $attempt_result;
+			}
+			usleep( wp_rand( 5000, 25000 ) );
+		}
+
+		$result['success'] = false;
+		return $result;
+	}
+
+	/** Execute one complete reconciliation transaction attempt. */
+	private static function commitReconciliationAttempt( int $job_id, array $flow_step_config, array $source_claims, array $resolved, array $seed_data, array $result, int $recovery_generation, string $recovery_claim_token ): array {
+		global $wpdb;
+		$jobs       = new Jobs();
+		$jobs_table = $jobs->get_table_name();
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) {
+			$result['success'] = false;
+			$result['_retryable'] = $jobs->has_retryable_transaction_error();
+			return $result;
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Identifier and job ID are prepared.
+		$job_row = $wpdb->get_row( $wpdb->prepare( 'SELECT job_id, engine_data FROM %i WHERE job_id = %d FOR UPDATE', $jobs_table, $job_id ), ARRAY_A );
+		if ( ! is_array( $job_row ) ) {
+			$wpdb->query( 'ROLLBACK' );
+			$result['success'] = false;
+			return $result;
+		}
+		$encoded = $job_row['engine_data'] ?? null;
+		$engine = is_string( $encoded ) ? json_decode( $encoded, true ) : $encoded;
+		$engine = is_array( $engine ) ? $engine : array();
+		if ( $recovery_generation > 0 && ! ChildJobRecoveryPolicy::recoveryExecutionMatches( $engine, $recovery_generation, $recovery_claim_token ) ) {
+			$wpdb->query( 'ROLLBACK' );
+			$result['success'] = false;
+			$result['stale']   = true;
+			return $result;
+		}
+
+		$current = empty( $source_claims ) ? ProcessedItems::disposition_claims( $engine ) : $source_claims;
+		ksort( $current, SORT_STRING );
+		$processed = new ProcessedItems();
+		foreach ( $current as $claim ) {
+			if ( ! $processed->lock_owned_claim_in_transaction( $claim ) ) {
+				$retryable = $jobs->has_retryable_transaction_error();
+				$wpdb->query( 'ROLLBACK' );
+				wp_cache_delete( $job_id, 'datamachine_engine_data' );
+				$result['success']    = false;
+				$result['_retryable'] = $retryable;
+				return $result;
+			}
+		}
+		$retained = array();
+		$completed = array();
+		$released = array();
+		$omitted = array();
+		$index = 0;
+		$is_transfer = in_array( 'transferred', $resolved, true );
+		foreach ( $current as $disposition_id => $claim ) {
+			$default     = ( empty( $resolved ) && ! empty( $source_claims ) ) || $is_transfer ? 'succeeded' : '';
+			$disposition = $resolved[ $disposition_id ] ?? $default;
+			if ( 'succeeded' === $disposition ) {
+				$retained[ $disposition_id ] = $claim;
+				continue;
+			}
+			if ( 'transferred' === $disposition ) {
+				$released[] = $disposition_id;
+				continue;
+			}
+			$allowed = apply_filters( 'datamachine_packet_reconciliation_claim_mutation', true, $index, $disposition_id, $disposition, $job_id );
+			if ( ! $allowed ) {
+				$wpdb->query( 'ROLLBACK' );
+				wp_cache_delete( $job_id, 'datamachine_engine_data' );
+				$result['success'] = false;
+				$result['_retryable'] = false;
+				return $result;
+			}
+			++$index;
+			if ( 'reject_source' === $disposition ) {
+				if ( ! self::completeClaim( $claim, $job_id, true ) ) {
+					$retryable = $jobs->has_retryable_transaction_error();
+					$wpdb->query( 'ROLLBACK' );
+					wp_cache_delete( $job_id, 'datamachine_engine_data' );
+					$result['success'] = false;
+					$result['_retryable'] = $retryable;
+					return $result;
+				}
+				$completed[] = $disposition_id;
+				continue;
+			}
+			if ( 1 !== self::releaseClaim( $claim ) ) {
+				$retryable = $jobs->has_retryable_transaction_error();
+				$wpdb->query( 'ROLLBACK' );
+				wp_cache_delete( $job_id, 'datamachine_engine_data' );
+				$result['success'] = false;
+				$result['_retryable'] = $retryable;
+				return $result;
+			}
+			$released[] = $disposition_id;
+			if ( '' === $disposition ) {
+				$omitted[] = $disposition_id;
+			}
+		}
+
+		$evidence = self::claimEvidence( $flow_step_config, array_keys( $retained ), $completed, $released, $omitted );
+		$engine   = array_replace_recursive( $engine, $seed_data );
+		if ( isset( $seed_data['packet_fanout_transfer'] ) ) {
+			$engine['packet_fanout_transfer'] = $seed_data['packet_fanout_transfer'];
+		}
+		unset( $engine[ ProcessedItems::CLAIM_METADATA_KEY ], $engine[ ProcessedItems::CLAIMS_METADATA_KEY ] );
+		if ( ! empty( $retained ) ) {
+			$engine[ ProcessedItems::CLAIMS_METADATA_KEY ] = array_values( $retained );
+		}
+		$history                                = is_array( $engine['packet_disposition_evidence'] ?? null ) ? $engine['packet_disposition_evidence'] : array();
+		$history[]                              = $evidence;
+		$engine['packet_disposition_evidence'] = array_slice( $history, -20 );
+		$engine = self::compactPacketRuntimeState( $engine, array_keys( $retained ) );
+		$persist = apply_filters( 'datamachine_packet_reconciliation_engine_persist', true, $job_id, $engine );
+		if ( ! $persist || ! $jobs->store_engine_data_in_transaction( $job_id, $engine ) ) {
+			$retryable = $persist && $jobs->has_retryable_transaction_error();
+			$wpdb->query( 'ROLLBACK' );
+			wp_cache_delete( $job_id, 'datamachine_engine_data' );
+			$result['success'] = false;
+			$result['_retryable'] = $retryable;
+			return $result;
+		}
+		if ( false === $wpdb->query( 'COMMIT' ) ) {
+			$retryable = $jobs->has_retryable_transaction_error();
+			$wpdb->query( 'ROLLBACK' );
+			wp_cache_delete( $job_id, 'datamachine_engine_data' );
+			$result['success']    = false;
+			$result['_retryable'] = $retryable;
+			return $result;
+		}
+		$jobs->publish_committed_engine_data( $job_id, $engine );
+		$result['retained']  = count( $retained );
+		$result['completed'] = count( $completed );
+		$result['released']  = count( $released );
+		$result['omitted']   = count( $omitted );
+		$result['explicit']  = count( $resolved );
+		$result['evidence']  = $evidence;
+		$result['_retryable'] = false;
+		return $result;
+	}
+
+	/** Renew every retained claim while a waiting or retryable execution is parked. */
+	public static function renewParkedClaims( int $job_id, int $recovery_generation = 0, string $recovery_claim_token = '' ): array {
+		global $wpdb;
+		$result     = array( 'success' => false, 'stale' => false, 'renewed' => 0 );
+		$jobs       = new Jobs();
+		$jobs_table = $jobs->get_table_name();
+		if ( $job_id <= 0 || false === $wpdb->query( 'START TRANSACTION' ) ) {
+			return $result;
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Identifier and job ID are prepared.
+		$job = $wpdb->get_row( $wpdb->prepare( 'SELECT status, engine_data FROM %i WHERE job_id = %d FOR UPDATE', $jobs_table, $job_id ), ARRAY_A );
+		if ( ! is_array( $job ) ) {
+			$wpdb->query( 'ROLLBACK' );
+			return $result;
+		}
+		$encoded = $job['engine_data'] ?? null;
+		$engine  = is_string( $encoded ) ? json_decode( $encoded, true ) : $encoded;
+		$engine = is_array( $engine ) ? $engine : array();
+		if ( JobStatus::isStatusFinal( (string) ( $job['status'] ?? '' ) ) ) {
+			$wpdb->query( 'ROLLBACK' );
+			return $result;
+		}
+		if ( $recovery_generation > 0 && ! ChildJobRecoveryPolicy::recoveryExecutionMatches( $engine, $recovery_generation, $recovery_claim_token ) ) {
+			$wpdb->query( 'ROLLBACK' );
+			$result['stale'] = true;
+			return $result;
+		}
+		if ( ProcessedItems::has_claim_metadata( $engine ) && ! ProcessedItems::has_valid_claim_metadata( $engine ) ) {
+			$wpdb->query( 'ROLLBACK' );
+			return $result;
+		}
+
+		$claims = ProcessedItems::disposition_claims( $engine );
+		ksort( $claims, SORT_STRING );
+		$processed = new ProcessedItems();
+		foreach ( $claims as $claim ) {
+			if ( ! $processed->renew_owned_claim_in_transaction( $claim, $job_id ) ) {
+				$wpdb->query( 'ROLLBACK' );
+				return $result;
+			}
+			++$result['renewed'];
+		}
+		if ( false === $wpdb->query( 'COMMIT' ) ) {
+			$wpdb->query( 'ROLLBACK' );
+			$result['renewed'] = 0;
+			return $result;
+		}
+		$result['success'] = true;
+		return $result;
+	}
+
+	/** Remove claims transferred to fanout packets from parent terminal ownership. */
+	public static function transferClaimsToFanout( int $job_id, array $packets, int $recovery_generation = 0, string $recovery_claim_token = '' ): array {
+		$claims = array();
+		foreach ( $packets as $packet ) {
+			$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+			if ( ProcessedItems::has_claim_metadata( $metadata ) && ! ProcessedItems::has_valid_claim_metadata( $metadata ) ) {
+				return array( 'success' => false, 'stale' => false );
+			}
+			$packet_claims = ProcessedItems::disposition_claims( $metadata );
+			if ( count( $packet_claims ) > 1 ) {
+				return array( 'success' => false, 'stale' => false );
+			}
+			$claims = array_replace( $claims, $packet_claims );
+		}
+		if ( empty( $claims ) ) {
+			return array( 'success' => true, 'stale' => false );
+		}
+		$transfer_id = bin2hex( random_bytes( 16 ) );
+		$result = self::commitReconciliation(
+			$job_id,
+			array( 'step_type' => 'fanout_transfer' ),
+			$claims,
+			array_fill_keys( array_keys( $claims ), 'transferred' ),
+			array(
+				'packet_fanout_transfer' => array(
+					'transfer_id' => $transfer_id,
+					'state'       => 'prepared',
+					'prepared_at' => gmdate( 'c' ),
+					'recovery_generation' => $recovery_generation,
+					'claims'      => $claims,
+				),
+			),
+			array( 'success' => true, 'handled' => true, 'retained' => 0, 'completed' => 0, 'released' => 0, 'omitted' => 0, 'explicit' => 0, 'stale' => false ),
+			$recovery_generation,
+			$recovery_claim_token
+		);
+		$result['transfer_id'] = $transfer_id;
+		return $result;
+	}
+
+	/** Mark a prepared transfer adopted only after BatchItems and batch state are durable. */
+	public static function adoptPreparedFanoutTransfer( int $job_id, string $transfer_id, int $recovery_generation = 0, string $recovery_claim_token = '' ): bool {
+		return ! empty( self::mutateFanoutTransfer( $job_id, $transfer_id, 'adopt', $recovery_generation, $recovery_claim_token )['success'] );
+	}
+
+	/** Mark pipeline claim transfer adopted in the same CAS that adopts batch state. */
+	public static function filterBatchAdoptionState( array $engine, string $context, string $worklist_checksum ): array {
+		$transfer = is_array( $engine['packet_fanout_transfer'] ?? null ) ? $engine['packet_fanout_transfer'] : array();
+		if ( 'pipeline' !== $context || 'prepared' !== (string) ( $transfer['state'] ?? '' ) ) {
+			return $engine;
+		}
+		$engine['packet_fanout_transfer']['state']             = 'adopted';
+		$engine['packet_fanout_transfer']['worklist_checksum'] = $worklist_checksum;
+		$engine['packet_fanout_transfer']['adopted_at']        = gmdate( 'c' );
+		return $engine;
+	}
+
+	/** Restore parent ownership when an adopted worklist cannot obtain an initial action. */
+	public static function filterBatchAdoptionRollbackState( array $engine, string $context, string $worklist_checksum ): array {
+		$transfer = is_array( $engine['packet_fanout_transfer'] ?? null ) ? $engine['packet_fanout_transfer'] : array();
+		if ( 'pipeline' !== $context
+			|| 'adopted' !== (string) ( $transfer['state'] ?? '' )
+			|| ! hash_equals( $worklist_checksum, (string) ( $transfer['worklist_checksum'] ?? '' ) ) ) {
+			return $engine;
+		}
+		$claims = is_array( $transfer['claims'] ?? null ) ? $transfer['claims'] : array();
+		if ( empty( $claims ) ) {
+			return $engine;
+		}
+		$current = ProcessedItems::disposition_claims( $engine );
+		$current = array_replace( $current, $claims );
+		unset( $engine[ ProcessedItems::CLAIM_METADATA_KEY ], $engine['packet_fanout_transfer'] );
+		$engine[ ProcessedItems::CLAIMS_METADATA_KEY ] = array_values( $current );
+		return $engine;
+	}
+
+	/** Restore prepared fanout claims only when no durable batch adopted them. */
+	public static function restorePreparedFanoutTransfer( int $job_id, string $transfer_id, int $recovery_generation = 0, string $recovery_claim_token = '' ): bool {
+		return ! empty( self::mutateFanoutTransfer( $job_id, $transfer_id, 'restore', $recovery_generation, $recovery_claim_token )['success'] );
+	}
+
+	/** Clear a transfer marker only after durable adoption has been established. */
+	public static function finalizePreparedFanoutTransfer( int $job_id, string $transfer_id, int $recovery_generation = 0, string $recovery_claim_token = '' ): bool {
+		return ! empty( self::mutateFanoutTransfer( $job_id, $transfer_id, 'finalize', $recovery_generation, $recovery_claim_token )['success'] );
+	}
+
+	/** Recover a stale marker from the current locked snapshot. */
+	public static function recoverPreparedFanoutTransfer( int $job_id, int $recovery_generation = 0, string $recovery_claim_token = '' ): array {
+		return self::mutateFanoutTransfer( $job_id, '', 'recover', $recovery_generation, $recovery_claim_token );
+	}
+
+	/** Transactionally fence fanout adoption, restoration, finalization, and recovery. */
+	private static function mutateFanoutTransfer( int $job_id, string $transfer_id, string $action, int $recovery_generation, string $recovery_claim_token ): array {
+		global $wpdb;
+		$result     = array( 'success' => false, 'stale' => false, 'adopted' => false, 'restored' => false, 'handled' => false );
+		$jobs       = new Jobs();
+		$jobs_table = $jobs->get_table_name();
+		if ( $job_id <= 0 || false === $wpdb->query( 'START TRANSACTION' ) ) {
+			return $result;
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Identifier and job ID are prepared.
+		$job = $wpdb->get_row( $wpdb->prepare( 'SELECT status, engine_data FROM %i WHERE job_id = %d FOR UPDATE', $jobs_table, $job_id ), ARRAY_A );
+		if ( ! is_array( $job ) ) {
+			$wpdb->query( 'ROLLBACK' );
+			return $result;
+		}
+		$encoded = $job['engine_data'] ?? null;
+		$engine  = is_string( $encoded ) ? json_decode( $encoded, true ) : $encoded;
+		$engine = is_array( $engine ) ? $engine : array();
+		if ( JobStatus::isStatusFinal( (string) ( $job['status'] ?? '' ) ) ) {
+			$wpdb->query( 'ROLLBACK' );
+			return $result;
+		}
+		if ( $recovery_generation > 0 && ! ChildJobRecoveryPolicy::recoveryExecutionMatches( $engine, $recovery_generation, $recovery_claim_token ) ) {
+			$wpdb->query( 'ROLLBACK' );
+			$result['stale'] = true;
+			return $result;
+		}
+
+		$transfer = is_array( $engine['packet_fanout_transfer'] ?? null ) ? $engine['packet_fanout_transfer'] : array();
+		$current_id = (string) ( $transfer['transfer_id'] ?? '' );
+		if ( '' === $current_id ) {
+			$wpdb->query( 'ROLLBACK' );
+			$result['success'] = 'recover' === $action;
+			return $result;
+		}
+		if ( '' !== $transfer_id && ! hash_equals( $transfer_id, $current_id ) ) {
+			$wpdb->query( 'ROLLBACK' );
+			return $result;
+		}
+		$result['handled'] = true;
+		$durably_adopted   = 'adopted' === (string) ( $transfer['state'] ?? '' ) || is_array( $engine['batch_state'] ?? null );
+		$effective_action  = 'recover' === $action ? ( $durably_adopted ? 'finalize' : 'restore' ) : $action;
+
+		if ( 'adopt' === $effective_action ) {
+			if ( ! $durably_adopted ) {
+				$wpdb->query( 'ROLLBACK' );
+				return $result;
+			}
+			$engine['packet_fanout_transfer']['state']      = 'adopted';
+			$engine['packet_fanout_transfer']['adopted_at'] = gmdate( 'c' );
+			$result['adopted'] = true;
+		} elseif ( 'finalize' === $effective_action ) {
+			if ( ! $durably_adopted ) {
+				$wpdb->query( 'ROLLBACK' );
+				return $result;
+			}
+			unset( $engine['packet_fanout_transfer'] );
+			$result['adopted'] = true;
+		} elseif ( 'restore' === $effective_action ) {
+			if ( 'prepared' !== (string) ( $transfer['state'] ?? '' ) || $durably_adopted ) {
+				$wpdb->query( 'ROLLBACK' );
+				return $result;
+			}
+			$claims = is_array( $transfer['claims'] ?? null ) ? $transfer['claims'] : array();
+			if ( empty( $claims ) ) {
+				$wpdb->query( 'ROLLBACK' );
+				return $result;
+			}
+			ksort( $claims, SORT_STRING );
+			$processed = new ProcessedItems();
+			foreach ( $claims as $claim ) {
+				if ( ! is_array( $claim ) || ! $processed->renew_owned_claim_in_transaction( $claim, $job_id ) ) {
+					$wpdb->query( 'ROLLBACK' );
+					return $result;
+				}
+			}
+			$current = ProcessedItems::disposition_claims( $engine );
+			$current = array_replace( $current, $claims );
+			unset( $engine[ ProcessedItems::CLAIM_METADATA_KEY ], $engine['packet_fanout_transfer'] );
+			$engine[ ProcessedItems::CLAIMS_METADATA_KEY ] = array_values( $current );
+			$result['restored'] = true;
+		} else {
+			$wpdb->query( 'ROLLBACK' );
+			return $result;
+		}
+
+		if ( ! $jobs->store_engine_data_in_transaction( $job_id, $engine ) || false === $wpdb->query( 'COMMIT' ) ) {
+			$wpdb->query( 'ROLLBACK' );
+			wp_cache_delete( $job_id, 'datamachine_engine_data' );
+			return array_merge( $result, array( 'success' => false ) );
+		}
+		$jobs->publish_committed_engine_data( $job_id, $engine );
+		$result['success'] = true;
+		return $result;
+	}
+
+	/** Build bounded structured evidence containing safe identities only. */
+	private static function claimEvidence( array $flow_step_config, array $retained, array $completed, array $released, array $omitted ): array {
+		return array(
+			'schema_version' => 'datamachine.packet_disposition.v1',
+			'flow_step_id'   => (string) ( $flow_step_config['flow_step_id'] ?? $flow_step_config['step_id'] ?? '' ),
+			'step_type'      => (string) ( $flow_step_config['step_type'] ?? '' ),
+			'retained_ids'   => array_values( $retained ),
+			'completed_ids'  => array_values( $completed ),
+			'released_ids'   => array_values( $released ),
+			'omitted_ids'    => array_values( $omitted ),
+		);
+	}
+
+	/** Remove packet-scoped records as their claim identities leave the job. */
+	private static function compactPacketRuntimeState( array $engine, array $active_ids ): array {
+		$active = array_fill_keys( $active_ids, true );
+		foreach ( array( 'packet_dispositions' ) as $key ) {
+			$records = is_array( $engine[ $key ] ?? null ) ? $engine[ $key ] : array();
+			$engine[ $key ] = array_intersect_key( $records, $active );
+			if ( empty( $engine[ $key ] ) ) {
+				unset( $engine[ $key ] );
+			}
+		}
+		foreach ( array( 'packet_tool_executions', 'successful_packet_tool_executions' ) as $key ) {
+			$tools = is_array( $engine[ $key ] ?? null ) ? $engine[ $key ] : array();
+			foreach ( $tools as $tool_name => $records ) {
+				$records = is_array( $records ) ? array_intersect_key( $records, $active ) : array();
+				if ( empty( $records ) ) {
+					unset( $tools[ $tool_name ] );
+				} else {
+					$tools[ $tool_name ] = $records;
+				}
+			}
+			if ( empty( $tools ) ) {
+				unset( $engine[ $key ] );
+			} else {
+				$engine[ $key ] = $tools;
+			}
+		}
+		return $engine;
+	}
+
+	/** Strip completed packet ownership and reservation state from terminal snapshots. */
+	public static function filterTerminalEngineData( array $engine, int $job_id, string $status ): array {
+		unset( $job_id, $status );
+		unset(
+			$engine[ ProcessedItems::CLAIM_METADATA_KEY ],
+			$engine[ ProcessedItems::CLAIMS_METADATA_KEY ],
+			$engine['packet_dispositions'],
+			$engine['packet_tool_executions'],
+			$engine['successful_packet_tool_executions'],
+			$engine['packet_fanout_transfer']
+		);
+		return $engine;
 	}
 
 	/**
@@ -165,6 +715,19 @@ class StepLifecycleHandler {
 	 */
 	public static function filterTerminalStatus( string $status, int $job_id, array $job ): string|\WP_Error {
 		$engine_data = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		if ( ProcessedItems::has_claim_metadata( $engine_data ) && ! ProcessedItems::has_valid_claim_metadata( $engine_data ) ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Terminal transition blocked by malformed packet claim metadata.',
+				array( 'job_id' => $job_id, 'status' => $status )
+			);
+			return new \WP_Error(
+				'item_claim_metadata_invalid',
+				'Explicit packet claim metadata is malformed.',
+				array( 'status' => JobStatus::failed( 'item_claim_metadata_invalid' )->toString() )
+			);
+		}
 		$prepared    = JobStatus::isStatusSuccess( $status )
 			? self::handleCompleted( $job_id, $engine_data, true )
 			: self::handleFailed( $job_id, $engine_data );
@@ -377,6 +940,11 @@ class StepLifecycleHandler {
 				return null;
 			}
 		}
+		$derived_id = ProcessedItems::disposition_identity( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] );
+		if ( isset( $claim['disposition_id'] ) && ( ! is_string( $claim['disposition_id'] ) || ! hash_equals( $derived_id, $claim['disposition_id'] ) ) ) {
+			return null;
+		}
+		$claim['disposition_id'] = $derived_id;
 
 		return $claim;
 	}

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -77,7 +77,7 @@ class StepLifecycleHandler {
 					$result['success'] = false;
 					return $result;
 				}
-				$current  = array_replace( $current, ProcessedItems::disposition_claims( $metadata ) );
+				$current = array_replace( $current, ProcessedItems::disposition_claims( $metadata ) );
 				if ( empty( $seed_data ) && is_array( $metadata['_engine_data'] ?? null ) ) {
 					$seed_data = PacketEngineData::sanitize( $metadata['_engine_data'], $job_id );
 				}
@@ -101,7 +101,7 @@ class StepLifecycleHandler {
 			$result['success'] = false;
 			return $result;
 		}
-		$current     = ProcessedItems::disposition_claims( $engine_data );
+		$current = ProcessedItems::disposition_claims( $engine_data );
 		if ( empty( $current ) ) {
 			return $result;
 		}
@@ -109,7 +109,7 @@ class StepLifecycleHandler {
 		$resolved          = array();
 		if ( $step_success ) {
 			foreach ( $packets as $packet ) {
-				$metadata      = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+				$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
 				if ( ProcessedItems::has_claim_metadata( $metadata ) && ! ProcessedItems::has_valid_claim_metadata( $metadata ) ) {
 					$result['success'] = false;
 					return $result;
@@ -185,7 +185,7 @@ class StepLifecycleHandler {
 		$jobs       = new Jobs();
 		$jobs_table = $jobs->get_table_name();
 		if ( false === $wpdb->query( 'START TRANSACTION' ) ) {
-			$result['success'] = false;
+			$result['success']    = false;
 			$result['_retryable'] = $jobs->has_retryable_transaction_error();
 			return $result;
 		}
@@ -198,8 +198,8 @@ class StepLifecycleHandler {
 			return $result;
 		}
 		$encoded = $job_row['engine_data'] ?? null;
-		$engine = is_string( $encoded ) ? json_decode( $encoded, true ) : $encoded;
-		$engine = is_array( $engine ) ? $engine : array();
+		$engine  = is_string( $encoded ) ? json_decode( $encoded, true ) : $encoded;
+		$engine  = is_array( $engine ) ? $engine : array();
 		if ( $recovery_generation > 0 && ! ChildJobRecoveryPolicy::recoveryExecutionMatches( $engine, $recovery_generation, $recovery_claim_token ) ) {
 			$wpdb->query( 'ROLLBACK' );
 			$result['success'] = false;
@@ -220,11 +220,11 @@ class StepLifecycleHandler {
 				return $result;
 			}
 		}
-		$retained = array();
-		$completed = array();
-		$released = array();
-		$omitted = array();
-		$index = 0;
+		$retained    = array();
+		$completed   = array();
+		$released    = array();
+		$omitted     = array();
+		$index       = 0;
 		$is_transfer = in_array( 'transferred', $resolved, true );
 		foreach ( $current as $disposition_id => $claim ) {
 			$default     = ( empty( $resolved ) && ! empty( $source_claims ) ) || $is_transfer ? 'succeeded' : '';
@@ -241,7 +241,7 @@ class StepLifecycleHandler {
 			if ( ! $allowed ) {
 				$wpdb->query( 'ROLLBACK' );
 				wp_cache_delete( $job_id, 'datamachine_engine_data' );
-				$result['success'] = false;
+				$result['success']    = false;
 				$result['_retryable'] = false;
 				return $result;
 			}
@@ -251,7 +251,7 @@ class StepLifecycleHandler {
 					$retryable = $jobs->has_retryable_transaction_error();
 					$wpdb->query( 'ROLLBACK' );
 					wp_cache_delete( $job_id, 'datamachine_engine_data' );
-					$result['success'] = false;
+					$result['success']    = false;
 					$result['_retryable'] = $retryable;
 					return $result;
 				}
@@ -262,7 +262,7 @@ class StepLifecycleHandler {
 				$retryable = $jobs->has_retryable_transaction_error();
 				$wpdb->query( 'ROLLBACK' );
 				wp_cache_delete( $job_id, 'datamachine_engine_data' );
-				$result['success'] = false;
+				$result['success']    = false;
 				$result['_retryable'] = $retryable;
 				return $result;
 			}
@@ -281,16 +281,16 @@ class StepLifecycleHandler {
 		if ( ! empty( $retained ) ) {
 			$engine[ ProcessedItems::CLAIMS_METADATA_KEY ] = array_values( $retained );
 		}
-		$history                                = is_array( $engine['packet_disposition_evidence'] ?? null ) ? $engine['packet_disposition_evidence'] : array();
-		$history[]                              = $evidence;
+		$history                               = is_array( $engine['packet_disposition_evidence'] ?? null ) ? $engine['packet_disposition_evidence'] : array();
+		$history[]                             = $evidence;
 		$engine['packet_disposition_evidence'] = array_slice( $history, -20 );
-		$engine = self::compactPacketRuntimeState( $engine, array_keys( $retained ) );
-		$persist = apply_filters( 'datamachine_packet_reconciliation_engine_persist', true, $job_id, $engine );
+		$engine                                = self::compactPacketRuntimeState( $engine, array_keys( $retained ) );
+		$persist                               = apply_filters( 'datamachine_packet_reconciliation_engine_persist', true, $job_id, $engine );
 		if ( ! $persist || ! $jobs->store_engine_data_in_transaction( $job_id, $engine ) ) {
 			$retryable = $persist && $jobs->has_retryable_transaction_error();
 			$wpdb->query( 'ROLLBACK' );
 			wp_cache_delete( $job_id, 'datamachine_engine_data' );
-			$result['success'] = false;
+			$result['success']    = false;
 			$result['_retryable'] = $retryable;
 			return $result;
 		}
@@ -303,12 +303,12 @@ class StepLifecycleHandler {
 			return $result;
 		}
 		$jobs->publish_committed_engine_data( $job_id, $engine );
-		$result['retained']  = count( $retained );
-		$result['completed'] = count( $completed );
-		$result['released']  = count( $released );
-		$result['omitted']   = count( $omitted );
-		$result['explicit']  = count( $resolved );
-		$result['evidence']  = $evidence;
+		$result['retained']   = count( $retained );
+		$result['completed']  = count( $completed );
+		$result['released']   = count( $released );
+		$result['omitted']    = count( $omitted );
+		$result['explicit']   = count( $resolved );
+		$result['evidence']   = $evidence;
 		$result['_retryable'] = false;
 		return $result;
 	}
@@ -316,7 +316,11 @@ class StepLifecycleHandler {
 	/** Renew every retained claim while a waiting or retryable execution is parked. */
 	public static function renewParkedClaims( int $job_id, int $recovery_generation = 0, string $recovery_claim_token = '' ): array {
 		global $wpdb;
-		$result     = array( 'success' => false, 'stale' => false, 'renewed' => 0 );
+		$result     = array(
+			'success' => false,
+			'stale'   => false,
+			'renewed' => 0,
+		);
 		$jobs       = new Jobs();
 		$jobs_table = $jobs->get_table_name();
 		if ( $job_id <= 0 || false === $wpdb->query( 'START TRANSACTION' ) ) {
@@ -331,7 +335,7 @@ class StepLifecycleHandler {
 		}
 		$encoded = $job['engine_data'] ?? null;
 		$engine  = is_string( $encoded ) ? json_decode( $encoded, true ) : $encoded;
-		$engine = is_array( $engine ) ? $engine : array();
+		$engine  = is_array( $engine ) ? $engine : array();
 		if ( JobStatus::isStatusFinal( (string) ( $job['status'] ?? '' ) ) ) {
 			$wpdb->query( 'ROLLBACK' );
 			return $result;
@@ -371,33 +375,51 @@ class StepLifecycleHandler {
 		foreach ( $packets as $packet ) {
 			$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
 			if ( ProcessedItems::has_claim_metadata( $metadata ) && ! ProcessedItems::has_valid_claim_metadata( $metadata ) ) {
-				return array( 'success' => false, 'stale' => false );
+				return array(
+					'success' => false,
+					'stale'   => false,
+				);
 			}
 			$packet_claims = ProcessedItems::disposition_claims( $metadata );
 			if ( count( $packet_claims ) > 1 ) {
-				return array( 'success' => false, 'stale' => false );
+				return array(
+					'success' => false,
+					'stale'   => false,
+				);
 			}
 			$claims = array_replace( $claims, $packet_claims );
 		}
 		if ( empty( $claims ) ) {
-			return array( 'success' => true, 'stale' => false );
+			return array(
+				'success' => true,
+				'stale'   => false,
+			);
 		}
-		$transfer_id = bin2hex( random_bytes( 16 ) );
-		$result = self::commitReconciliation(
+		$transfer_id           = bin2hex( random_bytes( 16 ) );
+		$result                = self::commitReconciliation(
 			$job_id,
 			array( 'step_type' => 'fanout_transfer' ),
 			$claims,
 			array_fill_keys( array_keys( $claims ), 'transferred' ),
 			array(
 				'packet_fanout_transfer' => array(
-					'transfer_id' => $transfer_id,
-					'state'       => 'prepared',
-					'prepared_at' => gmdate( 'c' ),
+					'transfer_id'         => $transfer_id,
+					'state'               => 'prepared',
+					'prepared_at'         => gmdate( 'c' ),
 					'recovery_generation' => $recovery_generation,
-					'claims'      => $claims,
+					'claims'              => $claims,
 				),
 			),
-			array( 'success' => true, 'handled' => true, 'retained' => 0, 'completed' => 0, 'released' => 0, 'omitted' => 0, 'explicit' => 0, 'stale' => false ),
+			array(
+				'success'   => true,
+				'handled'   => true,
+				'retained'  => 0,
+				'completed' => 0,
+				'released'  => 0,
+				'omitted'   => 0,
+				'explicit'  => 0,
+				'stale'     => false,
+			),
 			$recovery_generation,
 			$recovery_claim_token
 		);
@@ -459,7 +481,13 @@ class StepLifecycleHandler {
 	/** Transactionally fence fanout adoption, restoration, finalization, and recovery. */
 	private static function mutateFanoutTransfer( int $job_id, string $transfer_id, string $action, int $recovery_generation, string $recovery_claim_token ): array {
 		global $wpdb;
-		$result     = array( 'success' => false, 'stale' => false, 'adopted' => false, 'restored' => false, 'handled' => false );
+		$result     = array(
+			'success'  => false,
+			'stale'    => false,
+			'adopted'  => false,
+			'restored' => false,
+			'handled'  => false,
+		);
 		$jobs       = new Jobs();
 		$jobs_table = $jobs->get_table_name();
 		if ( $job_id <= 0 || false === $wpdb->query( 'START TRANSACTION' ) ) {
@@ -474,7 +502,7 @@ class StepLifecycleHandler {
 		}
 		$encoded = $job['engine_data'] ?? null;
 		$engine  = is_string( $encoded ) ? json_decode( $encoded, true ) : $encoded;
-		$engine = is_array( $engine ) ? $engine : array();
+		$engine  = is_array( $engine ) ? $engine : array();
 		if ( JobStatus::isStatusFinal( (string) ( $job['status'] ?? '' ) ) ) {
 			$wpdb->query( 'ROLLBACK' );
 			return $result;
@@ -485,7 +513,7 @@ class StepLifecycleHandler {
 			return $result;
 		}
 
-		$transfer = is_array( $engine['packet_fanout_transfer'] ?? null ) ? $engine['packet_fanout_transfer'] : array();
+		$transfer   = is_array( $engine['packet_fanout_transfer'] ?? null ) ? $engine['packet_fanout_transfer'] : array();
 		$current_id = (string) ( $transfer['transfer_id'] ?? '' );
 		if ( '' === $current_id ) {
 			$wpdb->query( 'ROLLBACK' );
@@ -507,7 +535,7 @@ class StepLifecycleHandler {
 			}
 			$engine['packet_fanout_transfer']['state']      = 'adopted';
 			$engine['packet_fanout_transfer']['adopted_at'] = gmdate( 'c' );
-			$result['adopted'] = true;
+			$result['adopted']                              = true;
 		} elseif ( 'finalize' === $effective_action ) {
 			if ( ! $durably_adopted ) {
 				$wpdb->query( 'ROLLBACK' );
@@ -537,7 +565,7 @@ class StepLifecycleHandler {
 			$current = array_replace( $current, $claims );
 			unset( $engine[ ProcessedItems::CLAIM_METADATA_KEY ], $engine['packet_fanout_transfer'] );
 			$engine[ ProcessedItems::CLAIMS_METADATA_KEY ] = array_values( $current );
-			$result['restored'] = true;
+			$result['restored']                            = true;
 		} else {
 			$wpdb->query( 'ROLLBACK' );
 			return $result;
@@ -570,7 +598,7 @@ class StepLifecycleHandler {
 	private static function compactPacketRuntimeState( array $engine, array $active_ids ): array {
 		$active = array_fill_keys( $active_ids, true );
 		foreach ( array( 'packet_dispositions' ) as $key ) {
-			$records = is_array( $engine[ $key ] ?? null ) ? $engine[ $key ] : array();
+			$records        = is_array( $engine[ $key ] ?? null ) ? $engine[ $key ] : array();
 			$engine[ $key ] = array_intersect_key( $records, $active );
 			if ( empty( $engine[ $key ] ) ) {
 				unset( $engine[ $key ] );
@@ -720,7 +748,10 @@ class StepLifecycleHandler {
 				'datamachine_log',
 				'error',
 				'Terminal transition blocked by malformed packet claim metadata.',
-				array( 'job_id' => $job_id, 'status' => $status )
+				array(
+					'job_id' => $job_id,
+					'status' => $status,
+				)
 			);
 			return new \WP_Error(
 				'item_claim_metadata_invalid',
@@ -728,7 +759,7 @@ class StepLifecycleHandler {
 				array( 'status' => JobStatus::failed( 'item_claim_metadata_invalid' )->toString() )
 			);
 		}
-		$prepared    = JobStatus::isStatusSuccess( $status )
+		$prepared = JobStatus::isStatusSuccess( $status )
 			? self::handleCompleted( $job_id, $engine_data, true )
 			: self::handleFailed( $job_id, $engine_data );
 		if ( $prepared ) {

--- a/tests/Unit/AI/Tools/HandlerToolResolutionTest.php
+++ b/tests/Unit/AI/Tools/HandlerToolResolutionTest.php
@@ -15,6 +15,7 @@
 
 namespace DataMachine\Tests\Unit\AI\Tools;
 
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Engine\AI\Tools\ToolManager;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 use WP_UnitTestCase;
@@ -119,6 +120,44 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'widget_publish_bound', $resolved );
 		$this->assertSame( array( 'job_id' ), $resolved['widget_publish_bound']['client_context_bindings'] );
+	}
+
+	public function test_claimed_packet_centrally_requires_disposition_id_on_handler_tool(): void {
+		add_filter(
+			'datamachine_tools',
+			function ( array $tools ): array {
+				$tools['__handler_tools_claimed_publish'] = ToolManager::handlerToolDeclaration(
+					static fn(): array => array(
+						'claimed_publish' => array(
+							'description' => 'Publish one claimed packet',
+							'parameters'  => array( 'title' => array( 'type' => 'string', 'required' => true ) ),
+						),
+					),
+					array( 'handler' => 'claimed_publish' )
+				);
+				return $tools;
+			}
+		);
+		$claim = array(
+			'identity_scope'  => 'fetch-step',
+			'source_type'     => 'fixture',
+			'item_identifier' => 'item-2',
+			'ownership_token' => 'opaque-owner-token',
+			'disposition_id'  => ProcessedItems::disposition_identity( 'fetch-step', 'fixture', 'item-2' ),
+		);
+
+		$resolved = $this->tool_manager->resolveHandlerTools(
+			'claimed_publish',
+			array(),
+			array( ProcessedItems::CLAIMS_METADATA_KEY => array( $claim ) ),
+			'claimed-publish-scope'
+		);
+
+		$this->assertTrue( $resolved['claimed_publish']['packet_disposition_bound'] );
+		$this->assertArrayHasKey( 'disposition_id', $resolved['claimed_publish']['parameters']['properties'] );
+		$this->assertContains( 'disposition_id', $resolved['claimed_publish']['parameters']['required'] );
+		$this->assertContains( 'title', $resolved['claimed_publish']['parameters']['required'] );
+		$this->assertStringNotContainsString( 'opaque-owner-token', wp_json_encode( $resolved ) );
 	}
 
 	public function test_resolves_three_param_filter_style_handler_callable_before_static_tool(): void {

--- a/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
+++ b/tests/Unit/AI/Tools/ToolExecutorValidationTest.php
@@ -10,6 +10,8 @@ namespace DataMachine\Tests\Unit\AI\Tools;
 use AgentsAPI\AI\Tools\WP_Agent_Tool_Parameters;
 use AgentsAPI\AI\WP_Agent_Provider_Turn_Request;
 use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
 use DataMachine\Engine\AI\Tools\ToolExecutor;
 use DataMachine\Engine\AI\Tools\ToolManager;
@@ -237,6 +239,54 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( 42, $result['result']['data']['query'] ?? null );
+	}
+
+	public function test_disposition_contract_infers_only_one_claim_and_rejects_ambiguous_or_invalid_ids(): void {
+		$first  = $this->dispositionClaim( 'first' );
+		$second = $this->dispositionClaim( 'second' );
+		$tools  = array(
+			'claimed_handler' => array(
+				'class'                      => TestToolHandler::class,
+				'method'                     => 'handle_tool_call',
+				'packet_disposition_bound'   => true,
+				'parameters'                 => array(
+					'type'       => 'object',
+					'properties' => array( 'disposition_id' => array( 'type' => 'string' ) ),
+					'required'   => array( 'disposition_id' ),
+				),
+			),
+		);
+		$job_id = ( new Jobs() )->create_job( array( 'source' => 'pipeline', 'label' => 'Packet execution reservation validation' ) );
+		$this->assertGreaterThan( 0, $job_id );
+		$this->assertTrue( ( new Jobs() )->store_engine_data( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $first ) ) );
+
+		$single = ToolExecutor::executeTool(
+			'claimed_handler',
+			array(),
+			$tools,
+			array( 'job_id' => $job_id, 'engine_data' => array( ProcessedItems::CLAIM_METADATA_KEY => $first ) )
+		);
+		$this->assertTrue( $single['success'] );
+		$this->assertSame( $first['disposition_id'], $single['disposition_id'] );
+		$this->assertSame( $first['disposition_id'], $single['result']['data']['disposition_id'] ?? null );
+
+		$ambiguous = ToolExecutor::executeTool(
+			'claimed_handler',
+			array(),
+			$tools,
+			array( 'engine_data' => array( ProcessedItems::CLAIMS_METADATA_KEY => array( $first, $second ) ) )
+		);
+		$this->assertFalse( $ambiguous['success'] );
+		$this->assertSame( 'invalid_packet_disposition', $ambiguous['code'] );
+
+		$invalid = ToolExecutor::executeTool(
+			'claimed_handler',
+			array( 'disposition_id' => str_repeat( 'f', 64 ) ),
+			$tools,
+			array( 'engine_data' => array( ProcessedItems::CLAIMS_METADATA_KEY => array( $first, $second ) ) )
+		);
+		$this->assertFalse( $invalid['success'] );
+		$this->assertSame( 'invalid_packet_disposition', $invalid['code'] );
 	}
 
 	public function test_execute_tool_applies_authoritative_caller_context_bindings(): void {
@@ -789,6 +839,16 @@ class ToolExecutorValidationTest extends WP_UnitTestCase {
 					),
 				),
 			),
+		);
+	}
+
+	private function dispositionClaim( string $item_identifier ): array {
+		return array(
+			'identity_scope'  => 'fetch-step',
+			'source_type'     => 'fixture',
+			'item_identifier' => $item_identifier,
+			'ownership_token' => 'owner-' . $item_identifier,
+			'disposition_id'  => ProcessedItems::disposition_identity( 'fetch-step', 'fixture', $item_identifier ),
 		);
 	}
 

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -390,8 +390,16 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 			'ownership_token' => 'opaque-token',
 			'completion'      => array(),
 		);
+		$claim['disposition_id'] = ProcessedItems::disposition_identity( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] );
+		$sibling = array(
+			'identity_scope'  => 'shared:source',
+			'source_type'     => 'source',
+			'item_identifier' => 'sibling-item',
+			'ownership_token' => 'sibling-token',
+		);
 		$packet = $this->make_data_packet( 'Claimed Event' );
 		$packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] = $claim;
+		$packet['metadata']['_engine_data'][ ProcessedItems::CLAIMS_METADATA_KEY ] = array( $sibling );
 
 		$scheduler = new PipelineBatchScheduler();
 		$scheduler->fanOut( $parent_id, 'step_abc_123', array( $packet ), $engine );
@@ -401,6 +409,7 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$child_id    = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT job_id FROM %i WHERE parent_job_id = %d', $wpdb->prefix . 'datamachine_jobs', $parent_id ) );
 		$child_engine = datamachine_get_engine_data( $child_id );
 		$this->assertSame( $claim, $child_engine[ ProcessedItems::CLAIM_METADATA_KEY ] );
+		$this->assertArrayNotHasKey( ProcessedItems::CLAIMS_METADATA_KEY, $child_engine );
 	}
 
 	public function test_process_chunk_respects_cancellation(): void {

--- a/tests/Unit/Core/ItemClaimLifecycleTest.php
+++ b/tests/Unit/Core/ItemClaimLifecycleTest.php
@@ -39,6 +39,8 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 	private ?Closure $chunk_size_filter         = null;
 	private ?Closure $tracked_handler_filter    = null;
 	private ?Closure $completion_handler_filter = null;
+	private ?Closure $reconciliation_claim_filter = null;
+	private ?Closure $reconciliation_persist_filter = null;
 
 	public function set_up(): void {
 		parent::set_up();
@@ -66,6 +68,12 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		}
 		if ( null !== $this->tracked_handler_filter ) {
 			remove_filter( 'datamachine_item_claim_completion_handlers', $this->tracked_handler_filter );
+		}
+		if ( null !== $this->reconciliation_claim_filter ) {
+			remove_filter( 'datamachine_packet_reconciliation_claim_mutation', $this->reconciliation_claim_filter );
+		}
+		if ( null !== $this->reconciliation_persist_filter ) {
+			remove_filter( 'datamachine_packet_reconciliation_engine_persist', $this->reconciliation_persist_filter );
 		}
 		$this->deleteTestRows();
 		parent::tear_down();
@@ -701,6 +709,217 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 		$this->assertFalse( $this->processed->has_active_claim( self::SCOPE, self::SOURCE, 'hydrate-id' ) );
 	}
 
+	public function test_non_contiguous_ai_output_replaces_claims_and_only_omissions_retry(): void {
+		$job_id = $this->createJobWithClaim( array(), true );
+		$claims = array(
+			'a' => $this->claim( 'subset-a', $job_id, 'revision-a' ),
+			'b' => $this->claim( 'subset-b', $job_id, 'revision-b' ),
+			'c' => $this->claim( 'subset-c', $job_id, 'revision-c' ),
+			'd' => $this->claim( 'subset-d', $job_id, 'revision-d' ),
+		);
+		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIMS_METADATA_KEY => array_values( $claims ) ) );
+
+		$reconciled = StepLifecycleHandler::reconcileStepOutput(
+			$job_id,
+			array( 'step_type' => 'ai', 'flow_step_id' => 'ai-subset' ),
+			array( $this->dispositionPacket( $claims['b'], 'succeeded' ), $this->dispositionPacket( $claims['d'], 'succeeded' ) ),
+			true
+		);
+
+		$this->assertTrue( $reconciled['success'] );
+		$this->assertSame( 2, $reconciled['retained'] );
+		$this->assertSame( 2, $reconciled['omitted'] );
+		$engine = datamachine_get_engine_data( $job_id );
+		$this->assertSame(
+			array( $claims['b']['disposition_id'], $claims['d']['disposition_id'] ),
+			array_column( $engine[ ProcessedItems::CLAIMS_METADATA_KEY ], 'disposition_id' )
+		);
+		$this->assertCount( 2, $engine[ ProcessedItems::CLAIMS_METADATA_KEY ], 'Exact replacement must not retain stale numeric tails.' );
+		$this->assertSame(
+			array( $claims['a']['disposition_id'], $claims['c']['disposition_id'] ),
+			$engine['packet_disposition_evidence'][0]['omitted_ids']
+		);
+
+		$this->assertTrue( $this->jobs->complete_job( $job_id, JobStatus::COMPLETED ) );
+		$this->assertNotNull( $this->tracked->get( self::NAMESPACE, 'subset-b' ) );
+		$this->assertNotNull( $this->tracked->get( self::NAMESPACE, 'subset-d' ) );
+		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'subset-a' ) );
+		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'subset-c' ) );
+		$this->assertIsArray( $this->context( 'retry-a', $job_id + 100 )->claimItemOwnership( self::SCOPE, 'subset-a' ) );
+		$this->assertIsArray( $this->context( 'retry-c', $job_id + 101 )->claimItemOwnership( self::SCOPE, 'subset-c' ) );
+		$this->assertFalse( $this->context( 'retry-b', $job_id + 102 )->claimItemOwnership( self::SCOPE, 'subset-b' ) );
+	}
+
+	public function test_zero_output_and_terminal_ai_boundaries_release_or_complete_exact_claims(): void {
+		$zero_job = $this->createJobWithClaim( array(), true );
+		$zero     = $this->claim( 'zero-output', $zero_job, 'zero-revision' );
+		datamachine_set_engine_data( $zero_job, array( ProcessedItems::CLAIM_METADATA_KEY => $zero ) );
+		$zero_result = StepLifecycleHandler::reconcileStepOutput( $zero_job, array( 'step_type' => 'ai' ), array(), false );
+		$this->assertTrue( $zero_result['success'] );
+		$this->assertSame( 1, $zero_result['omitted'] );
+		$this->assertIsArray( $this->context( 'zero-retry', $zero_job + 100 )->claimItemOwnership( self::SCOPE, 'zero-output' ) );
+
+		$terminal_job = $this->createJobWithClaim( array(), true );
+		$terminal     = $this->claim( 'terminal-ai-success', $terminal_job, 'terminal-revision' );
+		datamachine_set_engine_data( $terminal_job, array( ProcessedItems::CLAIM_METADATA_KEY => $terminal ) );
+		$terminal_result = StepLifecycleHandler::reconcileStepOutput(
+			$terminal_job,
+			array( 'step_type' => 'ai' ),
+			array( $this->dispositionPacket( $terminal, 'succeeded' ) ),
+			true
+		);
+		$this->assertTrue( $terminal_result['success'] );
+		$this->assertTrue( $this->jobs->complete_job( $terminal_job, JobStatus::COMPLETED ) );
+		$this->assertNotNull( $this->tracked->get( self::NAMESPACE, 'terminal-ai-success' ) );
+	}
+
+	public function test_multi_item_reject_and_defer_are_isolated_and_legacy_single_infers_identity(): void {
+		$job_id   = $this->createJobWithClaim( array(), true );
+		$rejected = $this->claim( 'isolated-reject', $job_id, 'reject-revision' );
+		$deferred = $this->claim( 'isolated-defer', $job_id, 'defer-revision' );
+		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIMS_METADATA_KEY => array( $rejected, $deferred ) ) );
+		$tool = new FetchItemDispositionTool();
+		$reject_result = $tool->handle_tool_call(
+			array( 'job_id' => $job_id, 'disposition_id' => $rejected['disposition_id'], 'reason' => 'irrelevant' ),
+			array( 'disposition' => 'reject_source' )
+		);
+		$defer_result = $tool->handle_tool_call(
+			array( 'job_id' => $job_id, 'disposition_id' => $deferred['disposition_id'], 'reason' => 'temporary' ),
+			array( 'disposition' => 'defer_item' )
+		);
+		$this->assertTrue( $reject_result['success'] );
+		$this->assertTrue( $defer_result['success'] );
+		$this->assertSame( $rejected['disposition_id'], $reject_result['disposition_id'] );
+		$this->assertSame( $deferred['disposition_id'], $defer_result['disposition_id'] );
+
+		$reconciled = StepLifecycleHandler::reconcileStepOutput(
+			$job_id,
+			array( 'step_type' => 'ai' ),
+			array( $this->dispositionPacket( $rejected, 'reject_source' ), $this->dispositionPacket( $deferred, 'defer_item' ) ),
+			true
+		);
+		$this->assertTrue( $reconciled['success'] );
+		$this->assertSame( 1, $reconciled['completed'] );
+		$this->assertSame( 1, $reconciled['released'] );
+		$this->assertNotNull( $this->tracked->get( self::NAMESPACE, 'isolated-reject' ) );
+		$this->assertNull( $this->tracked->get( self::NAMESPACE, 'isolated-defer' ) );
+		$this->assertIsArray( $this->context( 'defer-retry', $job_id + 200 )->claimItemOwnership( self::SCOPE, 'isolated-defer' ) );
+
+		$legacy_job = $this->createJobWithClaim( array(), true );
+		$legacy     = $this->claim( 'legacy-single-inference', $legacy_job, 'legacy-revision' );
+		datamachine_set_engine_data( $legacy_job, array( ProcessedItems::CLAIM_METADATA_KEY => $legacy ) );
+		$legacy_result = $tool->handle_tool_call(
+			array( 'job_id' => $legacy_job, 'reason' => 'single legacy caller' ),
+			array( 'disposition' => 'defer_item' )
+		);
+		$this->assertTrue( $legacy_result['success'] );
+		$this->assertSame( $legacy['disposition_id'], $legacy_result['disposition_id'] );
+	}
+
+	public function test_reconciliation_reports_release_ownership_failure(): void {
+		$job_id = $this->createJobWithClaim( array(), true );
+		$old    = $this->claim( 'release-race', $job_id, 'old-revision' );
+		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $old ) );
+		$this->expireClaim( 'release-race' );
+		$replacement = $this->claim( 'release-race', $job_id + 1, 'replacement-revision' );
+
+		$result = StepLifecycleHandler::reconcileStepOutput( $job_id, array( 'step_type' => 'ai' ), array(), false );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertTrue( $this->processed->owns_active_claim( $replacement, $job_id + 1 ) );
+	}
+
+	public function test_mid_batch_reconciliation_failure_rolls_back_every_claim_mutation(): void {
+		$job_id = $this->createJobWithClaim( array(), true );
+		$first  = $this->claim( 'mid-batch-first', $job_id, 'first-revision' );
+		$second = $this->claim( 'mid-batch-second', $job_id, 'second-revision' );
+		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIMS_METADATA_KEY => array( $first, $second ) ) );
+		$this->reconciliation_claim_filter = static fn( bool $allowed, int $index ): bool => $allowed && 1 !== $index;
+		add_filter( 'datamachine_packet_reconciliation_claim_mutation', $this->reconciliation_claim_filter, 10, 2 );
+
+		$result = StepLifecycleHandler::reconcileStepOutput( $job_id, array( 'step_type' => 'ai' ), array(), false );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertTrue( $this->processed->owns_active_claim( $first, $job_id ) );
+		$this->assertTrue( $this->processed->owns_active_claim( $second, $job_id ) );
+		$this->assertCount( 2, datamachine_get_engine_data( $job_id )[ ProcessedItems::CLAIMS_METADATA_KEY ] );
+	}
+
+	public function test_engine_persist_failure_rolls_back_claim_mutations_and_can_retry(): void {
+		$job_id = $this->createJobWithClaim( array(), true );
+		$first  = $this->claim( 'persist-failure-first', $job_id, 'first-revision' );
+		$second = $this->claim( 'persist-failure-second', $job_id, 'second-revision' );
+		datamachine_set_engine_data( $job_id, array( ProcessedItems::CLAIMS_METADATA_KEY => array( $first, $second ) ) );
+		$this->reconciliation_persist_filter = static fn(): bool => false;
+		add_filter( 'datamachine_packet_reconciliation_engine_persist', $this->reconciliation_persist_filter );
+
+		$failed = StepLifecycleHandler::reconcileStepOutput( $job_id, array( 'step_type' => 'ai' ), array( $this->dispositionPacket( $second, 'succeeded' ) ), true );
+		$this->assertFalse( $failed['success'] );
+		$this->assertTrue( $this->processed->owns_active_claim( $first, $job_id ) );
+		$this->assertTrue( $this->processed->owns_active_claim( $second, $job_id ) );
+		remove_filter( 'datamachine_packet_reconciliation_engine_persist', $this->reconciliation_persist_filter );
+		$this->reconciliation_persist_filter = null;
+
+		$retried = StepLifecycleHandler::reconcileStepOutput( $job_id, array( 'step_type' => 'ai' ), array( $this->dispositionPacket( $second, 'succeeded' ) ), true );
+		$this->assertTrue( $retried['success'] );
+		$this->assertIsArray( $this->context( 'persist-failure-retry', $job_id + 500 )->claimItemOwnership( self::SCOPE, 'persist-failure-first' ) );
+		$this->assertTrue( $this->processed->owns_active_claim( $second, $job_id ) );
+	}
+
+	public function test_mysql_reconciliation_lock_order_serializes_job_then_claim_rows(): void {
+		if ( ! class_exists( '\mysqli' ) || ! defined( 'MYSQLI_ASYNC' ) ) {
+			$this->markTestSkipped( 'MySQLi async support is unavailable.' );
+		}
+		$first  = $this->openMysqlConnection();
+		$second = $this->openMysqlConnection();
+		if ( ! $first instanceof \mysqli || ! $second instanceof \mysqli ) {
+			$this->markTestSkipped( 'Two direct test database connections are unavailable.' );
+		}
+
+		$job_id = $this->createJobWithClaim( array(), true );
+		$claim  = $this->claim( 'mysql-lock-order', $job_id, 'mysql-lock-revision' );
+		$jobs_table = str_replace( '`', '``', $this->jobs->get_table_name() );
+		$claims_table = str_replace( '`', '``', $this->processed->get_table_name() );
+		$claim_lock = sprintf(
+			"SELECT claim_token FROM `{$claims_table}` WHERE flow_step_id = '%s' AND source_type = '%s' AND item_identifier = '%s' AND claim_token = '%s' FOR UPDATE",
+			$first->real_escape_string( $claim['identity_scope'] ),
+			$first->real_escape_string( $claim['source_type'] ),
+			$first->real_escape_string( $claim['item_identifier'] ),
+			$first->real_escape_string( $claim['ownership_token'] )
+		);
+
+		try {
+			$this->assertTrue( $first->query( 'SET SESSION innodb_lock_wait_timeout = 2' ) );
+			$this->assertTrue( $second->query( 'SET SESSION innodb_lock_wait_timeout = 2' ) );
+			$this->assertTrue( $first->query( 'START TRANSACTION' ) );
+			$this->assertInstanceOf( \mysqli_result::class, $first->query( "SELECT job_id FROM `{$jobs_table}` WHERE job_id = {$job_id} FOR UPDATE" ) );
+			$this->assertInstanceOf( \mysqli_result::class, $first->query( $claim_lock ) );
+			$this->assertTrue( $second->query( 'START TRANSACTION' ) );
+			$this->assertTrue( $second->query( "SELECT job_id FROM `{$jobs_table}` WHERE job_id = {$job_id} FOR UPDATE", MYSQLI_ASYNC ) );
+			$read = array( $second );
+			$error = array();
+			$reject = array();
+			$this->assertSame( 0, \mysqli_poll( $read, $error, $reject, 0, 100000 ), 'The second reconciliation must wait on the job row before claim rows.' );
+			$this->assertTrue( $first->query( 'COMMIT' ) );
+			$ready = 0;
+			for ( $attempt = 0; $attempt < 20 && 0 === $ready; ++$attempt ) {
+				$read = array( $second );
+				$error = array();
+				$reject = array();
+				$ready = \mysqli_poll( $read, $error, $reject, 0, 100000 );
+			}
+			$this->assertSame( 1, $ready );
+			$this->assertInstanceOf( \mysqli_result::class, $second->reap_async_query() );
+			$this->assertInstanceOf( \mysqli_result::class, $second->query( str_replace( "'" . $first->real_escape_string( $claim['ownership_token'] ) . "'", "'" . $second->real_escape_string( $claim['ownership_token'] ) . "'", $claim_lock ) ) );
+			$this->assertTrue( $second->query( 'COMMIT' ) );
+		} finally {
+			$first->query( 'ROLLBACK' );
+			$second->query( 'ROLLBACK' );
+			$first->close();
+			$second->close();
+		}
+	}
+
 	public function test_corrupt_batch_payload_is_discarded_without_callback(): void {
 		$claim     = $this->claim( 'corrupt-id', 904, 'corrupt-revision' );
 		$parent_id = $this->createJobWithClaim( array(), true );
@@ -868,6 +1087,38 @@ class ItemClaimLifecycleTest extends WP_UnitTestCase {
 			'data'     => array( 'title' => 'Claimed item', 'body' => 'body' ),
 			'metadata' => array( ProcessedItems::CLAIM_METADATA_KEY => $claim ),
 		);
+	}
+
+	private function dispositionPacket( array $claim, string $disposition ): array {
+		return array(
+			'type'     => 'ai_handler_complete',
+			'data'     => array( 'title' => 'Dispositioned item' ),
+			'metadata' => array(
+				ProcessedItems::CLAIM_METADATA_KEY          => $claim,
+				ProcessedItems::DISPOSITION_ID_METADATA_KEY => $claim['disposition_id'],
+				'disposition_id'                            => $claim['disposition_id'],
+				'packet_disposition'                        => $disposition,
+				'step_execution_success'                    => true,
+			),
+		);
+	}
+
+	private function openMysqlConnection(): ?\mysqli {
+		$host   = DB_HOST;
+		$port   = null;
+		$socket = null;
+		if ( preg_match( '/^([^:]+):(\d+)$/', $host, $matches ) ) {
+			$host = $matches[1];
+			$port = (int) $matches[2];
+		} elseif ( preg_match( '/^([^:]+):(.+)$/', $host, $matches ) ) {
+			$host   = $matches[1];
+			$socket = $matches[2];
+		}
+		$connection = \mysqli_init();
+		if ( false === $connection || ! @$connection->real_connect( $host, DB_USER, DB_PASSWORD, DB_NAME, $port, $socket ) ) {
+			return null;
+		}
+		return $connection;
 	}
 
 	private function legacyEngineData( string $item_id ): array {

--- a/tests/Unit/Core/Steps/AI/AIStepTest.php
+++ b/tests/Unit/Core/Steps/AI/AIStepTest.php
@@ -8,6 +8,7 @@
 namespace DataMachine\Tests\Unit\Core\Steps\AI;
 
 use DataMachine\Core\Steps\AI\AIStep;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Engine\AI\DataPacketPromptProjector;
 use DataMachine\Engine\AI\Tools\ToolResultFinder;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
@@ -255,6 +256,40 @@ class AIStepTest extends TestCase {
 		$this->assertSame( $context, $received );
 	}
 
+	public function test_prompt_projection_recursively_redacts_tokens_after_filters_and_retains_safe_identity(): void {
+		$disposition_id = hash( 'sha256', 'safe-packet' );
+		$canonical      = array(
+			array(
+				'type'     => 'fetch',
+				'data'     => array( 'title' => 'Claimed packet' ),
+				'metadata' => array(
+					'_datamachine_packet_disposition_id' => $disposition_id,
+					'_datamachine_item_claim' => array(
+						'disposition_id' => $disposition_id,
+						'ownership_token' => 'top-secret-token',
+					),
+					'_datamachine_item_claims' => array(
+						array( 'ownership_token' => 'nested-secret-token' ),
+					),
+				),
+			),
+		);
+		add_filter(
+			'datamachine_ai_project_data_packet',
+			static fn( array $projected, array $packet ): array => $packet,
+			10,
+			2
+		);
+
+		$projected = DataPacketPromptProjector::project( $canonical );
+		$encoded   = wp_json_encode( $projected );
+
+		$this->assertStringNotContainsString( 'top-secret-token', $encoded );
+		$this->assertStringNotContainsString( 'nested-secret-token', $encoded );
+		$this->assertSame( $disposition_id, $projected[0]['metadata']['_datamachine_packet_disposition_id'] );
+		$this->assertSame( $disposition_id, $canonical[0]['metadata']['_datamachine_item_claim']['disposition_id'] );
+	}
+
 	/**
 	 * Test that processLoopResults does NOT carry forward input DataPackets.
 	 *
@@ -363,6 +398,48 @@ class AIStepTest extends TestCase {
 		);
 
 		$this->assertSame( 'ticketmaster', $result[0]['metadata']['source_type'] );
+	}
+
+	public function test_process_loop_results_correlates_non_contiguous_outputs_by_disposition_id(): void {
+		$method = new ReflectionMethod( AIStep::class, 'processLoopResults' );
+		$method->setAccessible( true );
+		$claims = array();
+		foreach ( array( 'a', 'b', 'c', 'd' ) as $item ) {
+			$claims[ $item ] = array(
+				'identity_scope'  => 'fetch-step',
+				'source_type'     => 'fixture',
+				'item_identifier' => $item,
+				'ownership_token' => 'owner-' . $item,
+				'disposition_id'  => ProcessedItems::disposition_identity( 'fetch-step', 'fixture', $item ),
+			);
+		}
+		$tool_results = array();
+		foreach ( array( 'd', 'b' ) as $item ) {
+			$tool_results[] = array(
+				'tool_name'       => 'fixture_upsert',
+				'result'          => array( 'success' => true, 'disposition_id' => $claims[ $item ]['disposition_id'] ),
+				'parameters'      => array( 'title' => strtoupper( $item ) ),
+				'is_handler_tool' => true,
+			);
+		}
+
+		$result = $method->invoke(
+			null,
+			array( 'messages' => array(), 'tool_execution_results' => $tool_results ),
+			array( array( 'metadata' => array( 'source_type' => 'fixture' ) ) ),
+			array(
+				'flow_step_id' => 'ai-step',
+				'engine_data'  => array( ProcessedItems::CLAIMS_METADATA_KEY => array_values( $claims ) ),
+			),
+			array( 'fixture_upsert' => array( 'handler' => 'fixture_upsert', 'handler_config' => array() ) )
+		);
+
+		$this->assertSame(
+			array( $claims['d']['disposition_id'], $claims['b']['disposition_id'] ),
+			array_column( array_column( $result, 'metadata' ), 'disposition_id' )
+		);
+		$this->assertSame( 'd', $result[0]['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ]['item_identifier'] );
+		$this->assertSame( 'b', $result[1]['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ]['item_identifier'] );
 	}
 
 	public function test_successful_handler_tool_result_is_findable_by_downstream_handler_slug(): void {

--- a/tests/Unit/Engine/AI/RuntimeToolRunStateStoreTest.php
+++ b/tests/Unit/Engine/AI/RuntimeToolRunStateStoreTest.php
@@ -58,7 +58,7 @@ class RuntimeToolRunStateStoreTest extends TestCase {
 		$this->assertSame( RuntimeToolRunStateStore::STATUS_FINALIZED, $second['status'] );
 	}
 
-	public function test_resume_is_idempotent(): void {
+	public function test_resume_returns_state_only_to_first_winner(): void {
 		$jobs  = new RuntimeToolRunStateJobsDouble();
 		$store = new RuntimeToolRunStateStore( $jobs );
 
@@ -73,9 +73,9 @@ class RuntimeToolRunStateStoreTest extends TestCase {
 		$first  = $store->resume( 42, array( 'session_id' => 'session-a' ) );
 		$second = $store->resume( 42, array( 'session_id' => 'session-b' ) );
 
-		$this->assertSame( $first, $second );
-		$this->assertSame( 'session-a', $second['resume_payload']['session_id'] );
-		$this->assertSame( RuntimeToolRunStateStore::STATUS_RESUMED, $second['status'] );
+		$this->assertSame( 'session-a', $first['resume_payload']['session_id'] );
+		$this->assertSame( RuntimeToolRunStateStore::STATUS_RESUMED, $first['status'] );
+		$this->assertNull( $second );
 	}
 
 	public function test_finalize_retries_conflicting_engine_data_write(): void {

--- a/tests/ai-error-status-propagation-smoke.php
+++ b/tests/ai-error-status-propagation-smoke.php
@@ -33,6 +33,11 @@ if ( ! function_exists( 'sanitize_key' ) ) {
 		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
 	}
 }
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( mixed $value, int $flags = 0 ): string|false {
+		return json_encode( $value, $flags );
+	}
+}
 
 $datamachine_test_engine_data = array();
 
@@ -47,6 +52,8 @@ require_once __DIR__ . '/../inc/Core/JobStatus.php';
 require_once __DIR__ . '/../inc/Core/StepExecutionResult.php';
 require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
 require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
+require_once __DIR__ . '/../inc/Core/Database/ProcessedItems/ProcessedItems.php';
+require_once __DIR__ . '/../inc/Engine/Actions/Handlers/StepLifecycleHandler.php';
 require_once __DIR__ . '/../inc/Abilities/Engine/EngineHelpers.php';
 require_once __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php';
 

--- a/tests/engine-transaction-cache-smoke.php
+++ b/tests/engine-transaction-cache-smoke.php
@@ -1,0 +1,68 @@
+<?php
+/** Verify production Jobs transaction writes never publish pre-commit cache state. */
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+final class EngineTransactionCacheWpdb {
+	public string $prefix = 'wp_';
+	public string $base_prefix = 'wp_';
+	public string $last_error = '';
+	public array $events = array();
+
+	public function get_var( string $query ): int { unset( $query ); return 16 * 1024 * 1024; }
+	public function update( string $table, array $data, array $where, array $format, array $where_format ): int {
+		unset( $table, $data, $where, $format, $where_format );
+		$this->events[] = 'sql-update';
+		return 1;
+	}
+	public function delete( string $table, array $where, array $format ): int {
+		unset( $table, $where, $format );
+		$this->events[] = 'metadata-delete';
+		return 1;
+	}
+	public function query( string $query ): int { $this->events[] = $query; return 1; }
+}
+
+$GLOBALS['wpdb'] = new EngineTransactionCacheWpdb();
+function wp_json_encode( mixed $value, int $flags = 0 ): string|false { return json_encode( $value, $flags ); }
+function sanitize_key( string $value ): string { return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $value ) ); }
+function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+	unset( $args );
+	return 'datamachine_run_metadata_index_paths' === $hook ? array() : $value;
+}
+function do_action( string $hook, mixed ...$args ): void { unset( $hook, $args ); }
+function wp_cache_set( mixed $key, mixed $value, string $group = '' ): bool {
+	unset( $key, $value, $group );
+	$GLOBALS['wpdb']->events[] = 'cache-set';
+	return true;
+}
+function wp_cache_delete( mixed $key, string $group = '' ): bool {
+	unset( $key, $group );
+	$GLOBALS['wpdb']->events[] = 'cache-delete';
+	return true;
+}
+
+require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
+require_once __DIR__ . '/../inc/Core/Database/RunMetadata/RunMetadata.php';
+require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
+
+$failures = 0;
+$passes   = 0;
+$assert = static function ( bool $condition, string $label ) use ( &$failures, &$passes ): void {
+	if ( $condition ) { ++$passes; echo "  [PASS] {$label}\n"; return; }
+	++$failures; echo "  [FAIL] {$label}\n";
+};
+
+$jobs = new DataMachine\Core\Database\Jobs\Jobs();
+$GLOBALS['wpdb']->query( 'START TRANSACTION' );
+$stored = $jobs->store_engine_data_in_transaction( 42, array( 'claims' => array( 'one' ) ) );
+$assert( $stored && ! in_array( 'cache-set', $GLOBALS['wpdb']->events, true ), 'transaction-only engine SQL does not publish cache state' );
+$GLOBALS['wpdb']->query( 'COMMIT' );
+$jobs->publish_committed_engine_data( 42, array( 'claims' => array( 'one' ) ) );
+$commit = array_search( 'COMMIT', $GLOBALS['wpdb']->events, true );
+$cache  = array_search( 'cache-delete', $GLOBALS['wpdb']->events, true );
+$assert( false !== $commit && false !== $cache && $cache > $commit, 'production cache invalidation follows commit' );
+$assert( 0 === count( array_filter( $GLOBALS['wpdb']->events, static fn( string $event ): bool => 'cache-set' === $event ) ), 'transaction path never publishes an unlocked snapshot' );
+
+echo "engine-transaction-cache-smoke: {$passes} passed, {$failures} failed\n";
+exit( $failures > 0 ? 1 : 0 );

--- a/tests/fanout-adoption-recovery-smoke.php
+++ b/tests/fanout-adoption-recovery-smoke.php
@@ -1,0 +1,181 @@
+<?php
+/** Executable fanout adoption rollback and crash-recovery coverage. */
+
+namespace DataMachine\Core\Database\BatchItems {
+	class BatchItems {
+		public const DEFAULT_LEASE_SECONDS = 60;
+		public static array $worklists = array();
+		public function insert_batch( int $job_id, array $items, array $cleanup ): array {
+			unset( $cleanup );
+			if ( isset( self::$worklists[ $job_id ] ) ) {
+				return array( 'success' => true, 'created' => false, 'existing' => true, 'ownership_token' => '' );
+			}
+			self::$worklists[ $job_id ] = array( 'items' => $items, 'token' => 'owner-' . $job_id, 'completed' => array() );
+			return array( 'success' => true, 'created' => true, 'existing' => false, 'ownership_token' => 'owner-' . $job_id );
+		}
+		public function discard_owned( int $job_id, string $token ): array {
+			unset( $job_id, $token );
+			return array( 'success' => true, 'rows' => array(), 'remaining' => false );
+		}
+		public function delete_owned_batch( int $job_id, string $token ): bool {
+			if ( ! isset( self::$worklists[ $job_id ] ) || $token !== self::$worklists[ $job_id ]['token'] ) {
+				return false;
+			}
+			unset( self::$worklists[ $job_id ] );
+			return true;
+		}
+		public function claim_chunk( int $job_id, int $offset, int $limit, int $lease, ?callable $owner = null ): array {
+			unset( $lease );
+			if ( ! isset( self::$worklists[ $job_id ] ) || ! empty( self::$worklists[ $job_id ]['completed'][ $offset ] ) ) {
+				return array();
+			}
+			if ( null !== $owner && ! $owner() ) {
+				return array();
+			}
+			$rows = array();
+			foreach ( array_slice( self::$worklists[ $job_id ]['items'], $offset, $limit, true ) as $index => $payload ) {
+				$rows[] = array( 'item_index' => $index, 'payload' => $payload, 'payload_valid' => true, 'payload_checksum' => hash( 'sha256', (string) json_encode( $payload ) ), 'cleanup_context' => array(), 'lease_token' => 'lease-' . $index );
+			}
+			return $rows;
+		}
+		public function complete( int $job_id, int $index, string $lease, mixed $result ): bool {
+			unset( $lease, $result );
+			if ( ! isset( self::$worklists[ $job_id ]['items'][ $index ] ) || ! empty( self::$worklists[ $job_id ]['completed'][ $index ] ) ) {
+				return false;
+			}
+			self::$worklists[ $job_id ]['completed'][ $index ] = true;
+			return true;
+		}
+		public function first_outstanding_index( int $job_id ): ?int {
+			foreach ( self::$worklists[ $job_id ]['items'] ?? array() as $index => $item ) {
+				unset( $item );
+				if ( empty( self::$worklists[ $job_id ]['completed'][ $index ] ) ) {
+					return $index;
+				}
+			}
+			return null;
+		}
+		public function count_completed( int $job_id ): int { return count( self::$worklists[ $job_id ]['completed'] ?? array() ); }
+	}
+}
+
+namespace DataMachine\Core\Database\Jobs {
+	class Jobs {}
+}
+
+namespace DataMachine\Core {
+	class PluginSettings { public static function get( string $key, array $default ): array { unset( $key ); return $default; } }
+	class DataPacketStore {
+		public static function reference_packet_collections_in_value( mixed $value ): mixed { return $value; }
+		public static function hydrate_packet_collections_with_status( mixed $value ): array { return array( 'success' => true, 'value' => $value ); }
+	}
+	class JobStatus { public static function isStatusFinal( string $status ): bool { return false; } }
+	class PacketEngineData {}
+	class RunMetrics { public static function start( int $job_id, array $context ): void { unset( $job_id, $context ); } }
+	class EngineData {
+		public static array $engines = array();
+		public static function mutate( int $job_id, callable $callback, string $event ): array {
+			unset( $event );
+			$current = self::$engines[ $job_id ] ?? array();
+			$next = $callback( $current );
+			if ( ! is_array( $next ) ) {
+				return array( 'success' => false, 'snapshot' => $current );
+			}
+			self::$engines[ $job_id ] = $next;
+			return array( 'success' => true, 'snapshot' => $next );
+		}
+		public static function retrieve( int $job_id ): array { return self::$engines[ $job_id ] ?? array(); }
+	}
+}
+
+namespace {
+	use DataMachine\Core\ActionScheduler\BatchScheduler;
+	use DataMachine\Core\Database\BatchItems\BatchItems;
+	use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+	use DataMachine\Core\EngineData;
+
+	define( 'ABSPATH', __DIR__ . '/' );
+	$GLOBALS['fanout_actions'] = array();
+	$GLOBALS['fanout_schedule_fails'] = false;
+	function absint( mixed $value ): int { return abs( (int) $value ); }
+	function current_time( string $type, bool $gmt = false ): string { unset( $type, $gmt ); return gmdate( 'Y-m-d H:i:s' ); }
+	function wp_json_encode( mixed $value ): string|false { return json_encode( $value ); }
+	function datamachine_get_engine_data( int $job_id ): array { return EngineData::$engines[ $job_id ] ?? array(); }
+	function do_action( string $hook, mixed ...$args ): void { unset( $hook, $args ); }
+	function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+		if ( 'datamachine_batch_engine_adoption_state' === $hook ) {
+			return \DataMachine\Engine\Actions\Handlers\StepLifecycleHandler::filterBatchAdoptionState( $value, (string) $args[0], (string) $args[1] );
+		}
+		if ( 'datamachine_batch_engine_adoption_rollback_state' === $hook ) {
+			return \DataMachine\Engine\Actions\Handlers\StepLifecycleHandler::filterBatchAdoptionRollbackState( $value, (string) $args[0], (string) $args[1] );
+		}
+		return $value;
+	}
+	function as_has_scheduled_action( string $hook, array $args, string $group ): int {
+		foreach ( $GLOBALS['fanout_actions'] as $id => $action ) {
+			if ( $hook === $action['hook'] && $args === $action['args'] && $group === $action['group'] ) {
+				return $id + 1;
+			}
+		}
+		return 0;
+	}
+	function as_schedule_single_action( int $timestamp, string $hook, array $args, string $group ): int {
+		unset( $timestamp );
+		if ( $GLOBALS['fanout_schedule_fails'] ) {
+			return 0;
+		}
+		$existing = as_has_scheduled_action( $hook, $args, $group );
+		if ( $existing > 0 ) {
+			return $existing;
+		}
+		$GLOBALS['fanout_actions'][] = compact( 'hook', 'args', 'group' );
+		return count( $GLOBALS['fanout_actions'] );
+	}
+
+	require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
+	require_once __DIR__ . '/../inc/Core/Database/ProcessedItems/ProcessedItems.php';
+	require_once __DIR__ . '/../inc/Engine/Actions/Handlers/StepLifecycleHandler.php';
+	require_once __DIR__ . '/../inc/Core/ActionScheduler/GroupRegistrar.php';
+	require_once __DIR__ . '/../inc/Core/ActionScheduler/BatchScheduler.php';
+
+	$passes = 0;
+	$failures = 0;
+	$assert = static function ( bool $condition, string $label ) use ( &$passes, &$failures ): void {
+		if ( $condition ) { ++$passes; echo "  [PASS] {$label}\n"; return; }
+		++$failures; echo "  [FAIL] {$label}\n";
+	};
+	$claim = array( 'identity_scope' => 'scope', 'source_type' => 'source', 'item_identifier' => 'one', 'ownership_token' => 'claim-owner' );
+	$claim['disposition_id'] = ProcessedItems::disposition_identity( 'scope', 'source', 'one' );
+	$item = array( 'metadata' => array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
+
+	EngineData::$engines[10] = array(
+		'packet_fanout_transfer' => array( 'transfer_id' => 'transfer-10', 'state' => 'prepared', 'claims' => array( $claim['disposition_id'] => $claim ) ),
+	);
+	$GLOBALS['fanout_schedule_fails'] = true;
+	$failed = BatchScheduler::start( 10, 'fanout_hook', array( $item ), array(), 'pipeline', BatchScheduler::COMPLETION_STRATEGY_CHILDREN_COMPLETE );
+	$failed_engine = EngineData::$engines[10];
+	$assert( ! $failed['scheduled'], 'initial scheduling failure is reported' );
+	$assert( ! isset( $failed_engine['packet_fanout_transfer'], $failed_engine['batch_state'] ), 'failed initial schedule atomically clears adopted transfer and batch state' );
+	$assert( isset( ProcessedItems::disposition_claims( $failed_engine )[ $claim['disposition_id'] ] ), 'failed initial schedule restores parent claim ownership' );
+	$assert( ! isset( BatchItems::$worklists[10] ), 'restored ownership permits worklist deletion without discarding the claim' );
+
+	$GLOBALS['fanout_schedule_fails'] = false;
+	EngineData::$engines[20] = array(
+		'packet_fanout_transfer' => array( 'transfer_id' => 'transfer-20', 'state' => 'prepared', 'claims' => array( $claim['disposition_id'] => $claim ) ),
+	);
+	BatchItems::$worklists[20] = array( 'items' => array( $item ), 'token' => 'crashed-owner', 'completed' => array() );
+	$recovered = BatchScheduler::start( 20, 'fanout_hook', array( $item ), array(), 'pipeline', BatchScheduler::COMPLETION_STRATEGY_CHILDREN_COMPLETE );
+	$retried   = BatchScheduler::start( 20, 'fanout_hook', array( $item ), array(), 'pipeline', BatchScheduler::COMPLETION_STRATEGY_CHILDREN_COMPLETE );
+	$assert( $recovered['scheduled'] && $recovered['adopted'], 'existing crash worklist is adopted only after an initial action exists' );
+	$assert( $retried['scheduled'] && $retried['adopted'], 'exact retry adopts the same scheduled worklist' );
+	$assert( 1 === count( $GLOBALS['fanout_actions'] ), 'existing-worklist recovery creates no duplicate initial actions' );
+	$assert( 1 === count( BatchItems::$worklists[20]['items'] ), 'existing-worklist recovery creates no duplicate work items' );
+	$children = 0;
+	$create_child = static function () use ( &$children ): int { return ++$children; };
+	BatchScheduler::processChunk( 20, $create_child, 0 );
+	BatchScheduler::processChunk( 20, $create_child, 0 );
+	$assert( 1 === $children, 'duplicate recovered chunk delivery creates exactly one child' );
+
+	echo "fanout-adoption-recovery-smoke: {$passes} passed, {$failures} failed\n";
+	exit( $failures > 0 ? 1 : 0 );
+}

--- a/tests/fetch-item-dispositions-smoke.php
+++ b/tests/fetch-item-dispositions-smoke.php
@@ -52,7 +52,7 @@ namespace {
 	}
 
 	if ( ! function_exists( 'datamachine_merge_engine_data' ) ) {
-		function datamachine_merge_engine_data( int $job_id, array $data ): void {
+		function datamachine_merge_engine_data( int $job_id, array $data ): bool {
 			$GLOBALS['fetch_disposition_smoke_engine'][ $job_id ] = array_merge(
 				$GLOBALS['fetch_disposition_smoke_engine'][ $job_id ] ?? array(),
 				$data
@@ -68,6 +68,7 @@ namespace {
 			// Keep the (possibly real) object cache coherent with the snapshot
 			// so EngineData::retrieve() never serves a stale pre-merge value.
 			wp_cache_set( $job_id, $GLOBALS['fetch_disposition_smoke_persisted_engine'][ $job_id ], 'datamachine_engine_data' );
+			return true;
 		}
 	}
 
@@ -90,6 +91,11 @@ namespace {
 			return strip_tags( $text );
 		}
 	}
+	if ( ! function_exists( 'sanitize_key' ) ) {
+		function sanitize_key( string $value ): string {
+			return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $value ) );
+		}
+	}
 }
 
 namespace DataMachine\Core\Database\Jobs {
@@ -97,11 +103,60 @@ namespace DataMachine\Core\Database\Jobs {
 		public function retrieve_engine_data( int $job_id ): array {
 			return $GLOBALS['fetch_disposition_smoke_persisted_engine'][ $job_id ] ?? array();
 		}
+		public function compare_and_swap_engine_data( int $job_id, array $expected, array $next ): array {
+			$current = $GLOBALS['fetch_disposition_smoke_persisted_engine'][ $job_id ] ?? array();
+			if ( is_array( $GLOBALS['fetch_disposition_smoke_cas_injection'][ $job_id ] ?? null ) ) {
+				$current['packet_dispositions'] = array_replace(
+					is_array( $current['packet_dispositions'] ?? null ) ? $current['packet_dispositions'] : array(),
+					$GLOBALS['fetch_disposition_smoke_cas_injection'][ $job_id ]
+				);
+				$GLOBALS['fetch_disposition_smoke_persisted_engine'][ $job_id ] = $current;
+				unset( $GLOBALS['fetch_disposition_smoke_cas_injection'][ $job_id ] );
+				return array( 'updated' => false, 'conflict' => true, 'error' => null );
+			}
+			if ( $current !== $expected ) {
+				return array( 'updated' => false, 'conflict' => true, 'error' => null );
+			}
+			$GLOBALS['fetch_disposition_smoke_persisted_engine'][ $job_id ] = $next;
+			$GLOBALS['fetch_disposition_smoke_engine'][ $job_id ] = $next;
+			return array( 'updated' => true, 'conflict' => false, 'error' => null );
+		}
 	}
 }
 
 namespace DataMachine\Core\Database\ProcessedItems {
 	class ProcessedItems {
+		public const CLAIM_METADATA_KEY          = '_datamachine_item_claim';
+		public const CLAIMS_METADATA_KEY         = '_datamachine_item_claims';
+		public const DISPOSITION_ID_METADATA_KEY = '_datamachine_packet_disposition_id';
+
+		public static function disposition_identity( string $scope, string $source, string $item ): string {
+			return hash( 'sha256', implode( "\0", array( $scope, $source, $item ) ) );
+		}
+
+		public static function disposition_claims( array $container ): array {
+			$candidates = isset( $container[ self::CLAIM_METADATA_KEY ] ) ? array( $container[ self::CLAIM_METADATA_KEY ] ) : array();
+			$candidates = array_merge( $candidates, is_array( $container[ self::CLAIMS_METADATA_KEY ] ?? null ) ? $container[ self::CLAIMS_METADATA_KEY ] : array() );
+			$claims     = array();
+			foreach ( $candidates as $claim ) {
+				if ( ! is_array( $claim ) ) {
+					continue;
+				}
+				$id                    = $claim['disposition_id'] ?? self::disposition_identity( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] );
+				$claim['disposition_id'] = $id;
+				$claims[ $id ]         = $claim;
+			}
+			return $claims;
+		}
+
+		public static function resolve_disposition_claim( array $container, string $id = '', bool $infer_single = true ): ?array {
+			$claims = self::disposition_claims( $container );
+			if ( '' !== $id ) {
+				return $claims[ $id ] ?? null;
+			}
+			return $infer_single && 1 === count( $claims ) ? reset( $claims ) : null;
+		}
+
 		public function release_claim( string $flow_step_id, string $source_type, string $item_identifier ): int|false {
 			$GLOBALS['fetch_disposition_smoke_released'][] = array( $flow_step_id, $source_type, $item_identifier );
 			return 1;
@@ -130,6 +185,13 @@ namespace {
 		}
 	}
 
+	$claim = array(
+		'identity_scope'  => 'fetch-step_7',
+		'source_type'     => 'rss',
+		'item_identifier' => 'source-123',
+		'ownership_token' => 'opaque-owner-token',
+	);
+	$claim['disposition_id'] = DataMachine\Core\Database\ProcessedItems\ProcessedItems::disposition_identity( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] );
 	$engine = new FetchDispositionSmokeEngine(
 		array(
 			'item_identifier' => 'source-123',
@@ -138,6 +200,7 @@ namespace {
 				'fetch-step_7' => array( 'step_type' => 'fetch' ),
 				'ai-step_7'    => array( 'step_type' => 'ai' ),
 			),
+			DataMachine\Core\Database\ProcessedItems\ProcessedItems::CLAIM_METADATA_KEY => $claim,
 		)
 	);
 
@@ -172,8 +235,8 @@ namespace {
 	assert_fetch_disposition_smoke( 'reject_source succeeds', true === ( $reject['success'] ?? false ) );
 	assert_fetch_disposition_smoke( 'reject_source reports explicit tool name', 'reject_source' === ( $reject['tool_name'] ?? '' ) );
 	assert_fetch_disposition_smoke( 'reject_source does not eagerly mark the claim processed', array() === $GLOBALS['fetch_disposition_smoke_processed'] );
-	assert_fetch_disposition_smoke( 'reject_source sets source-rejected status', 'agent_skipped - source-rejected' === ( $GLOBALS['fetch_disposition_smoke_engine'][1814]['job_status'] ?? '' ) );
-	$reject_diagnostic = $GLOBALS['fetch_disposition_smoke_engine'][1814]['disposition_diagnostic'] ?? array();
+	assert_fetch_disposition_smoke( 'reject_source preserves exact safe identity', $claim['disposition_id'] === ( $reject['disposition_id'] ?? '' ) );
+	$reject_diagnostic = $GLOBALS['fetch_disposition_smoke_engine'][1814]['packet_dispositions'][ $claim['disposition_id'] ]['diagnostic'] ?? array();
 	assert_fetch_disposition_smoke( 'reject_source persists disposition diagnostic', 'reject_source' === ( $reject_diagnostic['disposition'] ?? '' ) && 'duplicate-source' === ( $reject_diagnostic['reason'] ?? '' ) );
 	assert_fetch_disposition_smoke( 'reject_source diagnostic includes source identity', 'source-123' === ( $reject_diagnostic['item_identifier'] ?? '' ) && 'fixture-provider' === ( $reject_diagnostic['provider'] ?? '' ) && 'fetch-step_7' === ( $reject_diagnostic['flow_step_id'] ?? '' ) );
 	assert_fetch_disposition_smoke( 'reject_source diagnostic includes packet count and bounded excerpt', 1 === ( $reject_diagnostic['packet_count'] ?? 0 ) && 1200 === ( $reject_diagnostic['excerpt_limit'] ?? 0 ) && 1200 >= strlen( $reject_diagnostic['excerpt'] ?? '' ) );
@@ -195,8 +258,8 @@ namespace {
 	assert_fetch_disposition_smoke( 'defer_item reports explicit tool name', 'defer_item' === ( $defer['tool_name'] ?? '' ) );
 	assert_fetch_disposition_smoke( 'defer_item does not eagerly release the claim', array() === $GLOBALS['fetch_disposition_smoke_released'] );
 	assert_fetch_disposition_smoke( 'defer_item does not mark processed', array() === $GLOBALS['fetch_disposition_smoke_processed'] );
-	assert_fetch_disposition_smoke( 'tool-error deferral remains retry eligible', 'failed - item-deferred' === ( $GLOBALS['fetch_disposition_smoke_engine'][1815]['job_status'] ?? '' ) );
-	$defer_diagnostic = $GLOBALS['fetch_disposition_smoke_engine'][1815]['disposition_diagnostic'] ?? array();
+	assert_fetch_disposition_smoke( 'tool-error deferral remains packet scoped', ! isset( $GLOBALS['fetch_disposition_smoke_engine'][1815]['job_status'] ) );
+	$defer_diagnostic = $GLOBALS['fetch_disposition_smoke_engine'][1815]['packet_dispositions'][ $claim['disposition_id'] ]['diagnostic'] ?? array();
 	assert_fetch_disposition_smoke( 'defer_item persists disposition diagnostic', 'defer_item' === ( $defer_diagnostic['disposition'] ?? '' ) && 'tool-error' === ( $defer_diagnostic['reason'] ?? '' ) );
 
 	echo "Case 2b: reject_source hydrates engine data from job_id when runtime engine is absent\n";
@@ -207,6 +270,12 @@ namespace {
 		'flow_config'     => array(
 			'fetch-step_8' => array( 'step_type' => 'fetch' ),
 			'ai-step_8'    => array( 'step_type' => 'ai' ),
+		),
+		DataMachine\Core\Database\ProcessedItems\ProcessedItems::CLAIM_METADATA_KEY => array(
+			'identity_scope'  => 'fetch-step_8',
+			'source_type'     => 'mcp',
+			'item_identifier' => 'source-456',
+			'ownership_token' => 'opaque-owner-token-456',
 		),
 	);
 	$reject_hydrated = $tool->handle_tool_call(
@@ -237,9 +306,9 @@ namespace {
 	assert_fetch_disposition_smoke( 'second disposition returns success (no error-retry loop)', true === ( $defer_after_reject['success'] ?? false ) );
 	assert_fetch_disposition_smoke( 'second disposition reports already_dispositioned', true === ( $defer_after_reject['already_dispositioned'] ?? false ) );
 	assert_fetch_disposition_smoke( 'second disposition message references existing disposition', str_contains( $defer_after_reject['message'] ?? '', 'already dispositioned (source-rejected)' ) );
-	assert_fetch_disposition_smoke( 'defer_item does not downgrade source-rejected status', 'agent_skipped - source-rejected' === ( $GLOBALS['fetch_disposition_smoke_engine'][1814]['job_status'] ?? '' ) );
-	assert_fetch_disposition_smoke( 'second disposition preserves original disposition record', 'reject_source' === ( $GLOBALS['fetch_disposition_smoke_engine'][1814]['disposition_diagnostic']['disposition'] ?? '' ) );
-	assert_fetch_disposition_smoke( 'second disposition does not write item_deferral record', ! isset( $GLOBALS['fetch_disposition_smoke_engine'][1814]['item_deferral'] ) );
+	assert_fetch_disposition_smoke( 'defer_item does not downgrade source rejection', 'reject_source' === ( $defer_after_reject['disposition'] ?? '' ) );
+	assert_fetch_disposition_smoke( 'second disposition preserves original disposition record', 'reject_source' === ( $GLOBALS['fetch_disposition_smoke_engine'][1814]['packet_dispositions'][ $claim['disposition_id'] ]['disposition'] ?? '' ) );
+	assert_fetch_disposition_smoke( 'second disposition does not write a second packet record', 1 === count( $GLOBALS['fetch_disposition_smoke_engine'][1814]['packet_dispositions'] ?? array() ) );
 	assert_fetch_disposition_smoke( 'second disposition does not release the processed claim', array() === $GLOBALS['fetch_disposition_smoke_released'] );
 	assert_fetch_disposition_smoke( 'second disposition does not re-mark processed', array() === $GLOBALS['fetch_disposition_smoke_processed'] );
 
@@ -255,10 +324,25 @@ namespace {
 	);
 	assert_fetch_disposition_smoke( 'reject_source after defer_item returns success', true === ( $reject_after_defer['success'] ?? false ) );
 	assert_fetch_disposition_smoke( 'reject_source after defer_item reports already_dispositioned', true === ( $reject_after_defer['already_dispositioned'] ?? false ) );
-	assert_fetch_disposition_smoke( 'reject_source does not overwrite item-deferred status', 'failed - item-deferred' === ( $GLOBALS['fetch_disposition_smoke_engine'][1815]['job_status'] ?? '' ) );
+	assert_fetch_disposition_smoke( 'reject_source does not overwrite packet deferral', 'defer_item' === ( $reject_after_defer['disposition'] ?? '' ) );
 	assert_fetch_disposition_smoke( 'reject_source after defer does not mark processed', array() === $GLOBALS['fetch_disposition_smoke_processed'] );
 
-	echo "Case 2d: disposition tools declare terminal completion signal (#2609)\n";
+	echo "Case 2d: concurrent dispositions preserve the first CAS winner\n";
+	$GLOBALS['fetch_disposition_smoke_persisted_engine'][1816] = array(
+		DataMachine\Core\Database\ProcessedItems\ProcessedItems::CLAIM_METADATA_KEY => $claim,
+		'flow_config' => array( 'fetch-step_7' => array( 'step_type' => 'fetch' ) ),
+	);
+	$GLOBALS['fetch_disposition_smoke_cas_injection'][1816] = array(
+		$claim['disposition_id'] => array( 'disposition' => 'defer_item', 'reason' => 'competing-winner' ),
+	);
+	$contention = $tool->handle_tool_call(
+		array( 'job_id' => 1816, 'reason' => 'losing-rejection', 'engine' => $engine ),
+		array( 'disposition' => 'reject_source' )
+	);
+	assert_fetch_disposition_smoke( 'CAS loser returns idempotent success', true === ( $contention['success'] ?? false ) && true === ( $contention['already_dispositioned'] ?? false ) );
+	assert_fetch_disposition_smoke( 'CAS loser cannot overwrite first disposition', 'defer_item' === ( $contention['disposition'] ?? '' ) && 'competing-winner' === ( $contention['reason'] ?? '' ) );
+
+	echo "Case 2e: disposition tools declare terminal completion signal (#2609)\n";
 	$fetch_handler_src = file_get_contents( __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/FetchHandler.php' );
 	assert_fetch_disposition_smoke( 'both disposition tool definitions declare runtime completion_signal terminal', 2 === substr_count( $fetch_handler_src, "'completion_signal' => 'terminal'" ) );
 

--- a/tests/packet-disposition-contract-smoke.php
+++ b/tests/packet-disposition-contract-smoke.php
@@ -1,0 +1,77 @@
+<?php
+/** Executable identity, redaction, cache, and idempotency contract coverage. */
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+$projection_filter = null;
+function apply_filters( string $hook, mixed $value, ...$args ): mixed {
+	global $projection_filter;
+	if ( 'datamachine_ai_project_data_packet' === $hook && is_callable( $projection_filter ) ) {
+		return $projection_filter( $value, ...$args );
+	}
+	return $value;
+}
+function wp_json_encode( mixed $value, int $flags = 0 ): string|false { return json_encode( $value, $flags ); }
+function sanitize_key( string $value ): string { return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $value ) ); }
+
+require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
+require_once __DIR__ . '/../inc/Core/Database/ProcessedItems/ProcessedItems.php';
+require_once __DIR__ . '/../inc/Engine/AI/DataPacketPromptProjector.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolExecutor.php';
+require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolManager.php';
+
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachine\Engine\AI\DataPacketPromptProjector;
+use DataMachine\Engine\AI\Tools\ToolExecutor;
+use DataMachine\Engine\AI\Tools\ToolManager;
+
+$failures = 0;
+$passes   = 0;
+$assert = static function ( bool $condition, string $label ) use ( &$failures, &$passes ): void {
+	if ( $condition ) { ++$passes; echo "  [PASS] {$label}\n"; return; }
+	++$failures; echo "  [FAIL] {$label}\n";
+};
+
+$claim = array(
+	'identity_scope'  => 'scope',
+	'source_type'     => 'source',
+	'item_identifier' => 'item',
+	'ownership_token' => 'opaque-owner-token',
+);
+$derived = ProcessedItems::disposition_identity( 'scope', 'source', 'item' );
+$resolved = ProcessedItems::resolve_disposition_claim( array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
+$assert( $derived === ( $resolved['disposition_id'] ?? '' ), 'legacy single-item claim infers derived identity' );
+
+$forged = $claim;
+$forged['disposition_id'] = 'opaque-owner-token';
+$assert( null === ProcessedItems::resolve_disposition_claim( array( ProcessedItems::CLAIM_METADATA_KEY => $forged ) ), 'mismatched supplied identity is rejected' );
+
+$claim['disposition_id'] = $derived;
+$canonical = array( array( 'metadata' => array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) ) );
+$projection_filter = static function ( array $projected, array $packet ): array {
+	unset( $projected );
+	$packet['metadata']['filter_nested'] = array( 'ownership_token' => 'filter-secret' );
+	return $packet;
+};
+$projected = DataPacketPromptProjector::project( $canonical );
+$encoded   = (string) wp_json_encode( $projected );
+$assert( ! str_contains( $encoded, 'opaque-owner-token' ) && ! str_contains( $encoded, 'filter-secret' ), 'recursive ownership tokens are redacted after filters' );
+$assert( $derived === ( $projected[0]['metadata'][ ProcessedItems::DISPOSITION_ID_METADATA_KEY ] ?? '' ), 'safe derived identity is restored after filtering' );
+
+$prior = array(
+	array(
+		'tool_name' => 'handler_tool',
+		'parameters' => array( 'title' => 'old payload', 'disposition_id' => $derived ),
+		'result' => array( 'success' => true, 'disposition_id' => $derived ),
+	),
+);
+$duplicate = ToolExecutor::existingPacketExecutionResult( 'handler_tool', $derived, array( 'prior_tool_results' => $prior ) );
+$assert( true === ( $duplicate['success'] ?? false ) && true === ( $duplicate['already_dispositioned'] ?? false ), 'successful handler identity blocks changed-payload repeat before execution' );
+
+$cache_key = new ReflectionMethod( ToolManager::class, 'buildHandlerToolsCacheKey' );
+$unbound   = $cache_key->invoke( null, 'scope', 'handler', array(), array( 'job_id' => 10 ) );
+$bound     = $cache_key->invoke( null, 'scope', 'handler', array(), array( 'job_id' => 10, ProcessedItems::CLAIM_METADATA_KEY => $claim ) );
+$assert( $unbound !== $bound, 'handler-tool cache distinguishes bound and unbound schemas' );
+
+echo "packet-disposition-contract-smoke: {$passes} passed, {$failures} failed\n";
+exit( $failures > 0 ? 1 : 0 );

--- a/tests/packet-disposition-route-smoke.php
+++ b/tests/packet-disposition-route-smoke.php
@@ -1,0 +1,268 @@
+<?php
+/** Executable route-level acceptance coverage for packet disposition. */
+
+namespace DataMachine\Core\Database\Jobs {
+	class Jobs {
+		public static string $status = 'processing';
+		public static array $engine = array();
+		public array $transitions = array();
+		public function transition_job_status_result( int $job_id, string $status, bool $force = false ): array {
+			unset( $force );
+			$this->transitions[] = array( $job_id, $status );
+			return array( 'success' => true, 'changed' => true, 'status' => $status );
+		}
+		public function get_job( int $job_id ): array {
+			return array( 'job_id' => $job_id, 'status' => self::$status, 'engine_data' => self::$engine );
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\Flows { class Flows {} }
+namespace DataMachine\Core\Database\Pipelines { class Pipelines {} }
+namespace DataMachine\Core\Database\ProcessedItems {
+	class ProcessedItems {
+		public const CLAIM_METADATA_KEY = '_datamachine_item_claim';
+		public const CLAIMS_METADATA_KEY = '_datamachine_item_claims';
+		public static function has_claim_metadata( array $container ): bool {
+			return array_key_exists( self::CLAIM_METADATA_KEY, $container ) || array_key_exists( self::CLAIMS_METADATA_KEY, $container );
+		}
+	}
+}
+
+namespace DataMachine\Core {
+	class EngineData {
+		public function __construct( private array $data ) {}
+		public function getFlowStepConfig( string $id ): array { return $this->data['flow_config'][ $id ] ?? array(); }
+	}
+	class JobStatus {
+		public const COMPLETED = 'completed';
+		public const COMPLETED_NO_ITEMS = 'completed_no_items';
+		public const PENDING = 'pending';
+		public static function isStatusWaiting( mixed $status ): bool { return 'waiting' === $status; }
+		public static function isStatusSuccess( mixed $status ): bool { return in_array( $status, array( self::COMPLETED, self::COMPLETED_NO_ITEMS ), true ); }
+		public static function isStatusFinal( mixed $status ): bool { return self::isStatusSuccess( $status ) || str_starts_with( (string) $status, 'failed' ); }
+		public static function fromString( string $status ): object { return new class( $status ) { public function __construct( private string $status ) {} public function getBaseStatus(): string { return $this->status; } }; }
+	}
+	class StepExecutionResult {}
+	class RecoveryExecutionFence {}
+	class ChildJobRecoveryPolicy {
+		public static function recoveryExecutionMatches( array $engine, int $generation, string $token ): bool {
+			return $generation === (int) ( $engine['generation'] ?? 0 ) && hash_equals( $token, (string) ( $engine['token'] ?? '' ) );
+		}
+	}
+	class RunMetrics {}
+}
+
+namespace DataMachine\Core\FilesRepository {
+	class FileCleanup { public function cleanup_job_data_packets( int $job_id, array $context ): void { unset( $job_id, $context ); } }
+	class FileRetrieval {}
+}
+
+namespace DataMachine\Core\Steps {
+	class Step {}
+	class FlowStepConfig {
+		public static function usesHandler( array $config ): bool { return ! empty( $config['uses_handler'] ); }
+	}
+}
+
+namespace DataMachine\Engine {
+	class StepNavigator {
+		public function get_next_flow_step_id( string $id, array $payload ): ?string {
+			unset( $id, $payload );
+			return $GLOBALS['route_smoke_next'] ?? null;
+		}
+	}
+}
+
+namespace DataMachine\Engine\Actions\Handlers {
+	class StepLifecycleHandler {
+		public static int $calls = 0;
+		public static bool $fail = false;
+		public static bool $stale = false;
+		public static array $claims = array();
+		public static array $released = array();
+		public static array $transferred = array();
+		public static bool $takeover_after_transfer = false;
+		public static array $last_transfer_claims = array();
+
+		public static function reconcileStepOutput( int $job_id, array $config, array $packets, bool $success, int $generation = 0, string $token = '' ): array {
+			unset( $job_id, $config, $generation, $token );
+			++self::$calls;
+			if ( self::$fail || self::$stale ) {
+				return array( 'success' => false, 'stale' => self::$stale, 'handled' => true, 'retained' => count( self::$claims ), 'explicit' => 0 );
+			}
+			$resolved = array();
+			if ( $success ) {
+				foreach ( $packets as $packet ) {
+					$id = (string) ( $packet['metadata']['disposition_id'] ?? '' );
+					if ( '' !== $id && isset( self::$claims[ $id ] ) ) {
+						$resolved[ $id ] = true;
+					}
+				}
+			}
+			foreach ( array_keys( self::$claims ) as $id ) {
+				if ( ! isset( $resolved[ $id ] ) ) {
+					self::$released[] = $id;
+					unset( self::$claims[ $id ] );
+				}
+			}
+			return array( 'success' => true, 'stale' => false, 'handled' => true, 'retained' => count( self::$claims ), 'explicit' => count( $resolved ) );
+		}
+
+		public static function transferClaimsToFanout( int $job_id, array $packets, int $generation = 0, string $token = '' ): array {
+			unset( $job_id, $token );
+			self::$last_transfer_claims = array();
+			foreach ( $packets as $packet ) {
+				$id = (string) ( $packet['metadata']['disposition_id'] ?? '' );
+				if ( isset( self::$claims[ $id ] ) ) {
+					self::$last_transfer_claims[ $id ] = true;
+					self::$transferred[] = $id;
+					unset( self::$claims[ $id ] );
+				}
+			}
+			if ( self::$takeover_after_transfer ) {
+				\DataMachine\Core\Database\Jobs\Jobs::$engine = array( 'generation' => $generation + 1, 'token' => 'new-owner' );
+			}
+			return array( 'success' => true, 'stale' => false, 'transfer_id' => 'fixture-transfer' );
+		}
+		public static function renewParkedClaims( int $job_id, int $generation = 0, string $token = '' ): array { unset( $job_id, $generation, $token ); return array( 'success' => true, 'stale' => false, 'renewed' => count( self::$claims ) ); }
+		public static function recoverPreparedFanoutTransfer( int $job_id, int $generation = 0, string $token = '' ): array { unset( $job_id, $generation, $token ); return array( 'success' => true, 'stale' => false ); }
+		public static function restorePreparedFanoutTransfer( int $job_id, string $transfer_id, int $generation = 0, string $token = '' ): bool {
+			unset( $job_id, $generation, $token );
+			if ( 'fixture-transfer' !== $transfer_id ) { return false; }
+			self::$claims = array_replace( self::$claims, self::$last_transfer_claims );
+			return true;
+		}
+		public static function adoptPreparedFanoutTransfer( int $job_id, string $transfer_id, int $generation = 0, string $token = '' ): bool { unset( $job_id, $transfer_id, $generation, $token ); return true; }
+		public static function finalizePreparedFanoutTransfer( int $job_id, string $transfer_id, int $generation = 0, string $token = '' ): bool { unset( $job_id, $transfer_id, $generation, $token ); return true; }
+	}
+}
+
+namespace DataMachine\Abilities\Engine {
+	trait EngineHelpers {
+		protected \DataMachine\Core\Database\Jobs\Jobs $db_jobs;
+	}
+	class ParallelMapFanoutAdapter {
+		public const STEP_TYPE = 'parallel';
+		public const SHAPE_INLINE = 'inline';
+		public static bool $fanout = true;
+		public static array $children = array();
+		public static int $dispatches = 0;
+		public static function shouldFanOut( array $step, array $context = array() ): bool { unset( $step, $context ); return self::$fanout; }
+		public function dispatch( array $step, int $job_id, string $next, array $engine, ?bool $fanout = null ): array {
+			unset( $job_id, $next, $engine );
+			++self::$dispatches;
+			self::$children = array_map( static fn( array $packet ): array => array( $packet['metadata']['disposition_id'] ?? '' ), $step['items'] );
+			return false === $fanout ? array( 'shape' => self::SHAPE_INLINE ) : array( 'shape' => 'map', 'batch' => array( 'scheduled' => true, 'adopted' => true ) );
+		}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+	$GLOBALS['route_smoke_actions'] = array();
+	function do_action( string $hook, ...$args ): void { $GLOBALS['route_smoke_actions'][] = array( $hook, $args ); }
+	function datamachine_get_engine_data( int $job_id ): array { unset( $job_id ); return $GLOBALS['route_smoke_engine'] ?? array(); }
+	function datamachine_get_file_context( mixed $flow_id ): array { unset( $flow_id ); return array(); }
+	function sanitize_key( string $key ): string { return $key; }
+
+	require_once __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php';
+
+	use DataMachine\Abilities\Engine\ExecuteStepAbility;
+	use DataMachine\Abilities\Engine\ParallelMapFanoutAdapter;
+	use DataMachine\Core\Database\Jobs\Jobs;
+	use DataMachine\Core\EngineData;
+	use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
+
+	$failures = 0;
+	$passes   = 0;
+	$assert = static function ( bool $condition, string $label ) use ( &$failures, &$passes ): void {
+		if ( $condition ) { ++$passes; echo "  [PASS] {$label}\n"; return; }
+		++$failures; echo "  [FAIL] {$label}\n";
+	};
+	$reflection = new \ReflectionClass( ExecuteStepAbility::class );
+	$ability    = $reflection->newInstanceWithoutConstructor();
+	$jobs       = new Jobs();
+	$reflection->getProperty( 'db_jobs' )->setValue( $ability, $jobs );
+	$route = $reflection->getMethod( 'routeAfterExecution' );
+	$invoke = static function ( array $packets, bool $success, mixed $override = null, string $type = 'ai', array $next_config = array(), int $generation = 0, string $token = '', array $execution_result = array() ) use ( $route, $ability ): array {
+		$GLOBALS['route_smoke_next'] = empty( $next_config ) ? null : 'next';
+		$engine = new EngineData( array( 'flow_config' => array( 'next' => $next_config ) ) );
+		return $route->invoke( $ability, 77, 'current', 3, array( 'step_type' => $type ), $type, 'FixtureStep', $packets, array( 'engine' => $engine ), $success, $override, $execution_result, $generation, $token );
+	};
+	$packet = static fn( string $id, string $type = 'ai_handler_complete' ): array => array( 'type' => $type, 'metadata' => array( 'tool_name' => 'handler', 'handler_tool' => 'handler', 'disposition_id' => $id ) );
+
+	foreach ( range( 1, 52 ) as $id ) { StepLifecycleHandler::$claims[ (string) $id ] = true; }
+	$selected = array_values( array_filter( range( 1, 52 ), static fn( int $id ): bool => 0 !== $id % 2 || 52 === $id ) );
+	$output   = array_map( $packet, array_map( 'strval', $selected ) );
+	$result = $invoke( $output, true, null, 'ai', array( 'uses_handler' => true, 'step_type' => 'upsert' ) );
+	$assert( 'inline_continuation' === $result['outcome'], 'non-contiguous outputs continue inline' );
+	$assert( 27 === count( StepLifecycleHandler::$claims ) && 25 === count( StepLifecycleHandler::$released ), 'partial output retains 27 and releases exactly 25 identities' );
+
+	$GLOBALS['route_smoke_next'] = null;
+	$result = $invoke( $output, true );
+	$assert( 'completed' === $result['outcome'] && array( 77, 'completed' ) === end( $jobs->transitions ), 'successful terminal completes retained claims' );
+
+	StepLifecycleHandler::$claims = array( 'zero' => true );
+	$result = $invoke( array(), false );
+	$assert( 'failed' === $result['outcome'] && in_array( 'zero', StepLifecycleHandler::$released, true ), 'zero output releases its claim and fails' );
+
+	StepLifecycleHandler::$claims = array( 'waiting' => true );
+	$calls = StepLifecycleHandler::$calls;
+	$result = $invoke( array(), true, 'waiting' );
+	$assert( 'waiting' === $result['outcome'] && $calls === StepLifecycleHandler::$calls && isset( StepLifecycleHandler::$claims['waiting'] ), 'waiting skips reconciliation' );
+
+	StepLifecycleHandler::$claims = array( 'override' => true );
+	$result = $invoke( array( $packet( 'override' ) ), true, 'completed' );
+	$assert( 'completed_override' === $result['outcome'], 'successful status override completes through terminal route' );
+	StepLifecycleHandler::$claims = array( 'failed-override' => true );
+	$result = $invoke( array(), false, 'failed - fixture' );
+	$assert( 'completed_override' === $result['outcome'] && ! isset( StepLifecycleHandler::$claims['failed-override'] ), 'failure status override releases claims before terminal route' );
+
+	StepLifecycleHandler::$claims = array( 'transition' => true );
+	$result = $invoke( array( $packet( 'transition', 'tool_result' ) ), true, null, 'ai', array( 'uses_handler' => true, 'step_type' => 'publish' ) );
+	$assert( 'failed' === $result['outcome'], 'transition-filter failure does not schedule next work' );
+
+	StepLifecycleHandler::$claims = array( 'fan-a' => true, 'fan-b' => true );
+	$result = $invoke( array( $packet( 'fan-a' ), $packet( 'fan-b' ) ), true, null, 'transform', array( 'step_type' => 'transform' ) );
+	$assert( 'batch_scheduled' === $result['outcome'] && empty( StepLifecycleHandler::$claims ), 'fanout transfers parent ownership' );
+	$assert( array( array( 'fan-a' ), array( 'fan-b' ) ) === ParallelMapFanoutAdapter::$children, 'fanout children receive one matching identity each' );
+
+	StepLifecycleHandler::$claims = array( 'stale' => true );
+	StepLifecycleHandler::$stale = true;
+	$result = $invoke( array( $packet( 'stale' ) ), true, null, 'ai', array(), 2, 'old-owner' );
+	$assert( 'stale_recovery_noop' === $result['outcome'] && isset( StepLifecycleHandler::$claims['stale'] ), 'recovery takeover fences claim mutation' );
+	StepLifecycleHandler::$stale = false;
+
+	StepLifecycleHandler::$claims = array( 'fan-recovery-a' => true, 'fan-recovery-b' => true );
+	StepLifecycleHandler::$takeover_after_transfer = true;
+	Jobs::$engine = array( 'generation' => 4, 'token' => 'current-owner' );
+	$dispatches = ParallelMapFanoutAdapter::$dispatches;
+	$result = $invoke( array( $packet( 'fan-recovery-a' ), $packet( 'fan-recovery-b' ) ), true, null, 'transform', array( 'step_type' => 'transform' ), 4, 'current-owner' );
+	$assert( 'stale_recovery_noop' === $result['outcome'] && $dispatches === ParallelMapFanoutAdapter::$dispatches && 2 === count( StepLifecycleHandler::$claims ), 'post-transfer recovery takeover blocks dispatch and restores claims' );
+	StepLifecycleHandler::$takeover_after_transfer = false;
+	Jobs::$engine = array();
+
+	StepLifecycleHandler::$claims = array( 'blocked' => true );
+	$calls = StepLifecycleHandler::$calls;
+	$result = $invoke( array(), false, null, 'ai', array(), 0, '', array( 'status' => 'blocked' ) );
+	$assert( 'blocked' === $result['outcome'] && $calls === StepLifecycleHandler::$calls && isset( StepLifecycleHandler::$claims['blocked'] ), 'blocked AI concurrency retains claims for scheduled resume' );
+
+	StepLifecycleHandler::$claims = array( 'pending-retry' => true );
+	Jobs::$status = 'pending';
+	$GLOBALS['route_smoke_engine'] = array( 'retry' => array( 'next_retry_at' => '2026-08-15T20:00:00Z' ) );
+	$calls = StepLifecycleHandler::$calls;
+	$result = $invoke( array(), false );
+	$assert( 'failed' === $result['outcome'] && $calls === StepLifecycleHandler::$calls && isset( StepLifecycleHandler::$claims['pending-retry'] ), 'already-scheduled pending retry retains claims' );
+	Jobs::$status = 'processing';
+	$GLOBALS['route_smoke_engine'] = array();
+
+	StepLifecycleHandler::$fail = true;
+	$GLOBALS['route_smoke_actions'] = array();
+	$result = $invoke( array( $packet( 'stale' ) ), true, null, 'ai', array( 'step_type' => 'next' ) );
+	$schedules = array_filter( $GLOBALS['route_smoke_actions'], static fn( array $action ): bool => 'datamachine_schedule_next_step' === $action[0] );
+	$assert( 'claim_reconciliation_failed' === $result['outcome'] && empty( $schedules ), 'persistence failure prevents next-step scheduling' );
+
+	echo "packet-disposition-route-smoke: {$passes} passed, {$failures} failed\n";
+	exit( $failures > 0 ? 1 : 0 );
+}

--- a/tests/packet-execution-reservation-smoke.php
+++ b/tests/packet-execution-reservation-smoke.php
@@ -1,0 +1,81 @@
+<?php
+/** Executable durable packet-handler reservation state-machine coverage. */
+
+namespace DataMachine\Core\Database\Jobs {
+	class Jobs {
+		public static array $engines = array();
+		public static bool $fail_next_cas = false;
+
+		public function retrieve_engine_data( int $job_id ): array {
+			return self::$engines[ $job_id ] ?? array();
+		}
+
+		public function compare_and_swap_engine_data( int $job_id, array $expected, array $next ): array {
+			if ( self::$fail_next_cas ) {
+				self::$fail_next_cas = false;
+				return array( 'updated' => false, 'conflict' => false, 'retryable' => false, 'error' => 'forced_persist_failure' );
+			}
+			if ( ( self::$engines[ $job_id ] ?? array() ) !== $expected ) {
+				return array( 'updated' => false, 'conflict' => true, 'error' => null );
+			}
+			self::$engines[ $job_id ] = $next;
+			return array( 'updated' => true, 'conflict' => false, 'error' => null );
+		}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+	function sanitize_key( string $value ): string { return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $value ) ); }
+	function wp_cache_get( mixed $key, string $group = '' ): false { unset( $key, $group ); return false; }
+	function wp_cache_set( mixed $key, mixed $value, string $group = '' ): bool { unset( $key, $value, $group ); return true; }
+	function wp_rand( int $min, int $max ): int { unset( $max ); return $min; }
+	function do_action( string $hook, mixed ...$args ): void { unset( $hook, $args ); }
+
+	require_once __DIR__ . '/../inc/Core/EngineData.php';
+	require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolExecutor.php';
+
+	use DataMachine\Core\Database\Jobs\Jobs;
+	use DataMachine\Engine\AI\Tools\ToolExecutor;
+
+	$failures = 0;
+	$passes   = 0;
+	$assert = static function ( bool $condition, string $label ) use ( &$failures, &$passes ): void {
+		if ( $condition ) { ++$passes; echo "  [PASS] {$label}\n"; return; }
+		++$failures; echo "  [FAIL] {$label}\n";
+	};
+	$payload = static fn( int $job_id ): array => array( 'job_id' => $job_id, 'engine_data' => Jobs::$engines[ $job_id ] ?? array() );
+	$id      = hash( 'sha256', 'packet-identity' );
+
+	$first = ToolExecutor::beginPacketExecution( 'handler', $id, $payload( 1 ) );
+	$second = ToolExecutor::beginPacketExecution( 'handler', $id, $payload( 1 ) );
+	$assert( ! empty( $first['acquired'] ), 'first caller atomically acquires execution reservation' );
+	$assert( empty( $second['acquired'] ) && 'packet_execution_outcome_ambiguous' === ( $second['result']['code'] ?? '' ), 'concurrent caller is blocked before side effects' );
+	$assert( ToolExecutor::finishPacketExecution( 'handler', $id, $payload( 1 ), (string) $first['token'], 'succeeded' ), 'successful outcome is durably finalized' );
+	$duplicate = ToolExecutor::beginPacketExecution( 'handler', $id, $payload( 1 ) );
+	$assert( empty( $duplicate['acquired'] ) && ! empty( $duplicate['result']['already_dispositioned'] ), 'successful execution remains idempotently blocked' );
+
+	$ambiguous = ToolExecutor::beginPacketExecution( 'handler', $id, $payload( 2 ) );
+	Jobs::$fail_next_cas = true;
+	$assert( ! ToolExecutor::finishPacketExecution( 'handler', $id, $payload( 2 ), (string) $ambiguous['token'], 'succeeded' ), 'final persistence failure is reported' );
+	$after_failure = ToolExecutor::beginPacketExecution( 'handler', $id, $payload( 2 ) );
+	$assert( empty( $after_failure['acquired'] ) && ! empty( $after_failure['result']['automatic_replay_blocked'] ), 'ambiguous outcome survives process/persistence failure and blocks replay' );
+
+	$known_failure = ToolExecutor::beginPacketExecution( 'handler', $id, $payload( 3 ) );
+	$assert( ToolExecutor::finishPacketExecution( 'handler', $id, $payload( 3 ), (string) $known_failure['token'], 'failed' ), 'known failure is durably recorded' );
+	$retry = ToolExecutor::beginPacketExecution( 'handler', $id, $payload( 3 ) );
+	$assert( ! empty( $retry['acquired'] ), 'known pre-success failure permits a new reserved attempt' );
+	$request_id = 'runtime_tool_3';
+	$assert( ToolExecutor::finishPacketExecution( 'handler', $id, $payload( 3 ), (string) $retry['token'], 'pending', $request_id ), 'external pending outcome is durably parked' );
+	$pending = ToolExecutor::beginPacketExecution( 'handler', $id, $payload( 3 ) );
+	$assert( empty( $pending['acquired'] ) && ! empty( $pending['result']['automatic_replay_blocked'] ), 'pending external execution blocks duplicate initiation' );
+	$assert( ! ToolExecutor::finishPendingPacketExecution( 'handler', $id, 3, 'succeeded', 'wrong-token', $request_id ), 'replayed or forged reservation token is rejected' );
+	$assert( ! ToolExecutor::finishPendingPacketExecution( 'handler', $id, 3, 'succeeded', (string) $retry['token'], 'runtime_tool_old' ), 'replayed external request identity is rejected' );
+	$assert( ToolExecutor::finishPendingPacketExecution( 'handler', $id, 3, 'succeeded', (string) $retry['token'], $request_id ), 'submitted external result finalizes the same durable reservation' );
+	$assert( ToolExecutor::finishPendingPacketExecution( 'handler', $id, 3, 'succeeded', (string) $retry['token'], $request_id ), 'same callback identity is idempotent after a crash' );
+	$external_complete = ToolExecutor::beginPacketExecution( 'handler', $id, $payload( 3 ) );
+	$assert( empty( $external_complete['acquired'] ) && ! empty( $external_complete['result']['already_dispositioned'] ), 'fulfilled external execution is idempotently complete' );
+
+	echo "packet-execution-reservation-smoke: {$passes} passed, {$failures} failed\n";
+	exit( $failures > 0 ? 1 : 0 );
+}

--- a/tests/packet-reconciliation-transaction-smoke.php
+++ b/tests/packet-reconciliation-transaction-smoke.php
@@ -1,0 +1,288 @@
+<?php
+/** Executable transactional rollback coverage for packet reconciliation. */
+
+namespace DataMachine\Core\Database\Jobs {
+	class Jobs {
+		public function get_table_name(): string { return 'wp_datamachine_jobs'; }
+		public function store_engine_data_in_transaction( int $job_id, array $engine ): bool {
+			unset( $job_id );
+			$GLOBALS['transaction_smoke_events'][] = 'store';
+			$GLOBALS['wpdb']->engine = $engine;
+			return true;
+		}
+		public function publish_committed_engine_data( int $job_id, array $engine ): void { unset( $job_id, $engine ); $GLOBALS['transaction_smoke_events'][] = 'publish'; }
+		public function has_retryable_transaction_error(): bool { return str_contains( strtolower( $GLOBALS['wpdb']->last_error ), 'deadlock' ); }
+	}
+}
+
+namespace DataMachine\Core {
+	class ChildJobRecoveryPolicy { public static bool $matches = true; public static function recoveryExecutionMatches( array $engine, int $generation, string $token ): bool { unset( $engine, $generation, $token ); return self::$matches; } }
+	class EngineData {}
+	class JobStatus {
+		public static function isStatusFinal( string $status ): bool { return in_array( $status, array( 'completed', 'failed' ), true ); }
+		public static function isStatusSuccess( string $status ): bool { return 'completed' === $status; }
+		public static function failed( string $reason ): object { return new class( $reason ) { public function __construct( private string $reason ) {} public function toString(): string { return 'failed - ' . $this->reason; } }; }
+	}
+	class PacketEngineData { public static function sanitize( array $data, int $job_id ): array { unset( $job_id ); return $data; } }
+	class RunMetrics { public static function recordStepResult( int $job_id, string $step, array $data ): void { unset( $job_id, $step, $data ); } }
+	class DataPacketStore {}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+	define( 'ARRAY_A', 'ARRAY_A' );
+	class WP_Error { public function __construct( public string $code, public string $message, public mixed $data = null ) {} }
+
+	class PacketReconciliationFakeWpdb {
+		public string $prefix = 'wp_';
+		public string $last_error = '';
+		public array $engine = array();
+		public array $rows = array();
+		public bool $deadlock_once = false;
+		public bool $deadlock_commit_once = false;
+		public int $transaction_starts = 0;
+		private array $prepared_args = array();
+		private ?array $snapshot = null;
+		public function prepare( string $query, mixed ...$args ): string { $this->prepared_args = $args; return $query; }
+		public function get_row( string $query, string $output ): array {
+			unset( $output );
+			if ( str_contains( $query, 'engine_data' ) || str_contains( $query, 'datamachine_jobs' ) ) {
+				return array( 'job_id' => 9, 'status' => 'processing', 'engine_data' => json_encode( $this->engine ) );
+			}
+			$args = $this->prepared_args;
+			foreach ( $this->rows as $row ) {
+				if ( ( $row['flow_step_id'] ?? '' ) === ( $args[1] ?? null ) && ( $row['source_type'] ?? '' ) === ( $args[2] ?? null ) && ( $row['item_identifier'] ?? '' ) === ( $args[3] ?? null ) ) {
+					return $row;
+				}
+			}
+			return array();
+		}
+		public function get_var( string $query ): string|false {
+			unset( $query );
+			if ( $this->deadlock_once ) {
+				$this->deadlock_once = false;
+				$this->last_error = 'Deadlock found when trying to get lock; try restarting transaction';
+				return false;
+			}
+			$args = $this->prepared_args;
+			foreach ( $this->rows as $row ) {
+				if ( ( $row['flow_step_id'] ?? '' ) === ( $args[1] ?? null ) && ( $row['source_type'] ?? '' ) === ( $args[2] ?? null ) && ( $row['item_identifier'] ?? '' ) === ( $args[3] ?? null ) && ( $row['claim_token'] ?? '' ) === ( $args[4] ?? null ) && ( $row['status'] ?? '' ) === ( $args[5] ?? null ) ) {
+					return (string) $row['claim_token'];
+				}
+			}
+			return false;
+		}
+		public function query( string $query ): int|false {
+			$GLOBALS['transaction_smoke_events'][] = $query;
+			if ( 'START TRANSACTION' === $query ) { ++$this->transaction_starts; $this->last_error = ''; $this->snapshot = array( $this->engine, $this->rows ); return 1; }
+			if ( 'ROLLBACK' === $query ) { if ( null !== $this->snapshot ) { $this->engine = $this->snapshot[0]; $this->rows = $this->snapshot[1]; } $this->snapshot = null; return 1; }
+			if ( 'COMMIT' === $query && $this->deadlock_commit_once ) { $this->deadlock_commit_once = false; $this->last_error = 'Deadlock found when trying to commit; try restarting transaction'; return false; }
+			if ( 'COMMIT' === $query ) { $this->snapshot = null; return 1; }
+			if ( str_starts_with( $query, 'INSERT INTO' ) ) {
+				$args = $this->prepared_args;
+				foreach ( $this->rows as $row ) {
+					if ( ( $row['flow_step_id'] ?? '' ) === ( $args[1] ?? null ) && ( $row['source_type'] ?? '' ) === ( $args[2] ?? null ) && ( $row['item_identifier'] ?? '' ) === ( $args[3] ?? null ) ) {
+						return 0;
+					}
+				}
+				$this->rows[] = array( 'id' => count( $this->rows ) + 1, 'flow_step_id' => $args[1], 'source_type' => $args[2], 'item_identifier' => $args[3], 'job_id' => $args[4], 'status' => $args[5], 'claim_expires_at' => $args[6], 'claim_token' => $args[7] );
+				return 1;
+			}
+			if ( str_starts_with( $query, 'UPDATE ' ) ) {
+				$args = $this->prepared_args;
+				foreach ( $this->rows as &$row ) {
+					if ( ( $row['flow_step_id'] ?? '' ) === ( $args[4] ?? null ) && ( $row['source_type'] ?? '' ) === ( $args[5] ?? null ) && ( $row['item_identifier'] ?? '' ) === ( $args[6] ?? null ) && ( $row['claim_token'] ?? '' ) === ( $args[7] ?? null ) && ( $row['status'] ?? '' ) === ( $args[8] ?? null ) ) {
+						$row['status'] = $args[1];
+						$row['job_id'] = $args[2];
+						return 1;
+					}
+				}
+				unset( $row );
+				return 0;
+			}
+			return 1;
+		}
+		public function update( string $table, array $data, array $where, array $formats, array $where_formats ): int|false {
+			unset( $table, $formats, $where_formats );
+			foreach ( $this->rows as &$row ) {
+				if ( empty( array_diff_assoc( $where, $row ) ) ) { $row = array_merge( $row, $data ); return 1; }
+			}
+			unset( $row );
+			return 0;
+		}
+		public function delete( string $table, array $where, array $formats ): int|false {
+			unset( $table, $formats );
+			foreach ( $this->rows as $index => $row ) {
+				if ( empty( array_diff_assoc( $where, $row ) ) ) { unset( $this->rows[ $index ] ); return 1; }
+			}
+			return 0;
+		}
+	}
+
+	$GLOBALS['wpdb'] = new PacketReconciliationFakeWpdb();
+	$GLOBALS['transaction_smoke_claim_filter'] = null;
+	$GLOBALS['transaction_smoke_persist'] = true;
+	$GLOBALS['transaction_smoke_events'] = array();
+	function apply_filters( string $hook, mixed $value, ...$args ): mixed {
+		if ( 'datamachine_packet_reconciliation_claim_mutation' === $hook && is_callable( $GLOBALS['transaction_smoke_claim_filter'] ) ) {
+			return ( $GLOBALS['transaction_smoke_claim_filter'] )( $value, ...$args );
+		}
+		if ( 'datamachine_packet_reconciliation_engine_persist' === $hook ) { return $GLOBALS['transaction_smoke_persist']; }
+		return $value;
+	}
+	function do_action( string $hook, mixed ...$args ): void { unset( $hook, $args ); }
+	function wp_cache_delete( mixed ...$args ): void { unset( $args ); }
+	function wp_cache_set( mixed ...$args ): void { unset( $args ); }
+	function wp_rand( int $min, int $max ): int { unset( $max ); return $min; }
+	function current_time( string $type, bool $gmt = false ): string { unset( $type, $gmt ); return gmdate( 'Y-m-d H:i:s' ); }
+	function datamachine_get_engine_data( int $job_id ): array { unset( $job_id ); return $GLOBALS['wpdb']->engine; }
+
+	require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
+	require_once __DIR__ . '/../inc/Core/Database/ProcessedItems/ProcessedItems.php';
+	require_once __DIR__ . '/../inc/Engine/Actions/Handlers/StepLifecycleHandler.php';
+
+	use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+	use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
+
+	$claim = static function ( string $item ): array {
+		return array(
+			'identity_scope'  => 'scope',
+			'source_type'     => 'source',
+			'item_identifier' => $item,
+			'ownership_token' => 'owner-' . $item,
+			'disposition_id'  => ProcessedItems::disposition_identity( 'scope', 'source', $item ),
+		);
+	};
+	$packet = static fn( array $claim ): array => array( 'metadata' => array( ProcessedItems::CLAIM_METADATA_KEY => $claim, ProcessedItems::DISPOSITION_ID_METADATA_KEY => $claim['disposition_id'], 'disposition_id' => $claim['disposition_id'], 'packet_disposition' => 'succeeded' ) );
+	$reset = static function () use ( $claim ): array {
+		$claims = array( $claim( 'first' ), $claim( 'second' ), $claim( 'third' ) );
+		$GLOBALS['wpdb']->engine = array( ProcessedItems::CLAIMS_METADATA_KEY => $claims );
+		$GLOBALS['wpdb']->rows = array_map(
+			static fn( array $item ): array => array( 'flow_step_id' => $item['identity_scope'], 'source_type' => $item['source_type'], 'item_identifier' => $item['item_identifier'], 'claim_token' => $item['ownership_token'], 'status' => 'claimed' ),
+			$claims
+		);
+		return $claims;
+	};
+	$failures = 0;
+	$passes = 0;
+	$assert = static function ( bool $condition, string $label ) use ( &$failures, &$passes ): void { if ( $condition ) { ++$passes; echo "  [PASS] {$label}\n"; } else { ++$failures; echo "  [FAIL] {$label}\n"; } };
+
+	$claims = $reset();
+	$GLOBALS['transaction_smoke_claim_filter'] = static fn( bool $allowed, int $index ): bool => $allowed && 1 !== $index;
+	$result = StepLifecycleHandler::reconcileStepOutput( 9, array( 'step_type' => 'ai' ), array(), false );
+	$assert( ! $result['success'] && 3 === count( $GLOBALS['wpdb']->rows ) && 3 === count( $GLOBALS['wpdb']->engine[ ProcessedItems::CLAIMS_METADATA_KEY ] ), 'mid-batch mutation failure rolls back rows and engine' );
+
+	$claims = $reset();
+	$GLOBALS['transaction_smoke_claim_filter'] = null;
+	$GLOBALS['transaction_smoke_persist'] = false;
+	$result = StepLifecycleHandler::reconcileStepOutput( 9, array( 'step_type' => 'ai' ), array( $packet( $claims[1] ) ), true );
+	$assert( ! $result['success'] && 3 === count( $GLOBALS['wpdb']->rows ) && 3 === count( $GLOBALS['wpdb']->engine[ ProcessedItems::CLAIMS_METADATA_KEY ] ), 'final engine persistence failure rolls back prior claim releases' );
+
+	$GLOBALS['transaction_smoke_persist'] = true;
+	$result = StepLifecycleHandler::reconcileStepOutput( 9, array( 'step_type' => 'ai' ), array( $packet( $claims[1] ) ), true );
+	$retained = $GLOBALS['wpdb']->engine[ ProcessedItems::CLAIMS_METADATA_KEY ] ?? array();
+	$assert( $result['success'] && 1 === count( $retained ) && $claims[1]['disposition_id'] === $retained[0]['disposition_id'] && 1 === count( $GLOBALS['wpdb']->rows ), 'retry completes exact replacement after rollback' );
+
+	$claims = $reset();
+	$GLOBALS['transaction_smoke_events'] = array();
+	$result = StepLifecycleHandler::reconcileStepOutput( 9, array( 'step_type' => 'ai' ), array( $packet( $claims[1] ) ), true );
+	$commit_position  = array_search( 'COMMIT', $GLOBALS['transaction_smoke_events'], true );
+	$publish_position = array_search( 'publish', $GLOBALS['transaction_smoke_events'], true );
+	$assert( $result['success'] && false !== $commit_position && false !== $publish_position && $publish_position > $commit_position, 'cache publication occurs only after transaction commit' );
+
+	$claims = $reset();
+	$GLOBALS['wpdb']->deadlock_once = true;
+	$starts = $GLOBALS['wpdb']->transaction_starts;
+	$result = StepLifecycleHandler::reconcileStepOutput( 9, array( 'step_type' => 'ai' ), array( $packet( $claims[1] ) ), true );
+	$assert( $result['success'] && 2 === $GLOBALS['wpdb']->transaction_starts - $starts, 'deadlock restarts the complete reconciliation transaction once' );
+
+	$claims = $reset();
+	$GLOBALS['wpdb']->deadlock_commit_once = true;
+	$starts = $GLOBALS['wpdb']->transaction_starts;
+	$result = StepLifecycleHandler::reconcileStepOutput( 9, array( 'step_type' => 'ai' ), array( $packet( $claims[1] ) ), true );
+	$assert( $result['success'] && 2 === $GLOBALS['wpdb']->transaction_starts - $starts && 1 === count( $GLOBALS['wpdb']->rows ), 'commit-time deadlock retries the whole reconciliation transaction without duplicate claim effects' );
+
+	$malformed = $claim( 'malformed' );
+	$malformed['disposition_id'] = str_repeat( 'f', 64 );
+	$GLOBALS['wpdb']->engine = array( ProcessedItems::CLAIM_METADATA_KEY => $malformed );
+	$result = StepLifecycleHandler::reconcileStepOutput( 9, array( 'step_type' => 'ai' ), array(), false );
+	$assert( ! $result['success'], 'malformed persisted claim metadata fails closed' );
+	$GLOBALS['wpdb']->engine = array( 'ordinary_non_fetch_state' => true );
+	$result = StepLifecycleHandler::reconcileStepOutput( 9, array( 'step_type' => 'transform' ), array(), true );
+	$assert( $result['success'] && ! $result['handled'], 'claimless non-fetch pipeline remains a compatible no-op' );
+
+	$all_claims = array();
+	foreach ( range( 1, 52 ) as $index ) { $all_claims[] = $claim( 'full-' . $index ); }
+	$GLOBALS['wpdb']->engine = array( ProcessedItems::CLAIMS_METADATA_KEY => $all_claims );
+	$GLOBALS['wpdb']->rows = array_map(
+		static fn( array $item, int $index ): array => array( 'id' => $index + 1, 'flow_step_id' => $item['identity_scope'], 'source_type' => $item['source_type'], 'item_identifier' => $item['item_identifier'], 'job_id' => 9, 'claim_token' => $item['ownership_token'], 'status' => 'claimed' ),
+		$all_claims,
+		array_keys( $all_claims )
+	);
+	$selected_indexes = array_values( array_filter( range( 0, 51 ), static fn( int $index ): bool => 0 === $index % 2 || 51 === $index ) );
+	$selected_packets = array_map( static fn( int $index ): array => $packet( $all_claims[ $index ] ), $selected_indexes );
+	$ai_result = StepLifecycleHandler::reconcileStepOutput( 9, array( 'step_type' => 'ai', 'flow_step_id' => 'ai-52-27' ), $selected_packets, true );
+	$upsert_result = StepLifecycleHandler::reconcileStepOutput( 9, array( 'step_type' => 'upsert', 'flow_step_id' => 'upsert-52-27' ), $selected_packets, true );
+	$GLOBALS['wpdb']->query( 'START TRANSACTION' );
+	$terminal = StepLifecycleHandler::handleCompleted( 9, $GLOBALS['wpdb']->engine, true );
+	$GLOBALS['wpdb']->query( $terminal ? 'COMMIT' : 'ROLLBACK' );
+	$processed_rows = array_values( array_filter( $GLOBALS['wpdb']->rows, static fn( array $row ): bool => 'processed' === ( $row['status'] ?? '' ) ) );
+	$omitted_indexes = array_values( array_diff( range( 0, 51 ), $selected_indexes ) );
+	$reacquired = 0;
+	$processed_repository = new ProcessedItems();
+	foreach ( $omitted_indexes as $offset => $index ) {
+		if ( false !== $processed_repository->claim_item_owned( 'scope', 'source', 'full-' . ( $index + 1 ), 1000 + $offset ) ) { ++$reacquired; }
+	}
+	$assert( $ai_result['success'] && 27 === $ai_result['retained'] && 25 === $ai_result['omitted'], 'full AI boundary retains explicit non-contiguous 27 and releases 25' );
+	$assert( $upsert_result['success'] && 27 === $upsert_result['retained'], 'upsert-like continuation preserves the exact 27 claims' );
+	$assert( $terminal && 27 === count( $processed_rows ) && 25 === $reacquired, 'terminal result processes exactly 27 and all 25 omissions are immediately reacquirable' );
+
+	$cleanup_claim = $claim( 'cleanup-state' );
+	$cleanup_id    = $cleanup_claim['disposition_id'];
+	$GLOBALS['wpdb']->engine = array(
+		ProcessedItems::CLAIM_METADATA_KEY => $cleanup_claim,
+		'packet_dispositions' => array( $cleanup_id => array( 'disposition' => 'defer_item' ) ),
+		'packet_tool_executions' => array( 'handler' => array( $cleanup_id => array( 'state' => 'failed' ) ) ),
+		'successful_packet_tool_executions' => array( 'handler' => array( $cleanup_id => 'now' ) ),
+	);
+	$GLOBALS['wpdb']->rows = array( array( 'flow_step_id' => 'scope', 'source_type' => 'source', 'item_identifier' => 'cleanup-state', 'claim_token' => $cleanup_claim['ownership_token'], 'status' => 'claimed' ) );
+	$cleaned = StepLifecycleHandler::reconcileStepOutput( 9, array( 'step_type' => 'ai' ), array(), false );
+	$assert( $cleaned['success'] && ! isset( $GLOBALS['wpdb']->engine['packet_dispositions'], $GLOBALS['wpdb']->engine['packet_tool_executions'], $GLOBALS['wpdb']->engine['successful_packet_tool_executions'] ), 'resolved claims compact disposition and reservation state' );
+
+	$claims = $reset();
+	$transfer_id = 'prepared-transfer';
+	$GLOBALS['wpdb']->engine = array(
+		'packet_fanout_transfer' => array( 'transfer_id' => $transfer_id, 'state' => 'prepared', 'claims' => array_column( $claims, null, 'disposition_id' ) ),
+	);
+	$recovered = StepLifecycleHandler::recoverPreparedFanoutTransfer( 9 );
+	$assert( $recovered['success'] && $recovered['restored'] && 3 === count( $GLOBALS['wpdb']->engine[ ProcessedItems::CLAIMS_METADATA_KEY ] ?? array() ), 'stale pre-adoption marker restores currently owned claims' );
+
+	$GLOBALS['wpdb']->engine = array(
+		'packet_fanout_transfer' => array( 'transfer_id' => $transfer_id, 'state' => 'prepared', 'claims' => array_column( $claims, null, 'disposition_id' ) ),
+		'batch_state' => array( 'checksum' => 'durable-worklist' ),
+	);
+	$recovered = StepLifecycleHandler::recoverPreparedFanoutTransfer( 9 );
+	$assert( $recovered['success'] && $recovered['adopted'] && ! isset( $GLOBALS['wpdb']->engine['packet_fanout_transfer'] ) && ! isset( $GLOBALS['wpdb']->engine[ ProcessedItems::CLAIMS_METADATA_KEY ] ), 'post-adoption recovery clears marker without restoring parent claims' );
+
+	$GLOBALS['wpdb']->engine = array(
+		'packet_fanout_transfer' => array( 'transfer_id' => $transfer_id, 'state' => 'prepared', 'claims' => array_column( $claims, null, 'disposition_id' ) ),
+	);
+	\DataMachine\Core\ChildJobRecoveryPolicy::$matches = false;
+	$stale = StepLifecycleHandler::recoverPreparedFanoutTransfer( 9, 2, 'stale-token' );
+	$assert( ! $stale['success'] && $stale['stale'] && isset( $GLOBALS['wpdb']->engine['packet_fanout_transfer'] ), 'stale recovery worker cannot restore after takeover' );
+	\DataMachine\Core\ChildJobRecoveryPolicy::$matches = true;
+
+	$GLOBALS['wpdb']->engine = array( ProcessedItems::CLAIMS_METADATA_KEY => $claims );
+	$renewed = StepLifecycleHandler::renewParkedClaims( 9 );
+	$assert( $renewed['success'] && 3 === $renewed['renewed'], 'parked execution renews every token-owned claim atomically' );
+	$GLOBALS['wpdb']->rows[0]['claim_token'] = 'replacement-owner';
+	$lost = StepLifecycleHandler::renewParkedClaims( 9 );
+	$assert( ! $lost['success'], 'parked execution fails closed after ownership loss' );
+
+	$malformed = array( ProcessedItems::CLAIMS_METADATA_KEY => array( $claims[0], 'scalar-corruption' ) );
+	$terminal_validation = StepLifecycleHandler::filterTerminalStatus( 'completed', 9, array( 'engine_data' => $malformed ) );
+	$assert( $terminal_validation instanceof WP_Error, 'scalar malformed metadata blocks terminal approval without TypeError' );
+
+	echo "packet-reconciliation-transaction-smoke: {$passes} passed, {$failures} failed\n";
+	exit( $failures > 0 ? 1 : 0 );
+}

--- a/tests/parallel-map-fanout-adapter-smoke.php
+++ b/tests/parallel-map-fanout-adapter-smoke.php
@@ -203,9 +203,11 @@ namespace {
 	// (PipelineBatchScheduler) directly as a second fan-out entry point.
 	parallel_map_assert( true, str_contains( $execute_source, 'new ParallelMapFanoutAdapter()' ), 'ExecuteStepAbility dispatches via the adapter', $failures, $passes );
 	parallel_map_assert( false, str_contains( $execute_source, 'new PipelineBatchScheduler()' ), 'ExecuteStepAbility has no direct PipelineBatchScheduler fan-out path', $failures, $passes );
-	// The gate is evaluated once, inside the adapter. ExecuteStepAbility must
-	// not pre-evaluate ParallelMapFanoutAdapter::shouldFanOut itself.
-	parallel_map_assert( false, str_contains( $execute_source, 'ParallelMapFanoutAdapter::shouldFanOut' ), 'ExecuteStepAbility does not re-evaluate the fan-out gate', $failures, $passes );
+	// Claim transfer must know the gate decision before dispatch. ExecuteStepAbility
+	// evaluates it once and passes that decision into the adapter, which must not
+	// evaluate the filter a second time when the precomputed value is supplied.
+	parallel_map_assert( true, str_contains( $execute_source, 'ParallelMapFanoutAdapter::shouldFanOut' ), 'ExecuteStepAbility precomputes the single fan-out gate decision', $failures, $passes );
+	parallel_map_assert( true, str_contains( $adapter_source, 'null === $should_fanout ? self::shouldFanOut' ), 'adapter reuses a supplied gate decision without re-evaluation', $failures, $passes );
 	// The inline-vs-fanned decision keys off the adapter's contract shape.
 	parallel_map_assert( true, str_contains( $execute_source, 'ParallelMapFanoutAdapter::SHAPE_INLINE' ), 'ExecuteStepAbility branches on the adapter contract shape', $failures, $passes );
 

--- a/tests/pipeline-child-claim-smoke.php
+++ b/tests/pipeline-child-claim-smoke.php
@@ -1,0 +1,67 @@
+<?php
+/** Execute the production child-engine builder against sibling claim injection. */
+
+namespace DataMachine\Core\Database\Jobs {
+	class Jobs {
+		public function create_job( array $args ): int { unset( $args ); return 501; }
+		public function create_or_get_job( array $args ): array { unset( $args ); return array( 'job_id' => 501 ); }
+		public function get_job( int $job_id ): array { return array( 'job_id' => $job_id, 'status' => 'processing' ); }
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+	$GLOBALS['pipeline_child_engines'] = array();
+	function current_time( string $type, bool $gmt = false ): string { unset( $type, $gmt ); return gmdate( 'Y-m-d H:i:s' ); }
+	function do_action( string $hook, mixed ...$args ): void { unset( $hook, $args ); }
+	function datamachine_get_engine_data( int $job_id ): array { return $GLOBALS['pipeline_child_engines'][ $job_id ] ?? array(); }
+	function datamachine_set_engine_data( int $job_id, array $engine ): bool { $GLOBALS['pipeline_child_engines'][ $job_id ] = $engine; return true; }
+
+	require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
+	require_once __DIR__ . '/../inc/Core/Database/ProcessedItems/ProcessedItems.php';
+	require_once __DIR__ . '/../inc/Core/EngineData.php';
+	require_once __DIR__ . '/../inc/Core/PacketEngineData.php';
+	require_once __DIR__ . '/../inc/Abilities/Engine/PipelineBatchScheduler.php';
+
+	use DataMachine\Abilities\Engine\PipelineBatchScheduler;
+	use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+
+	$claim = array(
+		'identity_scope'  => 'scope',
+		'source_type'     => 'source',
+		'item_identifier' => 'selected',
+		'ownership_token' => 'selected-token',
+	);
+	$claim['disposition_id'] = ProcessedItems::disposition_identity( 'scope', 'source', 'selected' );
+	$sibling = array(
+		'identity_scope'  => 'scope',
+		'source_type'     => 'source',
+		'item_identifier' => 'sibling',
+		'ownership_token' => 'sibling-token',
+	);
+	$packet = array(
+		'data' => array( 'title' => 'Selected packet' ),
+		'metadata' => array(
+			ProcessedItems::CLAIM_METADATA_KEY => $claim,
+			'_engine_data' => array( ProcessedItems::CLAIMS_METADATA_KEY => array( $sibling ) ),
+		),
+	);
+	$parent = array(
+		'job' => array( 'pipeline_id' => 2, 'flow_id' => 3, 'agent_id' => 4, 'user_id' => 5 ),
+		'flow_config' => array(),
+		ProcessedItems::CLAIMS_METADATA_KEY => array( $claim, $sibling ),
+		'packet_fanout_transfer' => array( 'state' => 'prepared', 'claims' => array( $sibling ) ),
+	);
+
+	$method = new ReflectionMethod( PipelineBatchScheduler::class, 'createChildJob' );
+	$child_id = $method->invoke( new PipelineBatchScheduler(), 99, 'next-step', $packet, $parent );
+	$engine   = $GLOBALS['pipeline_child_engines'][501] ?? array();
+	$valid    = 501 === $child_id
+		&& $claim === ( $engine[ ProcessedItems::CLAIM_METADATA_KEY ] ?? null )
+		&& ! array_key_exists( ProcessedItems::CLAIMS_METADATA_KEY, $engine )
+		&& ! array_key_exists( 'packet_fanout_transfer', $engine );
+
+	echo $valid ? "  [PASS] child receives exactly one validated claim after packet engine merge\n" : "  [FAIL] child claim isolation failed\n";
+	echo 'pipeline-child-claim-smoke: ' . ( $valid ? '1 passed, 0 failed' : '0 passed, 1 failed' ) . "\n";
+	exit( $valid ? 0 : 1 );
+}

--- a/tests/runtime-tool-contract-store-smoke.php
+++ b/tests/runtime-tool-contract-store-smoke.php
@@ -10,6 +10,7 @@
 declare(strict_types=1);
 
 namespace DataMachine\Core {
+	class JobStatus { public const WAITING = 'waiting'; }
 	class PluginSettings {
 		public const DEFAULT_MAX_TURNS = 8;
 	}
@@ -47,6 +48,7 @@ namespace DataMachine\Core\Database\Jobs {
 		public static array $jobs        = array();
 		public static array $engine_data = array();
 		public static int $next_id       = 1;
+		public static bool $fail_next_complete = false;
 
 		public function create_job( array $job ): int {
 			$job_id              = self::$next_id++;
@@ -55,8 +57,9 @@ namespace DataMachine\Core\Database\Jobs {
 			return $job_id;
 		}
 
-		public function start_job( int $job_id, string $status ): void {
+		public function start_job( int $job_id, string $status ): bool {
 			self::$jobs[ $job_id ]['status'] = $status;
+			return true;
 		}
 
 		public function store_engine_data( int $job_id, array $data ): void {
@@ -67,8 +70,18 @@ namespace DataMachine\Core\Database\Jobs {
 			return self::$engine_data[ $job_id ] ?? array();
 		}
 
-		public function complete_job( int $job_id, string $status ): void {
+		public function complete_job( int $job_id, string $status ): bool {
+			if ( self::$fail_next_complete ) {
+				self::$fail_next_complete = false;
+				return false;
+			}
 			self::$jobs[ $job_id ]['status'] = $status;
+			unset( self::$engine_data[ $job_id ]['packet_tool_executions'], self::$engine_data[ $job_id ]['_datamachine_item_claim'] );
+			return true;
+		}
+
+		public function get_job( int $job_id ): ?array {
+			return self::$jobs[ $job_id ] ?? null;
 		}
 	}
 }
@@ -130,6 +143,7 @@ namespace {
 	use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 	use DataMachine\Core\Database\Jobs\Jobs;
 	use function DataMachine\Engine\AI\datamachine_defer_runtime_tool_call;
+	use function DataMachine\Engine\AI\datamachine_prepare_runtime_tool_request;
 	use function DataMachine\Engine\AI\datamachine_runtime_tool_request_store;
 	use function DataMachine\Engine\AI\datamachine_resume_runtime_tool_request;
 	use function DataMachine\Engine\AI\datamachine_session_has_pending_runtime_tools;
@@ -169,12 +183,23 @@ namespace {
 	$GLOBALS['datamachine_runtime_tool_scheduled'] = array();
 	$GLOBALS['datamachine_runtime_tool_enqueued']  = array();
 
-	function as_schedule_single_action( int $timestamp, string $hook, array $args, string $group ): void {
+	function as_schedule_single_action( int $timestamp, string $hook, array $args, string $group ): int {
 		$GLOBALS['datamachine_runtime_tool_scheduled'][] = compact( 'timestamp', 'hook', 'args', 'group' );
+		return count( $GLOBALS['datamachine_runtime_tool_scheduled'] );
 	}
 
-	function as_enqueue_async_action( string $hook, array $args, string $group ): void {
+	function as_enqueue_async_action( string $hook, array $args, string $group ): int {
 		$GLOBALS['datamachine_runtime_tool_enqueued'][] = compact( 'hook', 'args', 'group' );
+		return count( $GLOBALS['datamachine_runtime_tool_enqueued'] );
+	}
+
+	function as_has_scheduled_action( string $hook, array $args, string $group ): int {
+		foreach ( $GLOBALS['datamachine_runtime_tool_enqueued'] as $index => $action ) {
+			if ( $hook === $action['hook'] && $args === $action['args'] && $group === $action['group'] ) {
+				return $index + 1;
+			}
+		}
+		return 0;
 	}
 
 	if ( ! function_exists( 'do_action' ) ) {
@@ -196,6 +221,7 @@ namespace {
 	require __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-runtime-tool-continuation.php';
 	require __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-runtime-tool-lifecycle.php';
 	require __DIR__ . '/../inc/Engine/AI/RuntimeToolRunStateStore.php';
+	require __DIR__ . '/../inc/Engine/AI/Tools/ToolExecutor.php';
 	require __DIR__ . '/../inc/Engine/AI/conversation-loop.php';
 
 	$failures = array();
@@ -249,13 +275,22 @@ namespace {
 
 	$submission = datamachine_submit_runtime_tool_result( $request_id, array( 'selected_id' => 'block-1' ) );
 	$stored     = Jobs::$engine_data[1]['runtime_tool_request'];
-	$assert( true === ( $submission['success'] ?? false ), 'result submission succeeds' );
+	$assert( is_array( $submission ) && true === ( $submission['success'] ?? false ), 'result submission succeeds' . ( $submission instanceof WP_Error ? ': ' . $submission->get_error_message() : '' ) );
 	$assert( WP_Agent_Runtime_Tool_Result::STATUS_SUBMITTED === ( $stored['metadata']['datamachine']['result']['status'] ?? '' ), 'submitted result is stored in canonical result shape' );
 	$assert( 'fulfilled' === ( $stored['metadata']['datamachine']['persistence_status'] ?? '' ), 'submitted result completes namespaced Data Machine status' );
 	$assert( 'completed' === ( Jobs::$jobs[1]['status'] ?? '' ), 'successful result completes the Data Machine job' );
 	$assert( 1 === count( $chat_db->sessions['session-1']['messages'] ), 'submitted result appends a transcript tool message' );
 	$assert( false === ( $chat_db->sessions['session-1']['metadata']['has_pending_tools'] ?? true ), 'submitted result clears pending session state' );
 	$assert( 'datamachine_runtime_tool_resume' === ( $GLOBALS['datamachine_runtime_tool_enqueued'][0]['hook'] ?? '' ), 'submitted result enqueues resume action' );
+	$before_recovery_messages = count( $chat_db->sessions['session-1']['messages'] );
+	$before_recovery_actions  = count( $GLOBALS['datamachine_runtime_tool_enqueued'] );
+	$duplicate_submission = datamachine_submit_runtime_tool_result( $request_id, array( 'selected_id' => 'block-1' ) );
+	$assert( is_array( $duplicate_submission ) && true === ( $duplicate_submission['success'] ?? false ), 'duplicate result submission enters idempotent continuation recovery' . ( $duplicate_submission instanceof WP_Error ? ': ' . $duplicate_submission->get_error_message() : '' ) );
+	$assert( $before_recovery_messages === count( $chat_db->sessions['session-1']['messages'] ), 'duplicate result submission does not duplicate transcript projection' );
+	$assert( $before_recovery_actions === count( $GLOBALS['datamachine_runtime_tool_enqueued'] ), 'duplicate result submission adopts existing resume action' );
+	datamachine_timeout_runtime_tool_request( $request_id );
+	$assert( $before_recovery_messages === count( $chat_db->sessions['session-1']['messages'] ), 'fulfilled timeout recovery does not duplicate transcript projection' );
+	$assert( $before_recovery_actions === count( $GLOBALS['datamachine_runtime_tool_enqueued'] ), 'fulfilled timeout recovery adopts existing resume action idempotently' );
 	datamachine_resume_runtime_tool_request( $request_id );
 	$delegated_resume = \DataMachine\Api\Chat\ChatOrchestrator::$calls[0] ?? array();
 	$assert( 7 === ( $delegated_resume['user_id'] ?? null ), 'async delegated resume retains runtime/session ownership' );
@@ -307,8 +342,101 @@ namespace {
 	$assert( array() === ( $system_resume['tools'] ?? null ), 'owner-scoped tools do not appear after async no-human resume' );
 	$assert( 0 === ( Jobs::$engine_data[3]['runtime_tool_run_state']['resume_payload']['calling_user_id'] ?? null ), 'runtime run-state records explicit zero in its resume payload' );
 
+	$chat_db->sessions['session-packet'] = array( 'messages' => array(), 'metadata' => array(), 'provider' => 'openai', 'model' => 'gpt' );
+	$packet_token = 'packet-reservation-token';
+	$packet_id    = hash( 'sha256', 'packet-runtime-identity' );
+	$packet_request = datamachine_prepare_runtime_tool_request(
+		array(
+			'tool_name'  => 'client/packet_handler',
+			'call_id'    => 'call-packet',
+			'parameters' => array( 'disposition_id' => $packet_id ),
+			'turn_count' => 4,
+			'session_id' => 'session-packet',
+			'mode'       => 'pipeline',
+			'modes'      => array( 'pipeline' ),
+		),
+		array(
+			'user_id' => 7,
+			'agent_id' => 11,
+			'job_id' => 404,
+			'packet_execution_identity' => array(
+				'job_id'            => 0,
+				'tool_name'         => 'client/packet_handler',
+				'disposition_id'    => $packet_id,
+				'reservation_token' => $packet_token,
+			),
+		)
+	);
+	$packet_job_id = (int) substr( (string) $packet_request['request_id'], strlen( 'runtime_tool_' ) );
+	$packet_request['metadata']['datamachine']['packet_execution']['job_id'] = $packet_job_id;
+	Jobs::$engine_data[ $packet_job_id ] = array(
+		'preserved_key' => 'preserved-value',
+		'_datamachine_item_claim' => array( 'ownership_token' => 'claim-token' ),
+		'packet_tool_executions' => array(
+			'client/packet_handler' => array(
+				$packet_id => array(
+					'state'      => 'pending',
+					'token'      => $packet_token,
+					'request_id' => $packet_request['request_id'],
+					'started_at' => gmdate( 'c' ),
+				),
+			),
+		),
+	);
+	\AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle::create_pending_request( datamachine_runtime_tool_request_store(), $packet_request );
+	$assert( 'preserved-value' === ( Jobs::$engine_data[ $packet_job_id ]['preserved_key'] ?? null ), 'packet-bound request creation preserves the existing engine snapshot' );
+	$assert( 'pending' === ( Jobs::$engine_data[ $packet_job_id ]['packet_tool_executions']['client/packet_handler'][ $packet_id ]['state'] ?? null ), 'packet-bound request creation preserves claim reservation state' );
+	$assert( $packet_token === ( Jobs::$engine_data[ $packet_job_id ]['packet_tool_executions']['client/packet_handler'][ $packet_id ]['token'] ?? null ) && ! str_contains( (string) json_encode( $packet_request ), $packet_token ), 'packet reservation token remains only in server-side engine state' );
+	$assert( isset( Jobs::$engine_data[ $packet_job_id ]['_datamachine_item_claim'] ), 'packet-bound request creation preserves packet claim metadata' );
+
+	Jobs::$fail_next_complete = true;
+	$first_packet_submission = datamachine_submit_runtime_tool_result( (string) $packet_request['request_id'], array( 'published' => true ) );
+	$packet_phases = Jobs::$engine_data[ $packet_job_id ]['runtime_tool_request']['metadata']['datamachine']['completion_phases'] ?? array();
+	$assert( true === ( $first_packet_submission['success'] ?? false ) && false === ( $first_packet_submission['scheduled'] ?? true ), 'request terminal transition survives a crash before job terminalization' );
+	$assert( ! empty( $packet_phases['request_terminal_at'] ) && ! empty( $packet_phases['reservation_finalized_at'] ) && empty( $packet_phases['job_terminalized_at'] ), 'crash snapshot records exactly the completed runtime phases' );
+	$assert( 'succeeded' === ( Jobs::$engine_data[ $packet_job_id ]['packet_tool_executions']['client/packet_handler'][ $packet_id ]['state'] ?? null ), 'reservation finalizes before terminal cleanup' );
+
+	$before_packet_messages = count( $chat_db->sessions['session-packet']['messages'] );
+	$duplicate_packet_submission = datamachine_submit_runtime_tool_result( (string) $packet_request['request_id'], array( 'published' => true ) );
+	$packet_phases = Jobs::$engine_data[ $packet_job_id ]['runtime_tool_request']['metadata']['datamachine']['completion_phases'] ?? array();
+	$assert( true === ( $duplicate_packet_submission['success'] ?? false ) && true === ( $duplicate_packet_submission['scheduled'] ?? false ), 'duplicate callback completes every missing phase after terminalization failure' );
+	$assert( 'completed' === ( Jobs::$jobs[ $packet_job_id ]['status'] ?? '' ), 'duplicate callback retries and completes job terminalization' );
+	$assert( ! isset( Jobs::$engine_data[ $packet_job_id ]['packet_tool_executions'] ), 'terminal cleanup runs only after reservation finalization is durable' );
+	$assert( ! empty( $packet_phases['job_terminalized_at'] ) && ! empty( $packet_phases['session_projected_at'] ) && ! empty( $packet_phases['resume_scheduled_at'] ), 'duplicate callback persists terminal, projection, and resume phases' );
+	$assert( $before_packet_messages + 1 === count( $chat_db->sessions['session-packet']['messages'] ), 'recovery projects the packet result exactly once' );
+	$before_packet_resumes = count( \DataMachine\Api\Chat\ChatOrchestrator::$calls );
+	datamachine_resume_runtime_tool_request( (string) $packet_request['request_id'] );
+	datamachine_resume_runtime_tool_request( (string) $packet_request['request_id'] );
+	$assert( $before_packet_resumes + 1 === count( \DataMachine\Api\Chat\ChatOrchestrator::$calls ), 'duplicate resume action delivery continues the conversation exactly once' );
+	$GLOBALS['datamachine_runtime_tool_enqueued'] = array_values( array_filter( $GLOBALS['datamachine_runtime_tool_enqueued'], static fn( array $action ): bool => 'datamachine_runtime_tool_resume' !== $action['hook'] || array( $packet_request['request_id'] ) !== $action['args'] ) );
+	datamachine_submit_runtime_tool_result( (string) $packet_request['request_id'], array( 'published' => true ) );
+	$assert( 0 === count( array_filter( $GLOBALS['datamachine_runtime_tool_enqueued'], static fn( array $action ): bool => 'datamachine_runtime_tool_resume' === $action['hook'] && array( $packet_request['request_id'] ) === $action['args'] ) ), 'completed duplicate callback does not enqueue another resume after the first action ran' );
 	$assert( array() === datamachine_runtime_tool_request_store()->recent_pending(), 'store adapter implements the Agents API recent-pending contract' );
 
+	$chat_db->sessions['session-client-output'] = array( 'messages' => array(), 'metadata' => array(), 'provider' => 'openai', 'model' => 'gpt' );
+	$client_pending = datamachine_defer_runtime_tool_call(
+		array(
+			'tool_name'  => 'client/packet_handler',
+			'call_id'    => 'call-client-output',
+			'parameters' => array( 'disposition_id' => $packet_id ),
+			'session_id' => 'session-client-output',
+		),
+		array(
+			'user_id' => 7,
+			'agent_id' => 11,
+			'job_id' => 808,
+			'packet_execution_identity' => array(
+				'job_id'            => 808,
+				'tool_name'         => 'client/packet_handler',
+				'disposition_id'    => $packet_id,
+				'reservation_token' => 'must-never-leave-engine-state',
+			),
+		)
+	);
+	$client_request   = is_array( $client_pending['runtime_tool_request'] ?? null ) ? $client_pending['runtime_tool_request'] : array();
+	$client_execution = $client_request['metadata']['datamachine']['packet_execution'] ?? array();
+	$assert( ! str_contains( (string) json_encode( $client_pending ), 'reservation_token' ) && ! str_contains( (string) json_encode( $client_pending ), 'must-never-leave-engine-state' ), 'actual client-visible deferred request output contains no reservation token' );
+	$assert( 808 === ( $client_execution['job_id'] ?? null ) && 'client/packet_handler' === ( $client_execution['tool_name'] ?? null ) && $packet_id === ( $client_execution['disposition_id'] ?? null ), 'client-visible deferred request retains only safe packet execution identity' );
 	if ( $failures ) {
 		echo "\nFAILED: " . count( $failures ) . " runtime tool contract store assertions failed.\n";
 		exit( 1 );

--- a/tests/transition-fanout-policy-smoke.php
+++ b/tests/transition-fanout-policy-smoke.php
@@ -121,6 +121,19 @@ transition_fanout_assert_same( 'inline', $route['mode'], 'multi-handler completi
 transition_fanout_assert_same( 2, count( $route['packets'] ), 'multi-handler completions are both available to next step', $failures, $passes );
 
 $route = ExecuteStepAbility::resolveTransitionRoute(
+	array( 'step_type' => 'ai' ),
+	array( 'step_type' => 'upsert', 'handler_slugs' => array( 'upsert_event' ) ),
+	array(
+		transition_fanout_packet( 'ai_handler_complete', array( 'tool_name' => 'upsert_event', 'handler_tool' => 'upsert_event', 'disposition_id' => 'packet-a' ) ),
+		transition_fanout_packet( 'ai_handler_complete', array( 'tool_name' => 'upsert_event', 'handler_tool' => 'upsert_event', 'disposition_id' => 'packet-b' ) ),
+		transition_fanout_packet( 'ai_handler_complete', array( 'tool_name' => 'upsert_event', 'handler_tool' => 'upsert_event', 'disposition_id' => 'packet-a' ) ),
+	)
+);
+
+transition_fanout_assert_same( 'inline', $route['mode'], 'same handler remains inline for claimed packet set', $failures, $passes );
+transition_fanout_assert_same( 2, count( $route['packets'] ), 'same handler preserves distinct identities and removes only exact duplicates', $failures, $passes );
+
+$route = ExecuteStepAbility::resolveTransitionRoute(
 	array( 'step_type' => 'fetch' ),
 	array( 'step_type' => 'ai' ),
 	array(


### PR DESCRIPTION
## Summary
- replace fetch-time acknowledgement with explicit per-packet disposition identities carried safely through AI, handler, continuation, terminal, retry, and fanout paths
- complete only successful or explicitly rejected claims while releasing deferred, failed, zero-output, and unexplained omissions for retry
- add transactional claim reconciliation with deterministic row locking, whole-transaction deadlock retry, recovery-generation fencing, parked-claim renewal, and post-commit cache invalidation
- add durable handler execution reservations and crash-idempotent external runtime-tool completion without exposing ownership tokens
- make fanout claim transfer/adoption recoverable across scheduling crashes while guaranteeing one validated claim per child
- add focused executable contracts for the exact production 52 input -> 27 output -> 25 retry lifecycle and associated failure/concurrency paths

## Production Reproduction
Phoenix venue flow `858` extracted 52 fresh source packets. AI emitted 27 packets, upsert received 27, and the job completed with no errors. An immediate rerun returned no items because all 52 identifiers had been acknowledged before downstream disposition.

## Verification
- 229 executable smoke assertions passed across packet routing, reconciliation, runtime tools, fanout, cache ordering, claim isolation, fetch dispositions, and AI failure propagation
- exact 52 -> non-contiguous 27 -> terminal 27 processed + 25 immediately reacquirable passes
- runtime-tool composed lifecycle: 49 assertions
- reconciliation transaction lifecycle: 18 assertions
- PHP syntax checks passed for every changed PHP file
- PHPCS passed for the complete changed surface
- `git diff --check` passed
- repeated independent code reviews reached a final no-findings approval

## Test Infrastructure
A real two-connection MySQL lock-order test is included in `ItemClaimLifecycleTest`. Local execution is blocked because `/tmp/wordpress-tests-lib/wp-tests-config.php` is not configured; tracked separately in #3207. Deterministic production-class transaction tests cover rollback, deadlock retry, cache ordering, recovery takeover, and exact claim outcomes locally.

## Compatibility And Safety
- single-packet consumers retain server-side disposition inference
- multi-packet tools require exact validated packet identity
- ownership tokens remain engine-side and are recursively removed from model/client projections
- no event- or vendor-specific behavior was added to the generic substrate
- ambiguous side-effect outcomes block automatic replay rather than risking duplicate execution

Fixes #3206

AI assistance: Used for production diagnosis, iterative implementation, adversarial concurrency review, fault-injection test design, and final verification. Multiple unsafe intermediate candidates were rejected before this version reached a clean independent review.