### PR TITLE
feat: add principal-scoped named mailboxes

### DIFF
--- a/inc/Abilities/AuthAbilities.php
+++ b/inc/Abilities/AuthAbilities.php
@@ -468,7 +468,7 @@ class AuthAbilities {
 				'is_configured'    => method_exists( $instance, 'is_configured' ) ? $instance->is_configured() : false,
 				'is_authenticated' => $is_authenticated,
 				'auth_fields'      => method_exists( $instance, 'get_config_fields' ) ? $instance->get_config_fields() : array(),
-				'config_values'    => method_exists( $instance, 'get_config' ) ? $instance->get_config() : array(),
+				'config_values'    => method_exists( $instance, 'get_config' ) && method_exists( $instance, 'strip_auth_config_secrets' ) ? $instance->strip_auth_config_secrets( $instance->get_config() ) : array(),
 				'callback_url'     => null,
 				'account_details'  => null,
 			);

--- a/inc/Abilities/Email/EmailAbilities.php
+++ b/inc/Abilities/Email/EmailAbilities.php
@@ -20,6 +20,7 @@ defined( 'ABSPATH' ) || exit;
 class EmailAbilities {
 
 	private static bool $registered = false;
+	private ?array $activeMailbox = null;
 
 	public function __construct() {
 		if ( self::$registered ) {
@@ -43,6 +44,7 @@ class EmailAbilities {
 						'type'       => 'object',
 						'required'   => array( 'to', 'subject', 'body', 'in_reply_to' ),
 						'properties' => array(
+							'auth_ref'     => self::authRefProperty(),
 							'to'           => array(
 								'type'        => 'string',
 								'description' => __( 'Recipient email address', 'data-machine' ),
@@ -100,6 +102,7 @@ class EmailAbilities {
 						'type'       => 'object',
 						'required'   => array( 'uid' ),
 						'properties' => array(
+							'auth_ref' => self::authRefProperty(),
 							'uid'    => array(
 								'type'        => 'integer',
 								'description' => __( 'Message UID to delete', 'data-machine' ),
@@ -135,6 +138,7 @@ class EmailAbilities {
 						'type'       => 'object',
 						'required'   => array( 'uid', 'destination' ),
 						'properties' => array(
+							'auth_ref'     => self::authRefProperty(),
 							'uid'         => array(
 								'type'        => 'integer',
 								'description' => __( 'Message UID to move', 'data-machine' ),
@@ -174,6 +178,7 @@ class EmailAbilities {
 						'type'       => 'object',
 						'required'   => array( 'uid', 'flag' ),
 						'properties' => array(
+							'auth_ref' => self::authRefProperty(),
 							'uid'    => array(
 								'type'        => 'integer',
 								'description' => __( 'Message UID', 'data-machine' ),
@@ -218,6 +223,7 @@ class EmailAbilities {
 						'type'       => 'object',
 						'required'   => array( 'search', 'destination' ),
 						'properties' => array(
+							'auth_ref'     => self::authRefProperty(),
 							'search'      => array(
 								'type'        => 'string',
 								'description' => __( 'IMAP search criteria (e.g., FROM "github.com")', 'data-machine' ),
@@ -264,6 +270,7 @@ class EmailAbilities {
 						'type'       => 'object',
 						'required'   => array( 'search', 'flag' ),
 						'properties' => array(
+							'auth_ref' => self::authRefProperty(),
 							'search' => array(
 								'type'        => 'string',
 								'description' => __( 'IMAP search criteria', 'data-machine' ),
@@ -314,6 +321,7 @@ class EmailAbilities {
 						'type'       => 'object',
 						'required'   => array( 'search' ),
 						'properties' => array(
+							'auth_ref' => self::authRefProperty(),
 							'search' => array(
 								'type'        => 'string',
 								'description' => __( 'IMAP search criteria', 'data-machine' ),
@@ -356,6 +364,7 @@ class EmailAbilities {
 						'type'       => 'object',
 						'required'   => array( 'uid' ),
 						'properties' => array(
+							'auth_ref' => self::authRefProperty(),
 							'uid'    => array(
 								'type'        => 'integer',
 								'description' => __( 'Message UID to unsubscribe from', 'data-machine' ),
@@ -392,6 +401,7 @@ class EmailAbilities {
 						'type'       => 'object',
 						'required'   => array( 'search' ),
 						'properties' => array(
+							'auth_ref' => self::authRefProperty(),
 							'search' => array(
 								'type'        => 'string',
 								'description' => __( 'IMAP search criteria', 'data-machine' ),
@@ -433,7 +443,7 @@ class EmailAbilities {
 					'category'            => 'datamachine-email',
 					'input_schema'        => array(
 						'type'       => 'object',
-						'properties' => new \stdClass(),
+						'properties' => array( 'auth_ref' => self::authRefProperty() ),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
@@ -455,7 +465,15 @@ class EmailAbilities {
 	}
 
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' ) || PermissionHelper::can_manage();
+	}
+
+	private static function authRefProperty(): array {
+		return array(
+			'type'        => 'string',
+			'default'     => 'email_imap:default',
+			'description' => __( 'Non-secret mailbox auth ref', 'data-machine' ),
+		);
 	}
 
 	/**
@@ -498,11 +516,17 @@ class EmailAbilities {
 			return new \WP_Error( 'invalid_email_recipient', 'No valid recipient address', array( 'status' => 400 ) );
 		}
 
+		$mailbox = $this->resolveMailbox( $input, 'reply' );
+		if ( is_wp_error( $mailbox ) ) {
+			return $mailbox;
+		}
+		$headers[] = 'From: ' . $mailbox['credentials']['imap_user'];
+
 		$sent = wp_mail( $to, $input['subject'], $input['body'], $headers );
 
 		if ( $sent ) {
 			if ( ! $this->isConfiguredMailboxRecipient( $to, $cc_list ) ) {
-				$this->saveToSentFolder( $to, $input['subject'], $input['body'], $headers );
+				$this->saveToSentFolder( $to, $input['subject'], $input['body'], $headers, $input );
 			}
 
 			return array(
@@ -525,7 +549,7 @@ class EmailAbilities {
 	 * Delete an email from the IMAP server.
 	 */
 	public function executeDelete( array $input ): array|\WP_Error {
-		$connection = $this->connect( $input['folder'] ?? 'INBOX' );
+		$connection = $this->connect( $input, 'delete' );
 		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
@@ -545,7 +569,7 @@ class EmailAbilities {
 	 * Move an email to a different folder.
 	 */
 	public function executeMove( array $input ): array|\WP_Error {
-		$connection = $this->connect( $input['folder'] ?? 'INBOX' );
+		$connection = $this->connect( $input, array( 'organize', 'delete' ) );
 		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
@@ -573,7 +597,8 @@ class EmailAbilities {
 	 * Set or clear a flag on an email.
 	 */
 	public function executeFlag( array $input ): array|\WP_Error {
-		$connection = $this->connect( $input['folder'] ?? 'INBOX' );
+		$operation  = 'deleted' === strtolower( (string) ( $input['flag'] ?? '' ) ) ? 'delete' : 'organize';
+		$connection = $this->connect( $input, $operation );
 		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
@@ -610,26 +635,25 @@ class EmailAbilities {
 	 * Test the IMAP connection with stored credentials.
 	 */
 	public function executeTestConnection( array $input ): array|\WP_Error {
-		unset( $input );
-
 		if ( ! function_exists( 'imap_open' ) ) {
 			return new \WP_Error( 'email_imap_unavailable', 'PHP IMAP extension is not installed', array( 'status' => 400 ) );
 		}
 
-		$auth = $this->getAuthProvider();
-		if ( ! $auth || ! $auth->is_authenticated() ) {
-			return new \WP_Error( 'email_imap_not_configured', 'IMAP credentials not configured', array( 'status' => 400 ) );
+		$resolved = $this->resolveMailbox( $input, 'read' );
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
 		}
+		$credentials = $resolved['credentials'];
 
 		$mailbox = $this->buildMailboxString(
-			$auth->getHost(),
-			$auth->getPort(),
-			$auth->getEncryption(),
+			$credentials['imap_host'],
+			(int) ( $credentials['imap_port'] ?? 993 ),
+			$credentials['imap_encryption'] ?? 'ssl',
 			'INBOX'
 		);
 
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-		$connection = @imap_open( $mailbox, $auth->getUser(), $auth->getPassword() );
+		$connection = @imap_open( $mailbox, $credentials['imap_user'], $credentials['imap_password'] );
 
 		if ( false === $connection ) {
 			return new \WP_Error( 'email_imap_connection_failed', 'Connection failed: ' . imap_last_error(), array( 'status' => 400 ) );
@@ -637,17 +661,17 @@ class EmailAbilities {
 
 		$check = imap_check( $connection );
 		$info  = array(
-			'mailbox'   => $check->Mailbox ?? '',
+			'mailbox'   => $resolved['ref'],
 			'messages'  => $check->Nmsgs ?? 0,
 			'recent'    => $check->Recent ?? 0,
 			'connected' => true,
 		);
 
 		// List available folders.
-		$folders     = imap_list( $connection, $this->buildMailboxString( $auth->getHost(), $auth->getPort(), $auth->getEncryption(), '' ), '*' );
+		$folders     = imap_list( $connection, $this->buildMailboxString( $credentials['imap_host'], (int) ( $credentials['imap_port'] ?? 993 ), $credentials['imap_encryption'] ?? 'ssl', '' ), '*' );
 		$folder_list = array();
 		if ( is_array( $folders ) ) {
-			$prefix = $this->buildMailboxString( $auth->getHost(), $auth->getPort(), $auth->getEncryption(), '' );
+			$prefix = $this->buildMailboxString( $credentials['imap_host'], (int) ( $credentials['imap_port'] ?? 993 ), $credentials['imap_encryption'] ?? 'ssl', '' );
 			foreach ( $folders as $folder ) {
 				$folder_list[] = str_replace( $prefix, '', imap_utf7_decode( $folder ) );
 			}
@@ -658,7 +682,7 @@ class EmailAbilities {
 
 		return array(
 			'success'      => true,
-			'message'      => sprintf( 'Connected to %s — %d messages in INBOX', $auth->getHost(), $info['messages'] ),
+			'message'      => sprintf( 'Connected to %s — %d messages in INBOX', $resolved['ref'], $info['messages'] ),
 			'mailbox_info' => $info,
 		);
 	}
@@ -672,7 +696,7 @@ class EmailAbilities {
 	 * 3. mailto: → send email via wp_mail()
 	 */
 	public function executeUnsubscribe( array $input ): array|\WP_Error {
-		$connection = $this->connect( $input['folder'] ?? 'INBOX' );
+		$connection = $this->connect( $input, array( 'unsubscribe', 'read' ) );
 		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
@@ -731,7 +755,7 @@ class EmailAbilities {
 	 * it only unsubscribes once using the most recent message's headers.
 	 */
 	public function executeBatchUnsubscribe( array $input ): array|\WP_Error {
-		$connection = $this->connect( $input['folder'] ?? 'INBOX' );
+		$connection = $this->connect( $input, array( 'unsubscribe', 'read', 'search' ) );
 		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
@@ -1038,7 +1062,7 @@ class EmailAbilities {
 	 * Batch move: search → move all matches to destination.
 	 */
 	public function executeBatchMove( array $input ): array|\WP_Error {
-		$connection = $this->connect( $input['folder'] ?? 'INBOX' );
+		$connection = $this->connect( $input, array( 'organize', 'delete' ) );
 		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
@@ -1090,7 +1114,8 @@ class EmailAbilities {
 	 * Batch flag: search → set/clear flag on all matches.
 	 */
 	public function executeBatchFlag( array $input ): array|\WP_Error {
-		$connection = $this->connect( $input['folder'] ?? 'INBOX' );
+		$operation  = 'deleted' === strtolower( (string) ( $input['flag'] ?? '' ) ) ? 'delete' : 'organize';
+		$connection = $this->connect( $input, $operation );
 		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
@@ -1147,7 +1172,7 @@ class EmailAbilities {
 	 * Batch delete: search → delete all matches.
 	 */
 	public function executeBatchDelete( array $input ): array|\WP_Error {
-		$connection = $this->connect( $input['folder'] ?? 'INBOX' );
+		$connection = $this->connect( $input, 'delete' );
 		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
@@ -1190,28 +1215,30 @@ class EmailAbilities {
 	/**
 	 * Open an IMAP connection using stored credentials.
 	 *
-	 * @param string $folder Mail folder.
+	 * @param array  $input Input containing auth_ref and folder.
+	 * @param string|array $operation Required mailbox operation(s).
 	 * @return resource|\WP_Error IMAP connection or error.
 	 */
-	private function connect( string $folder = 'INBOX' ) {
+	private function connect( array $input, string|array $operation ) {
 		if ( ! function_exists( 'imap_open' ) ) {
 			return new \WP_Error( 'email_imap_unavailable', 'PHP IMAP extension is not installed', array( 'status' => 400 ) );
 		}
 
-		$auth = $this->getAuthProvider();
-		if ( ! $auth || ! $auth->is_authenticated() ) {
-			return new \WP_Error( 'email_imap_not_configured', 'IMAP credentials not configured', array( 'status' => 400 ) );
+		$mailbox = $this->resolveMailbox( $input, $operation );
+		if ( is_wp_error( $mailbox ) ) {
+			return $mailbox;
 		}
+		$credentials = $mailbox['credentials'];
 
 		$mailbox = $this->buildMailboxString(
-			$auth->getHost(),
-			$auth->getPort(),
-			$auth->getEncryption(),
-			$folder
+			$credentials['imap_host'],
+			(int) ( $credentials['imap_port'] ?? 993 ),
+			$credentials['imap_encryption'] ?? 'ssl',
+			$input['folder'] ?? 'INBOX'
 		);
 
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-		$connection = @imap_open( $mailbox, $auth->getUser(), $auth->getPassword() );
+		$connection = @imap_open( $mailbox, $credentials['imap_user'], $credentials['imap_password'] );
 
 		if ( false === $connection ) {
 			return new \WP_Error( 'email_imap_connection_failed', 'IMAP connection failed: ' . imap_last_error(), array( 'status' => 400 ) );
@@ -1230,6 +1257,18 @@ class EmailAbilities {
 		return $providers['email_imap'] ?? null;
 	}
 
+	private function resolveMailbox( array $input, string|array $operation ): array|\WP_Error {
+		$auth = $this->getAuthProvider();
+		if ( ! $auth || ! method_exists( $auth, 'resolve_mailbox' ) ) {
+			return new \WP_Error( 'email_imap_not_configured', 'IMAP credentials not configured', array( 'status' => 400 ) );
+		}
+		$mailbox = $auth->resolve_mailbox( $input['auth_ref'] ?? 'email_imap:default', $operation );
+		if ( ! is_wp_error( $mailbox ) ) {
+			$this->activeMailbox = $mailbox;
+		}
+		return $mailbox;
+	}
+
 	/**
 	 * Check whether the configured mailbox will receive the sent message.
 	 *
@@ -1237,12 +1276,18 @@ class EmailAbilities {
 	 * @param array $cc Valid Cc addresses.
 	 */
 	private function isConfiguredMailboxRecipient( array $to, array $cc ): bool {
-		$auth = $this->getAuthProvider();
-		if ( ! $auth ) {
+		$credentials = $this->activeMailbox['credentials'] ?? null;
+		if ( ! is_array( $credentials ) ) {
+			$auth = $this->getAuthProvider();
+			if ( $auth && method_exists( $auth, 'getUser' ) ) {
+				$credentials = array( 'imap_user' => $auth->getUser() );
+			}
+		}
+		if ( ! is_array( $credentials ) ) {
 			return false;
 		}
 
-		$mailbox = strtolower( trim( $auth->getUser() ) );
+		$mailbox = strtolower( trim( (string) ( $credentials['imap_user'] ?? '' ) ) );
 		if ( ! is_email( $mailbox ) ) {
 			return false;
 		}
@@ -1280,15 +1325,17 @@ class EmailAbilities {
 	 * @param string $body    Email body.
 	 * @param array  $headers Email headers (Content-Type, In-Reply-To, References, etc.).
 	 */
-	private function saveToSentFolder( array $to, string $subject, string $body, array $headers ): void {
+	private function saveToSentFolder( array $to, string $subject, string $body, array $headers, array $input ): void {
 		// Determine the Sent folder name. Gmail uses "[Gmail]/Sent Mail".
 		$sent_folder = '[Gmail]/Sent Mail';
 
-		$connection = $this->connect( $sent_folder );
+		$input['folder'] = $sent_folder;
+		$connection      = $this->connect( $input, 'reply' );
 		if ( is_wp_error( $connection ) ) {
 			// Non-Gmail server or folder not found — try common alternatives.
 			foreach ( array( 'Sent', 'Sent Items', 'INBOX.Sent' ) as $fallback ) {
-				$connection = $this->connect( $fallback );
+				$input['folder'] = $fallback;
+				$connection      = $this->connect( $input, 'reply' );
 				if ( ! is_wp_error( $connection ) ) {
 					$sent_folder = $fallback;
 					break;
@@ -1301,9 +1348,9 @@ class EmailAbilities {
 			}
 		}
 
-		$auth = $this->getAuthProvider();
-		if ( $auth ) {
-			$from = $auth->getUser();
+		$credentials = $this->activeMailbox['credentials'] ?? null;
+		if ( is_array( $credentials ) ) {
+			$from = $credentials['imap_user'];
 		} else {
 			// Derive a sane fallback From address from the WordPress site itself
 			// rather than hardcoding any specific domain.
@@ -1336,9 +1383,9 @@ class EmailAbilities {
 
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		@imap_append( $connection, $this->buildMailboxString(
-			$auth->getHost(),
-			$auth->getPort(),
-			$auth->getEncryption(),
+			$credentials['imap_host'],
+			(int) ( $credentials['imap_port'] ?? 993 ),
+			$credentials['imap_encryption'] ?? 'ssl',
 			$sent_folder
 		), $message, '\\Seen' );
 

--- a/inc/Abilities/Email/EmailAbilities.php
+++ b/inc/Abilities/Email/EmailAbilities.php
@@ -1042,7 +1042,14 @@ class EmailAbilities {
 			$subject = 'unsubscribe';
 		}
 
-		$sent = wp_mail( $address, $subject, 'unsubscribe' );
+		$headers     = array();
+		$credentials = $this->activeMailbox['credentials'] ?? array();
+		$identity    = (string) ( $credentials['imap_user'] ?? '' );
+		if ( is_email( $identity ) ) {
+			$headers[] = 'From: ' . $identity;
+			$headers[] = 'Reply-To: ' . $identity;
+		}
+		$sent = wp_mail( $address, $subject, 'unsubscribe', $headers );
 
 		if ( $sent ) {
 			return array(
@@ -1062,7 +1069,7 @@ class EmailAbilities {
 	 * Batch move: search → move all matches to destination.
 	 */
 	public function executeBatchMove( array $input ): array|\WP_Error {
-		$connection = $this->connect( $input, array( 'organize', 'delete' ) );
+		$connection = $this->connect( $input, array( 'organize', 'delete', 'search' ) );
 		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
@@ -1115,7 +1122,7 @@ class EmailAbilities {
 	 */
 	public function executeBatchFlag( array $input ): array|\WP_Error {
 		$operation  = 'deleted' === strtolower( (string) ( $input['flag'] ?? '' ) ) ? 'delete' : 'organize';
-		$connection = $this->connect( $input, $operation );
+		$connection = $this->connect( $input, array( $operation, 'search' ) );
 		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
@@ -1172,7 +1179,7 @@ class EmailAbilities {
 	 * Batch delete: search → delete all matches.
 	 */
 	public function executeBatchDelete( array $input ): array|\WP_Error {
-		$connection = $this->connect( $input, 'delete' );
+		$connection = $this->connect( $input, array( 'delete', 'search' ) );
 		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}
@@ -1374,6 +1381,9 @@ class EmailAbilities {
 		$message .= "Date: {$date}\r\n";
 
 		foreach ( $headers as $header ) {
+			if ( 0 === stripos( $header, 'From:' ) ) {
+				continue;
+			}
 			$message .= $header . "\r\n";
 		}
 

--- a/inc/Abilities/Fetch/FetchEmailAbility.php
+++ b/inc/Abilities/Fetch/FetchEmailAbility.php
@@ -403,7 +403,7 @@ class FetchEmailAbility {
 		}
 
 		// Fetch body.
-		$body = $this->fetchBody( $connection, $uid );
+		$body = $this->fetchBody( $connection, $uid, ! $config['mark_as_read'] );
 
 		// Check for attachments.
 		$structure        = imap_fetchstructure( $connection, $uid, FT_UID );
@@ -417,7 +417,7 @@ class FetchEmailAbility {
 
 			if ( $config['download_attachments'] && ! empty( $attachments ) ) {
 				foreach ( $attachments as $attachment ) {
-					$file_info = $this->downloadAttachment( $connection, $uid, $attachment );
+					$file_info = $this->downloadAttachment( $connection, $uid, $attachment, ! $config['mark_as_read'] );
 					if ( null === $file_info ) {
 						++$skipped_count;
 						do_action(
@@ -485,7 +485,8 @@ class FetchEmailAbility {
 	 * @param int      $uid        Message UID.
 	 * @return string Message body text.
 	 */
-	private function fetchBody( $connection, int $uid ): string {
+	private function fetchBody( $connection, int $uid, bool $peek ): string {
+		$fetch_flags = FT_UID | ( $peek ? FT_PEEK : 0 );
 		$structure = imap_fetchstructure( $connection, $uid, FT_UID );
 		if ( ! $structure ) {
 			return '';
@@ -493,7 +494,7 @@ class FetchEmailAbility {
 
 		// Simple single-part message.
 		if ( empty( $structure->parts ) ) {
-			$body = imap_fetchbody( $connection, $uid, '1', FT_UID );
+			$body = imap_fetchbody( $connection, $uid, '1', $fetch_flags );
 			return $this->decodeBody( $body, $structure->encoding ?? 0 );
 		}
 
@@ -506,7 +507,7 @@ class FetchEmailAbility {
 
 			if ( 0 === ( $part->type ?? -1 ) ) {
 				$subtype = strtolower( $part->subtype ?? '' );
-				$body    = imap_fetchbody( $connection, $uid, $part_number, FT_UID );
+				$body    = imap_fetchbody( $connection, $uid, $part_number, $fetch_flags );
 				$decoded = $this->decodeBody( $body, $part->encoding ?? 0 );
 
 				if ( 'plain' === $subtype && empty( $plain_body ) ) {
@@ -523,7 +524,7 @@ class FetchEmailAbility {
 
 					if ( 0 === ( $sub_part->type ?? -1 ) ) {
 						$subtype = strtolower( $sub_part->subtype ?? '' );
-						$body    = imap_fetchbody( $connection, $uid, $sub_number, FT_UID );
+						$body    = imap_fetchbody( $connection, $uid, $sub_number, $fetch_flags );
 						$decoded = $this->decodeBody( $body, $sub_part->encoding ?? 0 );
 
 						if ( 'plain' === $subtype && empty( $plain_body ) ) {
@@ -620,8 +621,9 @@ class FetchEmailAbility {
 	/**
 	 * Download an attachment to temp storage.
 	 */
-	private function downloadAttachment( $connection, int $uid, array $attachment_info ): ?array {
-		$body = imap_fetchbody( $connection, $uid, $attachment_info['part_number'], FT_UID );
+	private function downloadAttachment( $connection, int $uid, array $attachment_info, bool $peek ): ?array {
+		$flags = FT_UID | ( $peek ? FT_PEEK : 0 );
+		$body  = imap_fetchbody( $connection, $uid, $attachment_info['part_number'], $flags );
 		if ( empty( $body ) ) {
 			return null;
 		}

--- a/inc/Abilities/Fetch/FetchEmailAbility.php
+++ b/inc/Abilities/Fetch/FetchEmailAbility.php
@@ -19,6 +19,7 @@
 namespace DataMachine\Abilities\Fetch;
 
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Steps\Fetch\Handlers\Email\EmailAuth;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -45,29 +46,12 @@ class FetchEmailAbility {
 					'category'            => 'datamachine-fetch',
 					'input_schema'        => array(
 						'type'       => 'object',
-						'required'   => array( 'imap_host', 'imap_user', 'imap_password' ),
+						'required'   => array(),
 						'properties' => array(
-							'imap_host'            => array(
+							'auth_ref'             => array(
 								'type'        => 'string',
-								'description' => __( 'IMAP server hostname (e.g., imap.gmail.com)', 'data-machine' ),
-							),
-							'imap_port'            => array(
-								'type'        => 'integer',
-								'default'     => 993,
-								'description' => __( 'IMAP server port', 'data-machine' ),
-							),
-							'imap_encryption'      => array(
-								'type'        => 'string',
-								'default'     => 'ssl',
-								'description' => __( 'Connection encryption: ssl, tls, or none', 'data-machine' ),
-							),
-							'imap_user'            => array(
-								'type'        => 'string',
-								'description' => __( 'IMAP username (usually your email address)', 'data-machine' ),
-							),
-							'imap_password'        => array(
-								'type'        => 'string',
-								'description' => __( 'IMAP app password (not your account password)', 'data-machine' ),
+								'default'     => 'email_imap:default',
+								'description' => __( 'Non-secret mailbox auth ref', 'data-machine' ),
 							),
 							'folder'               => array(
 								'type'        => 'string',
@@ -145,7 +129,7 @@ class FetchEmailAbility {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' ) || PermissionHelper::can_manage();
 	}
 
 	/**
@@ -160,6 +144,10 @@ class FetchEmailAbility {
 	 * @return array|\WP_Error Result with items or an error.
 	 */
 	public function execute( array $input ): array|\WP_Error {
+		return $this->executeWithContext( $input, array() );
+	}
+
+	public function executeWithContext( array $input, array $context ): array|\WP_Error {
 		$logs = array();
 
 		if ( ! function_exists( 'imap_open' ) ) {
@@ -170,7 +158,25 @@ class FetchEmailAbility {
 			return new \WP_Error( 'email_imap_unavailable', 'PHP IMAP extension is required but not installed. Install php-imap and restart your web server.', array( 'status' => 400 ) );
 		}
 
-		$config = $this->normalizeConfig( $input );
+		$config     = $this->normalizeConfig( $input );
+		$operations = array( 'read' );
+		if ( empty( $config['uid'] ) && ! empty( $config['search_criteria'] ) ) {
+			$operations[] = 'search';
+		}
+		if ( $config['mark_as_read'] ) {
+			$operations[] = 'organize';
+		}
+		$auth = $this->getAuthProvider();
+		if ( ! $auth ) {
+			return new \WP_Error( 'email_imap_not_configured', 'Email IMAP provider is not registered.', array( 'status' => 400 ) );
+		}
+		$resolved = empty( $context )
+			? $auth->resolve_mailbox( $config['auth_ref'], $operations )
+			: $auth->resolve_mailbox_for_principal( $config['auth_ref'], $operations, $context );
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
+		}
+		$config = array_merge( $config, $resolved['credentials'] );
 
 		$mailbox = $this->buildMailboxString(
 			$config['imap_host'],
@@ -689,11 +695,7 @@ class FetchEmailAbility {
 	 */
 	private function normalizeConfig( array $input ): array {
 		$defaults = array(
-			'imap_host'            => '',
-			'imap_port'            => 993,
-			'imap_user'            => '',
-			'imap_password'        => '',
-			'imap_encryption'      => 'ssl',
+			'auth_ref'             => 'email_imap:default',
 			'folder'               => 'INBOX',
 			'search_criteria'      => 'UNSEEN',
 			'max_messages'         => 10,
@@ -705,5 +707,11 @@ class FetchEmailAbility {
 		);
 
 		return array_merge( $defaults, $input );
+	}
+
+	private function getAuthProvider(): ?EmailAuth {
+		$providers = apply_filters( 'datamachine_auth_providers', array() );
+		$auth      = $providers['email_imap'] ?? null;
+		return $auth instanceof EmailAuth ? $auth : null;
 	}
 }

--- a/inc/Abilities/Publish/SendEmailAbility.php
+++ b/inc/Abilities/Publish/SendEmailAbility.php
@@ -112,6 +112,10 @@ class SendEmailAbility {
 					// continue to work unchanged.
 					'required'   => array( 'to', 'subject' ),
 					'properties' => array(
+						'auth_ref'     => array(
+							'type'        => 'string',
+							'description' => __( 'Optional non-secret mailbox auth ref authorizing the sender identity', 'data-machine' ),
+						),
 						'to'           => array(
 							'type'        => 'string',
 							'description' => __( 'Comma-separated recipient email addresses', 'data-machine' ),
@@ -202,7 +206,7 @@ class SendEmailAbility {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' ) || PermissionHelper::can_manage();
 	}
 
 	/**
@@ -214,6 +218,22 @@ class SendEmailAbility {
 	public function execute( array $input ): array|\WP_Error {
 		$logs   = array();
 		$config = $this->normalizeConfig( $input );
+		if ( ! empty( $config['auth_ref'] ) ) {
+			$providers = apply_filters( 'datamachine_auth_providers', array() );
+			$auth      = $providers['email_imap'] ?? null;
+			if ( ! $auth || ! method_exists( $auth, 'resolve_mailbox' ) ) {
+				return new \WP_Error( 'email_imap_not_configured', 'Email IMAP provider is not registered.', array( 'status' => 400 ) );
+			}
+			$context = $this->verifiedMailboxContext( $config );
+			$resolved = null === $context
+				? $auth->resolve_mailbox( $config['auth_ref'], 'send' )
+				: $auth->resolve_mailbox_for_principal( $config['auth_ref'], 'send', $context );
+			if ( is_wp_error( $resolved ) ) {
+				return $resolved;
+			}
+			$config['from_email'] = $resolved['credentials']['imap_user'];
+			$config['reply_to']   = $resolved['credentials']['imap_user'];
+		}
 
 		// 1. Parse and validate recipients.
 		$to = array_map( 'trim', explode( ',', $config['to'] ) );
@@ -457,6 +477,7 @@ class SendEmailAbility {
 	 */
 	private function normalizeConfig( array $input ): array {
 		$defaults = array(
+			'auth_ref'     => '',
 			'to'           => '',
 			'cc'           => '',
 			'bcc'          => '',
@@ -473,6 +494,24 @@ class SendEmailAbility {
 		);
 
 		return array_merge( $defaults, $input );
+	}
+
+	private function verifiedMailboxContext( array $config ): ?array {
+		$grant = $config['_mailbox_grant'] ?? null;
+		if ( ! is_array( $grant ) || empty( $grant['signature'] ) ) {
+			return null;
+		}
+		$user_id  = absint( $grant['user_id'] ?? 0 );
+		$agent_id = absint( $grant['agent_id'] ?? 0 );
+		$payload  = (string) $config['auth_ref'] . '|' . $user_id . '|' . $agent_id;
+		$expected = hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) );
+		if ( ! hash_equals( $expected, (string) $grant['signature'] ) ) {
+			return null;
+		}
+		return array(
+			'user_id'  => $user_id,
+			'agent_id' => $agent_id,
+		);
 	}
 
 	/**

--- a/inc/Abilities/Publish/SendEmailAbility.php
+++ b/inc/Abilities/Publish/SendEmailAbility.php
@@ -530,7 +530,7 @@ class SendEmailAbility {
 			'agent_id'     => $agent_id,
 			'token_id'     => absint( $grant['token_id'] ?? 0 ),
 			'issuer_type'  => (string) ( $grant['issuer_type'] ?? '' ),
-			'legacy_sender'=> ! empty( $grant['legacy_sender'] ),
+			'legacy_sender' => ! empty( $grant['legacy_sender'] ),
 		);
 	}
 

--- a/inc/Abilities/Publish/SendEmailAbility.php
+++ b/inc/Abilities/Publish/SendEmailAbility.php
@@ -216,24 +216,12 @@ class SendEmailAbility {
 	 * @return array|\WP_Error Result with success data or an error.
 	 */
 	public function execute( array $input ): array|\WP_Error {
-		$logs   = array();
-		$config = $this->normalizeConfig( $input );
-		if ( ! empty( $config['auth_ref'] ) ) {
-			$providers = apply_filters( 'datamachine_auth_providers', array() );
-			$auth      = $providers['email_imap'] ?? null;
-			if ( ! $auth || ! method_exists( $auth, 'resolve_mailbox' ) ) {
-				return new \WP_Error( 'email_imap_not_configured', 'Email IMAP provider is not registered.', array( 'status' => 400 ) );
-			}
-			$context = $this->verifiedMailboxContext( $config );
-			$resolved = null === $context
-				? $auth->resolve_mailbox( $config['auth_ref'], 'send' )
-				: $auth->resolve_mailbox_for_principal( $config['auth_ref'], 'send', $context );
-			if ( is_wp_error( $resolved ) ) {
-				return $resolved;
-			}
-			$config['from_email'] = $resolved['credentials']['imap_user'];
-			$config['reply_to']   = $resolved['credentials']['imap_user'];
+		$logs           = array();
+		$queued_context = $this->verifiedMailboxContext( $input );
+		if ( is_wp_error( $queued_context ) ) {
+			return $queued_context;
 		}
+		$config = $this->normalizeConfig( $input );
 
 		// 1. Parse and validate recipients.
 		$to = array_map( 'trim', explode( ',', $config['to'] ) );
@@ -249,6 +237,27 @@ class SendEmailAbility {
 				'data'    => array( 'raw_to' => $config['to'] ),
 			);
 			return new \WP_Error( 'invalid_email_recipient', 'No valid recipient email addresses', array( 'status' => 400 ) );
+		}
+
+		if ( ! empty( $config['auth_ref'] ) ) {
+			$providers = apply_filters( 'datamachine_auth_providers', array() );
+			$auth      = $providers['email_imap'] ?? null;
+			if ( ! $auth || ! method_exists( $auth, 'resolve_mailbox' ) ) {
+				return new \WP_Error( 'email_imap_not_configured', 'Email IMAP provider is not registered.', array( 'status' => 400 ) );
+			}
+			$resolved = null === $queued_context
+				? $auth->resolve_mailbox( $config['auth_ref'], 'send' )
+				: $auth->resolve_mailbox_for_principal( $config['auth_ref'], 'send', $queued_context );
+			if ( is_wp_error( $resolved ) ) {
+				return $resolved;
+			}
+			$config['from_email'] = $resolved['credentials']['imap_user'];
+			$config['reply_to']   = $resolved['credentials']['imap_user'];
+			$config['from_name']  = (string) ( $resolved['credentials']['display_name'] ?? '' );
+		} else {
+			if ( ! $this->canUseLegacySender() && ( ! is_array( $queued_context ) || empty( $queued_context['legacy_sender'] ) ) ) {
+				return new \WP_Error( 'email_auth_ref_required', 'An authorized mailbox ref is required to send email.', array( 'status' => 403 ) );
+			}
 		}
 
 		// 2. Build headers.
@@ -496,22 +505,61 @@ class SendEmailAbility {
 		return array_merge( $defaults, $input );
 	}
 
-	private function verifiedMailboxContext( array $config ): ?array {
+	private function verifiedMailboxContext( array $config ): array|null|\WP_Error {
 		$grant = $config['_mailbox_grant'] ?? null;
-		if ( ! is_array( $grant ) || empty( $grant['signature'] ) ) {
+		if ( null === $grant ) {
 			return null;
+		}
+		if ( ! is_array( $grant ) || empty( $grant['signature'] ) ) {
+			return new \WP_Error( 'email_queue_grant_invalid', 'Queued mailbox authorization is invalid.', array( 'status' => 403 ) );
 		}
 		$user_id  = absint( $grant['user_id'] ?? 0 );
 		$agent_id = absint( $grant['agent_id'] ?? 0 );
-		$payload  = (string) $config['auth_ref'] . '|' . $user_id . '|' . $agent_id;
+		$issued_at = absint( $grant['issued_at'] ?? 0 );
+		$nonce     = (string) ( $grant['nonce'] ?? '' );
+		$payload   = $this->mailboxGrantPayload( $config, $user_id, $agent_id, $issued_at, $nonce );
 		$expected = hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) );
 		if ( ! hash_equals( $expected, (string) $grant['signature'] ) ) {
-			return null;
+			return new \WP_Error( 'email_queue_grant_invalid', 'Queued mailbox authorization is invalid.', array( 'status' => 403 ) );
 		}
 		return array(
-			'user_id'  => $user_id,
-			'agent_id' => $agent_id,
+			'user_id'      => $user_id,
+			'agent_id'     => $agent_id,
+			'legacy_sender'=> ! empty( $grant['legacy_sender'] ),
 		);
+	}
+
+	private function mailboxGrantPayload( array $config, int $user_id, int $agent_id, int $issued_at, string $nonce ): string {
+		$payload = $config;
+		unset( $payload['_attempt'], $payload['_mailbox_grant'] );
+		$payload = $this->canonicalizeGrantValue( $payload );
+		return implode( '|', array(
+			hash( 'sha256', serialize( $payload ) ),
+			(string) $user_id,
+			(string) $agent_id,
+			(string) $issued_at,
+			$nonce,
+			! empty( $config['_mailbox_grant']['legacy_sender'] ) ? '1' : '0',
+		) );
+	}
+
+	private function canonicalizeGrantValue( array $value ): array {
+		if ( ! array_is_list( $value ) ) {
+			ksort( $value, SORT_STRING );
+		}
+		foreach ( $value as $key => $item ) {
+			if ( is_array( $item ) ) {
+				$value[ $key ] = $this->canonicalizeGrantValue( $item );
+			}
+		}
+		return $value;
+	}
+
+	private function canUseLegacySender(): bool {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return PermissionHelper::can_manage();
+		}
+		return PermissionHelper::acting_user_id() > 0 && PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/Publish/SendEmailAbility.php
+++ b/inc/Abilities/Publish/SendEmailAbility.php
@@ -255,7 +255,10 @@ class SendEmailAbility {
 			$config['reply_to']   = $resolved['credentials']['imap_user'];
 			$config['from_name']  = (string) ( $resolved['credentials']['display_name'] ?? '' );
 		} else {
-			if ( ! $this->canUseLegacySender() && ( ! is_array( $queued_context ) || empty( $queued_context['legacy_sender'] ) ) ) {
+			$legacy_sender_allowed = is_array( $queued_context )
+				? ! empty( $queued_context['legacy_sender'] ) && $this->userCanManageLegacySender( absint( $queued_context['user_id'] ?? 0 ) )
+				: $this->canUseLegacySender();
+			if ( ! $legacy_sender_allowed ) {
 				return new \WP_Error( 'email_auth_ref_required', 'An authorized mailbox ref is required to send email.', array( 'status' => 403 ) );
 			}
 		}
@@ -560,6 +563,18 @@ class SendEmailAbility {
 			return PermissionHelper::can_manage();
 		}
 		return PermissionHelper::acting_user_id() > 0 && PermissionHelper::can_manage();
+	}
+
+	private function userCanManageLegacySender( int $user_id ): bool {
+		if ( $user_id <= 0 || ! function_exists( 'user_can' ) ) {
+			return false;
+		}
+		foreach ( array( 'manage_options', 'datamachine_manage_flows', 'datamachine_manage_settings', 'datamachine_manage_agents' ) as $capability ) {
+			if ( user_can( $user_id, $capability ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/inc/Abilities/Publish/SendEmailAbility.php
+++ b/inc/Abilities/Publish/SendEmailAbility.php
@@ -528,6 +528,8 @@ class SendEmailAbility {
 		return array(
 			'user_id'      => $user_id,
 			'agent_id'     => $agent_id,
+			'token_id'     => absint( $grant['token_id'] ?? 0 ),
+			'issuer_type'  => (string) ( $grant['issuer_type'] ?? '' ),
 			'legacy_sender'=> ! empty( $grant['legacy_sender'] ),
 		);
 	}
@@ -540,6 +542,8 @@ class SendEmailAbility {
 			hash( 'sha256', serialize( $payload ) ),
 			(string) $user_id,
 			(string) $agent_id,
+			(string) absint( $config['_mailbox_grant']['token_id'] ?? 0 ),
+			(string) ( $config['_mailbox_grant']['issuer_type'] ?? '' ),
 			(string) $issued_at,
 			$nonce,
 			! empty( $config['_mailbox_grant']['legacy_sender'] ) ? '1' : '0',

--- a/inc/Abilities/Publish/SendEmailQueuedAbility.php
+++ b/inc/Abilities/Publish/SendEmailQueuedAbility.php
@@ -23,6 +23,8 @@ namespace DataMachine\Abilities\Publish;
 
 use DataMachine\Abilities\AbilityRegistration;
 use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\Database\Agents\AgentTokens;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -270,9 +272,13 @@ class SendEmailQueuedAbility {
 	public function execute( array $input ): array {
 		$logs = array();
 		$context = array(
-			'user_id'  => PermissionHelper::acting_user_id(),
-			'agent_id' => absint( PermissionHelper::get_acting_agent_id() ),
+			'user_id'   => PermissionHelper::acting_user_id(),
+			'agent_id'  => absint( PermissionHelper::get_acting_agent_id() ),
+			'token_id'  => absint( PermissionHelper::get_acting_token_id() ),
 		);
+		if ( $context['user_id'] <= 0 ) {
+			return array( 'success' => false, 'error' => 'An identified issuer is required to queue email.', 'logs' => $logs );
+		}
 		if ( ! empty( $input['auth_ref'] ) ) {
 			$providers = apply_filters( 'datamachine_auth_providers', array() );
 			$auth      = $providers['email_imap'] ?? null;
@@ -381,7 +387,8 @@ class SendEmailQueuedAbility {
 		}
 
 		$attempt = isset( $payload['_attempt'] ) ? max( 1, (int) $payload['_attempt'] ) : 1;
-		if ( is_wp_error( $this->verifyMailboxGrant( $payload ) ) ) {
+		$grant = $this->verifyMailboxGrant( $payload );
+		if ( is_wp_error( $grant ) || ! $this->currentIssuerAuthorized( $grant ) ) {
 			do_action( 'datamachine_log', 'error', 'Email worker: queued authorization denied', array( 'attempt' => $attempt ) );
 			return;
 		}
@@ -461,6 +468,8 @@ class SendEmailQueuedAbility {
 		$grant     = array(
 			'user_id'      => (int) $context['user_id'],
 			'agent_id'     => (int) $context['agent_id'],
+			'token_id'     => (int) $context['token_id'],
+			'issuer_type'  => (int) $context['agent_id'] > 0 ? ( (int) $context['token_id'] > 0 ? 'agent_token' : 'agent' ) : 'user',
 			'issued_at'    => $issued_at,
 			'nonce'        => $nonce,
 			'legacy_sender'=> empty( $input['auth_ref'] ),
@@ -469,7 +478,7 @@ class SendEmailQueuedAbility {
 		return $grant;
 	}
 
-	private function verifyMailboxGrant( array $payload ): true|\WP_Error {
+	private function verifyMailboxGrant( array $payload ): array|\WP_Error {
 		$grant = $payload['_mailbox_grant'] ?? null;
 		if ( ! is_array( $grant ) || empty( $grant['signature'] ) ) {
 			return new \WP_Error( 'email_queue_grant_missing', 'Queued email authorization is missing.' );
@@ -478,7 +487,7 @@ class SendEmailQueuedAbility {
 		if ( ! hash_equals( $expected, (string) $grant['signature'] ) ) {
 			return new \WP_Error( 'email_queue_grant_invalid', 'Queued email authorization is invalid.' );
 		}
-		return true;
+		return $grant;
 	}
 
 	private function mailboxGrantPayload( array $input, array $grant ): string {
@@ -489,10 +498,81 @@ class SendEmailQueuedAbility {
 			hash( 'sha256', serialize( $payload ) ),
 			(string) absint( $grant['user_id'] ?? 0 ),
 			(string) absint( $grant['agent_id'] ?? 0 ),
+			(string) absint( $grant['token_id'] ?? 0 ),
+			(string) ( $grant['issuer_type'] ?? '' ),
 			(string) absint( $grant['issued_at'] ?? 0 ),
 			(string) ( $grant['nonce'] ?? '' ),
 			! empty( $grant['legacy_sender'] ) ? '1' : '0',
 		) );
+	}
+
+	private function currentIssuerAuthorized( array $grant ): bool {
+		$user_id     = absint( $grant['user_id'] ?? 0 );
+		$agent_id    = absint( $grant['agent_id'] ?? 0 );
+		$token_id    = absint( $grant['token_id'] ?? 0 );
+		$issuer_type = (string) ( $grant['issuer_type'] ?? '' );
+		if ( $user_id <= 0 || ! get_user_by( 'id', $user_id ) ) {
+			return false;
+		}
+
+		if ( 'user' === $issuer_type ) {
+			return 0 === $agent_id && 0 === $token_id && $this->userHasQueueCapability( $user_id );
+		}
+		if ( ! in_array( $issuer_type, array( 'agent', 'agent_token' ), true ) || $agent_id <= 0 ) {
+			return false;
+		}
+
+		$agent = ( new Agents() )->get_agent( $agent_id );
+		if ( ! is_array( $agent ) || $user_id !== absint( $agent['owner_id'] ?? 0 ) ) {
+			return false;
+		}
+		if ( 'agent' === $issuer_type ) {
+			return 0 === $token_id && $this->userHasQueueCapability( $user_id );
+		}
+		if ( $token_id <= 0 ) {
+			return false;
+		}
+
+		$token = ( new AgentTokens() )->get_token( $token_id );
+		if ( ! $token instanceof \WP_Agent_Token || $token->is_expired() || $agent_id !== (int) $token->agent_id || $user_id !== $token->owner_user_id ) {
+			return false;
+		}
+		if ( ! $this->userHasQueueCapability( $user_id, $token->allowed_capabilities ) ) {
+			return false;
+		}
+
+		$scope = isset( $token->metadata['datamachine_scope'] ) && is_array( $token->metadata['datamachine_scope'] )
+			? $token->metadata['datamachine_scope']
+			: $token->allowed_capabilities;
+		return $this->scopeAllowsQueuedEmail( $scope );
+	}
+
+	private function userHasQueueCapability( int $user_id, ?array $ceiling = null ): bool {
+		foreach ( array( 'datamachine_use_tools', 'datamachine_manage_flows', 'datamachine_manage_settings', 'datamachine_manage_agents' ) as $capability ) {
+			if ( null !== $ceiling && ! in_array( $capability, $ceiling, true ) ) {
+				continue;
+			}
+			if ( user_can( $user_id, $capability ) || user_can( $user_id, 'manage_options' ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private function scopeAllowsQueuedEmail( ?array $payload ): bool {
+		$scope = AgentTokens::normalize_capability_payload( $payload )['stored_payload'];
+		if ( null === $scope || array_is_list( $scope ) ) {
+			return true;
+		}
+		$ability = 'datamachine/send-email-queued';
+		if ( in_array( $ability, (array) ( $scope['ability_deny'] ?? array() ), true ) ) {
+			return false;
+		}
+		if ( in_array( $ability, (array) ( $scope['ability_allow'] ?? array() ), true ) ) {
+			return true;
+		}
+		$categories = (array) ( $scope['ability_categories'] ?? array() );
+		return array() === $categories || in_array( 'datamachine-publishing', $categories, true );
 	}
 
 	private function canonicalizeGrantValue( array $value ): array {

--- a/inc/Abilities/Publish/SendEmailQueuedAbility.php
+++ b/inc/Abilities/Publish/SendEmailQueuedAbility.php
@@ -133,6 +133,10 @@ class SendEmailQueuedAbility {
 					// underlying ability runs.
 					'required'   => array( 'to', 'subject' ),
 					'properties' => array(
+						'auth_ref'     => array(
+							'type'        => 'string',
+							'description' => __( 'Optional non-secret mailbox auth ref authorizing the sender identity', 'data-machine' ),
+						),
 						'to'           => array(
 							'type'        => 'string',
 							'description' => __( 'Comma-separated recipient email addresses', 'data-machine' ),
@@ -254,7 +258,7 @@ class SendEmailQueuedAbility {
 	 * @return bool True if user has permission.
 	 */
 	public function checkPermission(): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' ) || PermissionHelper::can_manage();
 	}
 
 	/**
@@ -265,6 +269,23 @@ class SendEmailQueuedAbility {
 	 */
 	public function execute( array $input ): array {
 		$logs = array();
+		if ( ! empty( $input['auth_ref'] ) ) {
+			$providers = apply_filters( 'datamachine_auth_providers', array() );
+			$auth      = $providers['email_imap'] ?? null;
+			$context   = array(
+				'user_id'  => PermissionHelper::acting_user_id(),
+				'agent_id' => absint( PermissionHelper::get_acting_agent_id() ),
+			);
+			if ( ! $auth || ! method_exists( $auth, 'resolve_mailbox' ) || is_wp_error( $auth->resolve_mailbox( $input['auth_ref'], 'send', $context ) ) ) {
+				return array( 'success' => false, 'error' => 'Mailbox send authorization failed.', 'logs' => $logs );
+			}
+			$payload = (string) $input['auth_ref'] . '|' . $context['user_id'] . '|' . $context['agent_id'];
+			$input['_mailbox_grant'] = array(
+				'user_id'   => $context['user_id'],
+				'agent_id'  => $context['agent_id'],
+				'signature' => hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) ),
+			);
+		}
 
 		// Validate the bare minimum here. The underlying ability re-validates
 		// the full payload when the worker runs.

--- a/inc/Abilities/Publish/SendEmailQueuedAbility.php
+++ b/inc/Abilities/Publish/SendEmailQueuedAbility.php
@@ -269,22 +269,18 @@ class SendEmailQueuedAbility {
 	 */
 	public function execute( array $input ): array {
 		$logs = array();
+		$context = array(
+			'user_id'  => PermissionHelper::acting_user_id(),
+			'agent_id' => absint( PermissionHelper::get_acting_agent_id() ),
+		);
 		if ( ! empty( $input['auth_ref'] ) ) {
 			$providers = apply_filters( 'datamachine_auth_providers', array() );
 			$auth      = $providers['email_imap'] ?? null;
-			$context   = array(
-				'user_id'  => PermissionHelper::acting_user_id(),
-				'agent_id' => absint( PermissionHelper::get_acting_agent_id() ),
-			);
-			if ( ! $auth || ! method_exists( $auth, 'resolve_mailbox' ) || is_wp_error( $auth->resolve_mailbox( $input['auth_ref'], 'send', $context ) ) ) {
+			if ( ! $auth || ! method_exists( $auth, 'resolve_mailbox' ) || is_wp_error( $auth->resolve_mailbox( $input['auth_ref'], 'send' ) ) ) {
 				return array( 'success' => false, 'error' => 'Mailbox send authorization failed.', 'logs' => $logs );
 			}
-			$payload = (string) $input['auth_ref'] . '|' . $context['user_id'] . '|' . $context['agent_id'];
-			$input['_mailbox_grant'] = array(
-				'user_id'   => $context['user_id'],
-				'agent_id'  => $context['agent_id'],
-				'signature' => hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) ),
-			);
+		} elseif ( ! $this->canUseLegacySender() ) {
+			return array( 'success' => false, 'error' => 'An authorized mailbox ref is required to queue email.', 'logs' => $logs );
 		}
 
 		// Validate the bare minimum here. The underlying ability re-validates
@@ -304,6 +300,7 @@ class SendEmailQueuedAbility {
 		// Strip control fields from payload before scheduling.
 		$priority = isset( $input['priority'] ) ? (int) $input['priority'] : 10;
 		unset( $input['priority'] );
+		$input['_mailbox_grant'] = $this->createMailboxGrant( $input, $context );
 
 		// Initialize the attempt counter. `_attempt` is internal — not part of
 		// the public input schema.
@@ -384,6 +381,10 @@ class SendEmailQueuedAbility {
 		}
 
 		$attempt = isset( $payload['_attempt'] ) ? max( 1, (int) $payload['_attempt'] ) : 1;
+		if ( is_wp_error( $this->verifyMailboxGrant( $payload ) ) ) {
+			do_action( 'datamachine_log', 'error', 'Email worker: queued authorization denied', array( 'attempt' => $attempt ) );
+			return;
+		}
 
 		$ability = wp_get_ability( 'datamachine/send-email' );
 		if ( ! $ability ) {
@@ -452,6 +453,65 @@ class SendEmailQueuedAbility {
 				'error'           => $error_msg,
 			)
 		);
+	}
+
+	private function createMailboxGrant( array $input, array $context ): array {
+		$issued_at = time();
+		$nonce     = wp_generate_uuid4();
+		$grant     = array(
+			'user_id'      => (int) $context['user_id'],
+			'agent_id'     => (int) $context['agent_id'],
+			'issued_at'    => $issued_at,
+			'nonce'        => $nonce,
+			'legacy_sender'=> empty( $input['auth_ref'] ),
+		);
+		$grant['signature'] = hash_hmac( 'sha256', $this->mailboxGrantPayload( $input, $grant ), wp_salt( 'auth' ) );
+		return $grant;
+	}
+
+	private function verifyMailboxGrant( array $payload ): true|\WP_Error {
+		$grant = $payload['_mailbox_grant'] ?? null;
+		if ( ! is_array( $grant ) || empty( $grant['signature'] ) ) {
+			return new \WP_Error( 'email_queue_grant_missing', 'Queued email authorization is missing.' );
+		}
+		$expected = hash_hmac( 'sha256', $this->mailboxGrantPayload( $payload, $grant ), wp_salt( 'auth' ) );
+		if ( ! hash_equals( $expected, (string) $grant['signature'] ) ) {
+			return new \WP_Error( 'email_queue_grant_invalid', 'Queued email authorization is invalid.' );
+		}
+		return true;
+	}
+
+	private function mailboxGrantPayload( array $input, array $grant ): string {
+		$payload = $input;
+		unset( $payload['_attempt'], $payload['_mailbox_grant'] );
+		$payload = $this->canonicalizeGrantValue( $payload );
+		return implode( '|', array(
+			hash( 'sha256', serialize( $payload ) ),
+			(string) absint( $grant['user_id'] ?? 0 ),
+			(string) absint( $grant['agent_id'] ?? 0 ),
+			(string) absint( $grant['issued_at'] ?? 0 ),
+			(string) ( $grant['nonce'] ?? '' ),
+			! empty( $grant['legacy_sender'] ) ? '1' : '0',
+		) );
+	}
+
+	private function canonicalizeGrantValue( array $value ): array {
+		if ( ! array_is_list( $value ) ) {
+			ksort( $value, SORT_STRING );
+		}
+		foreach ( $value as $key => $item ) {
+			if ( is_array( $item ) ) {
+				$value[ $key ] = $this->canonicalizeGrantValue( $item );
+			}
+		}
+		return $value;
+	}
+
+	private function canUseLegacySender(): bool {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return PermissionHelper::can_manage();
+		}
+		return PermissionHelper::acting_user_id() > 0 && PermissionHelper::can_manage();
 	}
 
 	/**

--- a/inc/Abilities/Publish/SendEmailQueuedAbility.php
+++ b/inc/Abilities/Publish/SendEmailQueuedAbility.php
@@ -277,16 +277,28 @@ class SendEmailQueuedAbility {
 			'token_id'  => absint( PermissionHelper::get_acting_token_id() ),
 		);
 		if ( $context['user_id'] <= 0 ) {
-			return array( 'success' => false, 'error' => 'An identified issuer is required to queue email.', 'logs' => $logs );
+			return array(
+				'success' => false,
+				'error'   => 'An identified issuer is required to queue email.',
+				'logs'    => $logs,
+			);
 		}
 		if ( ! empty( $input['auth_ref'] ) ) {
 			$providers = apply_filters( 'datamachine_auth_providers', array() );
 			$auth      = $providers['email_imap'] ?? null;
 			if ( ! $auth || ! method_exists( $auth, 'resolve_mailbox' ) || is_wp_error( $auth->resolve_mailbox( $input['auth_ref'], 'send' ) ) ) {
-				return array( 'success' => false, 'error' => 'Mailbox send authorization failed.', 'logs' => $logs );
+				return array(
+					'success' => false,
+					'error'   => 'Mailbox send authorization failed.',
+					'logs'    => $logs,
+				);
 			}
 		} elseif ( ! $this->canUseLegacySender() ) {
-			return array( 'success' => false, 'error' => 'An authorized mailbox ref is required to queue email.', 'logs' => $logs );
+			return array(
+				'success' => false,
+				'error'   => 'An authorized mailbox ref is required to queue email.',
+				'logs'    => $logs,
+			);
 		}
 
 		// Validate the bare minimum here. The underlying ability re-validates
@@ -472,7 +484,7 @@ class SendEmailQueuedAbility {
 			'issuer_type'  => (int) $context['agent_id'] > 0 ? ( (int) $context['token_id'] > 0 ? 'agent_token' : 'agent' ) : 'user',
 			'issued_at'    => $issued_at,
 			'nonce'        => $nonce,
-			'legacy_sender'=> empty( $input['auth_ref'] ),
+			'legacy_sender' => empty( $input['auth_ref'] ),
 		);
 		$grant['signature'] = hash_hmac( 'sha256', $this->mailboxGrantPayload( $input, $grant ), wp_salt( 'auth' ) );
 		return $grant;
@@ -523,7 +535,7 @@ class SendEmailQueuedAbility {
 		}
 
 		$agent = ( new Agents() )->get_agent( $agent_id );
-		if ( ! is_array( $agent ) || $user_id !== absint( $agent['owner_id'] ?? 0 ) ) {
+		if ( ! is_array( $agent ) || absint( $agent['owner_id'] ?? 0 ) !== $user_id ) {
 			return false;
 		}
 		if ( 'agent' === $issuer_type ) {

--- a/inc/Api/Email.php
+++ b/inc/Api/Email.php
@@ -32,6 +32,7 @@ class Email {
 				'callback'            => array( self::class, 'handle_send' ),
 				'permission_callback' => array( self::class, 'check_permission' ),
 				'args'                => array(
+					...self::mailbox_args(),
 					'to'           => array(
 						'type'     => 'string',
 						'required' => true,
@@ -85,6 +86,7 @@ class Email {
 				'callback'            => array( self::class, 'handle_fetch' ),
 				'permission_callback' => array( self::class, 'check_permission' ),
 				'args'                => array(
+					...self::mailbox_args(),
 					'folder'               => array(
 						'type'    => 'string',
 						'default' => 'INBOX',
@@ -126,6 +128,7 @@ class Email {
 				'callback'            => array( self::class, 'handle_read' ),
 				'permission_callback' => array( self::class, 'check_permission' ),
 				'args'                => array(
+					...self::mailbox_args(),
 					'uid'    => array(
 						'type'     => 'integer',
 						'required' => true,
@@ -147,6 +150,7 @@ class Email {
 				'callback'            => array( self::class, 'handle_reply' ),
 				'permission_callback' => array( self::class, 'check_permission' ),
 				'args'                => array(
+					...self::mailbox_args(),
 					'to'           => array(
 						'type'     => 'string',
 						'required' => true,
@@ -188,6 +192,7 @@ class Email {
 				'callback'            => array( self::class, 'handle_delete' ),
 				'permission_callback' => array( self::class, 'check_permission' ),
 				'args'                => array(
+					...self::mailbox_args(),
 					'uid'    => array(
 						'type'     => 'integer',
 						'required' => true,
@@ -209,6 +214,7 @@ class Email {
 				'callback'            => array( self::class, 'handle_move' ),
 				'permission_callback' => array( self::class, 'check_permission' ),
 				'args'                => array(
+					...self::mailbox_args(),
 					'uid'         => array(
 						'type'     => 'integer',
 						'required' => true,
@@ -234,6 +240,7 @@ class Email {
 				'callback'            => array( self::class, 'handle_flag' ),
 				'permission_callback' => array( self::class, 'check_permission' ),
 				'args'                => array(
+					...self::mailbox_args(),
 					'uid'    => array(
 						'type'     => 'integer',
 						'required' => true,
@@ -263,6 +270,7 @@ class Email {
 				'callback'            => array( self::class, 'handle_batch_move' ),
 				'permission_callback' => array( self::class, 'check_permission' ),
 				'args'                => array(
+					...self::mailbox_args(),
 					'search'      => array(
 						'type'     => 'string',
 						'required' => true,
@@ -292,6 +300,7 @@ class Email {
 				'callback'            => array( self::class, 'handle_batch_flag' ),
 				'permission_callback' => array( self::class, 'check_permission' ),
 				'args'                => array(
+					...self::mailbox_args(),
 					'search' => array(
 						'type'     => 'string',
 						'required' => true,
@@ -325,6 +334,7 @@ class Email {
 				'callback'            => array( self::class, 'handle_batch_delete' ),
 				'permission_callback' => array( self::class, 'check_permission' ),
 				'args'                => array(
+					...self::mailbox_args(),
 					'search' => array(
 						'type'     => 'string',
 						'required' => true,
@@ -350,6 +360,7 @@ class Email {
 				'callback'            => array( self::class, 'handle_unsubscribe' ),
 				'permission_callback' => array( self::class, 'check_permission' ),
 				'args'                => array(
+					...self::mailbox_args(),
 					'uid'    => array(
 						'type'     => 'integer',
 						'required' => true,
@@ -371,6 +382,7 @@ class Email {
 				'callback'            => array( self::class, 'handle_batch_unsubscribe' ),
 				'permission_callback' => array( self::class, 'check_permission' ),
 				'args'                => array(
+					...self::mailbox_args(),
 					'search' => array(
 						'type'     => 'string',
 						'required' => true,
@@ -395,6 +407,7 @@ class Email {
 				'methods'             => 'POST',
 				'callback'            => array( self::class, 'handle_test_connection' ),
 				'permission_callback' => array( self::class, 'check_permission' ),
+				'args'                => self::mailbox_args(),
 			)
 		);
 	}
@@ -639,5 +652,18 @@ class Email {
 			$ref     = '' !== $mailbox ? 'email_imap:' . $mailbox : '';
 		}
 		return '' !== $ref ? $ref : ( $default ? 'email_imap:default' : '' );
+	}
+
+	private static function mailbox_args(): array {
+		return array(
+			'auth_ref' => array(
+				'type'        => 'string',
+				'description' => 'Non-secret mailbox auth ref, for example email_imap:event-submissions.',
+			),
+			'mailbox'  => array(
+				'type'        => 'string',
+				'description' => 'Mailbox account name shorthand for email_imap:<name>.',
+			),
+		);
 	}
 }

--- a/inc/Api/Email.php
+++ b/inc/Api/Email.php
@@ -30,7 +30,7 @@ class Email {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( self::class, 'handle_send' ),
-				'permission_callback' => array( self::class, 'check_permission' ),
+				'permission_callback' => self::ability_permission( 'datamachine/send-email' ),
 				'args'                => array(
 					...self::mailbox_args(),
 					'to'           => array(
@@ -84,7 +84,7 @@ class Email {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( self::class, 'handle_fetch' ),
-				'permission_callback' => array( self::class, 'check_permission' ),
+				'permission_callback' => self::ability_permission( 'datamachine/fetch-email' ),
 				'args'                => array(
 					...self::mailbox_args(),
 					'folder'               => array(
@@ -126,7 +126,7 @@ class Email {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( self::class, 'handle_read' ),
-				'permission_callback' => array( self::class, 'check_permission' ),
+				'permission_callback' => self::ability_permission( 'datamachine/fetch-email' ),
 				'args'                => array(
 					...self::mailbox_args(),
 					'uid'    => array(
@@ -148,7 +148,7 @@ class Email {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( self::class, 'handle_reply' ),
-				'permission_callback' => array( self::class, 'check_permission' ),
+				'permission_callback' => self::ability_permission( 'datamachine/email-reply' ),
 				'args'                => array(
 					...self::mailbox_args(),
 					'to'           => array(
@@ -190,7 +190,7 @@ class Email {
 			array(
 				'methods'             => 'DELETE',
 				'callback'            => array( self::class, 'handle_delete' ),
-				'permission_callback' => array( self::class, 'check_permission' ),
+				'permission_callback' => self::ability_permission( 'datamachine/email-delete' ),
 				'args'                => array(
 					...self::mailbox_args(),
 					'uid'    => array(
@@ -212,7 +212,7 @@ class Email {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( self::class, 'handle_move' ),
-				'permission_callback' => array( self::class, 'check_permission' ),
+				'permission_callback' => self::ability_permission( 'datamachine/email-move' ),
 				'args'                => array(
 					...self::mailbox_args(),
 					'uid'         => array(
@@ -238,7 +238,7 @@ class Email {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( self::class, 'handle_flag' ),
-				'permission_callback' => array( self::class, 'check_permission' ),
+				'permission_callback' => self::ability_permission( 'datamachine/email-flag' ),
 				'args'                => array(
 					...self::mailbox_args(),
 					'uid'    => array(
@@ -268,7 +268,7 @@ class Email {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( self::class, 'handle_batch_move' ),
-				'permission_callback' => array( self::class, 'check_permission' ),
+				'permission_callback' => self::ability_permission( 'datamachine/email-batch-move' ),
 				'args'                => array(
 					...self::mailbox_args(),
 					'search'      => array(
@@ -298,7 +298,7 @@ class Email {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( self::class, 'handle_batch_flag' ),
-				'permission_callback' => array( self::class, 'check_permission' ),
+				'permission_callback' => self::ability_permission( 'datamachine/email-batch-flag' ),
 				'args'                => array(
 					...self::mailbox_args(),
 					'search' => array(
@@ -332,7 +332,7 @@ class Email {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( self::class, 'handle_batch_delete' ),
-				'permission_callback' => array( self::class, 'check_permission' ),
+				'permission_callback' => self::ability_permission( 'datamachine/email-batch-delete' ),
 				'args'                => array(
 					...self::mailbox_args(),
 					'search' => array(
@@ -358,7 +358,7 @@ class Email {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( self::class, 'handle_unsubscribe' ),
-				'permission_callback' => array( self::class, 'check_permission' ),
+				'permission_callback' => self::ability_permission( 'datamachine/email-unsubscribe' ),
 				'args'                => array(
 					...self::mailbox_args(),
 					'uid'    => array(
@@ -380,7 +380,7 @@ class Email {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( self::class, 'handle_batch_unsubscribe' ),
-				'permission_callback' => array( self::class, 'check_permission' ),
+				'permission_callback' => self::ability_permission( 'datamachine/email-batch-unsubscribe' ),
 				'args'                => array(
 					...self::mailbox_args(),
 					'search' => array(
@@ -406,15 +406,25 @@ class Email {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( self::class, 'handle_test_connection' ),
-				'permission_callback' => array( self::class, 'check_permission' ),
+				'permission_callback' => self::ability_permission( 'datamachine/email-test-connection' ),
 				'args'                => self::mailbox_args(),
 			)
 		);
 	}
 
+	private static function ability_permission( string $ability_name ): callable {
+		return static fn( \WP_REST_Request $request ): bool => self::check_ability_permission( $request, $ability_name );
+	}
+
 	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- REST permission callbacks receive the request by contract.
-	public static function check_permission( \WP_REST_Request $request ): bool {
-		return PermissionHelper::can( 'use_tools' ) || PermissionHelper::can_manage();
+	private static function check_ability_permission( \WP_REST_Request $request, string $ability_name ): bool {
+		if ( ! PermissionHelper::can( 'use_tools' ) && ! PermissionHelper::can_manage() ) {
+			return false;
+		}
+
+		$ability  = wp_get_ability( $ability_name );
+		$category = is_object( $ability ) && method_exists( $ability, 'get_category' ) ? (string) $ability->get_category() : '';
+		return PermissionHelper::can_use_ability( $ability_name, $category );
 	}
 
 	public static function handle_send( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {

--- a/inc/Api/Email.php
+++ b/inc/Api/Email.php
@@ -401,7 +401,7 @@ class Email {
 
 	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- REST permission callbacks receive the request by contract.
 	public static function check_permission( \WP_REST_Request $request ): bool {
-		return PermissionHelper::can_manage();
+		return PermissionHelper::can( 'use_tools' ) || PermissionHelper::can_manage();
 	}
 
 	public static function handle_send( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
@@ -411,6 +411,7 @@ class Email {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref'     => self::mailbox_ref( $request, false ),
 			'to'           => $request->get_param( 'to' ),
 			'subject'      => $request->get_param( 'subject' ),
 			'body'         => $request->get_param( 'body' ),
@@ -427,22 +428,13 @@ class Email {
 	}
 
 	public static function handle_fetch( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
-		$auth = self::get_imap_auth();
-		if ( is_wp_error( $auth ) ) {
-			return $auth;
-		}
-
 		$ability = wp_get_ability( 'datamachine/fetch-email' );
 		if ( ! $ability ) {
 			return new \WP_Error( 'ability_not_found', 'Fetch email ability not available', array( 'status' => 500 ) );
 		}
 
 		$result = $ability->execute( array(
-			'imap_host'            => $auth->getHost(),
-			'imap_port'            => $auth->getPort(),
-			'imap_encryption'      => $auth->getEncryption(),
-			'imap_user'            => $auth->getUser(),
-			'imap_password'        => $auth->getPassword(),
+			'auth_ref'             => self::mailbox_ref( $request ),
 			'folder'               => $request->get_param( 'folder' ) ?? 'INBOX',
 			'search_criteria'      => $request->get_param( 'search' ) ?? 'UNSEEN',
 			'max_messages'         => (int) ( $request->get_param( 'max' ) ?? 10 ),
@@ -456,41 +448,18 @@ class Email {
 	}
 
 	public static function handle_read( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
-		$auth = self::get_imap_auth();
-		if ( is_wp_error( $auth ) ) {
-			return $auth;
-		}
-
 		$ability = wp_get_ability( 'datamachine/fetch-email' );
 		if ( ! $ability ) {
 			return new \WP_Error( 'ability_not_found', 'Fetch email ability not available', array( 'status' => 500 ) );
 		}
 
 		$result = $ability->execute( array(
-			'imap_host'       => $auth->getHost(),
-			'imap_port'       => $auth->getPort(),
-			'imap_encryption' => $auth->getEncryption(),
-			'imap_user'       => $auth->getUser(),
-			'imap_password'   => $auth->getPassword(),
+			'auth_ref'        => self::mailbox_ref( $request ),
 			'folder'          => $request->get_param( 'folder' ) ?? 'INBOX',
 			'uid'             => (int) $request->get_param( 'uid' ),
 		) );
 
 		return self::to_response( $result );
-	}
-
-	/**
-	 * Get IMAP auth provider or WP_Error.
-	 */
-	private static function get_imap_auth(): object {
-		$providers = apply_filters( 'datamachine_auth_providers', array() );
-		$auth      = $providers['email_imap'] ?? null;
-
-		if ( ! $auth || ! $auth->is_authenticated() ) {
-			return new \WP_Error( 'not_configured', 'IMAP credentials not configured', array( 'status' => 400 ) );
-		}
-
-		return $auth;
 	}
 
 	public static function handle_reply( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
@@ -500,6 +469,7 @@ class Email {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref'     => self::mailbox_ref( $request ),
 			'to'           => $request->get_param( 'to' ),
 			'subject'      => $request->get_param( 'subject' ),
 			'body'         => $request->get_param( 'body' ),
@@ -519,6 +489,7 @@ class Email {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref' => self::mailbox_ref( $request ),
 			'uid'    => (int) $request->get_param( 'uid' ),
 			'folder' => $request->get_param( 'folder' ) ?? 'INBOX',
 		) );
@@ -533,6 +504,7 @@ class Email {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref'     => self::mailbox_ref( $request ),
 			'uid'         => (int) $request->get_param( 'uid' ),
 			'destination' => $request->get_param( 'destination' ),
 			'folder'      => $request->get_param( 'folder' ) ?? 'INBOX',
@@ -548,6 +520,7 @@ class Email {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref' => self::mailbox_ref( $request ),
 			'uid'    => (int) $request->get_param( 'uid' ),
 			'flag'   => $request->get_param( 'flag' ),
 			'action' => $request->get_param( 'action' ) ?? 'set',
@@ -564,6 +537,7 @@ class Email {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref'     => self::mailbox_ref( $request ),
 			'search'      => $request->get_param( 'search' ),
 			'destination' => $request->get_param( 'destination' ),
 			'folder'      => $request->get_param( 'folder' ) ?? 'INBOX',
@@ -580,6 +554,7 @@ class Email {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref' => self::mailbox_ref( $request ),
 			'search' => $request->get_param( 'search' ),
 			'flag'   => $request->get_param( 'flag' ),
 			'action' => $request->get_param( 'action' ) ?? 'set',
@@ -597,6 +572,7 @@ class Email {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref' => self::mailbox_ref( $request ),
 			'search' => $request->get_param( 'search' ),
 			'folder' => $request->get_param( 'folder' ) ?? 'INBOX',
 			'max'    => (int) ( $request->get_param( 'max' ) ?? 100 ),
@@ -612,6 +588,7 @@ class Email {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref' => self::mailbox_ref( $request ),
 			'uid'    => (int) $request->get_param( 'uid' ),
 			'folder' => $request->get_param( 'folder' ) ?? 'INBOX',
 		) );
@@ -626,6 +603,7 @@ class Email {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref' => self::mailbox_ref( $request ),
 			'search' => $request->get_param( 'search' ),
 			'folder' => $request->get_param( 'folder' ) ?? 'INBOX',
 			'max'    => (int) ( $request->get_param( 'max' ) ?? 20 ),
@@ -641,7 +619,7 @@ class Email {
 			return new \WP_Error( 'ability_not_found', 'Email test connection ability not available', array( 'status' => 500 ) );
 		}
 
-		$result = $ability->execute( array() );
+		$result = $ability->execute( array( 'auth_ref' => self::mailbox_ref( $request ) ) );
 
 		return self::to_response( $result );
 	}
@@ -652,5 +630,14 @@ class Email {
 		}
 
 		return rest_ensure_response( $result );
+	}
+
+	private static function mailbox_ref( \WP_REST_Request $request, bool $default = true ): string {
+		$ref = trim( (string) $request->get_param( 'auth_ref' ) );
+		if ( '' === $ref ) {
+			$mailbox = trim( (string) $request->get_param( 'mailbox' ) );
+			$ref     = '' !== $mailbox ? 'email_imap:' . $mailbox : '';
+		}
+		return '' !== $ref ? $ref : ( $default ? 'email_imap:default' : '' );
 	}
 }

--- a/inc/Cli/Commands/EmailCommand.php
+++ b/inc/Cli/Commands/EmailCommand.php
@@ -71,6 +71,7 @@ class EmailCommand extends BaseCommand {
 		}
 
 		$input = array(
+			'auth_ref'     => $this->mailboxRef( $assoc_args, false ),
 			'to'           => $assoc_args['to'],
 			'subject'      => $assoc_args['subject'],
 			'body'         => $assoc_args['body'],
@@ -175,6 +176,7 @@ class EmailCommand extends BaseCommand {
 		}
 
 		$input = array(
+			'auth_ref'     => $this->mailboxRef( $assoc_args, false ),
 			'to'           => $assoc_args['to'],
 			'subject'      => $assoc_args['subject'],
 			'body'         => $assoc_args['body'] ?? '',
@@ -285,22 +287,13 @@ class EmailCommand extends BaseCommand {
 	 * @subcommand fetch
 	 */
 	public function fetch( array $args, array $assoc_args ): void {
-		$auth = $this->getAuthProvider();
-		if ( ! $auth || ! $auth->is_authenticated() ) {
-			WP_CLI::error( 'IMAP credentials not configured. Run: wp datamachine auth save email_imap' );
-		}
-
 		$ability = wp_get_ability( 'datamachine/fetch-email' );
 		if ( ! $ability ) {
 			WP_CLI::error( 'Fetch email ability not available.' );
 		}
 
 		$input = array(
-			'imap_host'            => $auth->getHost(),
-			'imap_port'            => $auth->getPort(),
-			'imap_encryption'      => $auth->getEncryption(),
-			'imap_user'            => $auth->getUser(),
-			'imap_password'        => $auth->getPassword(),
+			'auth_ref'             => $this->mailboxRef( $assoc_args ),
 			'folder'               => $assoc_args['folder'] ?? 'INBOX',
 			'search_criteria'      => $assoc_args['search'] ?? 'UNSEEN',
 			'max_messages'         => (int) ( $assoc_args['max'] ?? 10 ),
@@ -406,22 +399,13 @@ class EmailCommand extends BaseCommand {
 			WP_CLI::error( 'Invalid message UID.' );
 		}
 
-		$auth = $this->getAuthProvider();
-		if ( ! $auth || ! $auth->is_authenticated() ) {
-			WP_CLI::error( 'IMAP credentials not configured.' );
-		}
-
 		$ability = wp_get_ability( 'datamachine/fetch-email' );
 		if ( ! $ability ) {
 			WP_CLI::error( 'Fetch email ability not available.' );
 		}
 
 		$result = $ability->execute( array(
-			'imap_host'       => $auth->getHost(),
-			'imap_port'       => $auth->getPort(),
-			'imap_encryption' => $auth->getEncryption(),
-			'imap_user'       => $auth->getUser(),
-			'imap_password'   => $auth->getPassword(),
+			'auth_ref'        => $this->mailboxRef( $assoc_args ),
 			'folder'          => $assoc_args['folder'] ?? 'INBOX',
 			'uid'             => $uid,
 		) );
@@ -507,6 +491,7 @@ class EmailCommand extends BaseCommand {
 		}
 
 		$input = array(
+			'auth_ref'     => $this->mailboxRef( $assoc_args ),
 			'to'           => $assoc_args['to'],
 			'subject'      => $assoc_args['subject'],
 			'body'         => $assoc_args['body'],
@@ -569,6 +554,7 @@ class EmailCommand extends BaseCommand {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref' => $this->mailboxRef( $assoc_args ),
 			'uid'    => $uid,
 			'folder' => $assoc_args['folder'] ?? 'INBOX',
 		) );
@@ -622,6 +608,7 @@ class EmailCommand extends BaseCommand {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref'     => $this->mailboxRef( $assoc_args ),
 			'uid'         => $uid,
 			'destination' => $destination,
 			'folder'      => $assoc_args['folder'] ?? 'INBOX',
@@ -685,6 +672,7 @@ class EmailCommand extends BaseCommand {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref' => $this->mailboxRef( $assoc_args ),
 			'uid'    => $uid,
 			'flag'   => $flag,
 			'action' => $assoc_args['action'] ?? 'set',
@@ -754,6 +742,7 @@ class EmailCommand extends BaseCommand {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref'     => $this->mailboxRef( $assoc_args ),
 			'search'      => $search,
 			'destination' => $destination,
 			'folder'      => $assoc_args['folder'] ?? 'INBOX',
@@ -833,6 +822,7 @@ class EmailCommand extends BaseCommand {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref' => $this->mailboxRef( $assoc_args ),
 			'search' => $search,
 			'flag'   => $flag,
 			'action' => $action,
@@ -897,6 +887,7 @@ class EmailCommand extends BaseCommand {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref' => $this->mailboxRef( $assoc_args ),
 			'search' => $search,
 			'folder' => $assoc_args['folder'] ?? 'INBOX',
 			'max'    => (int) ( $assoc_args['max'] ?? 100 ),
@@ -948,6 +939,7 @@ class EmailCommand extends BaseCommand {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref' => $this->mailboxRef( $assoc_args ),
 			'uid'    => $uid,
 			'folder' => $assoc_args['folder'] ?? 'INBOX',
 		) );
@@ -1013,6 +1005,7 @@ class EmailCommand extends BaseCommand {
 		}
 
 		$result = $ability->execute( array(
+			'auth_ref' => $this->mailboxRef( $assoc_args ),
 			'search' => $search,
 			'folder' => $assoc_args['folder'] ?? 'INBOX',
 			'max'    => (int) ( $assoc_args['max'] ?? 20 ),
@@ -1056,7 +1049,7 @@ class EmailCommand extends BaseCommand {
 			WP_CLI::error( 'Email test connection ability not available.' );
 		}
 
-		$result = $ability->execute( array() );
+		$result = $ability->execute( array( 'auth_ref' => $this->mailboxRef( $assoc_args ) ) );
 
 		if ( is_wp_error( $result ) ) {
 			WP_CLI::error( $result->get_error_message() );
@@ -1086,5 +1079,13 @@ class EmailCommand extends BaseCommand {
 	private function getAuthProvider(): ?object {
 		$providers = apply_filters( 'datamachine_auth_providers', array() );
 		return $providers['email_imap'] ?? null;
+	}
+
+	private function mailboxRef( array $assoc_args, bool $default = true ): string {
+		$ref = trim( (string) ( $assoc_args['auth-ref'] ?? '' ) );
+		if ( '' === $ref && ! empty( $assoc_args['mailbox'] ) ) {
+			$ref = 'email_imap:' . trim( (string) $assoc_args['mailbox'] );
+		}
+		return '' !== $ref ? $ref : ( $default ? 'email_imap:default' : '' );
 	}
 }

--- a/inc/Cli/Commands/EmailCommand.php
+++ b/inc/Cli/Commands/EmailCommand.php
@@ -24,6 +24,12 @@ class EmailCommand extends BaseCommand {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--auth-ref=<ref>]
+	 * : Authorized mailbox ref. Required for non-management callers.
+	 *
+	 * [--mailbox=<name>]
+	 * : Mailbox name shorthand for email_imap:<name>.
+	 *
 	 * --to=<emails>
 	 * : Comma-separated recipient email addresses.
 	 *
@@ -109,6 +115,12 @@ class EmailCommand extends BaseCommand {
 	 * invokes `datamachine/send-email` under the hood.
 	 *
 	 * ## OPTIONS
+	 *
+	 * [--auth-ref=<ref>]
+	 * : Authorized mailbox ref. Required for non-management callers.
+	 *
+	 * [--mailbox=<name>]
+	 * : Mailbox name shorthand for email_imap:<name>.
 	 *
 	 * --to=<emails>
 	 * : Comma-separated recipient email addresses.
@@ -226,6 +238,12 @@ class EmailCommand extends BaseCommand {
 	 * Fetch emails from IMAP inbox.
 	 *
 	 * ## OPTIONS
+	 *
+	 * [--auth-ref=<ref>]
+	 * : Authorized mailbox ref.
+	 *
+	 * [--mailbox=<name>]
+	 * : Mailbox name shorthand for email_imap:<name>.
 	 *
 	 * [--folder=<folder>]
 	 * : Mail folder to fetch from.
@@ -368,6 +386,12 @@ class EmailCommand extends BaseCommand {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--auth-ref=<ref>]
+	 * : Authorized mailbox ref.
+	 *
+	 * [--mailbox=<name>]
+	 * : Mailbox name shorthand for email_imap:<name>.
+	 *
 	 * <uid>
 	 * : Message UID to read.
 	 *
@@ -454,6 +478,12 @@ class EmailCommand extends BaseCommand {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--auth-ref=<ref>]
+	 * : Authorized mailbox ref.
+	 *
+	 * [--mailbox=<name>]
+	 * : Mailbox name shorthand for email_imap:<name>.
+	 *
 	 * --to=<email>
 	 * : Recipient email address.
 	 *
@@ -519,6 +549,12 @@ class EmailCommand extends BaseCommand {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--auth-ref=<ref>]
+	 * : Authorized mailbox ref.
+	 *
+	 * [--mailbox=<name>]
+	 * : Mailbox name shorthand for email_imap:<name>.
+	 *
 	 * <uid>
 	 * : Message UID to delete.
 	 *
@@ -575,6 +611,12 @@ class EmailCommand extends BaseCommand {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--auth-ref=<ref>]
+	 * : Authorized mailbox ref.
+	 *
+	 * [--mailbox=<name>]
+	 * : Mailbox name shorthand for email_imap:<name>.
+	 *
 	 * <uid>
 	 * : Message UID to move.
 	 *
@@ -629,6 +671,12 @@ class EmailCommand extends BaseCommand {
 	 * Set or clear a flag on an email.
 	 *
 	 * ## OPTIONS
+	 *
+	 * [--auth-ref=<ref>]
+	 * : Authorized mailbox ref.
+	 *
+	 * [--mailbox=<name>]
+	 * : Mailbox name shorthand for email_imap:<name>.
 	 *
 	 * <uid>
 	 * : Message UID.
@@ -694,6 +742,12 @@ class EmailCommand extends BaseCommand {
 	 * Move all emails matching a search to a folder.
 	 *
 	 * ## OPTIONS
+	 *
+	 * [--auth-ref=<ref>]
+	 * : Authorized mailbox ref.
+	 *
+	 * [--mailbox=<name>]
+	 * : Mailbox name shorthand for email_imap:<name>.
 	 *
 	 * --search=<criteria>
 	 * : IMAP search criteria (e.g., FROM "github.com", SUBJECT "newsletter").
@@ -764,6 +818,12 @@ class EmailCommand extends BaseCommand {
 	 * Set or clear a flag on all emails matching a search.
 	 *
 	 * ## OPTIONS
+	 *
+	 * [--auth-ref=<ref>]
+	 * : Authorized mailbox ref.
+	 *
+	 * [--mailbox=<name>]
+	 * : Mailbox name shorthand for email_imap:<name>.
 	 *
 	 * --search=<criteria>
 	 * : IMAP search criteria.
@@ -846,6 +906,12 @@ class EmailCommand extends BaseCommand {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--auth-ref=<ref>]
+	 * : Authorized mailbox ref.
+	 *
+	 * [--mailbox=<name>]
+	 * : Mailbox name shorthand for email_imap:<name>.
+	 *
 	 * --search=<criteria>
 	 * : IMAP search criteria.
 	 *
@@ -912,6 +978,12 @@ class EmailCommand extends BaseCommand {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--auth-ref=<ref>]
+	 * : Authorized mailbox ref.
+	 *
+	 * [--mailbox=<name>]
+	 * : Mailbox name shorthand for email_imap:<name>.
+	 *
 	 * <uid>
 	 * : Message UID to unsubscribe from.
 	 *
@@ -962,6 +1034,12 @@ class EmailCommand extends BaseCommand {
 	 * From address using the most recent message's headers.
 	 *
 	 * ## OPTIONS
+	 *
+	 * [--auth-ref=<ref>]
+	 * : Authorized mailbox ref.
+	 *
+	 * [--mailbox=<name>]
+	 * : Mailbox name shorthand for email_imap:<name>.
 	 *
 	 * --search=<criteria>
 	 * : IMAP search criteria.
@@ -1036,6 +1114,14 @@ class EmailCommand extends BaseCommand {
 
 	/**
 	 * Test the IMAP connection.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--auth-ref=<ref>]
+	 * : Authorized mailbox ref.
+	 *
+	 * [--mailbox=<name>]
+	 * : Mailbox name shorthand for email_imap:<name>.
 	 *
 	 * ## EXAMPLES
 	 *

--- a/inc/Core/Bootstrap/ActivationServiceProvider.php
+++ b/inc/Core/Bootstrap/ActivationServiceProvider.php
@@ -121,6 +121,7 @@ final class ActivationServiceProvider {
 	public static function activate_for_site(): void {
 		self::register_capabilities();
 		self::ensure_all_tables();
+		datamachine_migrate_legacy_email_flow_auth();
 
 		if ( ! datamachine_ensure_default_memory_files() ) {
 			set_transient( 'datamachine_needs_scaffold', 1, HOUR_IN_SECONDS );

--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -427,7 +427,7 @@ abstract class BaseAuthProvider {
 		return $matches;
 	}
 
-	private function normalize_named_account_name( string $account_name ): string {
+	protected function normalize_named_account_name( string $account_name ): string {
 		$account_name = strtolower( trim( $account_name ) );
 		return preg_match( '/^[a-z0-9][a-z0-9._-]*$/', $account_name ) ? $account_name : '';
 	}

--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -435,7 +435,7 @@ abstract class BaseAuthProvider {
 	/**
 	 * @return string|null|false Scope key, null for site, or false when invalid.
 	 */
-	private function named_account_scope( string $owner_type, int $owner_id ) {
+	protected function named_account_scope( string $owner_type, int $owner_id ) {
 		if ( self::AUTH_SCOPE_SITE === $owner_type ) {
 			return null;
 		}

--- a/inc/Core/OAuth/BaseAuthProvider.php
+++ b/inc/Core/OAuth/BaseAuthProvider.php
@@ -305,6 +305,147 @@ abstract class BaseAuthProvider {
 	}
 
 	/**
+	 * Get an exact named account from a site or principal scope.
+	 *
+	 * Named account lookups never consult scope policy and never fall back.
+	 *
+	 * @param string      $account_name Stable account name.
+	 * @param string      $owner_type   site, user, or agent.
+	 * @param int         $owner_id     User/agent ID; ignored for site accounts.
+	 * @return array|null Decrypted account data, or null when missing.
+	 */
+	public function get_named_account( string $account_name, string $owner_type = self::AUTH_SCOPE_SITE, int $owner_id = 0 ): ?array {
+		$account_name = $this->normalize_named_account_name( $account_name );
+		$scope        = $this->named_account_scope( $owner_type, $owner_id );
+		if ( '' === $account_name || false === $scope ) {
+			return null;
+		}
+
+		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
+		$provider_data = $all_auth_data[ $this->provider_slug ] ?? array();
+		$account       = null === $scope
+			? ( $provider_data['accounts'][ $account_name ] ?? null )
+			: ( $provider_data['principals'][ $scope ]['accounts'][ $account_name ] ?? null );
+
+		return is_array( $account ) && ! empty( $account ) ? $this->decrypt_fields( $account ) : null;
+	}
+
+	/**
+	 * Save an exact named account in a site or principal scope.
+	 */
+	public function save_named_account( string $account_name, array $account, string $owner_type = self::AUTH_SCOPE_SITE, int $owner_id = 0 ): bool {
+		$account_name = $this->normalize_named_account_name( $account_name );
+		$scope        = $this->named_account_scope( $owner_type, $owner_id );
+		if ( '' === $account_name || false === $scope || empty( $account ) ) {
+			return false;
+		}
+		foreach ( $this->find_named_accounts( $account_name ) as $existing ) {
+			if ( $existing['owner_type'] !== $owner_type || (int) $existing['owner_id'] !== $owner_id ) {
+				return false;
+			}
+		}
+
+		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
+		if ( ! isset( $all_auth_data[ $this->provider_slug ] ) || ! is_array( $all_auth_data[ $this->provider_slug ] ) ) {
+			$all_auth_data[ $this->provider_slug ] = array();
+		}
+
+		if ( null === $scope ) {
+			$all_auth_data[ $this->provider_slug ]['accounts'][ $account_name ] = $this->encrypt_fields( $account );
+		} else {
+			$all_auth_data[ $this->provider_slug ]['principals'][ $scope ]['accounts'][ $account_name ] = $this->encrypt_fields( $account );
+		}
+
+		return update_site_option( 'datamachine_auth_data', $all_auth_data );
+	}
+
+	/**
+	 * Delete one exact named account without affecting sibling accounts.
+	 */
+	public function delete_named_account( string $account_name, string $owner_type = self::AUTH_SCOPE_SITE, int $owner_id = 0 ): bool {
+		$account_name = $this->normalize_named_account_name( $account_name );
+		$scope        = $this->named_account_scope( $owner_type, $owner_id );
+		if ( '' === $account_name || false === $scope ) {
+			return false;
+		}
+
+		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
+		if ( null === $scope ) {
+			if ( ! isset( $all_auth_data[ $this->provider_slug ]['accounts'][ $account_name ] ) ) {
+				return true;
+			}
+			unset( $all_auth_data[ $this->provider_slug ]['accounts'][ $account_name ] );
+		} else {
+			if ( ! isset( $all_auth_data[ $this->provider_slug ]['principals'][ $scope ]['accounts'][ $account_name ] ) ) {
+				return true;
+			}
+			unset( $all_auth_data[ $this->provider_slug ]['principals'][ $scope ]['accounts'][ $account_name ] );
+		}
+
+		return update_site_option( 'datamachine_auth_data', $all_auth_data );
+	}
+
+	/**
+	 * Find every exact owner of a named account. Ambiguity is left to callers.
+	 *
+	 * @return array<int,array{owner_type:string,owner_id:int,account:array}>
+	 */
+	public function find_named_accounts( string $account_name ): array {
+		$account_name = $this->normalize_named_account_name( $account_name );
+		if ( '' === $account_name ) {
+			return array();
+		}
+
+		$all_auth_data = get_site_option( 'datamachine_auth_data', array() );
+		$provider_data = $all_auth_data[ $this->provider_slug ] ?? array();
+		$matches       = array();
+
+		if ( isset( $provider_data['accounts'][ $account_name ] ) && is_array( $provider_data['accounts'][ $account_name ] ) ) {
+			$matches[] = array(
+				'account_name' => $account_name,
+				'owner_type' => self::AUTH_SCOPE_SITE,
+				'owner_id'   => 0,
+				'account'    => $this->decrypt_fields( $provider_data['accounts'][ $account_name ] ),
+			);
+		}
+
+		foreach ( (array) ( $provider_data['principals'] ?? array() ) as $scope => $principal_data ) {
+			if ( ! isset( $principal_data['accounts'][ $account_name ] ) || ! is_array( $principal_data['accounts'][ $account_name ] ) ) {
+				continue;
+			}
+			if ( ! preg_match( '/^(user|agent):(\d+)$/', (string) $scope, $parts ) ) {
+				continue;
+			}
+			$matches[] = array(
+				'account_name' => $account_name,
+				'owner_type' => $parts[1],
+				'owner_id'   => (int) $parts[2],
+				'account'    => $this->decrypt_fields( $principal_data['accounts'][ $account_name ] ),
+			);
+		}
+
+		return $matches;
+	}
+
+	private function normalize_named_account_name( string $account_name ): string {
+		$account_name = strtolower( trim( $account_name ) );
+		return preg_match( '/^[a-z0-9][a-z0-9._-]*$/', $account_name ) ? $account_name : '';
+	}
+
+	/**
+	 * @return string|null|false Scope key, null for site, or false when invalid.
+	 */
+	private function named_account_scope( string $owner_type, int $owner_id ) {
+		if ( self::AUTH_SCOPE_SITE === $owner_type ) {
+			return null;
+		}
+		if ( ! in_array( $owner_type, array( self::AUTH_SCOPE_USER, self::AUTH_SCOPE_AGENT ), true ) || $owner_id <= 0 ) {
+			return false;
+		}
+		return $owner_type . ':' . $owner_id;
+	}
+
+	/**
 	 * Get OAuth account data directly from options.
 	 *
 	 * Automatically decrypts any encrypted fields. Principal-scoped credentials

--- a/inc/Core/Steps/Fetch/FetchStep.php
+++ b/inc/Core/Steps/Fetch/FetchStep.php
@@ -165,6 +165,7 @@ class FetchStep extends Step {
 				'job_id'       => $this->job_id,
 				'user_id'      => $owner_user_id,
 				'agent_id'     => $agent_id,
+				'principal_less_system' => 0 === $owner_user_id && 0 === $agent_id,
 			)
 		);
 

--- a/inc/Core/Steps/Fetch/Handlers/Email/Email.php
+++ b/inc/Core/Steps/Fetch/Handlers/Email/Email.php
@@ -74,7 +74,7 @@ class Email extends FetchHandler {
 			'pipeline_id'      => $context->getPipelineId(),
 			'flow_step_id'     => $context->getFlowStepId(),
 			'job_id'           => $context->getJobId(),
-			'_legacy_default'  => ! isset( $config['auth_ref'] ),
+			'principal_less_system' => null === $context->getAgentId() && 0 === get_current_user_id(),
 		);
 		$result = $ability->executeWithContext( $ability_input, $trusted_context );
 

--- a/inc/Core/Steps/Fetch/Handlers/Email/Email.php
+++ b/inc/Core/Steps/Fetch/Handlers/Email/Email.php
@@ -75,6 +75,7 @@ class Email extends FetchHandler {
 			'flow_step_id'     => $context->getFlowStepId(),
 			'job_id'           => $context->getJobId(),
 			'principal_less_system' => null === $context->getAgentId() && 0 === get_current_user_id(),
+			'legacy_default_auth' => (string) ( $config['_legacy_default_auth'] ?? '' ),
 		);
 		$result = $ability->executeWithContext( $ability_input, $trusted_context );
 

--- a/inc/Core/Steps/Fetch/Handlers/Email/Email.php
+++ b/inc/Core/Steps/Fetch/Handlers/Email/Email.php
@@ -52,24 +52,12 @@ class Email extends FetchHandler {
 	 * @return array Array with 'items' key containing fetched messages.
 	 */
 	protected function executeFetch( array $config, ExecutionContext $context ): array {
-		// Resolve IMAP credentials from auth provider.
-		$auth = $this->getAuthProvider( 'email_imap' );
-
-		if ( ! $auth || ! $auth->is_authenticated() ) {
-			$context->log( 'error', 'Email Fetch: IMAP credentials not configured. Set up authentication in handler settings.' );
-			return array();
-		}
-
 		// Build search criteria from config.
 		$search_criteria = $this->buildSearchCriteria( $config );
 
 		// Build ability input.
 		$ability_input = array(
-			'imap_host'            => $auth->getHost(),
-			'imap_port'            => $auth->getPort(),
-			'imap_encryption'      => $auth->getEncryption(),
-			'imap_user'            => $auth->getUser(),
-			'imap_password'        => $auth->getPassword(),
+			'auth_ref'             => $config['auth_ref'] ?? 'email_imap:default',
 			'folder'               => $config['folder'] ?? 'INBOX',
 			'search_criteria'      => $search_criteria,
 			'max_messages'         => (int) ( $config['max_messages'] ?? 10 ),
@@ -79,7 +67,16 @@ class Email extends FetchHandler {
 
 		// Delegate to ability.
 		$ability = new FetchEmailAbility();
-		$result  = $ability->execute( $ability_input );
+		$trusted_context = array(
+			'user_id'          => get_current_user_id(),
+			'agent_id'         => $context->getAgentId(),
+			'flow_id'          => $context->getFlowId(),
+			'pipeline_id'      => $context->getPipelineId(),
+			'flow_step_id'     => $context->getFlowStepId(),
+			'job_id'           => $context->getJobId(),
+			'_legacy_default'  => ! isset( $config['auth_ref'] ),
+		);
+		$result = $ability->executeWithContext( $ability_input, $trusted_context );
 
 		if ( is_wp_error( $result ) ) {
 			$context->log( 'error', 'Email fetch failed: ' . $result->get_error_message() );

--- a/inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php
+++ b/inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php
@@ -126,6 +126,12 @@ class EmailAuth extends BaseAuthProvider {
 	 */
 	public function resolve_auth_ref( string $account, string $handler_slug = '', array $context = array() ): array|\WP_Error {
 		unset( $handler_slug );
+		if ( empty( $context['runtime'] ) ) {
+			$exists = 'default' === $account ? $this->is_authenticated() : ! empty( $this->find_named_accounts( $account ) );
+			return $exists
+				? array( 'auth_ref' => 'email_imap:' . $account )
+				: new \WP_Error( 'auth_ref_unresolved', __( 'Email mailbox ref is not configured on this install.', 'data-machine' ) );
+		}
 		if ( ! empty( $context['runtime'] ) ) {
 			$context['_trusted_execution'] = true;
 		}
@@ -135,14 +141,10 @@ class EmailAuth extends BaseAuthProvider {
 			return $resolved;
 		}
 
-		if ( ! empty( $context['runtime'] ) ) {
-			return array(
-				'auth_ref'       => $resolved['ref'],
-				'legacy_default' => false,
-			);
-		}
-
-		return array( 'auth_ref' => $resolved['ref'] );
+		return array(
+			'auth_ref'       => $resolved['ref'],
+			'legacy_default' => false,
+		);
 	}
 
 	public function resolve_mailbox_for_principal( string $account, string|array $operations, array $context ): array|\WP_Error {
@@ -171,7 +173,7 @@ class EmailAuth extends BaseAuthProvider {
 		}
 
 		if ( 'default' === $account ) {
-			if ( $agent_id > 0 && empty( $context['_legacy_default'] ) ) {
+			if ( ! $this->can_use_legacy_default( $context, $agent_id, $user_id ) ) {
 				return $this->audit_error( 'email_mailbox_forbidden', $ref, $operations, $context, $agent_id, $user_id );
 			}
 			$credentials = $this->get_config();
@@ -204,6 +206,19 @@ class EmailAuth extends BaseAuthProvider {
 		);
 		$this->audit( $resolved, $operations, $context, $agent_id, $user_id, 'allowed' );
 		return $resolved;
+	}
+
+	private function can_use_legacy_default( array $context, int $agent_id, int $user_id ): bool {
+		if ( $agent_id > 0 ) {
+			return false;
+		}
+		if ( ! empty( $context['principal_less_system'] ) && ! empty( $context['_trusted_execution'] ) ) {
+			return true;
+		}
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return class_exists( PermissionHelper::class ) && PermissionHelper::can_manage();
+		}
+		return $this->user_has_management_capability( $user_id );
 	}
 
 	public function grant_agent( string $account, string $owner_type, int $owner_id, int $agent_id, array $operations ): bool {
@@ -283,7 +298,7 @@ class EmailAuth extends BaseAuthProvider {
 		if ( 0 === $agent_id && self::AUTH_SCOPE_USER === $match['owner_type'] && $user_id === $match['owner_id'] ) {
 			return true;
 		}
-		if ( 0 === $agent_id && self::AUTH_SCOPE_SITE === $match['owner_type'] && ( ! class_exists( PermissionHelper::class ) || PermissionHelper::can_manage() ) ) {
+		if ( 0 === $agent_id && self::AUTH_SCOPE_SITE === $match['owner_type'] && $this->has_management_principal( $user_id ) ) {
 			return true;
 		}
 		if ( $agent_id <= 0 ) {
@@ -293,6 +308,23 @@ class EmailAuth extends BaseAuthProvider {
 		$owner_key  = $match['owner_type'] . ':' . $match['owner_id'];
 		$grant      = $data['email_imap']['delegations'][ $owner_key ][ $match['account_name'] ][ 'agent:' . $agent_id ] ?? null;
 		return is_array( $grant ) && empty( array_diff( $operations, (array) ( $grant['operations'] ?? array() ) ) );
+	}
+
+	private function has_management_principal( int $user_id ): bool {
+		return ( defined( 'WP_CLI' ) && WP_CLI && class_exists( PermissionHelper::class ) && PermissionHelper::can_manage() )
+			|| $this->user_has_management_capability( $user_id );
+	}
+
+	private function user_has_management_capability( int $user_id ): bool {
+		if ( $user_id <= 0 || ! function_exists( 'user_can' ) ) {
+			return false;
+		}
+		foreach ( array( 'manage_options', 'datamachine_manage_agents', 'datamachine_manage_flows', 'datamachine_manage_settings' ) as $capability ) {
+			if ( user_can( $user_id, $capability ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private function valid_credentials( array $credentials ): bool {

--- a/inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php
+++ b/inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php
@@ -210,7 +210,13 @@ class EmailAuth extends BaseAuthProvider {
 
 	private function can_use_legacy_default( array $context, int $agent_id, int $user_id ): bool {
 		if ( $agent_id > 0 ) {
-			return false;
+			$expected = self::legacy_default_marker(
+				absint( $context['flow_id'] ?? 0 ),
+				(string) ( $context['flow_step_id'] ?? '' ),
+				$agent_id
+			);
+			$provided = (string) ( $context['legacy_default_auth'] ?? '' );
+			return ! empty( $context['_trusted_execution'] ) && '' !== $provided && hash_equals( $expected, $provided );
 		}
 		if ( ! empty( $context['principal_less_system'] ) && ! empty( $context['_trusted_execution'] ) ) {
 			return true;
@@ -221,7 +227,13 @@ class EmailAuth extends BaseAuthProvider {
 		return $this->user_has_management_capability( $user_id );
 	}
 
+	public static function legacy_default_marker( int $flow_id, string $flow_step_id, int $agent_id ): string {
+		$payload = implode( '|', array( 'email-default-v1', (string) $flow_id, $flow_step_id, (string) $agent_id ) );
+		return hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) );
+	}
+
 	public function grant_agent( string $account, string $owner_type, int $owner_id, int $agent_id, array $operations ): bool {
+		$account = $this->normalize_named_account_name( $account );
 		if ( $agent_id <= 0 || null === $this->get_named_account( $account, $owner_type, $owner_id ) ) {
 			return false;
 		}
@@ -244,7 +256,7 @@ class EmailAuth extends BaseAuthProvider {
 			return false;
 		}
 		$data = get_site_option( 'datamachine_auth_data', array() );
-		$data['email_imap']['delegations'][ $owner_type . ':' . $owner_id ][ strtolower( $account ) ][ 'agent:' . $agent_id ] = array(
+		$data['email_imap']['delegations'][ $owner_type . ':' . $owner_id ][ $account ][ 'agent:' . $agent_id ] = array(
 			'operations' => $operations,
 			'granted_at' => gmdate( 'c' ),
 			'granted_by' => $acting_user,
@@ -253,6 +265,10 @@ class EmailAuth extends BaseAuthProvider {
 	}
 
 	public function revoke_agent( string $account, string $owner_type, int $owner_id, int $agent_id ): bool {
+		$account = $this->normalize_named_account_name( $account );
+		if ( '' === $account || $agent_id <= 0 ) {
+			return false;
+		}
 		$acting_agent = class_exists( PermissionHelper::class ) ? absint( PermissionHelper::get_acting_agent_id() ) : 0;
 		$acting_user  = class_exists( PermissionHelper::class ) ? absint( PermissionHelper::acting_user_id() ) : 0;
 		if ( $acting_agent > 0 && ( self::AUTH_SCOPE_AGENT !== $owner_type || $acting_agent !== $owner_id ) ) {
@@ -273,7 +289,29 @@ class EmailAuth extends BaseAuthProvider {
 			return true;
 		}
 		unset( $data['email_imap']['delegations'][ $key ][ $account ][ 'agent:' . $agent_id ] );
-		return update_site_option( 'datamachine_auth_data', $data );
+		update_site_option( 'datamachine_auth_data', $data );
+		$current = get_site_option( 'datamachine_auth_data', array() );
+		return ! isset( $current['email_imap']['delegations'][ $key ][ $account ][ 'agent:' . $agent_id ] );
+	}
+
+	public function delete_named_account( string $account_name, string $owner_type = self::AUTH_SCOPE_SITE, int $owner_id = 0 ): bool {
+		$account_name = $this->normalize_named_account_name( $account_name );
+		if ( '' === $account_name ) {
+			return false;
+		}
+
+		$data      = get_site_option( 'datamachine_auth_data', array() );
+		$owner_key = $owner_type . ':' . $owner_id;
+		if ( isset( $data['email_imap']['delegations'][ $owner_key ][ $account_name ] ) ) {
+			unset( $data['email_imap']['delegations'][ $owner_key ][ $account_name ] );
+			update_site_option( 'datamachine_auth_data', $data );
+			$current = get_site_option( 'datamachine_auth_data', array() );
+			if ( isset( $current['email_imap']['delegations'][ $owner_key ][ $account_name ] ) ) {
+				return false;
+			}
+		}
+
+		return parent::delete_named_account( $account_name, $owner_type, $owner_id );
 	}
 
 	private function user_can_manage_agent_owner( int $user_id, int $agent_id ): bool {

--- a/inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php
+++ b/inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php
@@ -182,7 +182,10 @@ class EmailAuth extends BaseAuthProvider {
 			}
 			$resolved = array(
 				'ref'         => $ref,
-				'owner'       => array( 'type' => self::AUTH_SCOPE_SITE, 'id' => 0 ),
+				'owner'       => array(
+					'type' => self::AUTH_SCOPE_SITE,
+					'id'   => 0,
+				),
 				'credentials' => $credentials,
 			);
 			$this->audit( $resolved, $operations, $context, $agent_id, $user_id, 'allowed' );
@@ -201,7 +204,10 @@ class EmailAuth extends BaseAuthProvider {
 
 		$resolved = array(
 			'ref'         => $ref,
-			'owner'       => array( 'type' => $allowed[0]['owner_type'], 'id' => $allowed[0]['owner_id'] ),
+			'owner'       => array(
+				'type' => $allowed[0]['owner_type'],
+				'id'   => $allowed[0]['owner_id'],
+			),
 			'credentials' => $allowed[0]['account'],
 		);
 		$this->audit( $resolved, $operations, $context, $agent_id, $user_id, 'allowed' );
@@ -333,7 +339,7 @@ class EmailAuth extends BaseAuthProvider {
 			return false;
 		}
 		$agent = ( new Agents() )->get_agent( $agent_id );
-		return is_array( $agent ) && $user_id === (int) ( $agent['owner_id'] ?? 0 );
+		return is_array( $agent ) && (int) ( $agent['owner_id'] ?? 0 ) === $user_id;
 	}
 
 	private function can_access( array $match, string|array $operations, int $agent_id, int $user_id ): bool {
@@ -378,15 +384,42 @@ class EmailAuth extends BaseAuthProvider {
 	}
 
 	private function audit_error( string $code, string $ref, string|array $operations, array $context, int $agent_id, int $user_id ): \WP_Error {
-		$this->audit( array( 'ref' => $ref, 'owner' => null ), $operations, $context, $agent_id, $user_id, 'denied' );
-		return new \WP_Error( $code, sprintf( __( 'Mailbox ref "%s" could not be resolved or authorized.', 'data-machine' ), $ref ), array( 'status' => 403 ) );
+		$this->audit(
+			array(
+				'ref'   => $ref,
+				'owner' => null,
+			),
+			$operations,
+			$context,
+			$agent_id,
+			$user_id,
+			'denied'
+		);
+		return new \WP_Error(
+			$code,
+			sprintf(
+				/* translators: %s: mailbox auth reference. */
+				__( 'Mailbox ref "%s" could not be resolved or authorized.', 'data-machine' ),
+				$ref
+			),
+			array( 'status' => 403 )
+		);
 	}
 
 	private function audit( array $mailbox, string|array $operations, array $context, int $agent_id, int $user_id, string $result ): void {
+		$acting_principal = $agent_id > 0
+			? array(
+				'type' => 'agent',
+				'id'   => $agent_id,
+			)
+			: array(
+				'type' => 'user',
+				'id'   => $user_id,
+			);
 		$metadata = array(
 			'mailbox_ref'     => $mailbox['ref'],
 			'owner_principal' => $mailbox['owner'],
-			'acting_principal'=> $agent_id > 0 ? array( 'type' => 'agent', 'id' => $agent_id ) : array( 'type' => 'user', 'id' => $user_id ),
+			'acting_principal' => $acting_principal,
 			'operation'       => array_values( (array) $operations ),
 			'result'          => $result,
 		);

--- a/inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php
+++ b/inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php
@@ -296,22 +296,30 @@ class EmailAuth extends BaseAuthProvider {
 
 	public function delete_named_account( string $account_name, string $owner_type = self::AUTH_SCOPE_SITE, int $owner_id = 0 ): bool {
 		$account_name = $this->normalize_named_account_name( $account_name );
-		if ( '' === $account_name ) {
+		$scope        = $this->named_account_scope( $owner_type, $owner_id );
+		if ( '' === $account_name || false === $scope ) {
 			return false;
 		}
 
-		$data      = get_site_option( 'datamachine_auth_data', array() );
-		$owner_key = $owner_type . ':' . $owner_id;
-		if ( isset( $data['email_imap']['delegations'][ $owner_key ][ $account_name ] ) ) {
-			unset( $data['email_imap']['delegations'][ $owner_key ][ $account_name ] );
-			update_site_option( 'datamachine_auth_data', $data );
-			$current = get_site_option( 'datamachine_auth_data', array() );
-			if ( isset( $current['email_imap']['delegations'][ $owner_key ][ $account_name ] ) ) {
-				return false;
-			}
+		$data       = get_site_option( 'datamachine_auth_data', array() );
+		$owner_id   = self::AUTH_SCOPE_SITE === $owner_type ? 0 : $owner_id;
+		$owner_key  = $owner_type . ':' . $owner_id;
+		$has_grants = isset( $data['email_imap']['delegations'][ $owner_key ][ $account_name ] );
+		$has_account = null === $scope
+			? isset( $data['email_imap']['accounts'][ $account_name ] )
+			: isset( $data['email_imap']['principals'][ $scope ]['accounts'][ $account_name ] );
+		if ( ! $has_account && ! $has_grants ) {
+			return true;
 		}
 
-		return parent::delete_named_account( $account_name, $owner_type, $owner_id );
+		if ( null === $scope ) {
+			unset( $data['email_imap']['accounts'][ $account_name ] );
+		} else {
+			unset( $data['email_imap']['principals'][ $scope ]['accounts'][ $account_name ] );
+		}
+		unset( $data['email_imap']['delegations'][ $owner_key ][ $account_name ] );
+
+		return update_site_option( 'datamachine_auth_data', $data );
 	}
 
 	private function user_can_manage_agent_owner( int $user_id, int $agent_id ): bool {

--- a/inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php
+++ b/inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php
@@ -11,6 +11,8 @@
 
 namespace DataMachine\Core\Steps\Fetch\Handlers\Email;
 
+use DataMachine\Abilities\PermissionHelper;
+use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\OAuth\BaseAuthProvider;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -18,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class EmailAuth extends BaseAuthProvider {
+	public const OPERATIONS = array( 'read', 'search', 'draft', 'send', 'reply', 'organize', 'delete', 'unsubscribe' );
 
 	public function __construct() {
 		parent::__construct( 'email_imap' );
@@ -82,6 +85,17 @@ class EmailAuth extends BaseAuthProvider {
 			&& ! empty( $config['imap_password'] );
 	}
 
+	protected function get_encrypted_fields(): array {
+		return array_values( array_unique( array_merge( parent::get_encrypted_fields(), array( 'imap_password' ) ) ) );
+	}
+
+	public function strip_auth_config_secrets( array $handler_config ): array {
+		foreach ( array( 'imap_host', 'imap_port', 'imap_encryption', 'imap_user', 'imap_password' ) as $field ) {
+			unset( $handler_config[ $field ] );
+		}
+		return parent::strip_auth_config_secrets( $handler_config );
+	}
+
 	/**
 	 * Convert inline IMAP credentials to the install-local default ref.
 	 *
@@ -111,17 +125,199 @@ class EmailAuth extends BaseAuthProvider {
 	 * @return array|\WP_Error Local IMAP config or failure.
 	 */
 	public function resolve_auth_ref( string $account, string $handler_slug = '', array $context = array() ): array|\WP_Error {
-		unset( $handler_slug, $context );
-
-		if ( 'default' !== $account ) {
-			return new \WP_Error( 'auth_ref_unresolved', __( 'Email auth only supports the default local connection.', 'data-machine' ) );
+		unset( $handler_slug );
+		if ( ! empty( $context['runtime'] ) ) {
+			$context['_trusted_execution'] = true;
+		}
+		$operation = (string) ( $context['operation'] ?? 'read' );
+		$resolved  = $this->resolve_mailbox( $account, $operation, $context );
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
 		}
 
-		if ( ! $this->is_authenticated() ) {
-			return new \WP_Error( 'auth_ref_unresolved', __( 'Email IMAP credentials are not configured on this install.', 'data-machine' ) );
+		if ( ! empty( $context['runtime'] ) ) {
+			return array(
+				'auth_ref'       => $resolved['ref'],
+				'legacy_default' => false,
+			);
 		}
 
-		return $this->get_config();
+		return array( 'auth_ref' => $resolved['ref'] );
+	}
+
+	public function resolve_mailbox_for_principal( string $account, string|array $operations, array $context ): array|\WP_Error {
+		$context['_trusted_execution'] = true;
+		return $this->resolve_mailbox( $account, $operations, $context );
+	}
+
+	/**
+	 * Resolve and authorize a mailbox without exposing credentials externally.
+	 *
+	 * @param string       $account    Account segment or full auth ref.
+	 * @param string|array $operations Required operation(s).
+	 * @param array        $context    Trusted execution context.
+	 * @return array|\WP_Error Resolved internal mailbox envelope.
+	 */
+	public function resolve_mailbox( string $account, string|array $operations = 'read', array $context = array() ): array|\WP_Error {
+		$account = str_starts_with( $account, 'email_imap:' ) ? substr( $account, 11 ) : $account;
+		$account = strtolower( trim( $account ) );
+		$ref     = 'email_imap:' . $account;
+		$trusted  = ! empty( $context['_trusted_execution'] );
+		$agent_id = $trusted && isset( $context['agent_id'] ) ? absint( $context['agent_id'] ) : ( class_exists( PermissionHelper::class ) ? absint( PermissionHelper::get_acting_agent_id() ) : 0 );
+		$user_id  = $trusted && isset( $context['user_id'] ) ? absint( $context['user_id'] ) : ( class_exists( PermissionHelper::class ) ? absint( PermissionHelper::acting_user_id() ) : 0 );
+
+		if ( ! preg_match( '/^[a-z0-9][a-z0-9._-]*$/', $account ) ) {
+			return $this->audit_error( 'auth_ref_invalid', $ref, $operations, $context, $agent_id, $user_id );
+		}
+
+		if ( 'default' === $account ) {
+			if ( $agent_id > 0 && empty( $context['_legacy_default'] ) ) {
+				return $this->audit_error( 'email_mailbox_forbidden', $ref, $operations, $context, $agent_id, $user_id );
+			}
+			$credentials = $this->get_config();
+			if ( ! $this->valid_credentials( $credentials ) ) {
+				return $this->audit_error( 'auth_ref_unresolved', $ref, $operations, $context, $agent_id, $user_id );
+			}
+			$resolved = array(
+				'ref'         => $ref,
+				'owner'       => array( 'type' => self::AUTH_SCOPE_SITE, 'id' => 0 ),
+				'credentials' => $credentials,
+			);
+			$this->audit( $resolved, $operations, $context, $agent_id, $user_id, 'allowed' );
+			return $resolved;
+		}
+
+		$matches = $this->find_named_accounts( $account );
+		$allowed = array_values( array_filter( $matches, fn ( array $match ): bool => $this->can_access( $match, $operations, $agent_id, $user_id ) ) );
+		if ( 1 !== count( $allowed ) || ! $this->valid_credentials( $allowed[0]['account'] ) ) {
+			$code = empty( $matches ) ? 'auth_ref_unresolved' : 'email_mailbox_forbidden';
+			if ( count( $allowed ) > 1 ) {
+				$code = 'email_mailbox_ambiguous';
+			}
+			return $this->audit_error( $code, $ref, $operations, $context, $agent_id, $user_id );
+		}
+
+		$resolved = array(
+			'ref'         => $ref,
+			'owner'       => array( 'type' => $allowed[0]['owner_type'], 'id' => $allowed[0]['owner_id'] ),
+			'credentials' => $allowed[0]['account'],
+		);
+		$this->audit( $resolved, $operations, $context, $agent_id, $user_id, 'allowed' );
+		return $resolved;
+	}
+
+	public function grant_agent( string $account, string $owner_type, int $owner_id, int $agent_id, array $operations ): bool {
+		if ( $agent_id <= 0 || null === $this->get_named_account( $account, $owner_type, $owner_id ) ) {
+			return false;
+		}
+		$acting_agent = class_exists( PermissionHelper::class ) ? absint( PermissionHelper::get_acting_agent_id() ) : 0;
+		$acting_user  = class_exists( PermissionHelper::class ) ? absint( PermissionHelper::acting_user_id() ) : 0;
+		if ( $acting_agent > 0 && ( self::AUTH_SCOPE_AGENT !== $owner_type || $acting_agent !== $owner_id ) ) {
+			return false;
+		}
+		if ( 0 === $acting_agent && self::AUTH_SCOPE_USER === $owner_type && $acting_user !== $owner_id && class_exists( PermissionHelper::class ) && ! PermissionHelper::can_manage() ) {
+			return false;
+		}
+		if ( 0 === $acting_agent && self::AUTH_SCOPE_SITE === $owner_type && class_exists( PermissionHelper::class ) && ! PermissionHelper::can_manage() ) {
+			return false;
+		}
+		if ( 0 === $acting_agent && self::AUTH_SCOPE_AGENT === $owner_type && ! $this->user_can_manage_agent_owner( $acting_user, $owner_id ) ) {
+			return false;
+		}
+		$operations = array_values( array_unique( array_intersect( self::OPERATIONS, array_map( 'sanitize_key', $operations ) ) ) );
+		if ( empty( $operations ) ) {
+			return false;
+		}
+		$data = get_site_option( 'datamachine_auth_data', array() );
+		$data['email_imap']['delegations'][ $owner_type . ':' . $owner_id ][ strtolower( $account ) ][ 'agent:' . $agent_id ] = array(
+			'operations' => $operations,
+			'granted_at' => gmdate( 'c' ),
+			'granted_by' => $acting_user,
+		);
+		return update_site_option( 'datamachine_auth_data', $data );
+	}
+
+	public function revoke_agent( string $account, string $owner_type, int $owner_id, int $agent_id ): bool {
+		$acting_agent = class_exists( PermissionHelper::class ) ? absint( PermissionHelper::get_acting_agent_id() ) : 0;
+		$acting_user  = class_exists( PermissionHelper::class ) ? absint( PermissionHelper::acting_user_id() ) : 0;
+		if ( $acting_agent > 0 && ( self::AUTH_SCOPE_AGENT !== $owner_type || $acting_agent !== $owner_id ) ) {
+			return false;
+		}
+		if ( 0 === $acting_agent && self::AUTH_SCOPE_USER === $owner_type && $acting_user !== $owner_id && class_exists( PermissionHelper::class ) && ! PermissionHelper::can_manage() ) {
+			return false;
+		}
+		if ( 0 === $acting_agent && self::AUTH_SCOPE_SITE === $owner_type && class_exists( PermissionHelper::class ) && ! PermissionHelper::can_manage() ) {
+			return false;
+		}
+		if ( 0 === $acting_agent && self::AUTH_SCOPE_AGENT === $owner_type && ! $this->user_can_manage_agent_owner( $acting_user, $owner_id ) ) {
+			return false;
+		}
+		$data = get_site_option( 'datamachine_auth_data', array() );
+		$key  = $owner_type . ':' . $owner_id;
+		if ( ! isset( $data['email_imap']['delegations'][ $key ][ $account ][ 'agent:' . $agent_id ] ) ) {
+			return true;
+		}
+		unset( $data['email_imap']['delegations'][ $key ][ $account ][ 'agent:' . $agent_id ] );
+		return update_site_option( 'datamachine_auth_data', $data );
+	}
+
+	private function user_can_manage_agent_owner( int $user_id, int $agent_id ): bool {
+		if ( $user_id <= 0 || $agent_id <= 0 ) {
+			return false;
+		}
+		if ( class_exists( PermissionHelper::class ) && PermissionHelper::can( 'manage_agents' ) ) {
+			return true;
+		}
+		if ( ! class_exists( Agents::class ) ) {
+			return false;
+		}
+		$agent = ( new Agents() )->get_agent( $agent_id );
+		return is_array( $agent ) && $user_id === (int) ( $agent['owner_id'] ?? 0 );
+	}
+
+	private function can_access( array $match, string|array $operations, int $agent_id, int $user_id ): bool {
+		$operations = (array) $operations;
+		if ( $agent_id > 0 && self::AUTH_SCOPE_AGENT === $match['owner_type'] && $agent_id === $match['owner_id'] ) {
+			return true;
+		}
+		if ( 0 === $agent_id && self::AUTH_SCOPE_USER === $match['owner_type'] && $user_id === $match['owner_id'] ) {
+			return true;
+		}
+		if ( 0 === $agent_id && self::AUTH_SCOPE_SITE === $match['owner_type'] && ( ! class_exists( PermissionHelper::class ) || PermissionHelper::can_manage() ) ) {
+			return true;
+		}
+		if ( $agent_id <= 0 ) {
+			return false;
+		}
+		$data       = get_site_option( 'datamachine_auth_data', array() );
+		$owner_key  = $match['owner_type'] . ':' . $match['owner_id'];
+		$grant      = $data['email_imap']['delegations'][ $owner_key ][ $match['account_name'] ][ 'agent:' . $agent_id ] ?? null;
+		return is_array( $grant ) && empty( array_diff( $operations, (array) ( $grant['operations'] ?? array() ) ) );
+	}
+
+	private function valid_credentials( array $credentials ): bool {
+		return ! empty( $credentials['imap_host'] ) && ! empty( $credentials['imap_user'] ) && ! empty( $credentials['imap_password'] );
+	}
+
+	private function audit_error( string $code, string $ref, string|array $operations, array $context, int $agent_id, int $user_id ): \WP_Error {
+		$this->audit( array( 'ref' => $ref, 'owner' => null ), $operations, $context, $agent_id, $user_id, 'denied' );
+		return new \WP_Error( $code, sprintf( __( 'Mailbox ref "%s" could not be resolved or authorized.', 'data-machine' ), $ref ), array( 'status' => 403 ) );
+	}
+
+	private function audit( array $mailbox, string|array $operations, array $context, int $agent_id, int $user_id, string $result ): void {
+		$metadata = array(
+			'mailbox_ref'     => $mailbox['ref'],
+			'owner_principal' => $mailbox['owner'],
+			'acting_principal'=> $agent_id > 0 ? array( 'type' => 'agent', 'id' => $agent_id ) : array( 'type' => 'user', 'id' => $user_id ),
+			'operation'       => array_values( (array) $operations ),
+			'result'          => $result,
+		);
+		foreach ( array( 'flow_id', 'pipeline_id', 'flow_step_id', 'job_id' ) as $key ) {
+			if ( isset( $context[ $key ] ) ) {
+				$metadata[ $key ] = $context[ $key ];
+			}
+		}
+		do_action( 'datamachine_email_operation_audit', $metadata );
 	}
 
 	/**

--- a/inc/Core/Steps/Fetch/Handlers/Email/EmailFetchSettings.php
+++ b/inc/Core/Steps/Fetch/Handlers/Email/EmailFetchSettings.php
@@ -23,6 +23,12 @@ class EmailFetchSettings extends FetchHandlerSettings {
 	 */
 	public static function get_fields(): array {
 		$fields = array(
+			'auth_ref'             => array(
+				'type'        => 'text',
+				'label'       => __( 'Mailbox Auth Ref', 'data-machine' ),
+				'default'     => 'email_imap:default',
+				'description' => __( 'Named mailbox connection, for example email_imap:event-submissions.', 'data-machine' ),
+			),
 			'folder'               => array(
 				'type'        => 'text',
 				'label'       => __( 'Mail Folder', 'data-machine' ),

--- a/inc/migrations/email-flow-auth.php
+++ b/inc/migrations/email-flow-auth.php
@@ -20,10 +20,11 @@ function datamachine_migrate_legacy_email_flow_auth(): void {
 	}
 
 	global $wpdb;
-	$table = $wpdb->prefix . 'datamachine_flows';
+	$table      = $wpdb->prefix . 'datamachine_flows';
+	$repository = new \DataMachine\Core\Database\Flows\Flows();
 
 	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Trusted table name; one-time migration.
-	$flows = $wpdb->get_results( "SELECT flow_id, agent_id, flow_config FROM {$table} WHERE agent_id > 0", ARRAY_A );
+	$flows = $wpdb->get_results( "SELECT flow_id, agent_id FROM {$table} WHERE agent_id > 0", ARRAY_A );
 	if ( ! is_array( $flows ) ) {
 		return;
 	}
@@ -31,45 +32,61 @@ function datamachine_migrate_legacy_email_flow_auth(): void {
 	foreach ( $flows as $flow ) {
 		$flow_id = absint( $flow['flow_id'] ?? 0 );
 		$agent_id = absint( $flow['agent_id'] ?? 0 );
-		$config   = json_decode( (string) ( $flow['flow_config'] ?? '' ), true );
-		if ( $flow_id <= 0 || $agent_id <= 0 || ! is_array( $config ) ) {
+		if ( $flow_id <= 0 || $agent_id <= 0 ) {
 			continue;
 		}
 
-		$changed = false;
-		foreach ( $config as $flow_step_id => &$step ) {
-			if ( ! is_array( $step ) || ! in_array( 'email', (array) ( $step['handler_slugs'] ?? array() ), true ) ) {
-				continue;
+		$handled = false;
+		for ( $attempt = 0; $attempt < 3; ++$attempt ) {
+			$expected_json = $repository->get_flow_config_json( $flow_id );
+			$config        = null === $expected_json ? null : json_decode( $expected_json, true );
+			if ( ! is_array( $config ) ) {
+				$handled = true;
+				break;
 			}
-			$email_config = $step['handler_configs']['email'] ?? null;
-			if ( ! is_array( $email_config ) || ! empty( $email_config['auth_ref'] ) ) {
-				continue;
+
+			$changed = datamachine_mark_legacy_email_flow_auth_config( $config, $flow_id, $agent_id );
+			if ( ! $changed ) {
+				$handled = true;
+				break;
 			}
-
-			$step['handler_configs']['email']['_legacy_default_auth'] = \DataMachine\Core\Steps\Fetch\Handlers\Email\EmailAuth::legacy_default_marker(
-				$flow_id,
-				(string) $flow_step_id,
-				$agent_id
-			);
-			$changed = true;
+			if ( $repository->compare_and_swap_flow_config( $flow_id, $expected_json, $config ) ) {
+				$handled = true;
+				break;
+			}
 		}
-		unset( $step );
-
-		if ( ! $changed ) {
-			continue;
-		}
-
-		$updated = $wpdb->update(
-			$table,
-			array( 'flow_config' => wp_json_encode( $config ) ),
-			array( 'flow_id' => $flow_id ),
-			array( '%s' ),
-			array( '%d' )
-		);
-		if ( false === $updated ) {
+		if ( ! $handled ) {
 			return;
 		}
 	}
 
 	update_option( 'datamachine_legacy_email_flow_auth_migrated', 1, true );
+}
+
+/**
+ * Add exact legacy markers to one decoded flow config.
+ *
+ * @param array<string,mixed> $config Flow config, mutated by reference.
+ */
+function datamachine_mark_legacy_email_flow_auth_config( array &$config, int $flow_id, int $agent_id ): bool {
+	$changed = false;
+	foreach ( $config as $flow_step_id => &$step ) {
+		if ( ! is_array( $step ) || ! in_array( 'email', (array) ( $step['handler_slugs'] ?? array() ), true ) ) {
+			continue;
+		}
+		$email_config = $step['handler_configs']['email'] ?? null;
+		if ( ! is_array( $email_config ) || ! empty( $email_config['auth_ref'] ) || ! empty( $email_config['_legacy_default_auth'] ) ) {
+			continue;
+		}
+
+		$step['handler_configs']['email']['_legacy_default_auth'] = \DataMachine\Core\Steps\Fetch\Handlers\Email\EmailAuth::legacy_default_marker(
+			$flow_id,
+			(string) $flow_step_id,
+			$agent_id
+		);
+		$changed = true;
+	}
+	unset( $step );
+
+	return $changed;
 }

--- a/inc/migrations/email-flow-auth.php
+++ b/inc/migrations/email-flow-auth.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Persist authorization markers for legacy agent-owned email flows.
+ *
+ * @package DataMachine
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Mark existing agent-owned email fetch handlers that historically used the
+ * site default mailbox without an auth ref.
+ *
+ * New flows never pass through this migration. The signed marker binds legacy
+ * compatibility to the exact persisted flow, step, and agent principal.
+ */
+function datamachine_migrate_legacy_email_flow_auth(): void {
+	if ( get_option( 'datamachine_legacy_email_flow_auth_migrated', false ) ) {
+		return;
+	}
+
+	global $wpdb;
+	$table = $wpdb->prefix . 'datamachine_flows';
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Trusted table name; one-time migration.
+	$flows = $wpdb->get_results( "SELECT flow_id, agent_id, flow_config FROM {$table} WHERE agent_id > 0", ARRAY_A );
+	if ( ! is_array( $flows ) ) {
+		return;
+	}
+
+	foreach ( $flows as $flow ) {
+		$flow_id = absint( $flow['flow_id'] ?? 0 );
+		$agent_id = absint( $flow['agent_id'] ?? 0 );
+		$config   = json_decode( (string) ( $flow['flow_config'] ?? '' ), true );
+		if ( $flow_id <= 0 || $agent_id <= 0 || ! is_array( $config ) ) {
+			continue;
+		}
+
+		$changed = false;
+		foreach ( $config as $flow_step_id => &$step ) {
+			if ( ! is_array( $step ) || ! in_array( 'email', (array) ( $step['handler_slugs'] ?? array() ), true ) ) {
+				continue;
+			}
+			$email_config = $step['handler_configs']['email'] ?? null;
+			if ( ! is_array( $email_config ) || ! empty( $email_config['auth_ref'] ) ) {
+				continue;
+			}
+
+			$step['handler_configs']['email']['_legacy_default_auth'] = \DataMachine\Core\Steps\Fetch\Handlers\Email\EmailAuth::legacy_default_marker(
+				$flow_id,
+				(string) $flow_step_id,
+				$agent_id
+			);
+			$changed = true;
+		}
+		unset( $step );
+
+		if ( ! $changed ) {
+			continue;
+		}
+
+		$updated = $wpdb->update(
+			$table,
+			array( 'flow_config' => wp_json_encode( $config ) ),
+			array( 'flow_id' => $flow_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		if ( false === $updated ) {
+			return;
+		}
+	}
+
+	update_option( 'datamachine_legacy_email_flow_auth_migrated', 1, true );
+}

--- a/inc/migrations/load.php
+++ b/inc/migrations/load.php
@@ -15,6 +15,7 @@ require_once __DIR__ . '/scaffolding.php';
 require_once __DIR__ . '/site-md.php';
 require_once __DIR__ . '/agents-md.php';
 require_once __DIR__ . '/flows.php';
+require_once __DIR__ . '/email-flow-auth.php';
 require_once __DIR__ . '/bundle-artifacts.php';
 require_once __DIR__ . '/run-metadata.php';
 require_once __DIR__ . '/processed-item-claims.php';

--- a/inc/migrations/runtime.php
+++ b/inc/migrations/runtime.php
@@ -34,6 +34,7 @@ function datamachine_run_schema_migrations(): void {
 	datamachine_migrate_processed_item_claims();
 	datamachine_migrate_pending_actions_table();
 	datamachine_migrate_chat_sessions_to_network();
+	datamachine_migrate_legacy_email_flow_auth();
 }
 
 /**

--- a/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
+++ b/tests/Unit/Core/OAuth/BaseAuthProviderTest.php
@@ -335,6 +335,39 @@ class BaseAuthProviderTest extends WP_UnitTestCase {
 		$this->assertTrue( $this->provider->delete_site_account() );
 	}
 
+	public function test_named_accounts_support_multiple_exact_principal_slots(): void {
+		$this->assertTrue( $this->provider->save_named_account( 'primary', array( 'access_token' => 'site-primary' ) ) );
+		$this->assertTrue( $this->provider->save_named_account( 'archive', array( 'access_token' => 'site-archive' ) ) );
+		$this->assertTrue( $this->provider->save_named_account( 'user-primary', array( 'access_token' => 'user-primary' ), BaseAuthProvider::AUTH_SCOPE_USER, 42 ) );
+		$this->assertTrue( $this->provider->save_named_account( 'agent-primary', array( 'access_token' => 'agent-primary' ), BaseAuthProvider::AUTH_SCOPE_AGENT, 303 ) );
+
+		$this->assertSame( 'site-primary', $this->provider->get_named_account( 'primary' )['access_token'] );
+		$this->assertSame( 'site-archive', $this->provider->get_named_account( 'archive' )['access_token'] );
+		$this->assertSame( 'user-primary', $this->provider->get_named_account( 'user-primary', BaseAuthProvider::AUTH_SCOPE_USER, 42 )['access_token'] );
+		$this->assertSame( 'agent-primary', $this->provider->get_named_account( 'agent-primary', BaseAuthProvider::AUTH_SCOPE_AGENT, 303 )['access_token'] );
+		$this->assertNull( $this->provider->get_named_account( 'archive', BaseAuthProvider::AUTH_SCOPE_USER, 42 ) );
+		$this->assertFalse( $this->provider->save_named_account( 'primary', array( 'access_token' => 'duplicate' ), BaseAuthProvider::AUTH_SCOPE_USER, 42 ) );
+	}
+
+	public function test_named_account_delete_preserves_siblings_and_legacy_slots(): void {
+		$this->provider->save_site_account( array( 'access_token' => 'legacy' ) );
+		$this->provider->save_named_account( 'one', array( 'access_token' => 'one' ) );
+		$this->provider->save_named_account( 'two', array( 'access_token' => 'two' ) );
+
+		$this->assertTrue( $this->provider->delete_named_account( 'one' ) );
+		$this->assertNull( $this->provider->get_named_account( 'one' ) );
+		$this->assertSame( 'two', $this->provider->get_named_account( 'two' )['access_token'] );
+		$this->assertSame( 'legacy', $this->provider->get_site_account()['access_token'] );
+	}
+
+	public function test_named_accounts_reject_invalid_names_and_encrypt_secrets(): void {
+		$this->assertFalse( $this->provider->save_named_account( 'Bad Ref!', array( 'access_token' => 'secret' ) ) );
+		$this->assertTrue( $this->provider->save_named_account( 'valid-ref', array( 'access_token' => 'secret' ) ) );
+
+		$raw = get_site_option( 'datamachine_auth_data', array() );
+		$this->assertStringStartsWith( 'dm:enc:v1:', $raw['test_provider']['accounts']['valid-ref']['access_token'] );
+	}
+
 	public function test_site_account_methods_do_not_consult_scope_policy(): void {
 		add_filter(
 			'datamachine_auth_scope_policy',

--- a/tests/Unit/Core/Steps/Fetch/Handlers/Email/EmailAuthTest.php
+++ b/tests/Unit/Core/Steps/Fetch/Handlers/Email/EmailAuthTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Named mailbox and delegation tests.
+ *
+ * @package DataMachine\Tests\Unit
+ */
+
+namespace DataMachine\Tests\Unit\Core\Steps\Fetch\Handlers\Email;
+
+use DataMachine\Core\OAuth\BaseAuthProvider;
+use DataMachine\Core\Steps\Fetch\Handlers\Email\EmailAuth;
+use WP_UnitTestCase;
+
+class EmailAuthTest extends WP_UnitTestCase {
+	private EmailAuth $auth;
+
+	public function set_up(): void {
+		parent::set_up();
+		delete_site_option( 'datamachine_auth_data' );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$this->auth = new EmailAuth();
+	}
+
+	public function tear_down(): void {
+		delete_site_option( 'datamachine_auth_data' );
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	private function credentials( string $user ): array {
+		return array(
+			'imap_host'       => 'imap.example.test',
+			'imap_port'       => 993,
+			'imap_encryption' => 'ssl',
+			'imap_user'       => $user,
+			'imap_password'   => 'mail-secret-' . $user,
+		);
+	}
+
+	public function test_default_ref_preserves_legacy_config_compatibility(): void {
+		$this->auth->save_config( $this->credentials( 'legacy@example.test' ) );
+
+		$resolved = $this->auth->resolve_mailbox( 'email_imap:default', 'read' );
+		$this->assertFalse( is_wp_error( $resolved ) );
+		$this->assertSame( 'legacy@example.test', $resolved['credentials']['imap_user'] );
+		$this->assertSame( array( 'type' => 'site', 'id' => 0 ), $resolved['owner'] );
+	}
+
+	public function test_named_site_user_and_agent_mailboxes_resolve_exactly(): void {
+		$this->auth->save_named_account( 'site-box', $this->credentials( 'site@example.test' ) );
+		$this->auth->save_named_account( 'user-box', $this->credentials( 'user@example.test' ), BaseAuthProvider::AUTH_SCOPE_USER, 42 );
+		$this->auth->save_named_account( 'agent-box', $this->credentials( 'agent@example.test' ), BaseAuthProvider::AUTH_SCOPE_AGENT, 303 );
+
+		$site  = $this->auth->resolve_mailbox( 'site-box', 'read' );
+		$user  = $this->auth->resolve_mailbox_for_principal( 'user-box', 'read', array( 'user_id' => 42 ) );
+		$agent = $this->auth->resolve_mailbox_for_principal( 'agent-box', 'read', array( 'agent_id' => 303 ) );
+
+		$this->assertSame( 'site@example.test', $site['credentials']['imap_user'] );
+		$this->assertSame( 'user@example.test', $user['credentials']['imap_user'] );
+		$this->assertSame( 'agent@example.test', $agent['credentials']['imap_user'] );
+	}
+
+	public function test_agent_delegation_is_operation_scoped_and_has_no_default_fallback(): void {
+		$this->auth->save_config( $this->credentials( 'default@example.test' ) );
+		$this->auth->save_named_account( 'personal', $this->credentials( 'owner@example.test' ), BaseAuthProvider::AUTH_SCOPE_USER, 42 );
+		$this->assertTrue( $this->auth->grant_agent( 'personal', BaseAuthProvider::AUTH_SCOPE_USER, 42, 303, array( 'read', 'search', 'draft' ) ) );
+
+		$this->assertFalse( is_wp_error( $this->auth->resolve_mailbox_for_principal( 'personal', array( 'read', 'search' ), array( 'agent_id' => 303 ) ) ) );
+		$this->assertFalse( is_wp_error( $this->auth->resolve_mailbox_for_principal( 'personal', 'draft', array( 'agent_id' => 303 ) ) ) );
+		$this->assertWPError( $this->auth->resolve_mailbox_for_principal( 'personal', 'send', array( 'agent_id' => 303 ) ) );
+		$this->assertWPError( $this->auth->resolve_mailbox_for_principal( 'personal', 'delete', array( 'agent_id' => 303 ) ) );
+		$this->assertWPError( $this->auth->resolve_mailbox_for_principal( 'personal', 'read', array( 'agent_id' => 404 ) ) );
+		$this->assertWPError( $this->auth->resolve_mailbox_for_principal( 'default', 'read', array( 'agent_id' => 404 ) ) );
+	}
+
+	public function test_missing_named_mailbox_never_falls_back_and_audit_is_secret_free(): void {
+		$this->auth->save_config( $this->credentials( 'default@example.test' ) );
+		$audit = array();
+		add_action( 'datamachine_email_operation_audit', static function ( array $metadata ) use ( &$audit ): void {
+			$audit[] = $metadata;
+		} );
+
+		$result = $this->auth->resolve_mailbox_for_principal( 'missing', 'read', array( 'agent_id' => 303, 'flow_id' => 9, 'job_id' => 10 ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'email_imap:missing', $audit[0]['mailbox_ref'] );
+		$this->assertSame( array( 'type' => 'agent', 'id' => 303 ), $audit[0]['acting_principal'] );
+		$this->assertSame( 9, $audit[0]['flow_id'] );
+		$this->assertStringNotContainsString( 'mail-secret', wp_json_encode( $audit ) );
+	}
+
+	public function test_imap_password_is_encrypted_and_export_redacts_connection_identity(): void {
+		$this->auth->save_named_account( 'secure', $this->credentials( 'secure@example.test' ) );
+		$raw = get_site_option( 'datamachine_auth_data', array() );
+
+		$this->assertStringStartsWith( 'dm:enc:v1:', $raw['email_imap']['accounts']['secure']['imap_password'] );
+		$this->assertSame( array( 'folder' => 'INBOX' ), $this->auth->strip_auth_config_secrets( array_merge( $this->credentials( 'secure@example.test' ), array( 'folder' => 'INBOX' ) ) ) );
+	}
+}

--- a/tests/auth-ref-handler-config-smoke.php
+++ b/tests/auth-ref-handler-config-smoke.php
@@ -100,6 +100,7 @@ if ( ! function_exists( 'update_site_option' ) ) {
 require_once __DIR__ . '/../inc/Engine/Bundle/BundleValidationException.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AuthRef.php';
 require_once __DIR__ . '/../inc/Core/OAuth/BaseAuthProvider.php';
+require_once __DIR__ . '/../inc/Abilities/AbilityRegistration.php';
 require_once __DIR__ . '/../inc/Abilities/HandlerAbilities.php';
 require_once __DIR__ . '/../inc/Abilities/AuthAbilities.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AuthRefHandlerConfig.php';
@@ -182,7 +183,7 @@ $assert( 'export returns array', is_array( $rewritten ) );
 $assert( 'export inserts canonical auth_ref', 'email_imap:default' === ( $rewritten['auth_ref'] ?? null ) );
 $assert( 'export preserves non-secret handler fields', 'INBOX' === ( $rewritten['folder'] ?? null ) && 7 === ( $rewritten['max_messages'] ?? null ) );
 $assert( 'export strips password', ! array_key_exists( 'imap_password', $rewritten ) );
-$assert( 'export strips host/user credential fields that include no secret words only when provider marks them by encrypted field absence', array_key_exists( 'imap_host', $rewritten ) );
+$assert( 'export strips the complete IMAP connection identity', ! array_key_exists( 'imap_host', $rewritten ) && ! array_key_exists( 'imap_user', $rewritten ) );
 $assert( 'export output does not contain secret value', ! str_contains( wp_json_encode( $rewritten ), 'super-secret-app-password' ) );
 
 echo "\n[2] Import/runtime resolution restores local config while preserving static fields\n";
@@ -198,8 +199,8 @@ $resolved = apply_filters(
 );
 
 $assert( 'resolve returns array', is_array( $resolved ) );
-$assert( 'resolve removes auth_ref marker', ! array_key_exists( 'auth_ref', $resolved ) );
-$assert( 'resolve restores local secret only at runtime/import boundary', 'super-secret-app-password' === ( $resolved['imap_password'] ?? null ) );
+$assert( 'resolve preserves the non-secret auth_ref marker', 'email_imap:default' === ( $resolved['auth_ref'] ?? null ) );
+$assert( 'resolve never materializes credentials into flow config', ! array_key_exists( 'imap_password', $resolved ) );
 $assert( 'resolve preserves handler static fields', 'Support' === ( $resolved['folder'] ?? null ) && 3 === ( $resolved['max_messages'] ?? null ) );
 
 echo "\n[3] Unresolved and mismatched refs fail clearly without secret leakage\n";
@@ -222,7 +223,7 @@ $bootstrap       = (string) file_get_contents( $root . '/data-machine.php' );
 $assert( 'fetch step resolves auth_ref before handler execution', str_contains( $fetch_step, 'AuthRefHandlerConfig::resolve_runtime_config' ) );
 $assert( 'publish handler resolves auth_ref before execution', str_contains( $publish_handler, 'AuthRefHandlerConfig::resolve_runtime_config' ) );
 $assert( 'upsert handler resolves auth_ref before execution', str_contains( $upsert_handler, 'AuthRefHandlerConfig::resolve_runtime_config' ) );
-$assert( 'plugin bootstrap registers auth_ref filters after handlers load', str_contains( $bootstrap, 'AuthRefHandlerConfig::register();' ) );
+$assert( 'plugin bootstrap delegates auth_ref registration to the runtime service provider', str_contains( $bootstrap, 'RuntimeServiceProvider: AuthRefHandlerConfig::register()' ) );
 
 echo "\n=== Results ===\n";
 echo "Passed: {$passes}\n";

--- a/tests/email-flow-auth-migration-smoke.php
+++ b/tests/email-flow-auth-migration-smoke.php
@@ -13,6 +13,28 @@ namespace DataMachine\Core\Steps\Fetch\Handlers\Email {
 	}
 }
 
+namespace DataMachine\Core\Database\Flows {
+	class Flows {
+		public function get_flow_config_json( int $flow_id ): ?string {
+			return $GLOBALS['wpdb']->flows[ $flow_id ]['flow_config'] ?? null;
+		}
+		public function compare_and_swap_flow_config( int $flow_id, string $expected, array $replacement ): bool {
+			if ( ! empty( $GLOBALS['migration_conflict_once'] ) ) {
+				$GLOBALS['migration_conflict_once'] = false;
+				$concurrent = json_decode( $GLOBALS['wpdb']->flows[ $flow_id ]['flow_config'], true );
+				$concurrent['step-email']['handler_configs']['email']['folder'] = 'Concurrent Edit';
+				$GLOBALS['wpdb']->flows[ $flow_id ]['flow_config'] = json_encode( $concurrent );
+				return false;
+			}
+			if ( $expected !== ( $GLOBALS['wpdb']->flows[ $flow_id ]['flow_config'] ?? null ) ) {
+				return false;
+			}
+			$GLOBALS['wpdb']->flows[ $flow_id ]['flow_config'] = json_encode( $replacement );
+			return true;
+		}
+	}
+}
+
 namespace {
 	define( 'ABSPATH', __DIR__ . '/' );
 	define( 'ARRAY_A', 'ARRAY_A' );
@@ -29,15 +51,6 @@ namespace {
 		public function get_results( string $query, string $format ): array {
 			return array_values( array_filter( $this->flows, static fn ( array $flow ): bool => (int) $flow['agent_id'] > 0 ) );
 		}
-		public function update( string $table, array $data, array $where, array $formats, array $where_formats ): int|false {
-			foreach ( $this->flows as &$flow ) {
-				if ( (int) $flow['flow_id'] === (int) $where['flow_id'] ) {
-					$flow['flow_config'] = $data['flow_config'];
-					return 1;
-				}
-			}
-			return false;
-		}
 	}
 
 	$legacy_config = array(
@@ -48,19 +61,22 @@ namespace {
 	);
 	$new_config = $legacy_config;
 	$GLOBALS['wpdb'] = new EmailFlowMigrationWpdb();
-	$GLOBALS['wpdb']->flows[1] = array( 'flow_id' => 91, 'agent_id' => 303, 'flow_config' => json_encode( $legacy_config ) );
+	$GLOBALS['wpdb']->flows[91] = array( 'flow_id' => 91, 'agent_id' => 303, 'flow_config' => json_encode( $legacy_config ) );
+	$GLOBALS['migration_conflict_once'] = true;
 
 	require_once __DIR__ . '/../inc/migrations/email-flow-auth.php';
 	datamachine_migrate_legacy_email_flow_auth();
 
-	$migrated = json_decode( $GLOBALS['wpdb']->flows[1]['flow_config'], true );
+	$migrated = json_decode( $GLOBALS['wpdb']->flows[91]['flow_config'], true );
 	$legacy_marker = $migrated['step-email']['handler_configs']['email']['_legacy_default_auth'] ?? '';
-	$passed = 'signed:91:step-email:303' === $legacy_marker;
+	$passed = 'signed:91:step-email:303' === $legacy_marker
+		&& 'Concurrent Edit' === ( $migrated['step-email']['handler_configs']['email']['folder'] ?? '' );
 	echo ( $passed ? 'PASS' : 'FAIL' ) . ": existing persisted flow receives bound marker\n";
+	echo ( $passed ? 'PASS' : 'FAIL' ) . ": CAS retry preserves concurrent flow edit\n";
 
-	$GLOBALS['wpdb']->flows[2] = array( 'flow_id' => 92, 'agent_id' => 303, 'flow_config' => json_encode( $new_config ) );
+	$GLOBALS['wpdb']->flows[92] = array( 'flow_id' => 92, 'agent_id' => 303, 'flow_config' => json_encode( $new_config ) );
 	datamachine_migrate_legacy_email_flow_auth();
-	$new_after = json_decode( $GLOBALS['wpdb']->flows[2]['flow_config'], true );
+	$new_after = json_decode( $GLOBALS['wpdb']->flows[92]['flow_config'], true );
 	$new_unmarked = ! isset( $new_after['step-email']['handler_configs']['email']['_legacy_default_auth'] );
 	echo ( $new_unmarked ? 'PASS' : 'FAIL' ) . ": newly created omission remains unmarked and denied\n";
 

--- a/tests/email-flow-auth-migration-smoke.php
+++ b/tests/email-flow-auth-migration-smoke.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Pure-PHP coverage for the explicit legacy email-flow migration marker.
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Core\Steps\Fetch\Handlers\Email {
+	class EmailAuth {
+		public static function legacy_default_marker( int $flow_id, string $flow_step_id, int $agent_id ): string {
+			return "signed:{$flow_id}:{$flow_step_id}:{$agent_id}";
+		}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+	define( 'ARRAY_A', 'ARRAY_A' );
+
+	$GLOBALS['migration_options'] = array();
+	function get_option( string $name, $default = false ) { return $GLOBALS['migration_options'][ $name ] ?? $default; }
+	function update_option( string $name, $value, $autoload = null ): bool { $GLOBALS['migration_options'][ $name ] = $value; return true; }
+	function absint( $value ): int { return abs( (int) $value ); }
+	function wp_json_encode( $value ): string { return json_encode( $value ); }
+
+	class EmailFlowMigrationWpdb {
+		public string $prefix = 'wp_';
+		public array $flows = array();
+		public function get_results( string $query, string $format ): array {
+			return array_values( array_filter( $this->flows, static fn ( array $flow ): bool => (int) $flow['agent_id'] > 0 ) );
+		}
+		public function update( string $table, array $data, array $where, array $formats, array $where_formats ): int|false {
+			foreach ( $this->flows as &$flow ) {
+				if ( (int) $flow['flow_id'] === (int) $where['flow_id'] ) {
+					$flow['flow_config'] = $data['flow_config'];
+					return 1;
+				}
+			}
+			return false;
+		}
+	}
+
+	$legacy_config = array(
+		'step-email' => array(
+			'handler_slugs'  => array( 'email' ),
+			'handler_configs' => array( 'email' => array( 'folder' => 'INBOX' ) ),
+		),
+	);
+	$new_config = $legacy_config;
+	$GLOBALS['wpdb'] = new EmailFlowMigrationWpdb();
+	$GLOBALS['wpdb']->flows[1] = array( 'flow_id' => 91, 'agent_id' => 303, 'flow_config' => json_encode( $legacy_config ) );
+
+	require_once __DIR__ . '/../inc/migrations/email-flow-auth.php';
+	datamachine_migrate_legacy_email_flow_auth();
+
+	$migrated = json_decode( $GLOBALS['wpdb']->flows[1]['flow_config'], true );
+	$legacy_marker = $migrated['step-email']['handler_configs']['email']['_legacy_default_auth'] ?? '';
+	$passed = 'signed:91:step-email:303' === $legacy_marker;
+	echo ( $passed ? 'PASS' : 'FAIL' ) . ": existing persisted flow receives bound marker\n";
+
+	$GLOBALS['wpdb']->flows[2] = array( 'flow_id' => 92, 'agent_id' => 303, 'flow_config' => json_encode( $new_config ) );
+	datamachine_migrate_legacy_email_flow_auth();
+	$new_after = json_decode( $GLOBALS['wpdb']->flows[2]['flow_config'], true );
+	$new_unmarked = ! isset( $new_after['step-email']['handler_configs']['email']['_legacy_default_auth'] );
+	echo ( $new_unmarked ? 'PASS' : 'FAIL' ) . ": newly created omission remains unmarked and denied\n";
+
+	if ( ! $passed || ! $new_unmarked ) {
+		exit( 1 );
+	}
+	echo "email-flow-auth-migration-smoke: ok\n";
+}

--- a/tests/email-reply-sent-copy-smoke.php
+++ b/tests/email-reply-sent-copy-smoke.php
@@ -45,6 +45,16 @@ function is_email( $email ) {
 	return is_string( $email ) && false !== filter_var( $email, FILTER_VALIDATE_EMAIL ) ? $email : false;
 }
 
+function wp_parse_url( string $url ) {
+	return parse_url( $url );
+}
+
+$GLOBALS['email_reply_mail_calls'] = array();
+function wp_mail( $to, $subject, $body, $headers = array() ): bool {
+	$GLOBALS['email_reply_mail_calls'][] = compact( 'to', 'subject', 'body', 'headers' );
+	return true;
+}
+
 function is_wp_error( $value ): bool {
 	return $value instanceof WP_Error;
 }
@@ -82,7 +92,17 @@ email_reply_assert(
 	! $method->invoke( $ability, array( 'person@example.net' ), array( 'copy@example.org' ) )
 );
 
-echo "\n[2] Reply ability failure channel\n";
+echo "\n[2] Mailto unsubscribe sender identity\n";
+$mailbox_property = $reflection->getProperty( 'activeMailbox' );
+$mailbox_property->setValue( $ability, array( 'credentials' => array( 'imap_user' => 'authorized@example.com' ) ) );
+$mailto_method = $reflection->getMethod( 'executeMailtoUnsubscribe' );
+$result = $mailto_method->invoke( $ability, 'mailto:unsubscribe@example.net?subject=remove' );
+$headers = $GLOBALS['email_reply_mail_calls'][0]['headers'] ?? array();
+email_reply_assert( 'mailto unsubscribe succeeds', true === ( $result['success'] ?? false ) );
+email_reply_assert( 'mailto unsubscribe pins From identity', in_array( 'From: authorized@example.com', $headers, true ) );
+email_reply_assert( 'mailto unsubscribe pins Reply-To identity', in_array( 'Reply-To: authorized@example.com', $headers, true ) );
+
+echo "\n[3] Reply ability failure channel\n";
 $result = $ability->executeReply(
 	array(
 		'to'          => 'not-an-email',

--- a/tests/email-rest-ability-scope-smoke.php
+++ b/tests/email-rest-ability-scope-smoke.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Pure-PHP coverage for exact email REST route ability scopes.
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Abilities {
+	class PermissionHelper {
+		public static bool $broad = true;
+		public static bool $agent = false;
+		public static array $allowed = array();
+		public static array $allowed_categories = array();
+		public static array $checks = array();
+		public static function can( string $action ): bool { return self::$broad; }
+		public static function can_manage(): bool { return self::$broad; }
+		public static function can_use_ability( string $ability, string $category = '' ): bool {
+			self::$checks[] = array( $ability, $category );
+			return ! self::$agent || in_array( $ability, self::$allowed, true ) || in_array( $category, self::$allowed_categories, true );
+		}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+	$GLOBALS['email_rest_routes'] = array();
+
+	class WP_REST_Request {}
+	class WP_REST_Response {}
+	class WP_Error {}
+
+	function add_action( string $hook, callable $callback ): bool { return true; }
+	function register_rest_route( string $namespace, string $route, array $config ): bool {
+		$GLOBALS['email_rest_routes'][ $route ] = $config;
+		return true;
+	}
+	function wp_get_ability( string $ability ) {
+		$categories = array(
+			'datamachine/send-email' => 'datamachine-publishing',
+			'datamachine/fetch-email' => 'datamachine-fetch',
+		);
+		$category = $categories[ $ability ] ?? 'datamachine-email';
+		return new class( $category ) {
+			public function __construct( private string $category ) {}
+			public function get_category(): string { return $this->category; }
+		};
+	}
+
+	require_once __DIR__ . '/../inc/Api/Email.php';
+
+	use DataMachine\Abilities\PermissionHelper;
+	use DataMachine\Api\Email;
+
+	Email::register_routes();
+	$expected = array(
+		'/email/send' => array( 'datamachine/send-email', 'datamachine-publishing' ),
+		'/email/fetch' => array( 'datamachine/fetch-email', 'datamachine-fetch' ),
+		'/email/(?P<uid>\d+)/read' => array( 'datamachine/fetch-email', 'datamachine-fetch' ),
+		'/email/reply' => array( 'datamachine/email-reply', 'datamachine-email' ),
+		'/email/(?P<uid>\d+)' => array( 'datamachine/email-delete', 'datamachine-email' ),
+		'/email/(?P<uid>\d+)/move' => array( 'datamachine/email-move', 'datamachine-email' ),
+		'/email/(?P<uid>\d+)/flag' => array( 'datamachine/email-flag', 'datamachine-email' ),
+		'/email/batch/move' => array( 'datamachine/email-batch-move', 'datamachine-email' ),
+		'/email/batch/flag' => array( 'datamachine/email-batch-flag', 'datamachine-email' ),
+		'/email/batch/delete' => array( 'datamachine/email-batch-delete', 'datamachine-email' ),
+		'/email/(?P<uid>\d+)/unsubscribe' => array( 'datamachine/email-unsubscribe', 'datamachine-email' ),
+		'/email/batch/unsubscribe' => array( 'datamachine/email-batch-unsubscribe', 'datamachine-email' ),
+		'/email/test-connection' => array( 'datamachine/email-test-connection', 'datamachine-email' ),
+	);
+
+	$failed = 0;
+	$assert = static function ( bool $condition, string $message ) use ( &$failed ): void {
+		echo ( $condition ? 'PASS' : 'FAIL' ) . ": {$message}\n";
+		$failed += $condition ? 0 : 1;
+	};
+	$request = new WP_REST_Request();
+	$assert( count( $expected ) === count( $GLOBALS['email_rest_routes'] ), 'every email REST route is covered by the scope matrix' );
+
+	PermissionHelper::$agent = false;
+	foreach ( $expected as $route => $scope ) {
+		$callback = $GLOBALS['email_rest_routes'][ $route ]['permission_callback'] ?? null;
+		$assert( is_callable( $callback ) && true === $callback( $request ), "normal user/admin remains allowed for {$route}" );
+	}
+
+	PermissionHelper::$agent = true;
+	PermissionHelper::$allowed = array();
+	PermissionHelper::$allowed_categories = array();
+	foreach ( $expected as $route => $scope ) {
+		$callback = $GLOBALS['email_rest_routes'][ $route ]['permission_callback'];
+		$assert( false === $callback( $request ), "revoked agent token is denied for {$route}" );
+	}
+
+	foreach ( $expected as $route => $scope ) {
+		PermissionHelper::$allowed = array( $scope[0] );
+		PermissionHelper::$allowed_categories = array();
+		PermissionHelper::$checks  = array();
+		$callback = $GLOBALS['email_rest_routes'][ $route ]['permission_callback'];
+		$allowed  = $callback( $request );
+		$assert( true === $allowed, "explicit exact ability scope allows {$route}" );
+		$assert( array( $scope ) === PermissionHelper::$checks, "{$route} checks exact ability and registered category" );
+	}
+
+	$category_cases = array(
+		'datamachine-publishing' => array( '/email/send' ),
+		'datamachine-fetch'      => array( '/email/fetch', '/email/(?P<uid>\d+)/read' ),
+		'datamachine-email'      => array_values( array_diff( array_keys( $expected ), array( '/email/send', '/email/fetch', '/email/(?P<uid>\d+)/read' ) ) ),
+	);
+	PermissionHelper::$allowed = array();
+	foreach ( $category_cases as $category => $allowed_routes ) {
+		PermissionHelper::$allowed_categories = array( $category );
+		foreach ( $expected as $route => $scope ) {
+			$callback = $GLOBALS['email_rest_routes'][ $route ]['permission_callback'];
+			$assert( in_array( $route, $allowed_routes, true ) === $callback( $request ), "{$category} scope is isolated for {$route}" );
+		}
+	}
+
+	PermissionHelper::$broad = false;
+	PermissionHelper::$allowed = array_column( $expected, 0 );
+	PermissionHelper::$allowed_categories = array();
+	$send_callback = $GLOBALS['email_rest_routes']['/email/send']['permission_callback'];
+	$assert( false === $send_callback( $request ), 'exact scope never bypasses broad REST permission' );
+
+	if ( $failed ) {
+		exit( 1 );
+	}
+	echo "email-rest-ability-scope-smoke: ok\n";
+}

--- a/tests/fetch-owner-auth-context-smoke.php
+++ b/tests/fetch-owner-auth-context-smoke.php
@@ -48,6 +48,11 @@ assert_fetch_owner_auth_context(
 );
 
 assert_fetch_owner_auth_context(
+	'FetchStep marks only genuinely principal-less system execution',
+	str_contains( $file, "'principal_less_system' => 0 === \$owner_user_id && 0 === \$agent_id," )
+);
+
+assert_fetch_owner_auth_context(
 	'FetchStep executes handlers as owner user',
 	str_contains( $file, 'private function execute_handler_as_owner' ) && str_contains( $file, 'wp_set_current_user( $owner_user_id );' )
 );

--- a/tests/migration-runtime-smoke.php
+++ b/tests/migration-runtime-smoke.php
@@ -85,6 +85,7 @@ $schema_chain = array(
 	'datamachine_migrate_processed_item_claims',
 	'datamachine_migrate_pending_actions_table',
 	'datamachine_migrate_chat_sessions_to_network',
+	'datamachine_migrate_legacy_email_flow_auth',
 );
 
 foreach ( $schema_chain as $fn ) {

--- a/tests/named-mailbox-delegation-smoke.php
+++ b/tests/named-mailbox-delegation-smoke.php
@@ -32,6 +32,7 @@ namespace {
 	define( 'ABSPATH', __DIR__ . '/' );
 	$GLOBALS['named_mailbox_options'] = array();
 	$GLOBALS['named_mailbox_audit']   = array();
+	$GLOBALS['named_mailbox_option_updates'] = array();
 
 	class WP_Error {
 		public function __construct( private string $code, private string $message = '', private array $data = array() ) {}
@@ -44,7 +45,7 @@ namespace {
 	function sanitize_key( $value ): string { return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $value ) ); }
 	function user_can( int $user_id, string $capability ): bool { return 1 === $user_id; }
 	function get_site_option( string $name, $default = false ) { return $GLOBALS['named_mailbox_options'][ $name ] ?? $default; }
-	function update_site_option( string $name, $value ): bool { $GLOBALS['named_mailbox_options'][ $name ] = $value; return true; }
+	function update_site_option( string $name, $value ): bool { $GLOBALS['named_mailbox_options'][ $name ] = $value; $GLOBALS['named_mailbox_option_updates'][] = $value; return true; }
 	function wp_salt( string $scheme = 'auth' ): string { return 'named-mailbox-test-salt-' . $scheme; }
 	function apply_filters( string $hook, $value ) { return $value; }
 	function do_action( string $hook, ...$args ): void {
@@ -109,7 +110,10 @@ namespace {
 	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'archive', 'read', array( 'agent_id' => 303 ) ) ), 'normalized revoke removes the live grant used by queued reauthorization' );
 
 	$assert( $auth->grant_agent( 'personal', BaseAuthProvider::AUTH_SCOPE_USER, 42, 303, array( 'read' ) ), 'delete/recreate fixture has a delegation' );
+	$updates_before_delete = count( $GLOBALS['named_mailbox_option_updates'] );
 	$assert( $auth->delete_named_account( 'personal', BaseAuthProvider::AUTH_SCOPE_USER, 42 ), 'named mailbox deletion succeeds' );
+	$delete_updates = array_slice( $GLOBALS['named_mailbox_option_updates'], $updates_before_delete );
+	$assert( 1 === count( $delete_updates ) && ! isset( $delete_updates[0]['email_imap']['principals']['user:42']['accounts']['personal'] ) && ! isset( $delete_updates[0]['email_imap']['delegations']['user:42']['personal'] ), 'one option mutation removes the account and exact delegation together' );
 	$assert( $auth->save_named_account( 'personal', $credentials( 'recreated@example.test' ), BaseAuthProvider::AUTH_SCOPE_USER, 42 ), 'same mailbox name can be recreated' );
 	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'personal', 'read', array( 'agent_id' => 303 ) ) ), 'delete and recreate does not resurrect prior delegations' );
 

--- a/tests/named-mailbox-delegation-smoke.php
+++ b/tests/named-mailbox-delegation-smoke.php
@@ -94,6 +94,9 @@ namespace {
 	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'personal', 'delete', array( 'agent_id' => 303 ) ) ), 'undelegated delete is denied' );
 	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'personal', 'read', array( 'agent_id' => 404 ) ) ), 'undelegated agent is denied' );
 	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'default', 'read', array( 'agent_id' => 404 ) ) ), 'agent denial never falls back to legacy default' );
+	$legacy_marker = EmailAuth::legacy_default_marker( 91, 'step-email', 303 );
+	$assert( ! is_wp_error( $auth->resolve_mailbox_for_principal( 'default', 'read', array( 'agent_id' => 303, 'flow_id' => 91, 'flow_step_id' => 'step-email', 'legacy_default_auth' => $legacy_marker ) ) ), 'migrated legacy agent flow retains default mailbox access' );
+	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'default', 'read', array( 'agent_id' => 303, 'flow_id' => 92, 'flow_step_id' => 'step-email', 'legacy_default_auth' => $legacy_marker ) ) ), 'legacy marker cannot be copied to a newly created flow' );
 	$assert( ! is_wp_error( $auth->resolve_mailbox( 'default', 'read' ) ), 'legacy default remains compatible for administrators' );
 	PermissionHelper::$user_id = 2;
 	$assert( is_wp_error( $auth->resolve_mailbox( 'default', 'read' ) ), 'lower-privilege user cannot resolve legacy default' );
@@ -101,6 +104,14 @@ namespace {
 	$assert( is_wp_error( $auth->resolve_mailbox( 'default', 'read' ) ), 'principal-less pre-auth context cannot resolve legacy default' );
 	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'default', 'read', array( 'agent_id' => 303, 'principal_less_system' => true ) ) ), 'new agent flow omission cannot opt into legacy default' );
 	PermissionHelper::$user_id = 1;
+	$assert( $auth->grant_agent( 'archive', BaseAuthProvider::AUTH_SCOPE_USER, 42, 303, array( 'read' ) ), 'mixed-case revoke fixture is delegated' );
+	$assert( $auth->revoke_agent( '  ArChIvE  ', BaseAuthProvider::AUTH_SCOPE_USER, 42, 303 ), 'revoke normalizes mailbox name identically to grant' );
+	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'archive', 'read', array( 'agent_id' => 303 ) ) ), 'normalized revoke removes the live grant used by queued reauthorization' );
+
+	$assert( $auth->grant_agent( 'personal', BaseAuthProvider::AUTH_SCOPE_USER, 42, 303, array( 'read' ) ), 'delete/recreate fixture has a delegation' );
+	$assert( $auth->delete_named_account( 'personal', BaseAuthProvider::AUTH_SCOPE_USER, 42 ), 'named mailbox deletion succeeds' );
+	$assert( $auth->save_named_account( 'personal', $credentials( 'recreated@example.test' ), BaseAuthProvider::AUTH_SCOPE_USER, 42 ), 'same mailbox name can be recreated' );
+	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'personal', 'read', array( 'agent_id' => 303 ) ) ), 'delete and recreate does not resurrect prior delegations' );
 
 	$raw = get_site_option( 'datamachine_auth_data', array() );
 	$assert( str_starts_with( $raw['email_imap']['principals']['user:42']['accounts']['personal']['imap_password'], 'dm:enc:v1:' ), 'IMAP passwords are encrypted at rest' );

--- a/tests/named-mailbox-delegation-smoke.php
+++ b/tests/named-mailbox-delegation-smoke.php
@@ -21,6 +21,10 @@ namespace DataMachine\Abilities {
 		public static function can_manage(): bool {
 			return 1 === self::$user_id && 0 === self::$agent_id;
 		}
+
+		public static function can( string $action ): bool {
+			return self::can_manage();
+		}
 	}
 }
 
@@ -38,6 +42,7 @@ namespace {
 	function __( string $text, string $domain = '' ): string { return $text; }
 	function absint( $value ): int { return abs( (int) $value ); }
 	function sanitize_key( $value ): string { return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $value ) ); }
+	function user_can( int $user_id, string $capability ): bool { return 1 === $user_id; }
 	function get_site_option( string $name, $default = false ) { return $GLOBALS['named_mailbox_options'][ $name ] ?? $default; }
 	function update_site_option( string $name, $value ): bool { $GLOBALS['named_mailbox_options'][ $name ] = $value; return true; }
 	function wp_salt( string $scheme = 'auth' ): string { return 'named-mailbox-test-salt-' . $scheme; }
@@ -90,6 +95,12 @@ namespace {
 	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'personal', 'read', array( 'agent_id' => 404 ) ) ), 'undelegated agent is denied' );
 	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'default', 'read', array( 'agent_id' => 404 ) ) ), 'agent denial never falls back to legacy default' );
 	$assert( ! is_wp_error( $auth->resolve_mailbox( 'default', 'read' ) ), 'legacy default remains compatible for administrators' );
+	PermissionHelper::$user_id = 2;
+	$assert( is_wp_error( $auth->resolve_mailbox( 'default', 'read' ) ), 'lower-privilege user cannot resolve legacy default' );
+	PermissionHelper::$user_id = 0;
+	$assert( is_wp_error( $auth->resolve_mailbox( 'default', 'read' ) ), 'principal-less pre-auth context cannot resolve legacy default' );
+	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'default', 'read', array( 'agent_id' => 303, 'principal_less_system' => true ) ) ), 'new agent flow omission cannot opt into legacy default' );
+	PermissionHelper::$user_id = 1;
 
 	$raw = get_site_option( 'datamachine_auth_data', array() );
 	$assert( str_starts_with( $raw['email_imap']['principals']['user:42']['accounts']['personal']['imap_password'], 'dm:enc:v1:' ), 'IMAP passwords are encrypted at rest' );

--- a/tests/named-mailbox-delegation-smoke.php
+++ b/tests/named-mailbox-delegation-smoke.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Pure-PHP coverage for named mailbox storage and delegation.
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Abilities {
+	class PermissionHelper {
+		public static int $user_id = 1;
+		public static int $agent_id = 0;
+
+		public static function acting_user_id(): int {
+			return self::$user_id;
+		}
+
+		public static function get_acting_agent_id(): ?int {
+			return self::$agent_id ?: null;
+		}
+
+		public static function can_manage(): bool {
+			return 1 === self::$user_id && 0 === self::$agent_id;
+		}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+	$GLOBALS['named_mailbox_options'] = array();
+	$GLOBALS['named_mailbox_audit']   = array();
+
+	class WP_Error {
+		public function __construct( private string $code, private string $message = '', private array $data = array() ) {}
+		public function get_error_code(): string { return $this->code; }
+	}
+
+	function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+	function __( string $text, string $domain = '' ): string { return $text; }
+	function absint( $value ): int { return abs( (int) $value ); }
+	function sanitize_key( $value ): string { return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $value ) ); }
+	function get_site_option( string $name, $default = false ) { return $GLOBALS['named_mailbox_options'][ $name ] ?? $default; }
+	function update_site_option( string $name, $value ): bool { $GLOBALS['named_mailbox_options'][ $name ] = $value; return true; }
+	function wp_salt( string $scheme = 'auth' ): string { return 'named-mailbox-test-salt-' . $scheme; }
+	function apply_filters( string $hook, $value ) { return $value; }
+	function do_action( string $hook, ...$args ): void {
+		if ( 'datamachine_email_operation_audit' === $hook ) {
+			$GLOBALS['named_mailbox_audit'][] = $args[0];
+		}
+	}
+
+	require_once __DIR__ . '/../inc/Core/OAuth/BaseAuthProvider.php';
+	require_once __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php';
+
+	use DataMachine\Abilities\PermissionHelper;
+	use DataMachine\Core\OAuth\BaseAuthProvider;
+	use DataMachine\Core\Steps\Fetch\Handlers\Email\EmailAuth;
+
+	$failures = array();
+	$assert   = static function ( bool $condition, string $message ) use ( &$failures ): void {
+		if ( $condition ) {
+			echo "PASS: {$message}\n";
+			return;
+		}
+		$failures[] = $message;
+		echo "FAIL: {$message}\n";
+	};
+	$credentials = static fn ( string $user ): array => array(
+		'imap_host'       => 'imap.example.test',
+		'imap_port'       => 993,
+		'imap_encryption' => 'ssl',
+		'imap_user'       => $user,
+		'imap_password'   => 'secret-' . $user,
+	);
+
+	$auth = new EmailAuth();
+	$auth->save_config( $credentials( 'legacy@example.test' ) );
+	$auth->save_named_account( 'personal', $credentials( 'personal@example.test' ), BaseAuthProvider::AUTH_SCOPE_USER, 42 );
+	$auth->save_named_account( 'events', $credentials( 'events@example.test' ), BaseAuthProvider::AUTH_SCOPE_AGENT, 707 );
+	$auth->save_named_account( 'archive', $credentials( 'archive@example.test' ), BaseAuthProvider::AUTH_SCOPE_USER, 42 );
+
+	$assert( 'personal@example.test' === $auth->get_named_account( 'personal', BaseAuthProvider::AUTH_SCOPE_USER, 42 )['imap_user'], 'one principal stores multiple named mailboxes' );
+	$assert( 'archive@example.test' === $auth->get_named_account( 'archive', BaseAuthProvider::AUTH_SCOPE_USER, 42 )['imap_user'], 'named mailbox siblings remain isolated' );
+	$assert( 'events@example.test' === $auth->resolve_mailbox_for_principal( 'events', 'read', array( 'agent_id' => 707 ) )['credentials']['imap_user'], 'agent-owned mailbox resolves exactly' );
+
+	$assert( $auth->grant_agent( 'personal', BaseAuthProvider::AUTH_SCOPE_USER, 42, 303, array( 'read', 'search', 'draft' ) ), 'owner grants operation-scoped mailbox access' );
+	$assert( ! is_wp_error( $auth->resolve_mailbox_for_principal( 'personal', array( 'read', 'search' ), array( 'agent_id' => 303 ) ) ), 'delegated read and search are allowed' );
+	$assert( ! is_wp_error( $auth->resolve_mailbox_for_principal( 'personal', 'draft', array( 'agent_id' => 303 ) ) ), 'delegated draft is allowed' );
+	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'personal', 'send', array( 'agent_id' => 303 ) ) ), 'undelegated send is denied' );
+	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'personal', 'delete', array( 'agent_id' => 303 ) ) ), 'undelegated delete is denied' );
+	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'personal', 'read', array( 'agent_id' => 404 ) ) ), 'undelegated agent is denied' );
+	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'default', 'read', array( 'agent_id' => 404 ) ) ), 'agent denial never falls back to legacy default' );
+	$assert( ! is_wp_error( $auth->resolve_mailbox( 'default', 'read' ) ), 'legacy default remains compatible for administrators' );
+
+	$raw = get_site_option( 'datamachine_auth_data', array() );
+	$assert( str_starts_with( $raw['email_imap']['principals']['user:42']['accounts']['personal']['imap_password'], 'dm:enc:v1:' ), 'IMAP passwords are encrypted at rest' );
+	$assert( ! str_contains( json_encode( $GLOBALS['named_mailbox_audit'] ), 'secret-' ), 'audit metadata contains no credentials' );
+	$assert( array( 'folder' => 'INBOX' ) === $auth->strip_auth_config_secrets( array_merge( $credentials( 'redact@example.test' ), array( 'folder' => 'INBOX' ) ) ), 'export redacts the complete connection identity' );
+
+	if ( $failures ) {
+		exit( 1 );
+	}
+
+	echo 'named-mailbox-delegation-smoke: ok' . PHP_EOL;
+}

--- a/tests/named-mailbox-security-contract-smoke.php
+++ b/tests/named-mailbox-security-contract-smoke.php
@@ -38,6 +38,8 @@ $assert( str_contains( $handler, "null === \$context->getAgentId() && 0 === get_
 $assert( str_contains( $handler, "'legacy_default_auth' => (string) ( \$config['_legacy_default_auth'] ?? '' )" ), 'email handler forwards only the persisted legacy marker' );
 $assert( str_contains( $migration, "WHERE agent_id > 0" ) && str_contains( $migration, "! empty( \$email_config['auth_ref'] )" ), 'legacy migration targets persisted agent flows that omitted auth_ref' );
 $assert( strpos( $queue, 'verifyMailboxGrant( $payload )' ) < strpos( $queue, "wp_get_ability( 'datamachine/send-email' )" ), 'queue worker verifies signed authorization before ability execution' );
+$assert( strpos( $queue, 'currentIssuerAuthorized( $grant )' ) < strpos( $queue, "wp_get_ability( 'datamachine/send-email' )" ), 'queue worker revalidates explicit issuer authority before ability execution' );
+$assert( str_contains( $queue, "'token_id'     => (int) \$context['token_id']" ) && str_contains( $queue, "'issuer_type'" ), 'signed queue envelope captures stable non-secret issuer identity' );
 
 if ( $failures ) {
 	exit( 1 );

--- a/tests/named-mailbox-security-contract-smoke.php
+++ b/tests/named-mailbox-security-contract-smoke.php
@@ -12,6 +12,7 @@ $api        = (string) file_get_contents( $root . '/inc/Api/Email.php' );
 $cli        = (string) file_get_contents( $root . '/inc/Cli/Commands/EmailCommand.php' );
 $handler    = (string) file_get_contents( $root . '/inc/Core/Steps/Fetch/Handlers/Email/Email.php' );
 $queue      = (string) file_get_contents( $root . '/inc/Abilities/Publish/SendEmailQueuedAbility.php' );
+$migration  = (string) file_get_contents( $root . '/inc/migrations/email-flow-auth.php' );
 $failures   = array();
 
 $assert = static function ( bool $condition, string $message ) use ( &$failures ): void {
@@ -34,6 +35,8 @@ $assert( substr_count( $api, '...self::mailbox_args()' ) >= 12 && str_contains( 
 $assert( str_contains( $api, "'auth_ref' => array(" ) && str_contains( $api, "'mailbox'  => array(" ), 'REST schema declares auth_ref and mailbox' );
 $assert( substr_count( $cli, '[--auth-ref=<ref>]' ) >= 14 && substr_count( $cli, '[--mailbox=<name>]' ) >= 14, 'all email CLI commands document both mailbox selectors' );
 $assert( str_contains( $handler, "null === \$context->getAgentId() && 0 === get_current_user_id()" ), 'legacy omission compatibility is limited to unscoped system execution' );
+$assert( str_contains( $handler, "'legacy_default_auth' => (string) ( \$config['_legacy_default_auth'] ?? '' )" ), 'email handler forwards only the persisted legacy marker' );
+$assert( str_contains( $migration, "WHERE agent_id > 0" ) && str_contains( $migration, "! empty( \$email_config['auth_ref'] )" ), 'legacy migration targets persisted agent flows that omitted auth_ref' );
 $assert( strpos( $queue, 'verifyMailboxGrant( $payload )' ) < strpos( $queue, "wp_get_ability( 'datamachine/send-email' )" ), 'queue worker verifies signed authorization before ability execution' );
 
 if ( $failures ) {

--- a/tests/named-mailbox-security-contract-smoke.php
+++ b/tests/named-mailbox-security-contract-smoke.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Source-level security contracts for named mailbox execution paths.
+ *
+ * @package DataMachine\Tests
+ */
+
+$root       = dirname( __DIR__ );
+$fetch      = (string) file_get_contents( $root . '/inc/Abilities/Fetch/FetchEmailAbility.php' );
+$email      = (string) file_get_contents( $root . '/inc/Abilities/Email/EmailAbilities.php' );
+$api        = (string) file_get_contents( $root . '/inc/Api/Email.php' );
+$cli        = (string) file_get_contents( $root . '/inc/Cli/Commands/EmailCommand.php' );
+$handler    = (string) file_get_contents( $root . '/inc/Core/Steps/Fetch/Handlers/Email/Email.php' );
+$queue      = (string) file_get_contents( $root . '/inc/Abilities/Publish/SendEmailQueuedAbility.php' );
+$failures   = array();
+
+$assert = static function ( bool $condition, string $message ) use ( &$failures ): void {
+	if ( $condition ) {
+		echo "PASS: {$message}\n";
+		return;
+	}
+	$failures[] = $message;
+	echo "FAIL: {$message}\n";
+};
+
+$assert( str_contains( $fetch, 'FT_UID | ( $peek ? FT_PEEK : 0 )' ), 'read-only body and attachment fetches derive FT_PEEK flags' );
+$assert( substr_count( $fetch, 'imap_fetchbody( $connection' ) === substr_count( $fetch, '$fetch_flags )' ) + substr_count( $fetch, '$flags )' ), 'every IMAP body fetch uses explicit peek-aware flags' );
+$assert( str_contains( $email, "array( 'organize', 'delete', 'search' )" ), 'batch move requires organize, delete, and search' );
+$assert( str_contains( $email, "array( \$operation, 'search' )" ), 'batch flag requires its mutation operation and search' );
+$assert( str_contains( $email, "array( 'delete', 'search' )" ), 'batch delete requires delete and search' );
+$assert( str_contains( $email, "\$headers[] = 'From: ' . \$identity" ) && str_contains( $email, "\$headers[] = 'Reply-To: ' . \$identity" ), 'mailto unsubscribe uses the authorized mailbox identity' );
+$assert( str_contains( $email, "0 === stripos( \$header, 'From:' )" ), 'synthetic Sent copies suppress duplicate From headers' );
+$assert( substr_count( $api, '...self::mailbox_args()' ) >= 12 && str_contains( $api, "'args'                => self::mailbox_args()" ), 'all email REST routes advertise mailbox selectors' );
+$assert( str_contains( $api, "'auth_ref' => array(" ) && str_contains( $api, "'mailbox'  => array(" ), 'REST schema declares auth_ref and mailbox' );
+$assert( substr_count( $cli, '[--auth-ref=<ref>]' ) >= 14 && substr_count( $cli, '[--mailbox=<name>]' ) >= 14, 'all email CLI commands document both mailbox selectors' );
+$assert( str_contains( $handler, "null === \$context->getAgentId() && 0 === get_current_user_id()" ), 'legacy omission compatibility is limited to unscoped system execution' );
+$assert( strpos( $queue, 'verifyMailboxGrant( $payload )' ) < strpos( $queue, "wp_get_ability( 'datamachine/send-email' )" ), 'queue worker verifies signed authorization before ability execution' );
+
+if ( $failures ) {
+	exit( 1 );
+}
+
+echo 'named-mailbox-security-contract-smoke: ok' . PHP_EOL;

--- a/tests/send-email-ability-lazy-definitions-smoke.php
+++ b/tests/send-email-ability-lazy-definitions-smoke.php
@@ -45,6 +45,7 @@ function wp_register_ability( $name, $args ) {
 	$datamachine_test_registered[ $name ] = $args;
 }
 
+require_once __DIR__ . '/../inc/Abilities/AbilityRegistration.php';
 require_once __DIR__ . '/../inc/Abilities/Publish/SendEmailAbility.php';
 require_once __DIR__ . '/../inc/Abilities/Publish/SendEmailQueuedAbility.php';
 

--- a/tests/send-email-template-smoke.php
+++ b/tests/send-email-template-smoke.php
@@ -209,14 +209,14 @@ if ( ! function_exists( '__' ) ) {
  * -------------------------------------------------------------------------*/
 
 if ( ! class_exists( '\\DataMachine\\Abilities\\PermissionHelper' ) ) {
-	eval( 'namespace DataMachine\\Abilities; class PermissionHelper { public static function can_manage(): bool { return true; } }' );
+	eval( 'namespace DataMachine\\Abilities; class PermissionHelper { public static bool $manage = true; public static int $user_id = 1; public static int $agent_id = 0; public static function can_manage(): bool { return self::$manage; } public static function can( string $action ): bool { return self::$manage; } public static function acting_user_id(): int { return self::$user_id; } public static function get_acting_agent_id(): ?int { return self::$agent_id ?: null; } }' );
 }
 
 if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
 		private string $code;
 		private string $message;
-		public function __construct( string $code = '', string $message = '' ) {
+		public function __construct( string $code = '', string $message = '', array $data = array() ) {
 			$this->code    = $code;
 			$this->message = $message;
 		}
@@ -235,10 +235,29 @@ if ( ! function_exists( 'is_wp_error' ) ) {
     }
 }
 
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ): int {
+		return abs( (int) $value );
+	}
+}
+
+if ( ! function_exists( 'wp_salt' ) ) {
+	function wp_salt( string $scheme = 'auth' ): string {
+		return 'send-email-smoke-' . $scheme;
+	}
+}
+
+if ( ! function_exists( 'wp_generate_uuid4' ) ) {
+	function wp_generate_uuid4(): string {
+		return sprintf( '00000000-0000-4000-8000-%012d', ++$GLOBALS['ec_action_id_seq'] );
+	}
+}
+
 /* ---------------------------------------------------------------------------
  * Load the abilities under test.
  * -------------------------------------------------------------------------*/
 
+require_once __DIR__ . '/../inc/Abilities/AbilityRegistration.php';
 require_once __DIR__ . '/../inc/Abilities/Publish/SendEmailAbility.php';
 require_once __DIR__ . '/../inc/Abilities/Publish/SendEmailQueuedAbility.php';
 
@@ -270,6 +289,22 @@ ec_assert( 'raw body wp_mail called once', count( $GLOBALS['ec_wp_mail_calls'] )
 ec_assert( 'raw body subject placeholders resolved', false !== strpos( $GLOBALS['ec_wp_mail_calls'][0]['subject'], 'Test Site' ) );
 ec_assert( 'raw body content placeholders resolved', false !== strpos( $GLOBALS['ec_wp_mail_calls'][0]['body'], gmdate( 'Y' ) ) );
 ec_assert( 'raw body no switch_to_blog', count( $GLOBALS['ec_switch_history'] ) === 0 );
+
+echo "\nCase 1b: tool-only sender spoofing denied\n";
+\DataMachine\Abilities\PermissionHelper::$manage  = false;
+\DataMachine\Abilities\PermissionHelper::$user_id = 2;
+$GLOBALS['ec_wp_mail_calls'] = array();
+$res = $send->execute( array(
+	'to'         => 'user@example.com',
+	'subject'    => 'Spoof',
+	'body'       => 'body',
+	'from_email' => 'spoof@example.com',
+	'reply_to'   => 'spoof@example.com',
+) );
+ec_assert( 'tool-only immediate send requires auth_ref', is_wp_error( $res ) && 'email_auth_ref_required' === $res->get_error_code() );
+ec_assert( 'tool-only immediate spoof never calls wp_mail', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+\DataMachine\Abilities\PermissionHelper::$manage  = true;
+\DataMachine\Abilities\PermissionHelper::$user_id = 1;
 
 /* ---------------------------------------------------------------------------
  * Case 2 — template render + placeholder replacement after template.
@@ -306,8 +341,8 @@ $res = $send->execute( array(
 	'template' => 'does-not-exist',
 ) );
 
-ec_assert( 'unknown template fails', false === ( $res['success'] ?? true ) );
-ec_assert( 'unknown template error mentions id', isset( $res['error'] ) && false !== strpos( $res['error'], 'does-not-exist' ) );
+ec_assert( 'unknown template fails', is_wp_error( $res ) );
+ec_assert( 'unknown template error mentions id', is_wp_error( $res ) && false !== strpos( $res->get_error_message(), 'does-not-exist' ) );
 
 /* ---------------------------------------------------------------------------
  * Case 4 — mail_site_id wraps wp_mail in switch_to_blog/restore.
@@ -342,7 +377,7 @@ $res = $send->execute( array(
 	'mail_site_id' => 999,
 ) );
 
-ec_assert( 'invalid mail_site_id fails', false === ( $res['success'] ?? true ) );
+ec_assert( 'invalid mail_site_id fails', is_wp_error( $res ) );
 ec_assert( 'no switch_to_blog on invalid id', count( $GLOBALS['ec_switch_history'] ) === 0 );
 
 /* ---------------------------------------------------------------------------
@@ -364,6 +399,22 @@ ec_assert( 'queued async returned action_id > 0', ( $res['action_id'] ?? 0 ) > 0
 $first = reset( $GLOBALS['ec_scheduled'] );
 ec_assert( 'queued async used async action', ( $first['kind'] ?? '' ) === 'async' );
 ec_assert( 'queued async hook is worker', ( $first['hook'] ?? '' ) === 'datamachine_send_email_worker' );
+$legacy_payload = $first['args'][0] ?? array();
+
+\DataMachine\Abilities\PermissionHelper::$manage  = false;
+\DataMachine\Abilities\PermissionHelper::$user_id = 2;
+$GLOBALS['ec_scheduled'] = array();
+$res = $queued->execute( array(
+	'to'         => 'user@example.com',
+	'subject'    => 'Spoof',
+	'body'       => 'body',
+	'from_email' => 'spoof@example.com',
+	'reply_to'   => 'spoof@example.com',
+) );
+ec_assert( 'tool-only queued spoof requires auth_ref', false === ( $res['success'] ?? true ) );
+ec_assert( 'tool-only queued spoof is not scheduled', 0 === count( $GLOBALS['ec_scheduled'] ) );
+\DataMachine\Abilities\PermissionHelper::$manage  = true;
+\DataMachine\Abilities\PermissionHelper::$user_id = 1;
 
 /* ---------------------------------------------------------------------------
  * Case 7 — queued ability schedules single action when send_at is ISO 8601.
@@ -408,12 +459,8 @@ $GLOBALS['ec_wp_mail_result'] = false;
 $GLOBALS['ec_scheduled'] = array();
 
 $worker = new \DataMachine\Abilities\Publish\SendEmailQueuedAbility();
-$worker->runWorker( array(
-	'to'        => 'user@example.com',
-	'subject'   => 'Subject',
-	'body'      => 'body',
-	'_attempt'  => 1,
-) );
+$legacy_payload['_attempt'] = 1;
+$worker->runWorker( $legacy_payload );
 
 ec_assert( 'worker scheduled a retry on first failure', count( $GLOBALS['ec_scheduled'] ) === 1 );
 $retry = reset( $GLOBALS['ec_scheduled'] );
@@ -424,27 +471,78 @@ ec_assert( 'retry scheduled ~5 min out', abs( ( $retry['timestamp'] ?? 0 ) - ( t
 
 // Third attempt (max): should NOT re-enqueue.
 $GLOBALS['ec_scheduled'] = array();
-$worker->runWorker( array(
-	'to'        => 'user@example.com',
-	'subject'   => 'Subject',
-	'body'      => 'body',
-	'_attempt'  => 3,
-) );
+$legacy_payload['_attempt'] = 3;
+$worker->runWorker( $legacy_payload );
 ec_assert( 'worker gives up at MAX_ATTEMPTS', count( $GLOBALS['ec_scheduled'] ) === 0 );
 
 // Restore wp_mail success and verify worker succeeds and does NOT re-enqueue.
 $GLOBALS['ec_wp_mail_result'] = true;
 $GLOBALS['ec_scheduled']      = array();
 $GLOBALS['ec_wp_mail_calls']  = array();
-$worker->runWorker( array(
-	'to'        => 'user@example.com',
-	'subject'   => 'Subject',
-	'body'      => 'body',
-	'_attempt'  => 1,
-) );
+$legacy_payload['_attempt'] = 1;
+$worker->runWorker( $legacy_payload );
 ec_assert( 'worker success: no retry', count( $GLOBALS['ec_scheduled'] ) === 0 );
 ec_assert( 'worker success: wp_mail invoked', count( $GLOBALS['ec_wp_mail_calls'] ) === 1 );
 ec_assert( 'worker strips _attempt before forwarding', ! isset( $GLOBALS['ec_wp_mail_calls'][0]['_attempt'] ) );
+
+$GLOBALS['ec_wp_mail_calls'] = array();
+$worker->runWorker( array( 'to' => 'user@example.com', 'subject' => 'Ambient bypass', 'body' => 'body' ) );
+ec_assert( 'worker denies missing signed grant despite ambient scheduler access', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+
+$tampered = $legacy_payload;
+$tampered['from_email'] = 'tampered@example.com';
+$GLOBALS['ec_wp_mail_calls'] = array();
+$worker->runWorker( $tampered );
+ec_assert( 'worker denies tampered sender payload', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+
+$tampered = $legacy_payload;
+$tampered['to']   = 'redirected@example.com';
+$tampered['body'] = 'replacement body';
+$GLOBALS['ec_wp_mail_calls'] = array();
+$worker->runWorker( $tampered );
+ec_assert( 'worker denies tampered recipient and body payload', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+
+$GLOBALS['ec_mailbox_revoked'] = false;
+$fake_mailbox_auth = new class() {
+	public function resolve_mailbox( string $ref, string $operation ): array|WP_Error {
+		return $this->resolve( $ref );
+	}
+	public function resolve_mailbox_for_principal( string $ref, string $operation, array $context ): array|WP_Error {
+		return $this->resolve( $ref );
+	}
+	private function resolve( string $ref ): array|WP_Error {
+		if ( $GLOBALS['ec_mailbox_revoked'] ) {
+			return new WP_Error( 'email_mailbox_forbidden', 'Mailbox grant revoked.' );
+		}
+		return array(
+			'ref'         => $ref,
+			'credentials' => array( 'imap_user' => 'authorized@example.com' ),
+		);
+	}
+};
+add_filter( 'datamachine_auth_providers', static function ( array $providers ) use ( $fake_mailbox_auth ): array {
+	$providers['email_imap'] = $fake_mailbox_auth;
+	return $providers;
+} );
+\DataMachine\Abilities\PermissionHelper::$manage   = false;
+\DataMachine\Abilities\PermissionHelper::$user_id  = 42;
+\DataMachine\Abilities\PermissionHelper::$agent_id = 303;
+$GLOBALS['ec_scheduled'] = array();
+$queued->execute( array(
+	'auth_ref' => 'email_imap:delegated',
+	'to'       => 'user@example.com',
+	'subject'  => 'Revocation',
+	'body'     => 'body',
+) );
+$scheduled = reset( $GLOBALS['ec_scheduled'] );
+$revoked_payload = $scheduled['args'][0] ?? array();
+$GLOBALS['ec_mailbox_revoked'] = true;
+$GLOBALS['ec_wp_mail_calls']    = array();
+$worker->runWorker( $revoked_payload );
+ec_assert( 'worker rechecks and denies revoked mailbox grant', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+\DataMachine\Abilities\PermissionHelper::$manage   = true;
+\DataMachine\Abilities\PermissionHelper::$user_id  = 1;
+\DataMachine\Abilities\PermissionHelper::$agent_id = 0;
 
 /* ---------------------------------------------------------------------------
  * Summary

--- a/tests/send-email-template-smoke.php
+++ b/tests/send-email-template-smoke.php
@@ -42,6 +42,7 @@ $GLOBALS['ec_is_multisite']    = true;
 $GLOBALS['ec_scheduled']       = array();
 $GLOBALS['ec_abilities']       = array();
 $GLOBALS['ec_action_id_seq']   = 1000;
+$GLOBALS['ec_manage_users']    = array( 1 => true );
 
 if ( ! function_exists( 'add_filter' ) ) {
     function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): bool {
@@ -121,6 +122,12 @@ if ( ! function_exists( 'is_email' ) ) {
     	}
     	return preg_match( '/^[^@\s]+@[^@\s]+\.[^@\s]+$/', $email ) ? $email : false;
     }
+}
+
+if ( ! function_exists( 'user_can' ) ) {
+	function user_can( int $user_id, string $capability ): bool {
+		return ! empty( $GLOBALS['ec_manage_users'][ $user_id ] );
+	}
 }
 
 if ( ! function_exists( 'get_bloginfo' ) ) {
@@ -400,6 +407,13 @@ $first = reset( $GLOBALS['ec_scheduled'] );
 ec_assert( 'queued async used async action', ( $first['kind'] ?? '' ) === 'async' );
 ec_assert( 'queued async hook is worker', ( $first['hook'] ?? '' ) === 'datamachine_send_email_worker' );
 $legacy_payload = $first['args'][0] ?? array();
+
+$GLOBALS['ec_manage_users'][1] = false;
+$GLOBALS['ec_wp_mail_calls']    = array();
+$worker_for_demotion = new \DataMachine\Abilities\Publish\SendEmailQueuedAbility();
+$worker_for_demotion->runWorker( $legacy_payload );
+ec_assert( 'legacy queued send denies issuer demoted after enqueue', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+$GLOBALS['ec_manage_users'][1] = true;
 
 \DataMachine\Abilities\PermissionHelper::$manage  = false;
 \DataMachine\Abilities\PermissionHelper::$user_id = 2;

--- a/tests/send-email-template-smoke.php
+++ b/tests/send-email-template-smoke.php
@@ -43,6 +43,7 @@ $GLOBALS['ec_scheduled']       = array();
 $GLOBALS['ec_abilities']       = array();
 $GLOBALS['ec_action_id_seq']   = 1000;
 $GLOBALS['ec_manage_users']    = array( 1 => true );
+$GLOBALS['ec_users']           = array( 1 => true, 42 => true );
 
 if ( ! function_exists( 'add_filter' ) ) {
     function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): bool {
@@ -127,6 +128,12 @@ if ( ! function_exists( 'is_email' ) ) {
 if ( ! function_exists( 'user_can' ) ) {
 	function user_can( int $user_id, string $capability ): bool {
 		return ! empty( $GLOBALS['ec_manage_users'][ $user_id ] );
+	}
+}
+
+if ( ! function_exists( 'get_user_by' ) ) {
+	function get_user_by( string $field, int $user_id ) {
+		return ! empty( $GLOBALS['ec_users'][ $user_id ] ) ? (object) array( 'ID' => $user_id ) : false;
 	}
 }
 
@@ -216,7 +223,18 @@ if ( ! function_exists( '__' ) ) {
  * -------------------------------------------------------------------------*/
 
 if ( ! class_exists( '\\DataMachine\\Abilities\\PermissionHelper' ) ) {
-	eval( 'namespace DataMachine\\Abilities; class PermissionHelper { public static bool $manage = true; public static int $user_id = 1; public static int $agent_id = 0; public static function can_manage(): bool { return self::$manage; } public static function can( string $action ): bool { return self::$manage; } public static function acting_user_id(): int { return self::$user_id; } public static function get_acting_agent_id(): ?int { return self::$agent_id ?: null; } }' );
+	eval( 'namespace DataMachine\\Abilities; class PermissionHelper { public static bool $manage = true; public static int $user_id = 1; public static int $agent_id = 0; public static int $token_id = 0; public static function can_manage(): bool { return self::$manage; } public static function can( string $action ): bool { return self::$manage; } public static function acting_user_id(): int { return self::$user_id; } public static function get_acting_agent_id(): ?int { return self::$agent_id ?: null; } public static function get_acting_token_id(): ?int { return self::$token_id ?: null; } }' );
+}
+
+if ( ! class_exists( 'WP_Agent_Token' ) ) {
+	class WP_Agent_Token {
+		public function __construct( public int $token_id, public string $agent_id, public int $owner_user_id, public ?array $allowed_capabilities = null, public array $metadata = array(), public bool $expired = false ) {}
+		public function is_expired(): bool { return $this->expired; }
+	}
+}
+
+if ( ! class_exists( '\\DataMachine\\Core\\Database\\Agents\\Agents' ) ) {
+	eval( 'namespace DataMachine\\Core\\Database\\Agents; class Agents { public static array $rows = array(); public function get_agent(int $agent_id): ?array { return self::$rows[$agent_id] ?? null; } } class AgentTokens { public static array $tokens = array(); public function get_token(int $token_id): ?\\WP_Agent_Token { return self::$tokens[$token_id] ?? null; } public static function normalize_capability_payload(?array $payload): array { if (null === $payload) { return array("allowed_capabilities" => null, "stored_payload" => null); } $is_list = array_is_list($payload); return array("allowed_capabilities" => $is_list ? $payload : (array) ($payload["capabilities"] ?? array()), "stored_payload" => $payload); } }' );
 }
 
 if ( ! class_exists( 'WP_Error' ) ) {
@@ -395,6 +413,12 @@ echo "\nCase 6: queued enqueue async\n";
 $GLOBALS['ec_scheduled'] = array();
 $queued = wp_get_ability( 'datamachine/send-email-queued' );
 
+\DataMachine\Abilities\PermissionHelper::$user_id = 0;
+$GLOBALS['ec_scheduled'] = array();
+$res = $queued->execute( array( 'to' => 'user@example.com', 'subject' => 'No issuer', 'body' => 'body' ) );
+ec_assert( 'queued email rejects principal-less ambient execution', false === ( $res['success'] ?? true ) && 0 === count( $GLOBALS['ec_scheduled'] ) );
+\DataMachine\Abilities\PermissionHelper::$user_id = 1;
+
 $res = $queued->execute( array(
 	'to'      => 'user@example.com',
 	'subject' => 'Subject',
@@ -541,6 +565,8 @@ add_filter( 'datamachine_auth_providers', static function ( array $providers ) u
 \DataMachine\Abilities\PermissionHelper::$manage   = false;
 \DataMachine\Abilities\PermissionHelper::$user_id  = 42;
 \DataMachine\Abilities\PermissionHelper::$agent_id = 303;
+$GLOBALS['ec_manage_users'][42] = true;
+\DataMachine\Core\Database\Agents\Agents::$rows[303] = array( 'owner_id' => 42 );
 $GLOBALS['ec_scheduled'] = array();
 $queued->execute( array(
 	'auth_ref' => 'email_imap:delegated',
@@ -557,6 +583,77 @@ ec_assert( 'worker rechecks and denies revoked mailbox grant', 0 === count( $GLO
 \DataMachine\Abilities\PermissionHelper::$manage   = true;
 \DataMachine\Abilities\PermissionHelper::$user_id  = 1;
 \DataMachine\Abilities\PermissionHelper::$agent_id = 0;
+
+echo "\nCase 10: queued named-mailbox issuer authority revalidation\n";
+$enqueue_named = static function () use ( $queued ): array {
+	$GLOBALS['ec_mailbox_revoked'] = false;
+	$GLOBALS['ec_scheduled']       = array();
+	$queued->execute( array( 'auth_ref' => 'email_imap:delegated', 'to' => 'user@example.com', 'subject' => 'Authority', 'body' => 'body' ) );
+	$scheduled = reset( $GLOBALS['ec_scheduled'] );
+	return $scheduled['args'][0] ?? array();
+};
+
+\DataMachine\Abilities\PermissionHelper::$user_id  = 1;
+\DataMachine\Abilities\PermissionHelper::$agent_id = 0;
+\DataMachine\Abilities\PermissionHelper::$token_id = 0;
+$user_payload = $enqueue_named();
+$GLOBALS['ec_manage_users'][1] = false;
+$GLOBALS['ec_wp_mail_calls']   = array();
+$worker->runWorker( $user_payload );
+ec_assert( 'named queue denies user capability demotion after enqueue', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+$GLOBALS['ec_manage_users'][1] = true;
+$user_payload = $enqueue_named();
+$GLOBALS['ec_users'][1]        = false;
+$GLOBALS['ec_wp_mail_calls']   = array();
+$worker->runWorker( $user_payload );
+ec_assert( 'named queue denies deleted user after enqueue', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+$GLOBALS['ec_users'][1] = true;
+
+\DataMachine\Abilities\PermissionHelper::$user_id  = 42;
+\DataMachine\Abilities\PermissionHelper::$agent_id = 303;
+$agent_payload = $enqueue_named();
+unset( \DataMachine\Core\Database\Agents\Agents::$rows[303] );
+$GLOBALS['ec_wp_mail_calls'] = array();
+$worker->runWorker( $agent_payload );
+ec_assert( 'named queue denies deleted agent after enqueue', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+\DataMachine\Core\Database\Agents\Agents::$rows[303] = array( 'owner_id' => 42 );
+$agent_payload = $enqueue_named();
+$GLOBALS['ec_manage_users'][42] = false;
+$GLOBALS['ec_wp_mail_calls']    = array();
+$worker->runWorker( $agent_payload );
+ec_assert( 'named queue denies revoked agent owner capability ceiling', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+$GLOBALS['ec_manage_users'][42] = true;
+
+\DataMachine\Abilities\PermissionHelper::$token_id = 900;
+$valid_token = static fn ( ?array $caps = array( 'datamachine_use_tools' ), array $metadata = array() ): WP_Agent_Token => new WP_Agent_Token( 900, '303', 42, $caps, $metadata );
+\DataMachine\Core\Database\Agents\AgentTokens::$tokens[900] = $valid_token();
+$valid_token_payload = $enqueue_named();
+$GLOBALS['ec_wp_mail_calls'] = array();
+$worker->runWorker( $valid_token_payload );
+ec_assert( 'named queue allows unchanged live token authority', 1 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+
+$GLOBALS['ec_scheduled'] = array();
+$token_payload = $enqueue_named();
+unset( \DataMachine\Core\Database\Agents\AgentTokens::$tokens[900] );
+$GLOBALS['ec_wp_mail_calls'] = array();
+$worker->runWorker( $token_payload );
+ec_assert( 'named queue denies revoked token after enqueue', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+
+\DataMachine\Core\Database\Agents\AgentTokens::$tokens[900] = $valid_token();
+$token_payload = $enqueue_named();
+\DataMachine\Core\Database\Agents\AgentTokens::$tokens[900] = $valid_token( array() );
+$GLOBALS['ec_wp_mail_calls'] = array();
+$worker->runWorker( $token_payload );
+ec_assert( 'named queue denies narrowed token capability ceiling', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+
+\DataMachine\Core\Database\Agents\AgentTokens::$tokens[900] = $valid_token();
+$token_payload = $enqueue_named();
+$denied_scope = array( 'capabilities' => array( 'datamachine_use_tools' ), 'ability_deny' => array( 'datamachine/send-email-queued' ) );
+\DataMachine\Core\Database\Agents\AgentTokens::$tokens[900] = $valid_token( array( 'datamachine_use_tools' ), array( 'datamachine_scope' => $denied_scope ) );
+$GLOBALS['ec_wp_mail_calls'] = array();
+$worker->runWorker( $token_payload );
+ec_assert( 'named queue denies revoked token ability scope', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+\DataMachine\Abilities\PermissionHelper::$token_id = 0;
 
 /* ---------------------------------------------------------------------------
  * Summary


### PR DESCRIPTION
## Summary
- extend the existing auth option with provider-wide unique named accounts under exact site, user, or agent ownership
- add email-owned operation grants for read, search, draft, send, reply, organize, delete, and unsubscribe, with trusted-principal resolution and secret-free audit context
- thread non-secret `email_imap:<name>` refs through email abilities, REST, CLI, queued sends, and flow fetches while keeping folders separate

## Storage and delegation model
Named credentials remain in `datamachine_auth_data`; no parallel email credential store or table is introduced. Site accounts use `accounts[<name>]`, while user and agent accounts use `principals[<type>:<id>][accounts][<name>]`. Names are provider-wide unique so refs remain stable and unambiguous.

Delegations are stored beside the email provider and bind an exact owner principal + mailbox name to an agent and an explicit operation allow-list. Human execution resolves from the current execution principal. Flow execution uses trusted `ExecutionContext` ownership, and queued sends carry a signed non-secret principal envelope that is re-authorized by the worker.

## Compatibility
- `email_imap:default` continues to resolve the existing legacy site config for direct commands and legacy unscoped flows.
- Existing flows without an `auth_ref` retain default behavior.
- Explicit agent-scoped requests never fall back to the site default; agent flows selecting a ref require an exact owned mailbox or delegation.
- Mailbox-selected send/reply operations continue using `wp_mail()` for transport while pinning the authorized mailbox sender identity.

## Security boundaries
- IMAP passwords are encrypted at rest and raw credentials were removed from public fetch schemas and REST/CLI payloads.
- Auth-ref import/runtime configuration preserves refs instead of materializing credentials into flow config.
- Provider status output and auth-ref exports redact the complete IMAP connection identity.
- Mailbox authorization intersects the operation grant with the existing ability/capability ceiling.
- Move/expunge, deleted flags, unsubscribe, send, reply, and queued delivery enforce their specific operation requirements.
- Audit events contain only mailbox ref, owner principal, acting principal, operation, result, and available flow/job IDs.

## Tests
- `php tests/named-mailbox-delegation-smoke.php`
- `php tests/auth-ref-handler-config-smoke.php`
- `php tests/email-reply-sent-copy-smoke.php`
- `php tests/fetch-owner-auth-context-smoke.php`
- `php tests/send-email-ability-lazy-definitions-smoke.php`
- `php tests/abilities-send-email-load-order-smoke.php`
- PHP syntax checks for all modified runtime files
- `git diff --check`
- `composer lint`

`composer lint` passes; Composer emits PHP-runtime deprecation notices before PHPCS starts.

## Deferred scope
A dedicated mailbox administration UI is intentionally deferred. This PR provides the generic named-account APIs and email delegation domain methods; product-specific onboarding can compose those without introducing another credential store. SMTP remains owned by the existing WordPress mail transport rather than being coupled to IMAP mailbox records.

Closes #3215