### PR TITLE
fix: recover orphaned pending AI deferrals

### DIFF
--- a/inc/Abilities/Job/RecoverStuckJobsAbility.php
+++ b/inc/Abilities/Job/RecoverStuckJobsAbility.php
@@ -3,7 +3,7 @@
 /**
  * Recover Stuck Jobs Ability
  *
- * Recovers jobs stuck in processing state: jobs with status override in engine_data, and jobs exceeding timeout threshold.
+ * Recovers stuck processing jobs and expired pending AI deferrals whose exact scheduler action is absent.
  *
  * @package DataMachine\Abilities\Job
  * @since 0.17.0
@@ -56,7 +56,7 @@ class RecoverStuckJobsAbility {
 				'datamachine/recover-stuck-jobs',
 				array(
 					'label'               => __( 'Recover Stuck Jobs', 'data-machine' ),
-					'description'         => __( 'Recover jobs stuck in processing state: jobs with status override in engine_data, and jobs exceeding timeout threshold.', 'data-machine' ),
+					'description'         => __( 'Recover stuck processing jobs and expired pending AI deferrals whose exact scheduler action is absent.', 'data-machine' ),
 					'category'            => 'datamachine-jobs',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -112,6 +112,8 @@ class RecoverStuckJobsAbility {
 							'pathless_requeued' => array( 'type' => 'integer' ),
 							'claimed_elsewhere' => array( 'type' => 'integer' ),
 							'pathless_policy_skipped' => array( 'type' => 'integer' ),
+							'pending_ai_terminalized' => array( 'type' => 'integer' ),
+							'pending_ai_guarded' => array( 'type' => 'integer' ),
 							'mutations'     => array( 'type' => 'integer' ),
 							'attempted'     => array( 'type' => 'integer' ),
 							'touched'       => array( 'type' => 'integer' ),
@@ -168,6 +170,112 @@ class RecoverStuckJobsAbility {
 		$touched        = 0;
 		$mutated        = 0;
 		$limit_reached  = false;
+		$pending_ai_terminalized = 0;
+		$pending_ai_guarded      = 0;
+		$recovery_trigger = isset( $input['recovery_trigger'] ) ? sanitize_key( (string) $input['recovery_trigger'] ) : 'operator';
+
+		// Pending AI recovery is intentionally first so dry-run and apply inspect the
+		// same bounded candidate set before processing-only recovery consumes touches.
+		$pending_ai_jobs = $this->getExpiredPendingAIDeferrals( $flow_id, $job_id_scope, $apply_limit );
+		if ( count( $pending_ai_jobs ) > $apply_limit ) {
+			$limit_reached  = true;
+			$pending_ai_jobs = array_slice( $pending_ai_jobs, 0, $apply_limit );
+		}
+		foreach ( $pending_ai_jobs as $job ) {
+			$job_id      = (int) $job['job_id'];
+			$job_flow_id = (int) $job['flow_id'];
+			$engine_data = is_array( $job['engine_data'] ) ? $job['engine_data'] : array();
+			$throttle    = is_array( $engine_data['ai_concurrency_throttle'] ?? null ) ? $engine_data['ai_concurrency_throttle'] : array();
+			$resume      = is_array( $engine_data['ai_concurrency_resume_ownership'] ?? null ) ? $engine_data['ai_concurrency_resume_ownership'] : array();
+			$ownership   = array(
+				'action_id'     => (int) ( $throttle['action_id'] ?? 0 ),
+				'generation'    => (int) ( $throttle['resume_generation'] ?? 0 ),
+				'flow_step_id'  => (string) ( $throttle['flow_step_id'] ?? '' ),
+				'next_retry_at' => (string) ( $throttle['next_retry_at'] ?? '' ),
+			);
+			$retry_time = strtotime( $ownership['next_retry_at'] );
+			$legacy_receipt = empty( $resume ) && 0 === $ownership['generation'];
+			$modern_receipt = $ownership['generation'] > 0
+				&& 'scheduled' === (string) ( $resume['status'] ?? '' )
+				&& $ownership['action_id'] === (int) ( $resume['action_id'] ?? 0 )
+				&& $ownership['generation'] === (int) ( $resume['generation'] ?? 0 )
+				&& $ownership['flow_step_id'] === (string) ( $resume['flow_step_id'] ?? '' );
+			$valid_receipt = $ownership['action_id'] > 0
+				&& '' !== $ownership['flow_step_id']
+				&& false !== $retry_time
+				&& $retry_time < time()
+				&& ( $modern_receipt || $legacy_receipt );
+			$ownership['legacy'] = $legacy_receipt;
+			$action_evidence = $valid_receipt ? $this->getRecordedActionEvidence( $ownership['action_id'] ) : array( 'complete' => true, 'exists' => false, 'status' => '' );
+
+			if ( ! $valid_receipt || empty( $action_evidence['complete'] ) || ! empty( $action_evidence['exists'] ) ) {
+				++$skipped;
+				++$pending_ai_guarded;
+				$this->appendJobDetail(
+					$jobs,
+					$jobs_omitted,
+					array(
+						'job_id'       => $job_id,
+						'flow_id'      => $job_flow_id,
+						'scope'        => 'pending_ai_deferral',
+						'status'       => 'skipped',
+						'reason'       => ! $valid_receipt ? 'incomplete_ai_resume_ownership' : ( empty( $action_evidence['complete'] ) ? 'scheduler_evidence_incomplete' : 'recorded_scheduler_action_exists' ),
+						'action_id'    => $ownership['action_id'],
+						'action_status' => (string) ( $action_evidence['status'] ?? '' ),
+						'generation'   => $ownership['generation'],
+						'next_retry_at' => $ownership['next_retry_at'],
+					)
+				);
+				continue;
+			}
+
+			if ( $dry_run ) {
+				++$pending_ai_terminalized;
+				$this->appendJobDetail( $jobs, $jobs_omitted, array(
+					'job_id'       => $job_id,
+					'flow_id'      => $job_flow_id,
+					'scope'        => 'pending_ai_deferral',
+					'status'       => 'would_terminalize_expired_ai_deferral',
+					'target_status' => 'cancelled - ai_concurrency_stranded',
+					'reason'       => 'expired_retry_action_missing',
+					'action_id'    => $ownership['action_id'],
+					'generation'   => $ownership['generation'],
+					'next_retry_at' => $ownership['next_retry_at'],
+				) );
+				continue;
+			}
+
+			if ( ! $this->consumeTouchBudget( $attempted, $touched, $apply_limit ) ) {
+				$limit_reached = true;
+				break;
+			}
+			$result = $this->db_jobs->transition_expired_ai_deferral( $job_id, 'cancelled - ai_concurrency_stranded', $ownership, $recovery_trigger );
+			if ( ! empty( $result['success'] ) && ! empty( $result['changed'] ) ) {
+				++$pending_ai_terminalized;
+				++$mutations;
+				++$mutated;
+				$this->appendJobDetail( $jobs, $jobs_omitted, array(
+					'job_id'       => $job_id,
+					'flow_id'      => $job_flow_id,
+					'scope'        => 'pending_ai_deferral',
+					'status'       => 'terminalized_expired_ai_deferral',
+					'target_status' => 'cancelled - ai_concurrency_stranded',
+					'reason'       => 'expired_retry_action_missing',
+					'action_id'    => $ownership['action_id'],
+					'generation'   => $ownership['generation'],
+				) );
+			} else {
+				++$skipped;
+				++$pending_ai_guarded;
+				$this->appendJobDetail( $jobs, $jobs_omitted, array(
+					'job_id'  => $job_id,
+					'flow_id' => $job_flow_id,
+					'scope'   => 'pending_ai_deferral',
+					'status'  => 'skipped',
+					'reason'  => 'pending_ai_ownership_changed',
+				) );
+			}
+		}
 
 		$last_job_id = 0;
 		while ( true ) {
@@ -268,7 +376,6 @@ class RecoverStuckJobsAbility {
 		$pathless_requeued = 0;
 		$claimed_elsewhere = 0;
 		$pathless_policy_skipped = 0;
-		$recovery_trigger = isset( $input['recovery_trigger'] ) ? sanitize_key( (string) $input['recovery_trigger'] ) : 'operator';
 
 		$last_job_id = 0;
 		while ( true ) {
@@ -675,8 +782,8 @@ class RecoverStuckJobsAbility {
 		$jobs_truncated = $jobs_omitted > 0;
 
 		$message = $dry_run
-			? sprintf( 'Dry run complete. Would recover %d jobs, timeout %d jobs, requeue %d pathless children, terminalize %d pathless children, reconcile %d terminal-backed actions, and guard %d pathless children requiring explicit authorization.', $recovered, $timed_out, $pathless_requeued, $pathless_terminal, $stale_actions, $pathless_policy_skipped )
-			: sprintf( 'Recovery complete. Attempted/touched/mutated: %d/%d/%d (limit %d), outcomes: %d, recovered: %d, timed out: %d, pathless requeued: %d, pathless terminal: %d, reconciled actions: %d, policy-skipped: %d', $attempted, $touched, $mutated, $apply_limit, $mutations, $recovered, $timed_out, $pathless_requeued, $pathless_terminal, $stale_actions, $pathless_policy_skipped );
+			? sprintf( 'Dry run complete. Would terminalize %d expired pending AI deferrals, recover %d jobs, timeout %d jobs, requeue %d pathless children, terminalize %d pathless children, reconcile %d terminal-backed actions, guard %d pending AI deferrals, and guard %d pathless children requiring explicit authorization.', $pending_ai_terminalized, $recovered, $timed_out, $pathless_requeued, $pathless_terminal, $stale_actions, $pending_ai_guarded, $pathless_policy_skipped )
+			: sprintf( 'Recovery complete. Attempted/touched/mutated: %d/%d/%d (limit %d), outcomes: %d, pending AI terminalized: %d, recovered: %d, timed out: %d, pathless requeued: %d, pathless terminal: %d, reconciled actions: %d, pending AI guarded: %d, policy-skipped: %d', $attempted, $touched, $mutated, $apply_limit, $mutations, $pending_ai_terminalized, $recovered, $timed_out, $pathless_requeued, $pathless_terminal, $stale_actions, $pending_ai_guarded, $pathless_policy_skipped );
 
 		if ( ! $dry_run && ( $mutations > 0 || $claimed_elsewhere > 0 || $pathless_policy_skipped > 0 ) ) {
 			do_action(
@@ -692,6 +799,8 @@ class RecoverStuckJobsAbility {
 					'pathless_terminal' => $pathless_terminal,
 					'claimed_elsewhere' => $claimed_elsewhere,
 					'pathless_policy_skipped' => $pathless_policy_skipped,
+					'pending_ai_terminalized' => $pending_ai_terminalized,
+					'pending_ai_guarded' => $pending_ai_guarded,
 					'mutations'     => $mutations,
 					'attempted'     => $attempted,
 					'touched'       => $touched,
@@ -715,6 +824,8 @@ class RecoverStuckJobsAbility {
 			'pathless_requeued' => $pathless_requeued,
 			'claimed_elsewhere' => $claimed_elsewhere,
 			'pathless_policy_skipped' => $pathless_policy_skipped,
+			'pending_ai_terminalized' => $pending_ai_terminalized,
+			'pending_ai_guarded' => $pending_ai_guarded,
 			'mutations'      => $mutations,
 			'attempted'      => $attempted,
 			'touched'        => $touched,
@@ -724,8 +835,9 @@ class RecoverStuckJobsAbility {
 			'scope'          => array(
 				'job_id'                    => $job_id_scope,
 				'flow_id'                   => $flow_id,
-				'statuses'                  => array( 'processing' ),
-				'includes_pending_ai'       => false,
+				'statuses'                  => array( 'processing', 'pending' ),
+				'includes_pending_ai'       => true,
+				'pending_ai_requirement'    => 'expired deferred throttle with exact absent action receipt',
 				'recover_pathless_children' => $recover_pathless_children,
 			),
 			'dry_run'        => $dry_run,
@@ -761,6 +873,54 @@ class RecoverStuckJobsAbility {
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic WHERE clause is prepared above.
 		return (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table} {$where}" );
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	/** Fetch one bounded review set of expired pending AI deferrals. */
+	private function getExpiredPendingAIDeferrals( ?int $flow_id, ?int $job_id, int $limit ): array {
+		global $wpdb;
+		$table = $wpdb->prefix . 'datamachine_jobs';
+		$where = $wpdb->prepare(
+			"WHERE status = 'pending'
+			 AND COALESCE(JSON_UNQUOTE(JSON_EXTRACT(engine_data, '$.ai_concurrency_throttle.state')), 'deferred') = 'deferred'
+			 AND JSON_UNQUOTE(JSON_EXTRACT(engine_data, '$.ai_concurrency_throttle.next_retry_at')) < %s",
+			gmdate( 'c' )
+		);
+		if ( $flow_id ) {
+			$where .= $wpdb->prepare( ' AND flow_id = %d', $flow_id );
+		}
+		if ( $job_id ) {
+			$where .= $wpdb->prepare( ' AND job_id = %d', $job_id );
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Dynamic WHERE is prepared above and the limit is clamped by the ability schema.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT job_id, flow_id FROM {$table} {$where} ORDER BY job_id ASC LIMIT %d",
+				max( 1, min( self::MAX_APPLY_LIMIT, $limit ) ) + 1
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
+
+		foreach ( $rows as &$row ) {
+			$row['engine_data'] = $this->getJobEngineData( (int) $row['job_id'] );
+		}
+		unset( $row );
+		return $rows;
+	}
+
+	/** Read an exact Action Scheduler receipt and fail closed on query errors. */
+	private function getRecordedActionEvidence( int $action_id ): array {
+		global $wpdb;
+		$actions_table   = $wpdb->prefix . 'actionscheduler_actions';
+		$wpdb->last_error = '';
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Exact action receipt is required ownership evidence.
+		$row = $wpdb->get_row( $wpdb->prepare( "SELECT action_id, status FROM {$actions_table} WHERE action_id = %d LIMIT 1", $action_id ), ARRAY_A );
+		return array(
+			'complete' => '' === (string) $wpdb->last_error,
+			'exists'   => is_array( $row ),
+			'status'   => is_array( $row ) ? (string) ( $row['status'] ?? '' ) : '',
+		);
 	}
 
 	/** @return array<int,array<string,mixed>> */

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -110,7 +110,7 @@ class JobsCommand extends BaseCommand {
 	private array $liveness_fields = array( 'id', 'flow_id', 'classification', 'age_hours', 'defer_count', 'defer_age_seconds', 'pending_actions', 'in_progress_actions', 'owner_action_ids', 'owner_job_ids', 'oldest_pending', 'latest_attempt' );
 
 	/**
-	 * Recover stuck jobs that have job_status in engine_data but status is 'processing'.
+	 * Recover stuck processing jobs and expired pending AI deferrals with no scheduler action.
 	 *
 	 * Jobs can become stuck when the engine stores a status override (e.g., from skip_item)
 	 * in engine_data but the main status column doesn't get updated. This command finds
@@ -246,7 +246,7 @@ class JobsCommand extends BaseCommand {
 		);
 		WP_CLI::log(
 			sprintf(
-				'Recovery scope: processing jobs only; pending AI deferrals excluded; job=%s flow=%s touch-limit=%d pathless-apply=%s.',
+				'Recovery scope: processing jobs plus expired pending AI deferrals with absent exact action receipts; job=%s flow=%s touch-limit=%d pathless-apply=%s.',
 				$job_id ? (string) $job_id : 'all',
 				$flow_id ? (string) $flow_id : 'all',
 				$limit,
@@ -300,6 +300,10 @@ class JobsCommand extends BaseCommand {
 				WP_CLI::log( sprintf( 'Would timeout job %d (flow %d)', $job['job_id'], $job['flow_id'] ) );
 			} elseif ( 'timed_out' === $job['status'] ) {
 				WP_CLI::log( sprintf( 'Timed out job %d (flow %d)', $job['job_id'], $job['flow_id'] ) );
+			} elseif ( 'would_terminalize_expired_ai_deferral' === $job['status'] ) {
+				WP_CLI::log( sprintf( 'Would terminalize expired pending AI deferral %d (flow %d, missing action %d)', $job['job_id'], $job['flow_id'], $job['action_id'] ) );
+			} elseif ( 'terminalized_expired_ai_deferral' === $job['status'] ) {
+				WP_CLI::log( sprintf( 'Terminalized expired pending AI deferral %d (flow %d, missing action %d)', $job['job_id'], $job['flow_id'], $job['action_id'] ) );
 			} elseif ( 'would_reconcile_action' === $job['status'] ) {
 				WP_CLI::log(
 					sprintf(
@@ -347,6 +351,8 @@ class JobsCommand extends BaseCommand {
 		$pathless_terminal = (int) ( $result['pathless_terminal'] ?? 0 );
 		$claimed_elsewhere = (int) ( $result['claimed_elsewhere'] ?? 0 );
 		$pathless_policy_skipped = (int) ( $result['pathless_policy_skipped'] ?? 0 );
+		$pending_ai_terminalized = (int) ( $result['pending_ai_terminalized'] ?? 0 );
+		$pending_ai_guarded = (int) ( $result['pending_ai_guarded'] ?? 0 );
 		$mutations         = (int) ( $result['mutations'] ?? 0 );
 		$attempted         = (int) ( $result['attempted'] ?? 0 );
 		$touched           = (int) ( $result['touched'] ?? 0 );
@@ -361,14 +367,16 @@ class JobsCommand extends BaseCommand {
 			'pathless_terminal' => $pathless_terminal,
 			'claimed_elsewhere' => $claimed_elsewhere,
 			'pathless_policy_skipped' => $pathless_policy_skipped,
+			'pending_ai_terminalized' => $pending_ai_terminalized,
+			'pending_ai_guarded' => $pending_ai_guarded,
 			'mutations'     => $mutations,
 			'attempted'     => $attempted,
 			'touched'       => $touched,
 			'mutated'       => $mutated,
 			'apply_limit'   => (int) ( $result['apply_limit'] ?? 0 ),
 			'limit_reached' => ! empty( $result['limit_reached'] ) ? 1 : 0,
-			'actionable'    => $recovered + $timed_out + $stale_actions + $pathless_requeued + $pathless_terminal,
-			'total'         => $recovered + $timed_out + $stale_actions + $pathless_requeued + $pathless_terminal + $skipped,
+			'actionable'    => $pending_ai_terminalized + $recovered + $timed_out + $stale_actions + $pathless_requeued + $pathless_terminal,
+			'total'         => $pending_ai_terminalized + $recovered + $timed_out + $stale_actions + $pathless_requeued + $pathless_terminal + $skipped,
 			'requeued'      => (int) ( $result['requeued'] ?? 0 ),
 			'jobs_omitted'  => (int) ( $result['jobs_omitted'] ?? 0 ),
 		);
@@ -477,7 +485,7 @@ class JobsCommand extends BaseCommand {
 					'scope'           => array(
 						'statuses'            => array( 'processing', 'pending' ),
 						'pending_requirement' => 'ai_concurrency_throttle',
-						'note'                => 'Recovery scope excludes pending AI deferrals and inspects processing jobs only.',
+						'note'                => 'Recovery includes only expired pending AI deferrals whose exact recorded action is absent.',
 					),
 					'summary'         => $summary,
 					'jobs'            => $items,
@@ -495,7 +503,7 @@ class JobsCommand extends BaseCommand {
 		$this->format_items( $items, $this->liveness_fields, $assoc_args, 'id' );
 
 		if ( 'table' === $format ) {
-			WP_CLI::log( 'Liveness scope includes processing jobs plus pending AI concurrency deferrals; recover-stuck applies only to processing jobs.' );
+			WP_CLI::log( 'Liveness scope includes processing jobs plus pending AI concurrency deferrals; recover-stuck also handles expired deferrals with absent exact action receipts.' );
 			WP_CLI::log(
 				sprintf(
 					'Inspected %d active jobs: %d active, %d queued, %d AI concurrency-deferred, %d waiting on children, %d scheduler-starved, %d stale in-progress, %d without scheduler path.',

--- a/inc/Cli/JobLivenessClassifier.php
+++ b/inc/Cli/JobLivenessClassifier.php
@@ -27,8 +27,25 @@ class JobLivenessClassifier {
 				$actions,
 				static function ( array $action ) use ( $job, $engine_data ): bool {
 					$hook = (string) ( $action['hook'] ?? '' );
-					return ! in_array( $hook, array( 'datamachine_execute_step', 'datamachine_resume_ai_step' ), true )
-						|| ChildJobRecoveryPolicy::actionGenerationMatches( $job, $engine_data, $action );
+					if ( ! in_array( $hook, array( 'datamachine_execute_step', 'datamachine_resume_ai_step' ), true ) ) {
+						return true;
+					}
+					if ( ChildJobRecoveryPolicy::actionGenerationMatches( $job, $engine_data, $action ) ) {
+						return true;
+					}
+					if ( 'datamachine_resume_ai_step' !== $hook ) {
+						return false;
+					}
+
+					$throttle = is_array( $engine_data['ai_concurrency_throttle'] ?? null ) ? $engine_data['ai_concurrency_throttle'] : array();
+					$owner    = is_array( $engine_data['ai_concurrency_resume_ownership'] ?? null ) ? $engine_data['ai_concurrency_resume_ownership'] : array();
+					$args     = is_array( $action['decoded_args'] ?? null ) ? $action['decoded_args'] : array();
+					return empty( $owner )
+						&& ! isset( $throttle['resume_generation'] )
+						&& (int) ( $throttle['action_id'] ?? 0 ) > 0
+						&& (int) ( $throttle['action_id'] ?? 0 ) === (int) ( $action['action_id'] ?? 0 )
+						&& (string) ( $throttle['flow_step_id'] ?? '' ) === (string) ( $args['flow_step_id'] ?? '' )
+						&& ChildJobRecoveryPolicy::actionBelongsToJob( $args, (int) ( $job['job_id'] ?? 0 ) );
 				}
 			)
 		);
@@ -55,6 +72,15 @@ class JobLivenessClassifier {
 		$total_children  = (int) ( $child_counts['total'] ?? 0 );
 		$batch_total     = (int) ( $engine_data['batch_total'] ?? 0 );
 		$throttle        = is_array( $engine_data['ai_concurrency_throttle'] ?? null ) ? $engine_data['ai_concurrency_throttle'] : array();
+		$contention_actions = array_values(
+			array_filter(
+				$owner_actions,
+				static fn( array $action ): bool => 'datamachine_resume_ai_step' === (string) ( $action['hook'] ?? '' )
+			)
+		);
+		$contention_owned = ! empty( $throttle )
+			&& 'deferred' === ( $throttle['state'] ?? 'deferred' )
+			&& ! empty( $contention_actions );
 		$first_deferred  = strtotime( (string) ( $throttle['first_deferred_at'] ?? '' ) );
 		$defer_age       = false === $first_deferred ? (int) ( $throttle['defer_age_seconds'] ?? 0 ) : max( 0, $now - $first_deferred );
 
@@ -89,7 +115,7 @@ class JobLivenessClassifier {
 			'last_activity_at'        => is_string( $last_activity ) ? $last_activity : '',
 			'defer_count'             => max( 0, (int) ( $throttle['attempts'] ?? 0 ) ),
 			'defer_age_seconds'       => $defer_age,
-			'contention_active'       => ! empty( $throttle ) && 'deferred' === ( $throttle['state'] ?? 'deferred' ),
+			'contention_active'       => $contention_owned,
 			'contention_provider'     => (string) ( $throttle['provider'] ?? '' ),
 			'pending_actions'         => count( $pending ),
 			'in_progress_actions'     => count( $in_progress ),

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -2445,6 +2445,32 @@ class Jobs extends BaseRepository {
 		);
 	}
 
+	/** Terminalize an expired pending AI deferral only while its exact action receipt remains absent. */
+	public function transition_expired_ai_deferral( int $job_id, string $status, array $ownership, string $trigger ): array {
+		$action_id  = (int) ( $ownership['action_id'] ?? 0 );
+		$generation = (int) ( $ownership['generation'] ?? 0 );
+		$legacy     = ! empty( $ownership['legacy'] );
+		$flow_step  = (string) ( $ownership['flow_step_id'] ?? '' );
+		$retry_at   = (string) ( $ownership['next_retry_at'] ?? '' );
+		if ( ! JobStatus::isStatusFinal( $status ) || $action_id <= 0 || ( ! $legacy && $generation <= 0 ) || '' === $flow_step || '' === $retry_at ) {
+			return $this->status_transition_result( false, false, null, $status );
+		}
+
+		return $this->transition_terminal_job_status_result(
+			$job_id,
+			$status,
+			array(
+				'action_id'     => $action_id,
+				'generation'    => $generation,
+				'legacy'        => $legacy,
+				'flow_step_id'  => $flow_step,
+				'next_retry_at' => $retry_at,
+				'trigger'       => sanitize_key( $trigger ),
+				'mode'          => 'ai_deferral',
+			)
+		);
+	}
+
 	/** Renew the exact recovery generation immediately before handler execution. */
 	public function renew_recovery_execution_owner( int $job_id, string $token, int $generation ): bool {
 		if ( $job_id <= 0 || '' === $token || $generation <= 0 ) {
@@ -2851,7 +2877,9 @@ class Jobs extends BaseRepository {
 		$engine = (array) apply_filters( 'datamachine_job_terminal_engine_data', $engine, $job_id, $status );
 		$update_data['engine_data'] = wp_json_encode( $engine );
 		$update_formats[] = '%s';
-		$operation_recovery = is_array( $recovery_owner ) && 'operation' === (string) ( $recovery_owner['mode'] ?? '' );
+		$owner_mode         = is_array( $recovery_owner ) ? (string) ( $recovery_owner['mode'] ?? '' ) : '';
+		$operation_recovery = 'operation' === $owner_mode;
+		$ai_deferral_recovery = 'ai_deferral' === $owner_mode;
 		if ( $pending_direct_cancel || $operation_recovery ) {
 			$update_data['operation_state']       = 'cancelled';
 			$update_data['operation_claimed_at']  = null;
@@ -2872,7 +2900,29 @@ class Jobs extends BaseRepository {
 			);
 			$update_data['engine_data'] = wp_json_encode( $engine );
 		}
-		if ( is_array( $recovery_owner ) && ! $operation_recovery ) {
+		if ( $ai_deferral_recovery ) {
+			$throttle = is_array( $engine['ai_concurrency_throttle'] ?? null ) ? $engine['ai_concurrency_throttle'] : array();
+			$engine['ai_concurrency_history'] = array_slice(
+				array_merge(
+					is_array( $engine['ai_concurrency_history'] ?? null ) ? $engine['ai_concurrency_history'] : array(),
+					array(
+						array_merge(
+							$throttle,
+							array(
+								'state'       => 'stranded',
+								'reason'      => 'scheduler_action_missing',
+								'recovered_at' => gmdate( 'c' ),
+								'trigger'     => (string) ( $recovery_owner['trigger'] ?? '' ),
+							)
+						),
+					)
+				),
+				-20
+			);
+			unset( $engine['ai_concurrency_throttle'], $engine['ai_concurrency_resume_ownership'] );
+			$update_data['engine_data'] = wp_json_encode( $engine );
+		}
+		if ( is_array( $recovery_owner ) && ! $operation_recovery && ! $ai_deferral_recovery ) {
 			$engine['scheduler_recovery']['state']        = 'terminalized';
 			$engine['scheduler_recovery']['completed_at'] = gmdate( 'c' );
 			$engine['scheduler_recovery']['receipt']      = array(
@@ -3210,12 +3260,62 @@ class Jobs extends BaseRepository {
 		if ( 'operation' === $mode ) {
 			return $this->missing_direct_operation_owner_matches( $job, (int) ( $owner['action_id'] ?? 0 ), $generation, $token );
 		}
+		if ( 'ai_deferral' === $mode ) {
+			return $this->expired_ai_deferral_owner_matches( $job, $owner );
+		}
 		if ( 'execution' !== $mode ) {
 			return $this->recovery_owner_matches( $job, $token, $generation );
 		}
 
 		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
 		return ChildJobRecoveryPolicy::recoveryExecutionMatches( $engine, $generation, $token );
+	}
+
+	/** Validate an expired AI receipt and prove its exact scheduler action is absent. */
+	private function expired_ai_deferral_owner_matches( ?array $job, array $owner ): bool {
+		if ( ! is_array( $job ) || JobStatus::PENDING !== (string) ( $job['status'] ?? '' ) ) {
+			return false;
+		}
+
+		$engine     = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$throttle   = is_array( $engine['ai_concurrency_throttle'] ?? null ) ? $engine['ai_concurrency_throttle'] : array();
+		$resume     = is_array( $engine['ai_concurrency_resume_ownership'] ?? null ) ? $engine['ai_concurrency_resume_ownership'] : array();
+		$action_id  = (int) ( $owner['action_id'] ?? 0 );
+		$generation = (int) ( $owner['generation'] ?? 0 );
+		$legacy     = ! empty( $owner['legacy'] );
+		$flow_step  = (string) ( $owner['flow_step_id'] ?? '' );
+		$retry_at   = (string) ( $owner['next_retry_at'] ?? '' );
+		$retry_time = strtotime( $retry_at );
+
+		$throttle_state = (string) ( $throttle['state'] ?? 'deferred' );
+		$modern_owner_matches = ! $legacy
+			&& $generation > 0
+			&& $generation === (int) ( $throttle['resume_generation'] ?? 0 )
+			&& 'scheduled' === (string) ( $resume['status'] ?? '' )
+			&& $action_id === (int) ( $resume['action_id'] ?? 0 )
+			&& $generation === (int) ( $resume['generation'] ?? 0 )
+			&& $flow_step === (string) ( $resume['flow_step_id'] ?? '' );
+		$legacy_owner_matches = $legacy
+			&& empty( $resume )
+			&& ! isset( $throttle['resume_generation'] );
+
+		if ( 'deferred' !== $throttle_state
+			|| $action_id <= 0
+			|| $action_id !== (int) ( $throttle['action_id'] ?? 0 )
+			|| $flow_step !== (string) ( $throttle['flow_step_id'] ?? '' )
+			|| $retry_at !== (string) ( $throttle['next_retry_at'] ?? '' )
+			|| false === $retry_time
+			|| $retry_time >= time()
+			|| ( ! $modern_owner_matches && ! $legacy_owner_matches )
+		) {
+			return false;
+		}
+
+		$actions_table = $this->wpdb->prefix . 'actionscheduler_actions';
+		$this->wpdb->last_error = '';
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Exact receipt absence is the recovery ownership fence.
+		$exists = $this->wpdb->get_var( $this->wpdb->prepare( "SELECT action_id FROM {$actions_table} WHERE action_id = %d LIMIT 1", $action_id ) );
+		return '' === (string) $this->wpdb->last_error && null === $exists;
 	}
 
 	/** Validate the exact durable direct-operation receipt on a locked jobs row. */

--- a/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
+++ b/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
@@ -145,6 +145,99 @@ class JobLifecycleTransitionTest extends WP_UnitTestCase {
 		$this->assertCount( 3, $processing );
 	}
 
+	public function test_active_pending_ai_deferral_is_guarded(): void {
+		$job_id    = $this->db_jobs->create_job( array( 'label' => 'Active pending AI deferral' ) );
+		$generation = 1;
+		$action_id = as_schedule_single_action(
+			time() + HOUR_IN_SECONDS,
+			AIConcurrencyBackpressure::RESUME_HOOK,
+			array( 'job_id' => $job_id, 'flow_step_id' => 'ai-step', 'ai_resume_generation' => $generation ),
+			'data-machine-ai-resume-test',
+			true
+		);
+		$this->storePendingAIDeferral( $job_id, (int) $action_id, $generation );
+
+		$result = ( new RecoverStuckJobsAbility() )->execute( array( 'dry_run' => true, 'job_id' => $job_id, 'limit' => 1 ) );
+		$this->assertSame( 0, $result['pending_ai_terminalized'] );
+		$this->assertSame( 1, $result['pending_ai_guarded'] );
+		$this->assertSame( 'recorded_scheduler_action_exists', $result['jobs'][0]['reason'] );
+		$this->assertSame( JobStatus::PENDING, $this->db_jobs->get_job( $job_id )['status'] );
+	}
+
+	public function test_expired_pending_ai_deferral_dry_run_and_apply_are_coherent(): void {
+		$job_id = $this->db_jobs->create_job( array( 'label' => 'Expired pending AI deferral' ) );
+		$this->storePendingAIDeferral( $job_id, 900000001, 4 );
+
+		$dry_run = ( new RecoverStuckJobsAbility() )->execute( array( 'dry_run' => true, 'job_id' => $job_id, 'limit' => 1 ) );
+		$this->assertSame( 1, $dry_run['pending_ai_terminalized'] );
+		$this->assertSame( 0, $dry_run['mutations'] );
+		$this->assertSame( 0, $dry_run['touched'] );
+		$this->assertSame( 'would_terminalize_expired_ai_deferral', $dry_run['jobs'][0]['status'] );
+
+		$applied = ( new RecoverStuckJobsAbility() )->execute( array( 'job_id' => $job_id, 'limit' => 1 ) );
+		$this->assertSame( $dry_run['pending_ai_terminalized'], $applied['pending_ai_terminalized'] );
+		$this->assertSame( 1, $applied['mutations'] );
+		$this->assertSame( 1, $applied['touched'] );
+		$this->assertSame( 'terminalized_expired_ai_deferral', $applied['jobs'][0]['status'] );
+		$job = $this->db_jobs->get_job( $job_id );
+		$this->assertSame( JobStatus::CANCELLED, $job['status'] );
+		$this->assertArrayNotHasKey( 'ai_concurrency_throttle', $job['engine_data'] );
+		$this->assertSame( 'scheduler_action_missing', $job['engine_data']['ai_concurrency_history'][0]['reason'] );
+	}
+
+	public function test_legacy_expired_pending_ai_deferral_without_generation_is_recoverable(): void {
+		$job_id = $this->db_jobs->create_job( array( 'label' => 'Legacy expired pending AI deferral' ) );
+		$this->storePendingAIDeferral( $job_id, 900000002, 0, true );
+
+		$dry_run = ( new RecoverStuckJobsAbility() )->execute( array( 'dry_run' => true, 'job_id' => $job_id, 'limit' => 1 ) );
+		$this->assertSame( 1, $dry_run['pending_ai_terminalized'] );
+		$this->assertSame( 0, $dry_run['jobs'][0]['generation'] );
+
+		$applied = ( new RecoverStuckJobsAbility() )->execute( array( 'job_id' => $job_id, 'limit' => 1 ) );
+		$this->assertSame( 1, $applied['pending_ai_terminalized'] );
+		$this->assertSame( JobStatus::CANCELLED, $this->db_jobs->get_job( $job_id )['status'] );
+	}
+
+	public function test_pending_ai_recovery_honors_exact_scope_and_limit(): void {
+		$job_ids = array();
+		foreach ( array( 900000011, 900000012, 900000013 ) as $index => $action_id ) {
+			$job_id = $this->db_jobs->create_job( array( 'label' => 'Bounded pending AI deferral ' . $index ) );
+			$this->storePendingAIDeferral( $job_id, $action_id, 2 );
+			$job_ids[] = $job_id;
+		}
+
+		$exact = ( new RecoverStuckJobsAbility() )->execute( array( 'dry_run' => true, 'job_id' => $job_ids[1], 'limit' => 3 ) );
+		$this->assertSame( 1, $exact['pending_ai_terminalized'] );
+		$this->assertSame( $job_ids[1], $exact['jobs'][0]['job_id'] );
+
+		$dry_run = ( new RecoverStuckJobsAbility() )->execute( array( 'dry_run' => true, 'limit' => 2 ) );
+		$applied = ( new RecoverStuckJobsAbility() )->execute( array( 'limit' => 2 ) );
+		$this->assertSame( 2, $dry_run['pending_ai_terminalized'] );
+		$this->assertSame( $dry_run['pending_ai_terminalized'], $applied['pending_ai_terminalized'] );
+		$this->assertSame( 2, $applied['touched'] );
+		$this->assertCount( 1, array_filter( $job_ids, fn( int $id ): bool => JobStatus::PENDING === $this->db_jobs->get_job( $id )['status'] ) );
+	}
+
+	private function storePendingAIDeferral( int $job_id, int $action_id, int $generation, bool $legacy = false ): void {
+		$engine = datamachine_get_engine_data( $job_id );
+		$engine['ai_concurrency_throttle'] = array(
+			'flow_step_id'      => 'ai-step',
+			'next_retry_at'     => gmdate( 'c', time() - HOUR_IN_SECONDS ),
+			'action_id'         => $action_id,
+		);
+		if ( ! $legacy ) {
+			$engine['ai_concurrency_throttle']['state']             = 'deferred';
+			$engine['ai_concurrency_throttle']['resume_generation'] = $generation;
+			$engine['ai_concurrency_resume_ownership'] = array(
+				'status'       => 'scheduled',
+				'flow_step_id' => 'ai-step',
+				'action_id'    => $action_id,
+				'generation'   => $generation,
+			);
+		}
+		$this->assertTrue( datamachine_set_engine_data( $job_id, $engine ) );
+	}
+
 	public function test_action_history_overfetches_past_numeric_prefix_collisions(): void {
 		$exact_id = as_schedule_single_action( time(), 'datamachine_execute_step', array( 'job_id' => 42, 'flow_step_id' => 'exact' ), 'data-machine' );
 		for ( $index = 0; $index < 75; ++$index ) {

--- a/tests/job-liveness-cli-smoke.php
+++ b/tests/job-liveness-cli-smoke.php
@@ -76,6 +76,14 @@ $assert( 'fresh resume action with throttle is concurrency deferred', 'ai_concur
 $assert( 'deferred metrics expose count and age', 8 === $deferred['defer_count'] && 3600 === $deferred['defer_age_seconds'] );
 $assert( 'deferred contention is active', true === $deferred['contention_active'] );
 
+$orphaned_deferral = $classify( $deferred_job );
+$assert( 'stale throttle metadata without current scheduler ownership is not active contention', false === $orphaned_deferral['contention_active'] );
+$assert( 'orphaned pending deferral has no scheduler path', 'no_scheduler_path' === $orphaned_deferral['classification'] );
+
+$legacy_throttle = $job( array( 'ai_concurrency_throttle' => array( 'flow_step_id' => 'step', 'action_id' => 77 ) ) );
+$legacy_active = $classify( $legacy_throttle, array( $action( 'pending', '2026-07-22 11:50:00', array(), 'datamachine_resume_ai_step', 77 ) ) );
+$assert( 'legacy exact resume receipt remains active scheduler ownership', true === $legacy_active['contention_active'] && 'ai_concurrency_deferred' === $legacy_active['classification'] );
+
 $queued = $classify( $job(), array( $action( 'pending', '2026-07-22 11:50:00' ) ) );
 $assert( 'fresh pending action without throttle is queued', 'queued_next_step' === $queued['classification'] );
 

--- a/tests/recover-stuck-cli-output-smoke.php
+++ b/tests/recover-stuck-cli-output-smoke.php
@@ -35,7 +35,8 @@ assert_recover_stuck_cli_output_smoke( 'structured output includes truncation me
 
 echo "Case 2: recover-stuck separates actionable and guarded jobs\n";
 assert_recover_stuck_cli_output_smoke( 'summary helper exists', str_contains( $cli_source, 'private function summarize_recover_stuck_result' ) );
-assert_recover_stuck_cli_output_smoke( 'summary computes actionable total', str_contains( $cli_source, "'actionable'    => \$recovered + \$timed_out + \$stale_actions" ) );
+assert_recover_stuck_cli_output_smoke( 'summary computes actionable total', str_contains( $cli_source, "'actionable'    => \$pending_ai_terminalized + \$recovered + \$timed_out + \$stale_actions" ) );
+assert_recover_stuck_cli_output_smoke( 'summary explicitly includes expired pending AI terminalizations', str_contains( $cli_source, '$pending_ai_terminalized + $recovered' ) );
 assert_recover_stuck_cli_output_smoke( 'table headline reports guarded jobs separately', str_contains( $cli_source, 'Found %d recoverable jobs/actions and %d guarded jobs.' ) );
 assert_recover_stuck_cli_output_smoke( 'table output reports truncated details', str_contains( $cli_source, 'Output truncated; %d additional job/action details omitted.' ) );
 


### PR DESCRIPTION
## Summary
- classify AI contention as active only when an exact current resume action owns the deferral
- include expired pending AI deferrals in bounded recover-stuck dry-run/apply output
- terminalize actionless deferrals under a locked ownership compare-and-set and archive their throttle evidence

## Root cause
`recover-stuck` queried only `processing` rows, while AI concurrency backpressure parks deferred jobs as `pending`. Liveness selected those pending rows but treated persisted throttle metadata itself as active contention, even after the recorded Action Scheduler action had disappeared. That left historical deferrals visible as `no_scheduler_path` with no bounded mutation path.

## Eligibility predicate
Recovery considers only a bounded set of jobs where:
- base status is exactly `pending`
- `ai_concurrency_throttle` is deferred (including the legacy pre-`state` shape)
- `next_retry_at` parses successfully and is in the past
- `flow_step_id` and a positive recorded `action_id` exist
- modern rows have exact equality across throttle and `ai_concurrency_resume_ownership` for action ID, resume generation, scheduled state, and flow step
- legacy rows have no resume ownership object and no resume generation field
- the exact recorded Action Scheduler row is absent

Any present action, incomplete receipt, malformed expiry, ownership mismatch, or scheduler query error is guarded and skipped. Arbitrary pending jobs are never included.

## Recovery outcome
Eligible rows terminalize as `cancelled - ai_concurrency_stranded`, matching the existing age-bounded AI contention policy. Requeueing would require inventing a replacement resume-generation claim protocol for historical work; terminalization is the smaller deterministic policy and avoids replaying an AI step whose scheduler ownership was lost. The throttle is archived to bounded `ai_concurrency_history` with `scheduler_action_missing` evidence.

## Ownership and bounds
- apply revalidates pending status, expiry, the full modern generation receipt or strict legacy absence predicate, and exact scheduler action absence while holding the jobs row lock
- active pending or in-progress resume actions remain protected; generation mismatches fail closed
- existing child/parent, recovery-generation, direct-operation, and packet-disposition paths are unchanged
- pending candidate selection loads at most `limit + 1` IDs (maximum 101), hydrates payloads one at a time, and shares the existing hard 100-touch apply budget
- `--job-id` scopes the new diagnosis and mutation to one exact job
- dry-run reports `would_terminalize_expired_ai_deferral` without consuming touches or claiming mutations; apply reports the corresponding terminalized count

## Production evidence
On `events.extrachill.com` with Data Machine v0.172.31:
- liveness reports 87 total rows, all `no_scheduler_path`
- processing recovery reports 0 actionable rows
- a read-only predicate check found 87 expired pending throttle rows whose exact recorded action is absent
- job 660965 is the strict legacy shape: expired retry/action ID, no state, no generation ownership
- job 773614 is the modern shape: deferred state plus exact generation 32/action 71752949 ownership, with the action absent
- no direct database workaround was applied

## Verification
- `php tests/job-liveness-cli-smoke.php`
- `php tests/recover-stuck-cli-output-smoke.php`
- `php tests/recover-stuck-bounded-apply-smoke.php`
- `php tests/recover-stuck-active-action-guard-smoke.php`
- `php tests/recover-stuck-terminal-actions-smoke.php`
- `php tests/recover-stuck-bounded-memory-smoke.php`
- `php tests/job-status-accounting-smoke.php`
- `php tests/ai-step-backpressure-smoke.php`
- PHP syntax checks for every changed PHP surface
- targeted PHPCS for all changed files
- `git diff --check`
- targeted PHPUnit invocation exited successfully, though this worktree's PHPUnit runner emitted no console output; focused WordPress integration coverage was added for active protection, modern and legacy expiration, dry-run/apply coherence, exact job scope, and hard limits

Fixes #3210

## AI assistance
Implemented and reviewed with AI assistance. Production evidence was queried read-only; no production rows or files were modified.