### PR TITLE
fix: control HTTP error body logging

### DIFF
--- a/docs/core-system/http-client.md
+++ b/docs/core-system/http-client.md
@@ -9,3 +9,5 @@ The `HttpClient` class (`/inc/Core/HttpClient.php`) provides a consistent, centr
 - JSON error extraction to surface meaningful diagnostics without leaking sensitive data
 
 Consumers call `HttpClient::get`, `post`, `put`, `patch`, or `delete` with a URL and options array; the client returns `['success' => bool, 'data' => string|null, 'status_code' => int|null, 'headers' => array, 'response' => array, 'error' => string|null]` so handlers never handle raw WP responses directly.
+
+For non-2xx responses, `log_response_body_preview` controls whether the warning log context includes the bounded `body_preview` field. It accepts only booleans and defaults to `true`; set it to `false` for requests whose response bodies should not be written to logs. Other values are rejected before the request is dispatched.

--- a/inc/Core/HttpClient.php
+++ b/inc/Core/HttpClient.php
@@ -46,11 +46,20 @@ class HttpClient {
 	 *                        - auth_ref: string - Optional provider:account credential reference resolved through registered auth providers
 	 *                        - browser_mode: bool - Use browser-like headers (default false)
 	 *                        - context: string - Context for logging (default 'HTTP Request')
+	 *                        - log_response_body_preview: bool - Include up to 200 response-body bytes in non-2xx log context (default true; other types are rejected)
 	 * @return array{success: true, data: string, status_code: int, headers: mixed, response: array}|array{success: false, error: string, data?: string, status_code?: int, headers?: mixed, response?: array} Response array. Received non-2xx responses include HTTP metadata; transport failures do not.
 	 */
 	public static function request( string $method, string $url, array $options = array() ): array {
+		if ( array_key_exists( 'log_response_body_preview', $options ) && ! is_bool( $options['log_response_body_preview'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Invalid log_response_body_preview option; expected bool',
+			);
+		}
+
 		$method       = strtoupper( $method );
 		$context      = $options['context'] ?? 'HTTP Request';
+		$log_response_body_preview = $options['log_response_body_preview'] ?? true;
 		$proxy_filter = null;
 
 		if ( ! in_array( $method, self::VALID_METHODS, true ) ) {
@@ -103,7 +112,7 @@ class HttpClient {
 		$success_codes = self::SUCCESS_CODES[ $method ];
 
 		if ( ! in_array( $status_code, $success_codes, true ) ) {
-			return self::handleHttpError( $response, $status_code, $body, $method, $url, $context );
+			return self::handleHttpError( $response, $status_code, $body, $method, $url, $context, $log_response_body_preview );
 		}
 
 		return array(
@@ -400,7 +409,7 @@ class HttpClient {
 	/**
 	 * Handle non-success HTTP status code
 	 */
-	private static function handleHttpError( array $response, int $status_code, string $body, string $method, string $url, string $context ): array {
+	private static function handleHttpError( array $response, int $status_code, string $body, string $method, string $url, string $context, bool $log_response_body_preview ): array {
 		$error_message = sprintf(
 			'%1$s %2$s returned HTTP %3$d',
 			$context,
@@ -418,17 +427,21 @@ class HttpClient {
 		// third-party sites (403 bot-blocks, 404 moved pages, 5xx origin-down) and is
 		// not a Data-Machine-side fault. Log it at `warning`; true transport failures
 		// (no response at all) are handled separately in handleWpError() and stay `error`.
+		$log_context = array(
+			'context'     => $context,
+			'url'         => $url,
+			'method'      => $method,
+			'status_code' => $status_code,
+		);
+		if ( $log_response_body_preview ) {
+			$log_context['body_preview'] = substr( $body, 0, 200 );
+		}
+
 		do_action(
 			'datamachine_log',
 			'warning',
 			'HTTP Request: Error response',
-			array(
-				'context'      => $context,
-				'url'          => $url,
-				'method'       => $method,
-				'status_code'  => $status_code,
-				'body_preview' => substr( $body, 0, 200 ),
-			)
+			$log_context
 		);
 
 		return array(

--- a/tests/http-client-error-response-contract-smoke.php
+++ b/tests/http-client-error-response-contract-smoke.php
@@ -97,7 +97,7 @@ function http_client_error_contract_assert( string $label, bool $condition ): vo
 
 $normal_response = array(
 	'headers'  => array( 'Content-Type' => 'application/json' ),
-	'body'     => '{"message":"Invalid request"}',
+	'body'     => '{"message":"Invalid request","detail":"' . str_repeat( 'a', 250 ) . '"}',
 	'response' => array( 'code' => 400, 'message' => 'Bad Request' ),
 );
 
@@ -112,12 +112,23 @@ $rate_limit_response = array(
 
 $GLOBALS['datamachine_http_client_responses'] = array(
 	$normal_response,
+	$normal_response,
 	$rate_limit_response,
 	new WP_Error( 'http_request_failed', 'Connection timed out' ),
 );
 $GLOBALS['datamachine_http_client_logs'] = array();
 
-echo "\n[1] Received non-2xx response\n";
+echo "\n[1] Invalid response-body preview options\n";
+$responses_before_invalid_options = count( $GLOBALS['datamachine_http_client_responses'] );
+$string_option_result            = HttpClient::get( 'https://example.test/invalid-option', array( 'log_response_body_preview' => 'false' ) );
+$array_option_result             = HttpClient::get( 'https://example.test/invalid-option', array( 'log_response_body_preview' => array( false ) ) );
+
+http_client_error_contract_assert( 'string response-body preview option is rejected', 'Invalid log_response_body_preview option; expected bool' === ( $string_option_result['error'] ?? null ) );
+http_client_error_contract_assert( 'array response-body preview option is rejected', 'Invalid log_response_body_preview option; expected bool' === ( $array_option_result['error'] ?? null ) );
+http_client_error_contract_assert( 'invalid response-body preview options do not dispatch requests', $responses_before_invalid_options === count( $GLOBALS['datamachine_http_client_responses'] ) );
+http_client_error_contract_assert( 'invalid response-body preview options do not log', array() === $GLOBALS['datamachine_http_client_logs'] );
+
+echo "\n[2] Received non-2xx response\n";
 $normal_result = HttpClient::get( 'https://example.test/invalid', array( 'context' => 'Contract Test' ) );
 
 http_client_error_contract_assert( 'non-2xx response fails', false === $normal_result['success'] );
@@ -126,15 +137,42 @@ http_client_error_contract_assert( 'non-2xx response preserves headers', 'applic
 http_client_error_contract_assert( 'non-2xx response preserves body as data', $normal_response['body'] === $normal_result['data'] );
 http_client_error_contract_assert( 'non-2xx response preserves raw response', $normal_response === $normal_result['response'] );
 http_client_error_contract_assert( 'non-2xx response retains normalized error', str_contains( $normal_result['error'], 'Invalid request' ) );
+$normal_log_context = $GLOBALS['datamachine_http_client_logs'][0][2] ?? array();
+http_client_error_contract_assert( 'default error log includes a bounded body preview', substr( $normal_response['body'], 0, 200 ) === ( $normal_log_context['body_preview'] ?? null ) );
 
-echo "\n[2] Rate limit metadata\n";
-$rate_limit_result = HttpClient::get( 'https://example.test/limited', array( 'context' => 'Contract Test' ) );
+echo "\n[3] Explicit response body preview\n";
+$explicit_preview_result = HttpClient::get(
+	'https://example.test/explicit-preview',
+	array(
+		'context'                   => 'Contract Test',
+		'log_response_body_preview' => true,
+	)
+);
+
+http_client_error_contract_assert( 'explicit true response-body preview option preserves the response failure', false === $explicit_preview_result['success'] );
+$explicit_preview_log_context = $GLOBALS['datamachine_http_client_logs'][1][2] ?? array();
+http_client_error_contract_assert( 'explicit true response-body preview option includes a bounded preview', substr( $normal_response['body'], 0, 200 ) === ( $explicit_preview_log_context['body_preview'] ?? null ) );
+
+echo "\n[4] Suppressed error body preview\n";
+$rate_limit_result = HttpClient::get(
+	'https://example.test/limited',
+	array(
+		'context'                   => 'Contract Test',
+		'log_response_body_preview' => false,
+	)
+);
 
 http_client_error_contract_assert( '429 response preserves status code', 429 === $rate_limit_result['status_code'] );
 http_client_error_contract_assert( '429 response preserves Retry-After', '120' === ( $rate_limit_result['headers']['Retry-After'] ?? null ) );
 http_client_error_contract_assert( 'response headers are not copied into logs', ! str_contains( serialize( $GLOBALS['datamachine_http_client_logs'] ), 'session=secret' ) );
+$suppressed_log_context = $GLOBALS['datamachine_http_client_logs'][2][2] ?? array();
+http_client_error_contract_assert( 'suppressed error log omits body preview', ! array_key_exists( 'body_preview', $suppressed_log_context ) );
+http_client_error_contract_assert( 'suppressed error log preserves context', 'Contract Test' === ( $suppressed_log_context['context'] ?? null ) );
+http_client_error_contract_assert( 'suppressed error log preserves URL', 'https://example.test/limited' === ( $suppressed_log_context['url'] ?? null ) );
+http_client_error_contract_assert( 'suppressed error log preserves method', 'GET' === ( $suppressed_log_context['method'] ?? null ) );
+http_client_error_contract_assert( 'suppressed error log preserves status', 429 === ( $suppressed_log_context['status_code'] ?? null ) );
 
-echo "\n[3] Transport failure distinction\n";
+echo "\n[5] Transport failure distinction\n";
 $transport_result = HttpClient::get( 'https://example.test/unreachable', array( 'context' => 'Contract Test' ) );
 
 http_client_error_contract_assert( 'transport failure fails', false === $transport_result['success'] );


### PR DESCRIPTION
## Summary

- add a strictly typed `log_response_body_preview` HTTP request option
- let credential-bearing callers omit raw non-2xx body previews before log emission
- preserve existing preview behavior by default
- reject non-boolean option values before dispatch

Closes #3231.

## Verification

- `php tests/http-client-error-response-contract-smoke.php` (26 assertions)
- PHP lint and PHPCS
- `composer validate --no-check-publish`
- `git diff --check`

## AI assistance disclosure

OpenAI GPT-5.6-sol via OpenCode identified the generic logging boundary, implemented the opt-in suppression contract, added validation and regression coverage, and reviewed backward compatibility. Chris Huber directed and reviewed the work.