### PR TITLE
fix: resolve Plugin Check hook naming findings

### DIFF
--- a/docs/plugin-check-v01740-hook-names-dossier.md
+++ b/docs/plugin-check-v01740-hook-names-dossier.md
@@ -1,0 +1,53 @@
+# Plugin Check v0.174.0 Hook-Name Dossier
+
+## Scope
+
+Source evidence: `.homeboy/evidence/plugin-check-v01740/data-machine.json`.
+
+The declared evidence contains 6 `DynamicHooknameFound` warnings and 1
+`NonPrefixedHooknameFound` warning. This change addresses only those seven
+findings; the evidence's other 246 findings remain outside this boundary.
+
+## Hook Inventory
+
+| Hook or selector | Owner | Change kind | Compatibility decision |
+| --- | --- | --- | --- |
+| `wp_agent_workflow_should_fanout` | Agents API | WPCS justification | Retained as the canonical external contract. |
+| `agents_chat_runtime_principal_permission` | Agents API/WP Codebox | WPCS justification | Retained because WP Codebox consumes this shared runtime-principal authorization contract. |
+| `datamachine_job_terminal_committed`, `datamachine_job_complete` | Data Machine | WPCS justification | A fixed two-item literal set preserves ordered terminal notifications. |
+| `datamachine_delegated_operation_actions` | Data Machine | WPCS justification | A canonical constant names the registry extension point. |
+| `datamachine_job_artifact_*` | Data Machine | WPCS justification | The private helper has three explicit prefixed call sites. |
+| `datamachine_pending_action_resolution_token_html` | Data Machine | WPCS justification | A canonical constant names the response extension point. |
+| `datamachine_agent_config_artifact_projection_policies` | Data Machine | WPCS justification | The private helper has one explicit prefixed call site. |
+
+## Verification
+
+Before (declared Plugin Check evidence): 6 `DynamicHooknameFound`; 1
+`NonPrefixedHooknameFound`.
+
+After (targeted WPCS verification): 0 findings from
+`WordPress.NamingConventions.PrefixAllGlobals` across all seven affected source
+files. The repository does not provide a WordPress Plugin Check runner, so a
+full Plugin Check rerun is outside the available verification capability.
+WPCS justifications are intentionally narrow and document each bounded
+selector.
+
+Run:
+
+```sh
+php tests/parallel-map-fanout-adapter-smoke.php
+php tests/agents-chat-access-permission-smoke.php
+php tests/signed-pending-action-resolution-smoke.php
+php tests/job-status-accounting-smoke.php
+vendor/bin/phpcs --standard=WordPress --sniffs=WordPress.NamingConventions.PrefixAllGlobals inc/Abilities/Engine/ParallelMapFanoutAdapter.php inc/Abilities/Chat/AgentsChatHandler.php inc/Core/Database/Jobs/Jobs.php inc/Core/DelegatedOperations/DelegatedOperationRegistry.php inc/Core/JobArtifactSurfaces.php inc/Engine/AI/Actions/SignPendingActionResolutionAbility.php inc/Engine/Bundle/AgentConfigArtifactProjector.php
+```
+
+Runtime-change evidence boundary: all hook names and dispatch behavior are
+preserved. Narrow annotations document the shared external hook and bounded
+dynamic selectors; the listed runtime smoke tests verify the related fan-out,
+chat, and terminal-accounting contracts.
+
+## AI Disclosure
+
+GPT-5.6 Sol via OpenCode/Homeboy was used for implementation and verification.
+Chris Huber remains responsible for every line.

