### PR TITLE
fix: resolve Plugin Check slow-query findings

### DIFF
--- a/docs/development/plugin-check-v01740-slow-query-audit.md
+++ b/docs/development/plugin-check-v01740-slow-query-audit.md
@@ -1,0 +1,43 @@
+# Plugin Check v01740 Slow-Query Audit
+
+Evidence source: `.homeboy/evidence/plugin-check-v01740/data-machine.json` entries 1866-2118. This dossier is limited to those 15 SlowDBQuery findings; it does not claim coverage of other Plugin Check findings.
+
+## Finding Counts
+
+| Rule | Before | After |
+| --- | ---: | ---: |
+| `slow_db_query_meta_key` | 8 | 0 |
+| `slow_db_query_meta_query` | 4 | 0 |
+| `slow_db_query_tax_query` | 2 | 0 |
+| `slow_db_query_meta_value` | 1 | 0 |
+| Total | 15 | 0 |
+
+## Audit
+
+| Evidence location | Source relationship | Change kind | Review conclusion and evidence boundary |
+| --- | --- | --- | --- |
+| `UpsertPostAbility.php:854` | Legacy fallback after unusable direct-execute identity input | Exact suppression | Valid identities use the plugin-owned, indexed post-identity-reservations table. This fallback preserves historical direct-execute behavior; no replacement query was added. |
+| `QueryWordPressPostsAbility.php:80,338` | Ability schema and defaults | Exact suppression | Both are data declarations, not runtime queries. The actual taxonomy assignment at line 174 already has a local rationale. |
+| `PostQueryAbilities.php:28,32,39` | Static filter metadata | Exact suppression | These are configuration fields, not runtime queries. |
+| `PostQueryAbilities.php:277` | Runtime recent-managed-post list | Exact suppression plus behavior test | The canonical handler marker lives in WordPress-owned `wp_postmeta`; a plugin index would require write-path, backfill, and legacy-consistency ownership. Coverage verifies only tracked posts and the total. |
+| `PostQueryAbilities.php:389` | Runtime combined list filters | Exact suppression plus behavior test | Canonical tracking meta is required; pipeline IDs are already resolved from the owned flows table. Coverage verifies AND semantics and total. |
+| `PostQueryAbilities.php:477` | Runtime single filter list | Exact suppression | Canonical tracking meta is required; no independent plugin-owned index can preserve the existing contract without duplicate-state ownership. Existing handler, flow, pipeline, and pagination tests cover this family. |
+| `MetaDescriptionCommand.php:81` | CLI response payload | Exact suppression | Response field, not a query. |
+| `PostIdentityReservations.php:111,112` | Normalized identity payload | Exact suppression | Data fields, not queries. The reservation table is the indexed ownership boundary for valid identity upserts. |
+| `AltTextTask.php:127`, `InternalLinkingTask.php:228`, `SystemTask.php:847` | Undo-effect target/result payloads | Exact suppression | Data fields, not queries. |
+
+## Verification
+
+Executed from the repository root after `composer install --no-interaction --prefer-dist` restored the lockfile dependencies:
+
+```sh
+vendor/bin/phpcs inc/Abilities/Content/UpsertPostAbility.php inc/Abilities/Fetch/QueryWordPressPostsAbility.php inc/Abilities/PostQueryAbilities.php inc/Cli/Commands/MetaDescriptionCommand.php inc/Core/Database/PostIdentityReservations/PostIdentityReservations.php inc/Engine/AI/System/Tasks/AltTextTask.php inc/Engine/AI/System/Tasks/InternalLinkingTask.php inc/Engine/AI/System/Tasks/SystemTask.php tests/Unit/Abilities/PostQueryAbilitiesTest.php
+vendor/bin/phpunit tests/Unit/Abilities/PostQueryAbilitiesTest.php
+git diff --check
+```
+
+All three commands passed. `php -l` also passed for every changed PHP file. Plugin Check remains the authoritative confirmation for the declared evidence boundary; the `wordpress.plugin-check` runner is unavailable in this checkout, so no fresh Plugin Check artifact was claimed. Re-run it on the packaged plugin and confirm zero findings for the four listed SlowDBQuery rules.
+
+## AI Disclosure
+
+GPT-5.6 Sol via OpenCode/Homeboy was used for implementation and verification; Chris Huber remains responsible for every line.

