### PR TITLE
ci: skip known-red suite on main pushes

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -40,7 +40,7 @@ jobs:
     secrets: inherit
 
   homeboy-test:
-    if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'release:') }}
+    if: ${{ github.event_name != 'push' }}
     uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2
     with:
       # v2.14.2 keeps raw candidate evidence neutral; this reconciled Test gate


### PR DESCRIPTION
## Summary

- Keep full candidate/baseline differential PHPUnit gating on pull requests.
- Skip the known-red canonical suite on main pushes until #3226 makes the baseline independently green.
- Leave prefix policy and Release workflow gates unchanged.

Closes #3227.

Evidence: main run https://github.com/Extra-Chill/data-machine/actions/runs/32008889750 failed only because push events have no baseline reconciliation. Data Machine `v0.174.3` released successfully through the separate Release workflow.

## Verification

- Reusable workflow condition is limited to `github.event_name != 'push'`.
- `git diff --check`

## AI assistance

- **Model:** GPT-5.6 Sol
- **Tools:** OpenCode and Homeboy
- **Used for:** CI policy diagnosis and implementation. Chris Huber remains responsible for every line.