--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -43,6 +43,7 @@ class AgentsChatHandler {
 	public function checkPermission( bool $allowed, array $input ): bool {
 		if ( ! $allowed ) {
 			$principal = $this->resolveCallerPrincipal( $input );
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Shared Agents API runtime contract consumed by WP Codebox.
 			if ( null !== $principal && (bool) apply_filters( 'agents_chat_runtime_principal_permission', false, $principal, $input ) ) {
 				return true;
 			}

--- a/inc/Abilities/Engine/ParallelMapFanoutAdapter.php
+++ b/inc/Abilities/Engine/ParallelMapFanoutAdapter.php
@@ -154,6 +154,7 @@ class ParallelMapFanoutAdapter {
 		 * @param array $step    The `parallel`-map step spec.
 		 * @param array $context Caller context.
 		 */
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound -- The constant is the canonical external Agents API contract hook.
 		return (bool) apply_filters( self::FANOUT_GATE_FILTER, true, $step, $context );
 	}
 

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -2995,6 +2995,7 @@ class Jobs extends BaseRepository {
 			$errors = array();
 			foreach ( array( 'datamachine_job_terminal_committed', 'datamachine_job_complete' ) as $hook ) {
 				try {
+					// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound -- The bounded literal set contains only Data Machine lifecycle actions.
 					do_action( $hook, $job_id, $status );
 				} catch ( \Throwable $exception ) {
 					$errors[] = $this->terminal_accounting_error( $stage, 'extension_notification_failed', $exception->getMessage(), $hook );

--- a/inc/Core/DelegatedOperations/DelegatedOperationRegistry.php
+++ b/inc/Core/DelegatedOperations/DelegatedOperationRegistry.php
@@ -23,6 +23,7 @@ final class DelegatedOperationRegistry {
 			return new \WP_Error( 'delegated_action_invalid', __( 'The delegated action identifier is invalid.', 'data-machine' ) );
 		}
 
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound -- The constant is the canonical Data Machine delegated-operation registry hook.
 		$actions = apply_filters( self::FILTER, array() );
 		$action  = is_array( $actions ) && is_array( $actions[ $action_id ] ?? null ) ? $actions[ $action_id ] : null;
 		if ( null === $action ) {

--- a/inc/Core/JobArtifactSurfaces.php
+++ b/inc/Core/JobArtifactSurfaces.php
@@ -237,6 +237,7 @@ class JobArtifactSurfaces {
 			return $value;
 		}
 
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound -- Callers select only the three explicit datamachine_job_artifact_* hooks above.
 		return function_exists( 'apply_filters' ) ? apply_filters( $hook, $value ) : $value;
 	}
 

--- a/inc/Engine/AI/Actions/SignPendingActionResolutionAbility.php
+++ b/inc/Engine/AI/Actions/SignPendingActionResolutionAbility.php
@@ -356,6 +356,7 @@ final class SignPendingActionResolutionAbility {
 
 		$html = '<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>' . esc_html( $title ) . '</title></head><body><main><h1>' . esc_html( $title ) . '</h1><p>' . esc_html( $message ) . '</p></main></body></html>';
 
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound -- The constant is the canonical Data Machine HTML response hook.
 		return (string) apply_filters( self::HTML_RESPONSE_FILTER, $html, $result, $status );
 	}
 

--- a/inc/Engine/Bundle/AgentConfigArtifactProjector.php
+++ b/inc/Engine/Bundle/AgentConfigArtifactProjector.php
@@ -275,6 +275,7 @@ final class AgentConfigArtifactProjector {
 			return $value;
 		}
 
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound -- policies() supplies the single explicit Data Machine projection-policy hook.
 		return \apply_filters( $hook, $value );
 	}
 


### PR DESCRIPTION
## Summary

Resolve all seven hook-name findings from the Data Machine v0.174.0 Plugin Check artifact.

- Preserve the shared `agents_chat_runtime_principal_permission` contract consumed by WP Codebox.
- Preserve the canonical Agents API fan-out hook.
- Add narrow, documented justifications for bounded dynamic Data Machine hook selectors.
- Include the reviewer-facing hook ownership and compatibility inventory.

Closes #2300.

## Verification

- `composer lint`
- `php tests/parallel-map-fanout-adapter-smoke.php`
- `php tests/agents-chat-access-permission-smoke.php`
- `php tests/signed-pending-action-resolution-smoke.php`
- `php tests/job-status-accounting-smoke.php`

A fresh packaged Plugin Check rerun remains the acceptance authority; source-mounted validation was stopped after bounded transport timeouts.

## AI assistance

- **Model:** GPT-5.6 Sol
- **Tools:** OpenCode and Homeboy
- **Used for:** Auditing, implementing, reviewing, and verifying hook compatibility and Plugin Check annotations. Chris Huber remains responsible for every line.