--- a/inc/Abilities/Content/UpsertPostAbility.php
+++ b/inc/Abilities/Content/UpsertPostAbility.php
@@ -851,6 +851,7 @@ class UpsertPostAbility {
 			$args = array(
 				'post_type'      => $post_type,
 				'post_status'    => 'any',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Legacy direct-execute fallback; valid identities use the indexed post-identity-reservations table.
 				'meta_query'     => array(
 					array(
 						'key'   => $meta_key,

--- a/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
+++ b/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
@@ -344,5 +344,4 @@ class QueryWordPressPostsAbility {
 
 		return array_merge( $defaults, $input );
 	}
-
 }

--- a/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
+++ b/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
@@ -77,6 +77,7 @@ class QueryWordPressPostsAbility {
 								'default'     => 10,
 								'description' => __( 'Number of posts to query', 'data-machine' ),
 							),
+							// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Ability input-schema property; not a database query.
 							'tax_query'         => array(
 								'type'        => 'array',
 								'default'     => array(),
@@ -335,6 +336,7 @@ class QueryWordPressPostsAbility {
 			'exclude_keywords'  => '',
 			'randomize'         => false,
 			'posts_per_page'    => 10,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Configuration default; not a database query.
 			'tax_query'         => array(),
 			'processed_items'   => array(),
 			'include_file_info' => true,

--- a/inc/Abilities/PostQueryAbilities.php
+++ b/inc/Abilities/PostQueryAbilities.php
@@ -25,10 +25,12 @@ class PostQueryAbilities {
 	private static function get_filter_types(): array {
 		return array(
 			'handler'  => array(
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Filter configuration metadata; not a database query.
 				'meta_key'   => PostTracking::HANDLER_META_KEY,
 				'value_type' => 'string',
 			),
 			'flow'     => array(
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Filter configuration metadata; not a database query.
 				'meta_key'   => PostTracking::FLOW_ID_META_KEY,
 				'value_type' => 'integer',
 			),
@@ -36,6 +38,7 @@ class PostQueryAbilities {
 			// than a direct meta match, because pipeline_id is no longer
 			// stored on posts (#1091). See build_pipeline_meta_query().
 			'pipeline' => array(
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Filter configuration metadata; not a database query.
 				'meta_key'   => PostTracking::FLOW_ID_META_KEY,
 				'value_type' => 'integer',
 				'resolver'   => 'pipeline',
@@ -274,6 +277,7 @@ class PostQueryAbilities {
 			'offset'         => $offset,
 			'orderby'        => 'date',
 			'order'          => 'DESC',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Lists managed posts by the canonical handler marker; wp_postmeta index ownership is outside this plugin.
 			'meta_query'     => array(
 				array(
 					'key'     => PostTracking::HANDLER_META_KEY,
@@ -386,6 +390,7 @@ class PostQueryAbilities {
 			'offset'         => $offset,
 			'orderby'        => $orderby,
 			'order'          => $order,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Filters canonical tracking meta; pipeline IDs resolve from owned flows, while wp_postmeta index ownership is outside this plugin.
 			'meta_query'     => $meta_query,
 		);
 
@@ -474,6 +479,7 @@ class PostQueryAbilities {
 			'offset'         => $offset,
 			'orderby'        => 'date',
 			'order'          => 'DESC',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Filters canonical tracking meta; wp_postmeta index ownership is outside this plugin.
 			'meta_query'     => array( $meta_clause ),
 		);
 

--- a/inc/Cli/Commands/MetaDescriptionCommand.php
+++ b/inc/Cli/Commands/MetaDescriptionCommand.php
@@ -78,6 +78,7 @@ class MetaDescriptionCommand extends BaseCommand {
 				\wp_json_encode(
 					array(
 						'post_type'     => $result['post_type'] ?? $post_type,
+						// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- CLI response field; not a database query.
 						'meta_key'      => $result['meta_key'] ?? '',
 						'total_posts'   => $total,
 						'has_count'     => $has,

--- a/inc/Core/Database/PostIdentityReservations/PostIdentityReservations.php
+++ b/inc/Core/Database/PostIdentityReservations/PostIdentityReservations.php
@@ -108,7 +108,9 @@ class PostIdentityReservations extends BaseRepository {
 
 		return array(
 			'post_type'       => $post_type,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Normalized identity data; not a database query.
 			'meta_key'        => $meta_key,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Normalized identity data; not a database query.
 			'meta_value'      => $meta_value,
 			'identity_hash'   => hash( 'sha256', $canonical ),
 			'post_type_hash'  => hash( 'sha256', $post_type ),

--- a/inc/Engine/AI/System/Tasks/AltTextTask.php
+++ b/inc/Engine/AI/System/Tasks/AltTextTask.php
@@ -124,6 +124,7 @@ class AltTextTask extends SystemTask {
 				'type'           => 'post_meta_set',
 				'target'         => array(
 					'post_id'  => $attachment_id,
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Undo-effect target metadata; not a database query.
 					'meta_key' => '_wp_attachment_image_alt',
 				),
 				'previous_value' => ! empty( $current_alt ) ? $current_alt : null,

--- a/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
+++ b/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
@@ -225,6 +225,7 @@ class InternalLinkingTask extends SystemTask {
 			'type'           => 'post_meta_set',
 			'target'         => array(
 				'post_id'  => $post_id,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Undo-effect target metadata; not a database query.
 				'meta_key' => '_datamachine_internal_links',
 			),
 			'previous_value' => ! empty( $existing_meta ) ? $existing_meta : null,

--- a/inc/Engine/AI/System/Tasks/SystemTask.php
+++ b/inc/Engine/AI/System/Tasks/SystemTask.php
@@ -844,6 +844,7 @@ abstract class SystemTask {
 			'status'   => 'reverted',
 			'type'     => 'post_meta_set',
 			'post_id'  => $post_id,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Undo result payload; not a database query.
 			'meta_key' => $meta_key,
 		);
 	}

--- a/tests/Unit/Abilities/PostQueryAbilitiesTest.php
+++ b/tests/Unit/Abilities/PostQueryAbilitiesTest.php
@@ -196,6 +196,61 @@ class PostQueryAbilitiesTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'error', $result );
 	}
 
+	public function test_recent_posts_only_returns_tracked_posts(): void {
+		$tracked_post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Tracked Recent Post',
+			)
+		);
+		self::factory()->post->create(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Untracked Recent Post',
+			)
+		);
+		update_post_meta( $tracked_post_id, '_datamachine_post_handler', 'rss' );
+
+		$result = $this->post_query_abilities->executeQueryRecentPosts(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'per_page'    => 20,
+			)
+		);
+
+		$this->assertSame( array( $tracked_post_id ), wp_list_pluck( $result['posts'], 'id' ) );
+		$this->assertSame( 1, $result['total'] );
+	}
+
+	public function test_list_posts_combines_handler_and_flow_filters(): void {
+		$matching_post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$other_flow_id    = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$other_handler_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		update_post_meta( $matching_post_id, '_datamachine_post_handler', 'rss' );
+		update_post_meta( $matching_post_id, '_datamachine_post_flow_id', 123 );
+		update_post_meta( $other_flow_id, '_datamachine_post_handler', 'rss' );
+		update_post_meta( $other_flow_id, '_datamachine_post_flow_id', 456 );
+		update_post_meta( $other_handler_id, '_datamachine_post_handler', 'web' );
+		update_post_meta( $other_handler_id, '_datamachine_post_flow_id', 123 );
+
+		$result = $this->post_query_abilities->executeQueryPostsList(
+			array(
+				'handler'     => 'rss',
+				'flow_id'     => 123,
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'per_page'    => 20,
+			)
+		);
+
+		$this->assertSame( array( $matching_post_id ), wp_list_pluck( $result['posts'], 'id' ) );
+		$this->assertSame( 1, $result['total'] );
+	}
+
 	public function test_format_post_result_pipeline_id_is_zero_without_flow(): void {
 		// A tracked post whose flow_id is missing (either never set or whose
 		// flow row has been deleted) has no resolvable pipeline. The resolver


### PR DESCRIPTION
## Summary

Audit all 15 slow-query findings from the Data Machine v0.174.0 Plugin Check artifact.

- Document false positives on schemas, defaults, payloads, and undo metadata.
- Narrowly justify intentional canonical `wp_postmeta` queries where duplicate indexed state would create a second ownership model.
- Add behavioral coverage for tracked-post and combined-filter query semantics.
- Include the reviewer-facing finding inventory and rationale.

Closes #2299.

## Verification

- `composer lint`
- `vendor/bin/phpunit tests/Unit/Abilities/PostQueryAbilitiesTest.php`

A fresh packaged Plugin Check rerun remains the acceptance authority; source-mounted validation was stopped after bounded transport timeouts.

## AI assistance

- **Model:** GPT-5.6 Sol
- **Tools:** OpenCode and Homeboy
- **Used for:** Auditing, implementing, reviewing, and verifying the slow-query findings. Chris Huber remains responsible for every line.