### PR TITLE
Add reproducible agent exports

### DIFF
--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -119,28 +119,28 @@ class AgentAbilities {
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
-							'agent'       => array(
+							'agent'        => array(
 								'type'        => 'string',
 								'description' => 'Agent slug or ID to export. Slugs are preferred.',
 							),
-							'agent_slug'  => array(
+							'agent_slug'   => array(
 								'type'        => 'string',
 								'description' => 'Agent slug to export. Prefer agent for new callers.',
 							),
-							'agent_id'    => array(
+							'agent_id'     => array(
 								'type'        => 'integer',
 								'description' => 'Agent ID to export. Supported for compatibility; prefer agent slug.',
 							),
-							'profile'     => array(
+							'profile'      => array(
 								'type'        => 'string',
 								'enum'        => array( 'share', 'backup', 'fork' ),
 								'description' => 'Export profile. Defaults to share.',
 							),
-							'destination' => array(
+							'destination'  => array(
 								'type'        => 'string',
 								'description' => 'Destination directory or ZIP file path. Defaults to <agent-slug>-bundle.',
 							),
-							'format'      => array(
+							'format'       => array(
 								'type'        => 'string',
 								'enum'        => array( 'directory', 'zip' ),
 								'description' => 'Output format. Defaults to directory.',
@@ -476,11 +476,21 @@ class AgentAbilities {
 					'label'               => 'Project Agent Graph',
 					'description'         => 'Return the persisted coordinator graph, identity paths, and generic child runtime policy.',
 					'category'            => 'datamachine-agent',
-					'input_schema'        => array( 'type' => 'object', 'required' => array( 'slug' ), 'properties' => array( 'slug' => array( 'type' => 'string' ) ) ),
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'slug' ),
+						'properties' => array( 'slug' => array( 'type' => 'string' ) ),
+					),
 					'output_schema'       => array( 'type' => 'object' ),
 					'execute_callback'    => array( self::class, 'projectAgentGraph' ),
 					'permission_callback' => fn() => PermissionHelper::can( 'manage_agents' ),
-					'meta'                => array( 'show_in_rest' => true, 'annotations' => array( 'readonly' => true, 'idempotent' => true ) ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array(
+							'readonly'   => true,
+							'idempotent' => true,
+						),
+					),
 				)
 			);
 
@@ -2703,7 +2713,7 @@ class AgentAbilities {
 			new \RecursiveDirectoryIterator( $bundle_dir, \RecursiveDirectoryIterator::SKIP_DOTS ),
 			\RecursiveIteratorIterator::SELF_FIRST
 		);
-		$items = iterator_to_array( $iterator, false );
+		$items    = iterator_to_array( $iterator, false );
 		usort( $items, static fn( \SplFileInfo $left, \SplFileInfo $right ): int => strcmp( $left->getPathname(), $right->getPathname() ) );
 		foreach ( $items as $item ) {
 			$relative_path = sanitize_title( $agent_slug ) . '/' . substr( $item->getPathname(), strlen( $bundle_dir ) + 1 );

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -145,19 +145,24 @@ class AgentAbilities {
 								'enum'        => array( 'directory', 'zip' ),
 								'description' => 'Output format. Defaults to directory.',
 							),
+							'reproducible' => array(
+								'type'        => 'boolean',
+								'description' => 'Use stable export metadata and archive entry timestamps so unchanged state produces identical output.',
+							),
 						),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success'    => array( 'type' => 'boolean' ),
-							'path'       => array( 'type' => 'string' ),
-							'format'     => array( 'type' => 'string' ),
-							'profile'    => array( 'type' => 'string' ),
-							'manifest'   => array( 'type' => 'object' ),
-							'agent_id'   => array( 'type' => 'integer' ),
-							'agent_slug' => array( 'type' => 'string' ),
-							'error'      => array( 'type' => 'string' ),
+							'success'      => array( 'type' => 'boolean' ),
+							'path'         => array( 'type' => 'string' ),
+							'format'       => array( 'type' => 'string' ),
+							'profile'      => array( 'type' => 'string' ),
+							'manifest'     => array( 'type' => 'object' ),
+							'agent_id'     => array( 'type' => 'integer' ),
+							'agent_slug'   => array( 'type' => 'string' ),
+							'reproducible' => array( 'type' => 'boolean' ),
+							'error'        => array( 'type' => 'string' ),
 						),
 					),
 					'execute_callback'    => array( self::class, 'exportAgent' ),
@@ -2633,8 +2638,15 @@ class AgentAbilities {
 		$agent_slug   = (string) $agent['agent_slug'];
 		$destination  = trim( (string) ( $input['destination'] ?? '' ) );
 		$destination  = '' !== $destination ? $destination : $agent_slug . '-bundle' . ( 'zip' === $format ? '.zip' : '' );
+		$reproducible = ! empty( $input['reproducible'] );
 		$bundler      = new AgentBundler();
-		$export       = $bundler->export_directory_object( $agent_slug, array( 'profile' => $profile ) );
+		$export       = $bundler->export_directory_object(
+			$agent_slug,
+			array(
+				'profile'      => $profile,
+				'reproducible' => $reproducible,
+			)
+		);
 		$directory    = $export['directory'] ?? null;
 		$manifest     = $directory instanceof AgentBundleDirectory ? $directory->manifest()->to_array() : array();
 		$written_path = $destination;
@@ -2650,7 +2662,7 @@ class AgentAbilities {
 			if ( 'directory' === $format ) {
 				$directory->write( $destination );
 			} else {
-				$written_path = self::writeBundleZip( $directory, $destination, $agent_slug );
+				$written_path = self::writeBundleZip( $directory, $destination, $agent_slug, $reproducible );
 			}
 		} catch ( \Throwable $e ) {
 			return array(
@@ -2660,17 +2672,18 @@ class AgentAbilities {
 		}
 
 		return array(
-			'success'    => true,
-			'agent_id'   => $agent_id,
-			'agent_slug' => $agent_slug,
-			'profile'    => $profile,
-			'format'     => $format,
-			'path'       => $written_path,
-			'manifest'   => $manifest,
+			'success'      => true,
+			'agent_id'     => $agent_id,
+			'agent_slug'   => $agent_slug,
+			'profile'      => $profile,
+			'format'       => $format,
+			'reproducible' => $reproducible,
+			'path'         => $written_path,
+			'manifest'     => $manifest,
 		);
 	}
 
-	private static function writeBundleZip( AgentBundleDirectory $directory, string $zip_path, string $agent_slug ): string {
+	private static function writeBundleZip( AgentBundleDirectory $directory, string $zip_path, string $agent_slug, bool $reproducible = false ): string {
 		if ( ! class_exists( '\ZipArchive' ) ) {
 			throw new BundleValidationException( 'ZipArchive is not available.' );
 		}
@@ -2690,12 +2703,21 @@ class AgentAbilities {
 			new \RecursiveDirectoryIterator( $bundle_dir, \RecursiveDirectoryIterator::SKIP_DOTS ),
 			\RecursiveIteratorIterator::SELF_FIRST
 		);
-		foreach ( $iterator as $item ) {
+		$items = iterator_to_array( $iterator, false );
+		usort( $items, static fn( \SplFileInfo $left, \SplFileInfo $right ): int => strcmp( $left->getPathname(), $right->getPathname() ) );
+		foreach ( $items as $item ) {
 			$relative_path = sanitize_title( $agent_slug ) . '/' . substr( $item->getPathname(), strlen( $bundle_dir ) + 1 );
 			if ( $item->isDir() ) {
 				$zip->addEmptyDir( $relative_path );
+				$archive_path = rtrim( $relative_path, '/' ) . '/';
 			} else {
 				$zip->addFile( $item->getPathname(), $relative_path );
+				$archive_path = $relative_path;
+			}
+			if ( $reproducible && ( ! method_exists( $zip, 'setMtimeName' ) || ! $zip->setMtimeName( $archive_path, 315532800 ) ) ) {
+				$zip->close();
+				self::removeDirectory( $temp_dir );
+				throw new BundleValidationException( 'Reproducible ZIP exports require ZipArchive::setMtimeName().' );
 			}
 		}
 		$zip->close();

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -1301,6 +1301,10 @@ class AgentsCommand extends AgentBundleCommand {
 	 * : Output path. For zip, a file path. For directory, a directory path.
 	 *   Defaults to current directory with auto-generated filename.
 	 *
+	 * [--reproducible]
+	 * : Use stable metadata and ZIP entry timestamps so unchanged agent state
+	 *   produces byte-identical exports. Intended for automated drift harvesting.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Export as directory (default)
@@ -1315,10 +1319,11 @@ class AgentsCommand extends AgentBundleCommand {
 	 * @subcommand export
 	 */
 	public function export( array $args, array $assoc_args ): void {
-		$identifier  = (string) ( $args[0] ?? '' );
-		$format      = (string) ( $assoc_args['format'] ?? 'directory' );
-		$destination = (string) ( $assoc_args['destination'] ?? ( $assoc_args['output'] ?? '' ) );
-		$profile     = (string) ( $assoc_args['profile'] ?? 'share' );
+		$identifier   = (string) ( $args[0] ?? '' );
+		$format       = (string) ( $assoc_args['format'] ?? 'directory' );
+		$destination  = (string) ( $assoc_args['destination'] ?? ( $assoc_args['output'] ?? '' ) );
+		$profile      = (string) ( $assoc_args['profile'] ?? 'share' );
+		$reproducible = \WP_CLI\Utils\get_flag_value( $assoc_args, 'reproducible', false );
 
 		if ( '' === trim( $identifier ) ) {
 			WP_CLI::error( 'Agent ID or slug is required.' );
@@ -1336,9 +1341,10 @@ class AgentsCommand extends AgentBundleCommand {
 		}
 
 		$input = array(
-			'agent_id' => (int) $agent['agent_id'],
-			'profile'  => $profile,
-			'format'   => $format,
+			'agent_id'     => (int) $agent['agent_id'],
+			'profile'      => $profile,
+			'format'       => $format,
+			'reproducible' => $reproducible,
 		);
 		if ( '' !== trim( $destination ) ) {
 			$input['destination'] = $destination;

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -54,7 +54,7 @@ class AgentBundler {
 	/**
 	 * Bundle format version for forward compatibility.
 	 */
-	const BUNDLE_VERSION = 1;
+	const BUNDLE_VERSION                   = 1;
 	private const REPRODUCIBLE_EXPORTED_AT = '1970-01-01T00:00:00+00:00';
 
 	/**

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -55,6 +55,7 @@ class AgentBundler {
 	 * Bundle format version for forward compatibility.
 	 */
 	const BUNDLE_VERSION = 1;
+	private const REPRODUCIBLE_EXPORTED_AT = '1970-01-01T00:00:00+00:00';
 
 	/**
 	 * @var Agents
@@ -249,7 +250,7 @@ class AgentBundler {
 			(string) $agent['agent_slug']
 		);
 		$manifest          = new AgentBundleManifest(
-			gmdate( 'c' ),
+			self::exported_at_for_context( $context ),
 			defined( 'DATAMACHINE_VERSION' ) ? 'data-machine/' . DATAMACHINE_VERSION : 'data-machine/unknown',
 			sanitize_title( (string) $agent['agent_slug'] ),
 			(string) self::BUNDLE_VERSION,
@@ -295,6 +296,16 @@ class AgentBundler {
 			'directory' => $directory,
 			'package'   => AgentPackageProjection::from_directory( $directory ),
 		);
+	}
+
+	/**
+	 * Resolve export metadata without wall-clock drift when requested.
+	 *
+	 * @param array<string,mixed> $context Export context.
+	 * @return string ISO-8601 export timestamp.
+	 */
+	private static function exported_at_for_context( array $context ): string {
+		return ! empty( $context['reproducible'] ) ? self::REPRODUCIBLE_EXPORTED_AT : gmdate( 'c' );
 	}
 
 	/** @return array<int,array<string,mixed>> */

--- a/tests/export-agent-ability-smoke.php
+++ b/tests/export-agent-ability-smoke.php
@@ -35,6 +35,18 @@ if ( ! function_exists( 'is_wp_error' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_mkdir_p' ) ) {
+	function wp_mkdir_p( $path ) {
+		return is_dir( $path ) || mkdir( $path, 0775, true );
+	}
+}
+
+if ( ! function_exists( 'wp_delete_file' ) ) {
+	function wp_delete_file( $path ) {
+		return unlink( $path );
+	}
+}
+
 if ( ! function_exists( 'apply_filters' ) ) {
 	$GLOBALS['export_agent_smoke_filters'] = array();
 	if ( ! function_exists( 'add_filter' ) ) {
@@ -66,15 +78,19 @@ class WP_Error {
 require_once __DIR__ . '/../inc/Engine/Bundle/BundleValidationException.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/PortableSlug.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/BundleSchema.php';
+require_once __DIR__ . '/../inc/Engine/Agents/AgentSubagentGraph.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleSlugTrait.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleManifest.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundlePipelineFile.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleFlowFile.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleArtifactExtensions.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleArtifactDefinitions.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/BundleRelativePath.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleDirectory.php';
 require_once __DIR__ . '/../inc/Core/Agents/AgentBundler.php';
+require_once __DIR__ . '/../inc/Abilities/AgentAbilities.php';
 
+use DataMachine\Abilities\AgentAbilities;
 use DataMachine\Core\Agents\AgentBundler;
 use DataMachine\Engine\Bundle\AgentBundleDirectory;
 use DataMachine\Engine\Bundle\AgentBundleFlowFile;
@@ -96,6 +112,11 @@ $assert = function ( string $label, bool $condition ) use ( &$assertions, &$fail
 
 function export_agent_private( string $method, array $args = array() ) {
 	$reflection = new ReflectionMethod( AgentBundler::class, $method );
+	return $reflection->invokeArgs( null, $args );
+}
+
+function export_agent_ability_private( string $method, array $args = array() ) {
+	$reflection = new ReflectionMethod( AgentAbilities::class, $method );
 	return $reflection->invokeArgs( null, $args );
 }
 
@@ -178,7 +199,24 @@ $assert( 'manifest export is byte-identical across writes', $manifest_a === $man
 $assert( 'pipeline export is byte-identical across writes', file_get_contents( $dir_a . '/pipelines/pipeline-a.json' ) === file_get_contents( $dir_b . '/pipelines/pipeline-a.json' ) );
 $assert( 'manifest JSON sorts object keys', false !== strpos( (string) $manifest_a, "\"a\": 1,\n            \"b\": 2" ) );
 
-echo "\n[4] Ability and CLI route through value-object exporter\n";
+echo "\n[4] Reproducible export metadata and archives\n";
+$default_exported_at      = export_agent_private( 'exported_at_for_context', array( array() ) );
+$reproducible_exported_at = export_agent_private( 'exported_at_for_context', array( array( 'reproducible' => true ) ) );
+$assert( 'default export retains wall-clock metadata', '1970-01-01T00:00:00+00:00' !== $default_exported_at );
+$assert( 'reproducible export uses canonical metadata', '1970-01-01T00:00:00+00:00' === $reproducible_exported_at );
+
+if ( class_exists( 'ZipArchive' ) && method_exists( 'ZipArchive', 'setMtimeName' ) ) {
+	$zip_a = $tmp_base . '/a.zip';
+	$zip_b = $tmp_base . '/b.zip';
+	export_agent_ability_private( 'writeBundleZip', array( $directory, $zip_a, 'agent-test', true ) );
+	sleep( 2 );
+	export_agent_ability_private( 'writeBundleZip', array( $directory, $zip_b, 'agent-test', true ) );
+	$assert( 'reproducible ZIP exports are byte-identical', hash_file( 'sha256', $zip_a ) === hash_file( 'sha256', $zip_b ) );
+} else {
+	$assert( 'reproducible ZIP test skipped without timestamp support', true );
+}
+
+echo "\n[5] Ability and CLI route through value-object exporter\n";
 $ability_source = file_get_contents( __DIR__ . '/../inc/Abilities/AgentAbilities.php' ) ?: '';
 $cli_source     = file_get_contents( __DIR__ . '/../inc/Cli/Commands/AgentsCommand.php' ) ?: '';
 $bundler_source = file_get_contents( __DIR__ . '/../inc/Core/Agents/AgentBundler.php' ) ?: '';
@@ -186,6 +224,8 @@ $assert( 'ability registers datamachine/export-agent', str_contains( $ability_so
 $assert( 'ability calls AgentBundler export_directory_object', str_contains( $ability_source, 'export_directory_object' ) );
 $assert( 'ability writes AgentBundleDirectory directly', str_contains( $ability_source, '$directory->write( $destination )' ) );
 $assert( 'CLI export calls generic ability', str_contains( $cli_source, 'AgentAbilities::exportAgent' ) );
+$assert( 'ability exposes reproducible export input', str_contains( $ability_source, "'reproducible'" ) );
+$assert( 'CLI exposes reproducible export flag', str_contains( $cli_source, '[--reproducible]' ) );
 $assert( 'bundler applies datamachine_agent_export_manifest once', 1 === substr_count( $bundler_source, 'datamachine_agent_export_manifest' ) );
 
 echo "\nAssertions: {$assertions}\n";


### PR DESCRIPTION
## Summary
- add an explicit `reproducible` input to the agent export ability and `--reproducible` to WP-CLI
- pin volatile manifest metadata only in reproducible mode while preserving current default exports
- sort ZIP entries and normalize their timestamps so unchanged exports are byte-identical

## Ownership
- checked fresh `Automattic/intelligence`: it only advertises domain capabilities and does not own generic export
- checked fresh `Automattic/agents-api`: it already owns deterministic artifact hashing/package ordering but intentionally does not materialize filesystem bundles
- Data Machine owns the live bundle writer and introduces `exported_at`, so the missing materialization option belongs here

## Verification
- focused export smoke: 23 assertions passed
- adjacent bundle/package smokes: 137 assertions passed
- PHPCS passed on all changed files
- real Events-site export: two 704-flow directory exports had zero recursive differences
- real Events-site ZIP export: two delayed archives had identical SHA-256 `634572b804a52d2049ac7be6264b75d00f428365555bf7dc1422f5e95f61558a`

Fixes #3216