### PR TITLE
feat: support agent-scoped OAuth connections

### DIFF
--- a/docs/core-system/oauth-handlers.md
+++ b/docs/core-system/oauth-handlers.md
@@ -228,6 +228,24 @@ public function execute_my_handler( array $input, array $context = array() ) {
 }
 ```
 
+#### Agent-Scoped OAuth Callbacks
+
+`wp datamachine auth connect <handler> --agent=<slug-or-id>` is available only
+to `BaseOAuth2Provider` implementations that provide
+`get_agent_scoped_oauth_callback_config()`. Data Machine's final callback
+dispatcher then owns state verification, consumption, principal installation,
+and exact agent-slot storage; providers supply token-exchange and
+account-normalization callbacks only. OAuth1 and custom callback
+implementations remain site-scoped.
+
+Data Machine core currently has no production `BaseOAuth2Provider` subclass;
+integrations adopt this narrow hook when they need agent-scoped OAuth. Existing
+custom providers keep their unscoped `handle_oauth_callback()` behavior.
+
+For an agent-bound callback, the browser session must be the agent owner or an
+agent admin. The route validates state before resolving that principal; legacy
+unscoped callbacks retain the site-administrator requirement.
+
 #### Revocation
 
 ```bash

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -531,6 +531,10 @@ wp datamachine auth status wordpress-api
 # Connect (OAuth shows URL; direct accepts credentials)
 wp datamachine auth connect google --client_id=xxx --client_secret=xxx
 
+# Bind an OAuth connection to an agent. The CLI user must be the agent owner,
+# an agent admin, or a site administrator.
+wp --user=42 datamachine auth connect google --agent=writer
+
 # Revoke site-wide credentials
 wp datamachine auth revoke google --yes
 

--- a/inc/Abilities/PermissionHelper.php
+++ b/inc/Abilities/PermissionHelper.php
@@ -279,9 +279,10 @@ class PermissionHelper {
 	 * @param int        $agent_id     Agent ID.
 	 * @param int        $owner_id     Agent owner's WordPress user ID.
 	 * @param array|null $capabilities Token capability restrictions (null = unrestricted).
-	 * @param int|null   $token_id     Token ID for login-level runtime scoping.
+	 * @param int|null   $token_id        Token ID for login-level runtime scoping.
+	 * @param string     $request_context Agents API request context for the execution principal.
 	 */
-	public static function set_agent_context( int $agent_id, int $owner_id, ?array $capabilities = null, ?int $token_id = null ): void {
+	public static function set_agent_context( int $agent_id, int $owner_id, ?array $capabilities = null, ?int $token_id = null, string $request_context = WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST ): void {
 		$scope = AgentTokens::normalize_capability_payload( $capabilities );
 
 		self::$acting_agent_id     = $agent_id;
@@ -302,7 +303,7 @@ class PermissionHelper {
 				$owner_id,
 				(string) $agent_id,
 				$token_id,
-				WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST,
+				$request_context,
 				array(),
 				null,
 				null,
@@ -311,12 +312,57 @@ class PermissionHelper {
 			: WP_Agent_Execution_Principal::user_session(
 				$owner_id,
 				(string) $agent_id,
-				WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST,
+				$request_context,
 				array(),
 				null,
 				null,
 				self::$capability_ceiling
 			);
+	}
+
+	/**
+	 * Execute a callback in a temporary agent principal context.
+	 *
+	 * This is for trusted operator paths which need agent-scoped storage without
+	 * requiring an agent bearer token. The full prior runtime context is restored
+	 * even when the callback throws.
+	 *
+	 * @param int      $agent_id        Agent ID.
+	 * @param int      $owner_id        Agent owner's WordPress user ID.
+	 * @param callable $callback        Work to execute in the agent context.
+	 * @param string   $request_context Agents API request context for the principal.
+	 * @return mixed Callback return value.
+	 *
+	 * @throws \Throwable Re-throws callback exceptions after restoring context.
+	 */
+	public static function run_as_agent_context( int $agent_id, int $owner_id, callable $callback, string $request_context = WP_Agent_Execution_Principal::REQUEST_CONTEXT_CLI ) {
+		$previous = array(
+			'authenticated_context' => self::$authenticated_context,
+			'authenticated_user_id' => self::$authenticated_user_id,
+			'acting_agent_id'       => self::$acting_agent_id,
+			'acting_token_id'       => self::$acting_token_id,
+			'agent_owner_id'        => self::$agent_owner_id,
+			'capability_ceiling'    => self::$capability_ceiling,
+			'agent_token_scope'     => self::$agent_token_scope,
+			'execution_principal'   => self::$execution_principal,
+			'caller_context'        => self::$caller_context,
+		);
+
+		self::set_agent_context( $agent_id, $owner_id, null, null, $request_context );
+
+		try {
+			return $callback();
+		} finally {
+			self::$authenticated_context = $previous['authenticated_context'];
+			self::$authenticated_user_id = $previous['authenticated_user_id'];
+			self::$acting_agent_id       = $previous['acting_agent_id'];
+			self::$acting_token_id       = $previous['acting_token_id'];
+			self::$agent_owner_id        = $previous['agent_owner_id'];
+			self::$capability_ceiling    = $previous['capability_ceiling'];
+			self::$agent_token_scope     = $previous['agent_token_scope'];
+			self::$execution_principal   = $previous['execution_principal'];
+			self::$caller_context        = $previous['caller_context'];
+		}
 	}
 
 	/**

--- a/inc/Cli/Commands/AuthCommand.php
+++ b/inc/Cli/Commands/AuthCommand.php
@@ -13,8 +13,11 @@ namespace DataMachine\Cli\Commands;
 
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
+use DataMachine\Cli\AgentResolver;
 use DataMachine\Abilities\AuthAbilities;
+use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\OAuth\BaseOAuth2Provider;
+use DataMachine\Core\Database\Agents\AgentAccess;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -94,10 +97,16 @@ class AuthCommand extends BaseCommand {
 	 * [--<field>=<value>]
 	 * : Credential fields for non-OAuth handlers (e.g. --handle=user --app-password=xyz).
 	 *
+	 * [--agent=<slug-or-id>]
+	 * : Bind an OAuth connection to this agent. The current CLI user must own the agent, be an agent admin, or be a site administrator.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Start OAuth flow for Twitter
 	 *     wp datamachine auth connect twitter
+	 *
+	 *     # Connect OAuth for a specific agent (run as its owner, agent admin, or site admin)
+	 *     wp --user=42 datamachine auth connect twitter --agent=writer
 	 *
 	 *     # Connect a non-OAuth handler with credentials
 	 *     wp datamachine auth connect bluesky --handle=user.bsky.social --app-password=xyz
@@ -132,7 +141,11 @@ class AuthCommand extends BaseCommand {
 		$is_oauth = method_exists( $provider, 'get_authorization_url' );
 
 		if ( $is_oauth ) {
-			$this->connectOAuth( $handler_slug, $provider );
+			$agent_context = $this->resolveOAuthAgentContext( $assoc_args );
+			if ( null !== $agent_context && ( ! $provider instanceof BaseOAuth2Provider || ! $provider->supports_agent_scoped_oauth_callback() ) ) {
+				WP_CLI::error( sprintf( '%s does not support agent-scoped OAuth callbacks.', ucfirst( $handler_slug ) ) );
+			}
+			$this->connectOAuth( $handler_slug, $provider, $agent_context );
 		} else {
 			$this->connectDirect( $handler_slug, $provider, $assoc_args );
 		}
@@ -760,7 +773,7 @@ class AuthCommand extends BaseCommand {
 	 * @param string $handler_slug Handler slug.
 	 * @param object $provider     Auth provider instance.
 	 */
-	private function connectOAuth( string $handler_slug, object $provider ): void {
+	private function connectOAuth( string $handler_slug, object $provider, ?array $agent_context = null ): void {
 		// Check if configured first.
 		if ( method_exists( $provider, 'is_configured' ) && ! $provider->is_configured() ) {
 			WP_CLI::error( sprintf(
@@ -771,11 +784,26 @@ class AuthCommand extends BaseCommand {
 			return;
 		}
 
-		$result = $this->abilities->executeGetAuthStatus( array( 'handler_slug' => $handler_slug ) );
+		if ( null !== $agent_context && $provider instanceof BaseOAuth2Provider ) {
+			$provider->begin_agent_scoped_authorization();
+		}
+
+		$get_status = fn() => $this->abilities->executeGetAuthStatus( array( 'handler_slug' => $handler_slug ) );
+		$result     = null === $agent_context
+			? $get_status()
+			: PermissionHelper::run_as_agent_context( $agent_context['agent_id'], $agent_context['user_id'], $get_status );
 
 		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to get auth status.' );
 			return;
+		}
+
+		if ( null !== $agent_context && $provider instanceof BaseOAuth2Provider && ! $provider->has_agent_scoped_authorization_state() ) {
+			WP_CLI::error( sprintf( '%s did not create agent-bound OAuth state. Update the provider to use BaseOAuth2Provider::build_auth_url_params().', ucfirst( $handler_slug ) ) );
+		}
+
+		if ( null !== $agent_context ) {
+			WP_CLI::log( sprintf( 'OAuth principal: agent %s (ID %d), owner user %d.', $agent_context['agent_slug'], $agent_context['agent_id'], $agent_context['user_id'] ) );
 		}
 
 		if ( ! empty( $result['authenticated'] ) && ( $result['requires_auth'] ?? true ) === true ) {
@@ -789,11 +817,53 @@ class AuthCommand extends BaseCommand {
 		}
 
 		WP_CLI::log( '' );
+		if ( null !== $agent_context ) {
+			WP_CLI::log( 'The callback will store this connection in that agent slot.' );
+			WP_CLI::log( '' );
+		}
 		WP_CLI::log( sprintf( 'Authorize %s by visiting this URL:', ucfirst( $handler_slug ) ) );
 		WP_CLI::log( '' );
 		WP_CLI::log( $result['oauth_url'] );
 		WP_CLI::log( '' );
 		WP_CLI::log( 'After authorizing, you will be redirected back to your site to complete the connection.' );
+	}
+
+	/**
+	 * Resolve and authorize an explicitly requested OAuth agent principal.
+	 *
+	 * WP-CLI's broad ability permission bypass is intentionally not used here:
+	 * binding a browser identity must be authorized against the target agent.
+	 *
+	 * @param array $assoc_args Command arguments.
+	 * @return array{agent_id:int,user_id:int,agent_slug:string}|null
+	 */
+	private function resolveOAuthAgentContext( array $assoc_args ): ?array {
+		if ( ! array_key_exists( 'agent', $assoc_args ) || '' === $assoc_args['agent'] ) {
+			return null;
+		}
+
+		$context = AgentResolver::resolveEffectiveContext( array( 'agent' => $assoc_args['agent'] ) );
+		if ( empty( $context['agent_id'] ) || empty( $context['user_id'] ) || empty( $context['agent_slug'] ) ) {
+			WP_CLI::error( 'The requested agent could not be resolved to an owner.' );
+		}
+
+		$current_user_id = get_current_user_id();
+		if ( $current_user_id <= 0 ) {
+			WP_CLI::error( 'Agent-scoped OAuth connect requires a current WordPress CLI user. Use WP-CLI --user=<id>.' );
+		}
+
+		$is_owner       = $current_user_id === (int) $context['user_id'];
+		$is_site_admin  = current_user_can( 'manage_options' );
+		$has_admin_grant = ! $is_owner && ! $is_site_admin && ( new AgentAccess() )->user_can_access( (int) $context['agent_id'], $current_user_id, \WP_Agent_Access_Grant::ROLE_ADMIN );
+		if ( ! $is_owner && ! $has_admin_grant && ! $is_site_admin ) {
+			WP_CLI::error( sprintf( 'Current CLI user is not authorized to bind OAuth for agent "%s".', $context['agent_slug'] ) );
+		}
+
+		return array(
+			'agent_id'   => (int) $context['agent_id'],
+			'user_id'    => (int) $context['user_id'],
+			'agent_slug' => (string) $context['agent_slug'],
+		);
 	}
 
 	/**

--- a/inc/Core/OAuth/BaseOAuth2Provider.php
+++ b/inc/Core/OAuth/BaseOAuth2Provider.php
@@ -34,6 +34,16 @@ abstract class BaseOAuth2Provider extends BaseAuthProvider {
 	protected $oauth2;
 
 	/**
+	 * Agent state nonce created during the current authorization URL invocation.
+	 *
+	 * This is intentionally request-local: CLI uses it to reject subclasses that
+	 * bypass build_auth_url_params() while generating an agent-scoped URL.
+	 *
+	 * @var string|null
+	 */
+	private ?string $agent_state_nonce = null;
+
+	/**
 	 * Constructor
 	 *
 	 * @param string $provider_slug Provider identifier
@@ -590,7 +600,21 @@ abstract class BaseOAuth2Provider extends BaseAuthProvider {
 	 * @return array Query parameters for the authorization URL.
 	 */
 	protected function build_auth_url_params( array $state_payload = array() ): array {
+		// State survives the browser redirect, where the initiating CLI context is
+		// unavailable. Preserve the exact principal for callback account storage.
+		if ( class_exists( '\\DataMachine\\Abilities\\PermissionHelper' ) ) {
+			$agent_id = absint( \DataMachine\Abilities\PermissionHelper::get_acting_agent_id() );
+			$user_id  = absint( \DataMachine\Abilities\PermissionHelper::acting_user_id() );
+			if ( $agent_id > 0 && $user_id > 0 ) {
+				$state_payload['agent_id'] = $agent_id;
+				$state_payload['user_id']  = $user_id;
+			}
+		}
+
 		$state  = $this->oauth2->create_state( $this->provider_slug, $state_payload );
+		if ( isset( $state_payload['agent_id'], $state_payload['user_id'] ) ) {
+			$this->agent_state_nonce = $state;
+		}
 		$params = array(
 			'response_type' => $this->get_oauth_response_type(),
 			'redirect_uri'  => $this->get_callback_url(),
@@ -604,6 +628,93 @@ abstract class BaseOAuth2Provider extends BaseAuthProvider {
 		}
 
 		return $params;
+	}
+
+	/**
+	 * Begin an agent-scoped authorization URL invocation.
+	 *
+	 * @return void
+	 */
+	public function begin_agent_scoped_authorization(): void {
+		$this->agent_state_nonce = null;
+	}
+
+	/**
+	 * Whether the current authorization URL invocation created agent-bound state.
+	 *
+	 * @return bool
+	 */
+	public function has_agent_scoped_authorization_state(): bool {
+		return null !== $this->agent_state_nonce;
+	}
+
+	/**
+	 * Return central callback configuration for agent-scoped OAuth, or null.
+	 *
+	 * The final agent callback dispatcher owns state verification, consumption,
+	 * principal installation, and account storage. Providers supply only token
+	 * exchange and account-normalization details through this hook.
+	 *
+	 * @return array{token_url:string,token_params:array,account_details:callable,token_transform?:callable}|null
+	 */
+	protected function get_agent_scoped_oauth_callback_config(): ?array {
+		return null;
+	}
+
+	/**
+	 * Whether this provider can use the final agent-scoped callback dispatcher.
+	 *
+	 * @return bool Whether a central callback configuration is available.
+	 */
+	final public function supports_agent_scoped_oauth_callback(): bool {
+		$config = $this->get_agent_scoped_oauth_callback_config();
+		return is_array( $config ) && isset( $config['account_details'] ) && is_callable( $config['account_details'] ) && ( 'token' === $this->get_oauth_response_type() || ! empty( $config['token_url'] ) );
+	}
+
+	/**
+	 * Execute the non-overridable agent-scoped OAuth callback path.
+	 *
+	 * @return void
+	 */
+	final public function handle_agent_scoped_oauth_callback(): void {
+		$config = $this->get_agent_scoped_oauth_callback_config();
+		if ( ! is_array( $config ) || ! isset( $config['account_details'] ) || ! is_callable( $config['account_details'] ) ) {
+			wp_die( esc_html__( 'This OAuth provider does not support agent-scoped callbacks.', 'data-machine' ), esc_html__( 'Authentication Failed', 'data-machine' ), array( 'response' => 400 ) );
+		}
+
+		$storage_callback = fn( array $account ): bool => $this->store_agent_scoped_callback_account( $account );
+		if ( 'token' === $this->get_oauth_response_type() ) {
+			$this->dispatch_implicit_callback( $config['account_details'], $storage_callback );
+			return;
+		}
+
+		$this->oauth2->handle_callback(
+			$this->provider_slug,
+			(string) ( $config['token_url'] ?? '' ),
+			is_array( $config['token_params'] ?? null ) ? $config['token_params'] : array(),
+			$config['account_details'],
+			isset( $config['token_transform'] ) && is_callable( $config['token_transform'] ) ? $config['token_transform'] : null,
+			$storage_callback
+		);
+	}
+
+	/**
+	 * Persist a centrally verified agent callback account in its exact slot.
+	 *
+	 * @param array $account Account data from the provider.
+	 * @return bool Whether storage succeeded.
+	 */
+	private function store_agent_scoped_callback_account( array $account ): bool {
+		$agent_id = class_exists( '\\DataMachine\\Abilities\\PermissionHelper' ) ? absint( \DataMachine\Abilities\PermissionHelper::get_acting_agent_id() ) : 0;
+		$user_id  = class_exists( '\\DataMachine\\Abilities\\PermissionHelper' ) ? absint( \DataMachine\Abilities\PermissionHelper::acting_user_id() ) : 0;
+		if ( $agent_id > 0 ) {
+			return $this->save_account_for_agent( $agent_id, $account );
+		}
+		if ( $user_id > 0 ) {
+			return $this->save_account_for_user( $user_id, $account );
+		}
+
+		return false;
 	}
 
 	/**

--- a/inc/Core/OAuth/OAuth2Handler.php
+++ b/inc/Core/OAuth/OAuth2Handler.php
@@ -119,6 +119,32 @@ class OAuth2Handler {
 	 * @return array|false Payload array on success (may be empty), false on failure.
 	 */
 	public function verify_state( string $provider_key, string $state ) {
+		return $this->validate_state( $provider_key, $state, true );
+	}
+
+	/**
+	 * Validate OAuth state without consuming it.
+	 *
+	 * Callback routing uses this before authorization so an owner or agent admin
+	 * can reach the central handler, which consumes the same state before storage.
+	 *
+	 * @param string $provider_key Provider identifier.
+	 * @param string $state        State nonce value to validate.
+	 * @return array|false Payload array on success, false on failure.
+	 */
+	public function peek_state( string $provider_key, string $state ) {
+		return $this->validate_state( $provider_key, $state, false );
+	}
+
+	/**
+	 * Validate OAuth state, optionally consuming its one-time transient.
+	 *
+	 * @param string $provider_key Provider identifier.
+	 * @param string $state        State nonce value to validate.
+	 * @param bool   $consume      Whether to consume the transient after validation.
+	 * @return array|false Payload array on success, false on failure.
+	 */
+	private function validate_state( string $provider_key, string $state, bool $consume ) {
 		if ( empty( $state ) ) {
 			$this->log_state_verification( $provider_key, false );
 			return false;
@@ -141,7 +167,9 @@ class OAuth2Handler {
 			return false;
 		}
 
-		delete_transient( $this->state_transient_key( $provider_key, $state ) );
+		if ( $consume ) {
+			delete_transient( $this->state_transient_key( $provider_key, $state ) );
+		}
 		$this->log_state_verification( $provider_key, true );
 
 		return $record['payload'] ?? array();
@@ -461,7 +489,10 @@ class OAuth2Handler {
 		// so providers can access caller-defined context without touching OAuth2Handler directly.
 		$stored = false;
 		if ( $storage_fn ) {
-			$stored = call_user_func( $storage_fn, $account_data, $state_payload );
+			$stored = $this->store_callback_account(
+				static fn() => call_user_func( $storage_fn, $account_data, $state_payload ),
+				$state_payload
+			);
 		} else {
 			do_action(
 				'datamachine_log',
@@ -528,7 +559,6 @@ class OAuth2Handler {
 	 */
 	public function render_implicit_callback_page( string $provider_key, string $callback_url ): void {
 		$nonce = wp_create_nonce( "datamachine_implicit_{$provider_key}" );
-
 		// Minimal HTML page — extracts fragment params and POSTs to server.
 		header( 'Content-Type: text/html; charset=utf-8' );
 		echo '<!DOCTYPE html><html><head><title>Authenticating…</title></head><body>';
@@ -539,12 +569,14 @@ class OAuth2Handler {
 		echo 'else {';
 		echo '  var params = new URLSearchParams(hash);';
 		echo '  var token = params.get("access_token");';
-		echo '  if (!token) { document.body.innerHTML = "<p>Authentication failed: no access token in response.</p>"; }';
+		echo '  var state = params.get("state");';
+		echo '  if (!token || !state) { document.body.innerHTML = "<p>Authentication failed: missing token or state.</p>"; }';
 		echo '  else {';
 		echo '    var data = new URLSearchParams();';
 		echo '    data.append("datamachine_implicit_flow", "1");';
 		echo '    data.append("_wpnonce", ' . wp_json_encode( $nonce ) . ');';
 		echo '    data.append("provider", ' . wp_json_encode( $provider_key ) . ');';
+		echo '    data.append("state", state);';
 		// Forward all fragment params (access_token, token_type, expires_in, site_id, etc.)
 		echo '    params.forEach(function(v, k) { data.append(k, v); });';
 		echo '    fetch(' . wp_json_encode( $callback_url ) . ', {';
@@ -612,6 +644,25 @@ class OAuth2Handler {
 			echo wp_json_encode( array(
 				'success' => false,
 				'error'   => 'Invalid nonce.',
+			) );
+			exit;
+		}
+
+		// The state is the CSRF proof and carries trusted callback principal data.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- OAuth state is verified below.
+		$state = isset( $_POST['state'] ) ? sanitize_text_field( wp_unslash( $_POST['state'] ) ) : '';
+		$state_payload = $this->verify_state( $provider_key, $state );
+		if ( false === $state_payload ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'OAuth2: Implicit flow state verification failed',
+				array( 'provider' => $provider_key )
+			);
+
+			echo wp_json_encode( array(
+				'success' => false,
+				'error'   => 'Invalid OAuth state.',
 			) );
 			exit;
 		}
@@ -692,7 +743,10 @@ class OAuth2Handler {
 		// Store account data.
 		$stored = false;
 		if ( $storage_fn ) {
-			$stored = call_user_func( $storage_fn, $account_data );
+			$stored = $this->store_callback_account(
+				static fn() => call_user_func( $storage_fn, $account_data ),
+				$state_payload
+			);
 		}
 
 		if ( ! $stored ) {
@@ -735,6 +789,24 @@ class OAuth2Handler {
 			'redirect' => $redirect_url,
 		) );
 		exit;
+	}
+
+	/**
+	 * Store a callback account under the verified OAuth state principal.
+	 *
+	 * @param callable $storage_callback Callback that stores the account data.
+	 * @param array    $state_payload    Verified OAuth state payload.
+	 * @return bool Whether account storage succeeded.
+	 */
+	protected function store_callback_account( callable $storage_callback, array $state_payload ): bool {
+		$agent_id = absint( $state_payload['agent_id'] ?? 0 );
+		$user_id  = absint( $state_payload['user_id'] ?? 0 );
+
+		// OAuth callbacks are separate requests. Reinstall the trusted state
+		// principal so existing providers that use ambient scope save to its slot.
+		return $agent_id > 0 && $user_id > 0 && class_exists( '\\DataMachine\\Abilities\\PermissionHelper' )
+			? \DataMachine\Abilities\PermissionHelper::run_as_agent_context( $agent_id, $user_id, $storage_callback, \AgentsAPI\AI\WP_Agent_Execution_Principal::REQUEST_CONTEXT_REST )
+			: $storage_callback();
 	}
 
 	// -------------------------------------------------------------------------

--- a/inc/Engine/Filters/OAuth.php
+++ b/inc/Engine/Filters/OAuth.php
@@ -73,11 +73,26 @@ function datamachine_register_oauth_system() {
 			 * @param string $provider_slug  The provider slug from the URL (e.g. 'instagram', 'twitter').
 			 * @param array  $request_params The raw $_GET parameters for the callback request.
 			 */
+			$request_params = array_merge(
+				$_GET, // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- OAuth state is verified before agent callback authorization.
+				$_POST // phpcs:ignore WordPress.Security.NonceVerification.Missing -- OAuth state is verified before agent callback authorization.
+			);
+			$can_handle     = current_user_can( 'manage_options' );
+			$agent_callback = false;
+
+			if ( $auth_instance instanceof \DataMachine\Core\OAuth\BaseOAuth2Provider && $auth_instance->supports_agent_scoped_oauth_callback() ) {
+				$is_implicit_initial_request = 'token' === $auth_instance->get_oauth_response_type() && empty( $_POST['datamachine_implicit_flow'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- This only permits rendering a token/state relay page.
+				$agent_callback             = $is_implicit_initial_request || false !== datamachine_oauth_agent_callback_payload( $auth_instance, $request_params );
+				if ( ! $can_handle && $agent_callback ) {
+					$can_handle = $is_implicit_initial_request || datamachine_oauth_can_handle_agent_scoped_callback( $auth_instance, $request_params );
+				}
+			}
+
 			$can_handle = apply_filters(
 				'datamachine_oauth_can_handle_callback',
-				current_user_can( 'manage_options' ),
+				$can_handle,
 				$provider,
-				$_GET // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- OAuth callbacks use provider-specific state validation, not WP nonces.
+				$request_params
 			);
 
 			if ( ! $can_handle ) {
@@ -88,10 +103,71 @@ function datamachine_register_oauth_system() {
 				);
 			}
 
-			$auth_instance->handle_oauth_callback();
+			if ( $agent_callback ) {
+				$auth_instance->handle_agent_scoped_oauth_callback();
+			} else {
+				$auth_instance->handle_oauth_callback();
+			}
 
 			exit;
 		},
 		5
 	);
+}
+
+/**
+ * Authorize an agent-scoped OAuth callback from a verified, unconsumed state.
+ *
+ * The central callback handler consumes state before it stores an account.
+ * Unscoped state intentionally remains on the legacy site-admin path.
+ *
+ * @param \DataMachine\Core\OAuth\BaseOAuth2Provider $provider OAuth provider.
+ * @param array                                         $request  Callback request parameters.
+ * @return bool Whether the current user may complete this callback.
+ */
+function datamachine_oauth_can_handle_agent_scoped_callback( \DataMachine\Core\OAuth\BaseOAuth2Provider $provider, array $request ): bool {
+	$payload = datamachine_oauth_agent_callback_payload( $provider, $request );
+	if ( false === $payload ) {
+		return false;
+	}
+
+	$agent_id = absint( $payload['agent_id'] ?? 0 );
+	$user_id  = absint( $payload['user_id'] ?? 0 );
+	if ( get_current_user_id() <= 0 ) {
+		return false;
+	}
+
+	$agent = ( new \DataMachine\Core\Database\Agents\Agents() )->get_agent( $agent_id );
+	if ( ! $agent || (int) $agent['owner_id'] !== $user_id ) {
+		return false;
+	}
+
+	if ( get_current_user_id() === $user_id ) {
+		return true;
+	}
+
+	return ( new \DataMachine\Core\Database\Agents\AgentAccess() )->user_can_access( $agent_id, get_current_user_id(), \WP_Agent_Access_Grant::ROLE_ADMIN );
+}
+
+/**
+ * Return the verified agent-bound state payload without consuming it.
+ *
+ * @param \DataMachine\Core\OAuth\BaseOAuth2Provider $provider OAuth provider.
+ * @param array                                         $request  Callback request parameters.
+ * @return array|false Verified agent principal payload, or false.
+ */
+function datamachine_oauth_agent_callback_payload( \DataMachine\Core\OAuth\BaseOAuth2Provider $provider, array $request ) {
+	$state = isset( $request['state'] ) ? sanitize_text_field( wp_unslash( $request['state'] ) ) : '';
+	if ( '' === $state ) {
+		return false;
+	}
+
+	$payload  = ( new \DataMachine\Core\OAuth\OAuth2Handler() )->peek_state( $provider->get_provider_slug(), $state );
+	$agent_id = is_array( $payload ) ? absint( $payload['agent_id'] ?? 0 ) : 0;
+	$user_id  = is_array( $payload ) ? absint( $payload['user_id'] ?? 0 ) : 0;
+	if ( $agent_id <= 0 || $user_id <= 0 ) {
+		return false;
+	}
+
+	return $payload;
 }

--- a/tests/Unit/Abilities/PermissionHelperTest.php
+++ b/tests/Unit/Abilities/PermissionHelperTest.php
@@ -401,4 +401,66 @@ class PermissionHelperTest extends WP_UnitTestCase {
 		$this->assertNull( $principal->token_id );
 		$this->assertTrue( PermissionHelper::can( 'manage_agents' ) );
 	}
+
+	public function test_run_as_agent_context_restores_the_previous_context_after_success(): void {
+		$owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		PermissionHelper::set_agent_context( 123, $owner_id );
+
+		$result = PermissionHelper::run_as_agent_context(
+			456,
+			$owner_id,
+			function (): string {
+				$this->assertSame( 456, PermissionHelper::get_acting_agent_id() );
+				$this->assertSame( $owner_id, PermissionHelper::acting_user_id() );
+				return 'stored';
+			}
+		);
+
+		$this->assertSame( 'stored', $result );
+		$this->assertSame( 123, PermissionHelper::get_acting_agent_id() );
+		$this->assertSame( $owner_id, PermissionHelper::acting_user_id() );
+	}
+
+	public function test_run_as_agent_context_restores_the_previous_context_after_exception(): void {
+		$owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		PermissionHelper::set_agent_context( 123, $owner_id );
+
+		try {
+			PermissionHelper::run_as_agent_context(
+				456,
+				$owner_id,
+				function (): void {
+					$this->assertSame( 456, PermissionHelper::get_acting_agent_id() );
+					throw new \RuntimeException( 'expected callback failure' );
+				}
+			);
+			$this->fail( 'Expected the callback exception to be re-thrown.' );
+		} catch ( \RuntimeException $e ) {
+			$this->assertSame( 'expected callback failure', $e->getMessage() );
+		}
+
+		$this->assertSame( 123, PermissionHelper::get_acting_agent_id() );
+		$this->assertSame( $owner_id, PermissionHelper::acting_user_id() );
+	}
+
+	public function test_run_as_agent_context_restores_the_outer_context_when_nested(): void {
+		$owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		PermissionHelper::run_as_agent_context(
+			123,
+			$owner_id,
+			function () use ( $owner_id ): void {
+				PermissionHelper::run_as_agent_context(
+					456,
+					$owner_id,
+					function (): void {
+						$this->assertSame( 456, PermissionHelper::get_acting_agent_id() );
+					}
+				);
+				$this->assertSame( 123, PermissionHelper::get_acting_agent_id() );
+			}
+		);
+
+		$this->assertNull( PermissionHelper::get_acting_agent_id() );
+	}
 }

--- a/tests/Unit/Abilities/PermissionHelperTest.php
+++ b/tests/Unit/Abilities/PermissionHelperTest.php
@@ -409,7 +409,7 @@ class PermissionHelperTest extends WP_UnitTestCase {
 		$result = PermissionHelper::run_as_agent_context(
 			456,
 			$owner_id,
-			function (): string {
+			function () use ( $owner_id ): string {
 				$this->assertSame( 456, PermissionHelper::get_acting_agent_id() );
 				$this->assertSame( $owner_id, PermissionHelper::acting_user_id() );
 				return 'stored';

--- a/tests/Unit/Core/OAuth/BaseOAuth2ProviderTest.php
+++ b/tests/Unit/Core/OAuth/BaseOAuth2ProviderTest.php
@@ -12,6 +12,8 @@
 namespace DataMachine\Tests\Unit\Core\OAuth;
 
 use DataMachine\Core\OAuth\BaseOAuth2Provider;
+use DataMachine\Core\OAuth\OAuth2Handler;
+use DataMachine\Abilities\PermissionHelper;
 use WP_UnitTestCase;
 
 /**
@@ -60,6 +62,10 @@ class TestOAuth2Provider extends BaseOAuth2Provider {
 		return 'https://example.com/oauth/authorize';
 	}
 
+	public function get_authorization_params(): array {
+		return $this->build_auth_url_params();
+	}
+
 	public function handle_oauth_callback() {
 		// No-op for tests.
 	}
@@ -79,6 +85,13 @@ class TestOAuth2Provider extends BaseOAuth2Provider {
 			'access_token' => $this->refreshed_token,
 			'expires_at'   => time() + $this->refreshed_expires_in,
 		);
+	}
+}
+
+class TestCallbackOAuth2Handler extends OAuth2Handler {
+
+	public function store_callback_account_for_test( callable $storage_callback, array $state_payload ): bool {
+		return $this->store_callback_account( $storage_callback, $state_payload );
 	}
 }
 
@@ -103,9 +116,73 @@ class BaseOAuth2ProviderTest extends WP_UnitTestCase {
 	}
 
 	public function tear_down(): void {
+		PermissionHelper::clear_agent_context();
 		wp_clear_scheduled_hook( $this->provider->get_cron_hook_name() );
 		delete_site_option( 'datamachine_auth_data' );
 		parent::tear_down();
+	}
+
+	public function test_authorization_state_binds_the_active_agent_and_owner(): void {
+		$owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		PermissionHelper::set_agent_context( 303, $owner_id );
+
+		$params  = $this->provider->get_authorization_params();
+		$payload = ( new OAuth2Handler() )->verify_state( 'test_oauth2', $params['state'] );
+
+		$this->assertSame(
+			array(
+				'agent_id' => 303,
+				'user_id'  => $owner_id,
+			),
+			$payload
+		);
+	}
+
+	public function test_unscoped_authorization_state_remains_empty(): void {
+		$params  = $this->provider->get_authorization_params();
+		$payload = ( new OAuth2Handler() )->verify_state( 'test_oauth2', $params['state'] );
+
+		$this->assertSame( array(), $payload );
+	}
+
+	public function test_agent_state_marker_requires_the_base_url_helper_for_each_invocation(): void {
+		$owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		PermissionHelper::set_agent_context( 303, $owner_id );
+
+		$this->provider->begin_agent_scoped_authorization();
+		$this->assertFalse( $this->provider->has_agent_scoped_authorization_state() );
+		$this->provider->get_authorization_params();
+		$this->assertTrue( $this->provider->has_agent_scoped_authorization_state() );
+
+		$this->provider->begin_agent_scoped_authorization();
+		$this->assertFalse( $this->provider->has_agent_scoped_authorization_state() );
+	}
+
+	public function test_callback_storage_uses_the_verified_agent_slot_and_restores_context(): void {
+		$owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		add_filter(
+			'datamachine_auth_scope_policy',
+			static fn( string $policy, string $provider_slug ): string => 'test_oauth2' === $provider_slug ? BaseOAuth2Provider::AUTH_SCOPE_PRINCIPAL : $policy,
+			10,
+			2
+		);
+
+		PermissionHelper::set_agent_context( 111, $owner_id );
+		$handler = new TestCallbackOAuth2Handler();
+		$stored  = $handler->store_callback_account_for_test(
+			fn(): bool => $this->provider->save_account( array( 'access_token' => 'agent-callback-token' ) ),
+			array(
+				'agent_id' => 303,
+				'user_id'  => $owner_id,
+			)
+		);
+
+		$this->assertTrue( $stored );
+		$this->assertSame( 'agent-callback-token', $this->provider->get_account_for_agent( 303 )['access_token'] );
+		$this->assertNull( $this->provider->get_account_for_user( $owner_id ) );
+		$this->assertNull( $this->provider->get_site_account() );
+		$this->assertSame( 111, PermissionHelper::get_acting_agent_id() );
+		remove_all_filters( 'datamachine_auth_scope_policy' );
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/auth-cli-agent-scoped-oauth-smoke.php
+++ b/tests/auth-cli-agent-scoped-oauth-smoke.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * Behavioral coverage for agent-scoped OAuth CLI setup.
+ *
+ * Run with: php tests/auth-cli-agent-scoped-oauth-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Cli {
+	class BaseCommand {}
+
+	class AgentResolver {
+		public static function resolveEffectiveContext( array $args ): array {
+			if ( 'unknown' === $args['agent'] ) {
+				\WP_CLI::error( 'Agent "unknown" was not found.' );
+			}
+
+			return array(
+				'agent_id'   => 44,
+				'user_id'    => 77,
+				'agent_slug' => 'writer',
+			);
+		}
+	}
+}
+
+namespace DataMachine\Abilities {
+	class PermissionHelper {
+		public static ?int $agent_id = null;
+		public static ?int $user_id = null;
+
+		public static function run_as_agent_context( int $agent_id, int $user_id, callable $callback ) {
+			$previous_agent = self::$agent_id;
+			$previous_user  = self::$user_id;
+			self::$agent_id = $agent_id;
+			self::$user_id  = $user_id;
+
+			try {
+				return $callback();
+			} finally {
+				self::$agent_id = $previous_agent;
+				self::$user_id  = $previous_user;
+			}
+		}
+	}
+
+	class AuthAbilities {
+		private object $provider;
+
+		public function __construct() {
+			$this->provider = new class() extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
+				protected function get_agent_scoped_oauth_callback_config(): ?array { return array( 'account_details' => static fn(): array => array(), 'token_url' => 'https://provider.example/token', 'token_params' => array() ); }
+				public function get_authorization_url(): string {
+					$this->mark_agent_state_created();
+					return 'https://provider.example/authorize';
+				}
+			};
+		}
+		public function providerExists( string $handler_slug ): bool { return in_array( $handler_slug, array( 'oauth', 'oauth-bypass', 'oauth-custom', 'oauth1' ), true ); }
+		public function getProviderForHandler( string $handler_slug ): object {
+			if ( 'oauth1' === $handler_slug ) {
+				return new class() {
+					public function get_authorization_url(): string { return 'https://provider.example/oauth1'; }
+				};
+			}
+			if ( 'oauth-bypass' === $handler_slug ) {
+				return new class() extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
+					protected function get_agent_scoped_oauth_callback_config(): ?array { return array( 'account_details' => static fn(): array => array(), 'token_url' => 'https://provider.example/token', 'token_params' => array() ); }
+					public function get_authorization_url(): string { return 'https://provider.example/unsafe'; }
+				};
+			}
+			if ( 'oauth-custom' === $handler_slug ) {
+				return new class() extends \DataMachine\Core\OAuth\BaseOAuth2Provider {
+					public function get_authorization_url(): string { return 'https://provider.example/custom'; }
+					public function handle_oauth_callback(): void {}
+				};
+			}
+			return $this->provider;
+		}
+		public function executeGetAuthStatus( array $input ): array {
+			$url = $this->getProviderForHandler( $input['handler_slug'] )->get_authorization_url();
+			return array(
+				'success'       => true,
+				'authenticated' => false,
+				'requires_auth' => true,
+				'oauth_url'     => $url . '?agent=' . ( PermissionHelper::$agent_id ?? 'site' ),
+			);
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\Agents {
+	class AgentAccess {
+		public static bool $allowed = true;
+		public function user_can_access( int $agent_id, int $user_id, string $minimum_role ): bool {
+			return self::$allowed;
+		}
+	}
+}
+
+namespace DataMachine\Core\OAuth {
+	abstract class BaseOAuth2Provider {
+		private bool $agent_state_created = false;
+		public function begin_agent_scoped_authorization(): void { $this->agent_state_created = false; }
+		public function has_agent_scoped_authorization_state(): bool { return $this->agent_state_created; }
+		public function mark_agent_state_created(): void { $this->agent_state_created = true; }
+		protected function get_agent_scoped_oauth_callback_config(): ?array { return null; }
+		final public function supports_agent_scoped_oauth_callback(): bool { return null !== $this->get_agent_scoped_oauth_callback_config(); }
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+	}
+
+	function sanitize_text_field( $value ): string { return trim( (string) $value ); }
+	function get_current_user_id(): int { return (int) $GLOBALS['auth_cli_user_id']; }
+	function current_user_can( string $capability ): bool { return (bool) $GLOBALS['auth_cli_site_admin']; }
+
+	class WP_Agent_Access_Grant {
+		const ROLE_ADMIN = 'admin';
+	}
+
+	class WP_CLI {
+		public static array $logs = array();
+		public static function error( string $message ): void { throw new \RuntimeException( $message ); }
+		public static function log( string $message ): void { self::$logs[] = $message; }
+		public static function success( string $message ): void { self::$logs[] = $message; }
+	}
+
+	require_once dirname( __DIR__ ) . '/inc/Cli/Commands/AuthCommand.php';
+
+	function auth_cli_run( array $args ): array {
+		WP_CLI::$logs = array();
+		$command      = new \DataMachine\Cli\Commands\AuthCommand();
+		$command->connect( array( 'oauth' ), $args );
+		return WP_CLI::$logs;
+	}
+
+	$GLOBALS['auth_cli_user_id']    = 99;
+	$GLOBALS['auth_cli_site_admin'] = false;
+
+	$logs = auth_cli_run( array( 'agent' => 'writer' ) );
+	if ( ! in_array( 'OAuth principal: agent writer (ID 44), owner user 77.', $logs, true ) || ! in_array( 'https://provider.example/authorize?agent=44', $logs, true ) ) {
+		throw new \RuntimeException( 'Scoped OAuth connect did not generate and identify the agent-bound URL.' );
+	}
+	if ( null !== \DataMachine\Abilities\PermissionHelper::$agent_id || null !== \DataMachine\Abilities\PermissionHelper::$user_id ) {
+		throw new \RuntimeException( 'Scoped OAuth connect leaked its temporary agent context.' );
+	}
+
+	$logs = auth_cli_run( array() );
+	if ( ! in_array( 'https://provider.example/authorize?agent=site', $logs, true ) ) {
+		throw new \RuntimeException( 'Unscoped OAuth connect no longer uses the legacy site context.' );
+	}
+
+	\DataMachine\Core\Database\Agents\AgentAccess::$allowed = true;
+	try {
+		auth_cli_run( array( 'agent' => 'unknown' ) );
+		throw new \RuntimeException( 'Unknown agents must fail closed.' );
+	} catch ( \RuntimeException $e ) {
+		if ( 'Agent "unknown" was not found.' !== $e->getMessage() ) {
+			throw $e;
+		}
+	}
+
+	\DataMachine\Core\Database\Agents\AgentAccess::$allowed = false;
+	try {
+		auth_cli_run( array( 'agent' => 'writer' ) );
+		throw new \RuntimeException( 'Unauthorized agents must fail closed.' );
+	} catch ( \RuntimeException $e ) {
+		if ( false === strpos( $e->getMessage(), 'not authorized' ) ) {
+			throw $e;
+		}
+	}
+
+	\DataMachine\Core\Database\Agents\AgentAccess::$allowed = true;
+	try {
+		$command = new \DataMachine\Cli\Commands\AuthCommand();
+		$command->connect( array( 'oauth-bypass' ), array( 'agent' => 'writer' ) );
+		throw new \RuntimeException( 'Agent-scoped providers that bypass the helper must fail closed.' );
+	} catch ( \RuntimeException $e ) {
+		if ( false === strpos( $e->getMessage(), 'did not create agent-bound OAuth state' ) ) {
+			throw $e;
+		}
+	}
+
+	try {
+		$command = new \DataMachine\Cli\Commands\AuthCommand();
+		$command->connect( array( 'oauth-custom' ), array( 'agent' => 'writer' ) );
+		throw new \RuntimeException( 'Custom callback overrides must not opt into agent-scoped OAuth.' );
+	} catch ( \RuntimeException $e ) {
+		if ( false === strpos( $e->getMessage(), 'does not support agent-scoped OAuth callbacks' ) ) {
+			throw $e;
+		}
+	}
+
+	try {
+		$command = new \DataMachine\Cli\Commands\AuthCommand();
+		$command->connect( array( 'oauth1' ), array( 'agent' => 'writer' ) );
+		throw new \RuntimeException( 'OAuth1 must not support agent-scoped OAuth.' );
+	} catch ( \RuntimeException $e ) {
+		if ( false === strpos( $e->getMessage(), 'does not support agent-scoped OAuth callbacks' ) ) {
+			throw $e;
+		}
+	}
+
+	echo "auth-cli-agent-scoped-oauth-smoke passed\n";
+}

--- a/tests/oauth-agent-callback-authorization-smoke.php
+++ b/tests/oauth-agent-callback-authorization-smoke.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Behavioral coverage for verified-state OAuth callback authorization.
+ *
+ * Run with: php tests/oauth-agent-callback-authorization-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Core\OAuth {
+	class BaseOAuth2Provider {
+		public function get_provider_slug(): string { return 'test-provider'; }
+		protected function get_agent_scoped_oauth_callback_config(): ?array { return array( 'account_details' => static fn(): array => array(), 'token_url' => 'https://provider.example/token', 'token_params' => array() ); }
+		final public function supports_agent_scoped_oauth_callback(): bool { return null !== $this->get_agent_scoped_oauth_callback_config(); }
+		public function get_oauth_response_type(): string { return 'code'; }
+	}
+
+	class OAuth2Handler {
+		public static array|false $payload = false;
+		public function peek_state( string $provider, string $state ) { return 'valid-state' === $state ? self::$payload : false; }
+	}
+}
+
+namespace DataMachine\Core\Database\Agents {
+	class Agents {
+		public static ?array $agent = array( 'agent_id' => 303, 'owner_id' => 77 );
+		public function get_agent( int $agent_id ): ?array { return 303 === $agent_id ? self::$agent : null; }
+	}
+
+	class AgentAccess {
+		public static bool $admin = false;
+		public function user_can_access( int $agent_id, int $user_id, string $role ): bool { return 303 === $agent_id && 88 === $user_id && self::$admin && 'admin' === $role; }
+	}
+}
+
+namespace {
+	define( 'WPINC', 'wp-includes' );
+	$GLOBALS['oauth_callback_user_id'] = 0;
+	function sanitize_text_field( $value ): string { return trim( (string) $value ); }
+	function wp_unslash( $value ) { return $value; }
+	function absint( $value ): int { return abs( (int) $value ); }
+	function get_current_user_id(): int { return $GLOBALS['oauth_callback_user_id']; }
+	function current_user_can( string $capability ): bool { return false; }
+	class WP_Agent_Access_Grant { const ROLE_ADMIN = 'admin'; }
+
+	require_once dirname( __DIR__ ) . '/inc/Engine/Filters/OAuth.php';
+
+	$provider = new \DataMachine\Core\OAuth\BaseOAuth2Provider();
+	\DataMachine\Core\OAuth\OAuth2Handler::$payload = array( 'agent_id' => 303, 'user_id' => 77 );
+
+	$GLOBALS['oauth_callback_user_id'] = 77;
+	if ( ! datamachine_oauth_can_handle_agent_scoped_callback( $provider, array( 'state' => 'valid-state' ) ) ) {
+		throw new \RuntimeException( 'The verified agent owner should be authorized for the callback.' );
+	}
+
+	$GLOBALS['oauth_callback_user_id']                       = 88;
+	\DataMachine\Core\Database\Agents\AgentAccess::$admin = true;
+	if ( ! datamachine_oauth_can_handle_agent_scoped_callback( $provider, array( 'state' => 'valid-state' ) ) ) {
+		throw new \RuntimeException( 'A verified agent admin should be authorized for the callback.' );
+	}
+
+	\DataMachine\Core\Database\Agents\AgentAccess::$admin = false;
+	if ( datamachine_oauth_can_handle_agent_scoped_callback( $provider, array( 'state' => 'valid-state' ) ) ) {
+		throw new \RuntimeException( 'A non-owner without agent admin access must be rejected.' );
+	}
+
+	if ( datamachine_oauth_can_handle_agent_scoped_callback( $provider, array( 'state' => 'invalid-state' ) ) ) {
+		throw new \RuntimeException( 'An invalid state must be rejected before principal authorization.' );
+	}
+
+	\DataMachine\Core\OAuth\OAuth2Handler::$payload = array();
+	$GLOBALS['oauth_callback_user_id']                  = 77;
+	if ( datamachine_oauth_can_handle_agent_scoped_callback( $provider, array( 'state' => 'valid-state' ) ) ) {
+		throw new \RuntimeException( 'Unscoped state must retain the legacy site-admin callback path.' );
+	}
+
+	echo "oauth-agent-callback-authorization-smoke passed\n";
+}

--- a/tests/oauth2-implicit-agent-state-smoke.php
+++ b/tests/oauth2-implicit-agent-state-smoke.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Behavioral coverage for implicit OAuth state propagation and agent storage.
+ *
+ * Run with: php tests/oauth2-implicit-agent-state-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace AgentsAPI\AI {
+	class WP_Agent_Execution_Principal {
+		const REQUEST_CONTEXT_REST = 'rest';
+	}
+}
+
+namespace DataMachine\Abilities {
+	class PermissionHelper {
+		public static ?int $agent_id = null;
+		public static int $user_id = 0;
+
+		public static function run_as_agent_context( int $agent_id, int $user_id, callable $callback, string $request_context = 'rest' ) {
+			unset( $request_context );
+			$previous_agent = self::$agent_id;
+			$previous_user  = self::$user_id;
+			self::$agent_id = $agent_id;
+			self::$user_id  = $user_id;
+			try {
+				return $callback();
+			} finally {
+				self::$agent_id = $previous_agent;
+				self::$user_id  = $previous_user;
+			}
+		}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+	define( 'WPINC', 'wp-includes' );
+	define( 'MINUTE_IN_SECONDS', 60 );
+	$GLOBALS['oauth2_implicit_transients'] = array();
+
+	function __( string $text ): string { return $text; }
+	function esc_html__( string $text ): string { return $text; }
+	function esc_html( string $text ): string { return $text; }
+	function sanitize_text_field( $value ): string { return trim( (string) $value ); }
+	function wp_unslash( $value ) { return $value; }
+	function wp_create_nonce( string $action ): string { return 'nonce-' . $action; }
+	function wp_verify_nonce( string $nonce, string $action ): bool { return $nonce === 'nonce-' . $action; }
+	function wp_json_encode( $value ): string { return json_encode( $value ); }
+	function admin_url( string $path ): string { return 'https://site.test/' . $path; }
+	function add_query_arg( array $args, string $url ): string { return $url . '?' . http_build_query( $args ); }
+	function do_action( ...$args ): void { unset( $args ); }
+	function absint( $value ): int { return abs( (int) $value ); }
+	function maybe_serialize( $value ): string { return serialize( $value ); }
+	function set_transient( string $key, $value, int $expiration ): bool { $GLOBALS['oauth2_implicit_transients'][ $key ] = $value; return true; }
+	function get_transient( string $key ) { return $GLOBALS['oauth2_implicit_transients'][ $key ] ?? false; }
+	function delete_transient( string $key ): bool { unset( $GLOBALS['oauth2_implicit_transients'][ $key ] ); return true; }
+	function is_wp_error( $value ): bool { return false; }
+
+	require_once dirname( __DIR__ ) . '/inc/Core/OAuth/OAuthRedirects.php';
+	require_once dirname( __DIR__ ) . '/inc/Core/OAuth/OAuth2Handler.php';
+
+	$mode = $argv[1] ?? '';
+	if ( 'render' === $mode ) {
+		$_GET = array( 'state' => 'state<safe>' );
+		( new \DataMachine\Core\OAuth\OAuth2Handler() )->render_implicit_callback_page( 'implicit-test', 'https://site.test/callback' );
+	}
+
+	if ( 'post' === $mode || 'invalid' === $mode ) {
+		$handler = new \DataMachine\Core\OAuth\OAuth2Handler();
+		$state   = 'post' === $mode ? $handler->create_state( 'implicit-test', array( 'agent_id' => 303, 'user_id' => 77 ) ) : '';
+		$_POST   = array(
+			'_wpnonce'                  => 'nonce-datamachine_implicit_implicit-test',
+			'datamachine_implicit_flow' => '1',
+			'access_token'              => 'fragment-token',
+			'state'                     => $state,
+		);
+		\DataMachine\Abilities\PermissionHelper::$agent_id = 111;
+		\DataMachine\Abilities\PermissionHelper::$user_id  = 22;
+		$report = $argv[2] ?? '';
+		register_shutdown_function(
+			static function () use ( $report ): void {
+				$existing = is_file( $report ) ? json_decode( (string) file_get_contents( $report ), true ) : array();
+				$existing['restored_agent_id'] = \DataMachine\Abilities\PermissionHelper::$agent_id;
+				$existing['restored_user_id']  = \DataMachine\Abilities\PermissionHelper::$user_id;
+				file_put_contents( $report, json_encode( $existing ) );
+			}
+		);
+		$handler->handle_implicit_callback(
+			'implicit-test',
+			static fn( array $token ): array => array( 'access_token' => $token['access_token'] ),
+			static function ( array $account ) use ( $report ): bool {
+				file_put_contents(
+					$report,
+					json_encode(
+						array(
+							'account'  => $account,
+							'agent_id' => \DataMachine\Abilities\PermissionHelper::$agent_id,
+							'user_id'  => \DataMachine\Abilities\PermissionHelper::$user_id,
+						)
+					)
+				);
+				return true;
+			}
+		);
+	}
+
+	$render = shell_exec( escapeshellcmd( PHP_BINARY ) . ' ' . escapeshellarg( __FILE__ ) . ' render' );
+	if ( false === strpos( (string) $render, 'var state = params.get("state");' ) || false === strpos( (string) $render, 'data.append("state", state);' ) ) {
+		throw new \RuntimeException( 'Implicit callback render did not forward state from the OAuth fragment.' );
+	}
+
+	$report = tempnam( sys_get_temp_dir(), 'oauth2-implicit-' );
+	if ( false === $report ) {
+		throw new \RuntimeException( 'Could not allocate implicit callback test report.' );
+	}
+	shell_exec( escapeshellcmd( PHP_BINARY ) . ' ' . escapeshellarg( __FILE__ ) . ' post ' . escapeshellarg( $report ) );
+	$result = json_decode( (string) file_get_contents( $report ), true );
+	@unlink( $report );
+	if ( 303 !== ( $result['agent_id'] ?? null ) || 77 !== ( $result['user_id'] ?? null ) || 111 !== ( $result['restored_agent_id'] ?? null ) || 22 !== ( $result['restored_user_id'] ?? null ) ) {
+		throw new \RuntimeException( 'Implicit callback did not store under the verified agent principal and restore context.' );
+	}
+
+	$invalid_report = tempnam( sys_get_temp_dir(), 'oauth2-implicit-invalid-' );
+	$invalid        = shell_exec( escapeshellcmd( PHP_BINARY ) . ' ' . escapeshellarg( __FILE__ ) . ' invalid ' . escapeshellarg( (string) $invalid_report ) );
+	if ( false !== $invalid_report ) {
+		@unlink( $invalid_report );
+	}
+	if ( false === strpos( (string) $invalid, 'Invalid OAuth state.' ) ) {
+		throw new \RuntimeException( 'Implicit callback accepted missing OAuth state.' );
+	}
+
+	echo "oauth2-implicit-agent-state-smoke passed\n";
+}


### PR DESCRIPTION
## Summary

- add `wp datamachine auth connect <provider> --agent=<slug-or-id>`
- bind OAuth state to the authorized agent/user principal and restore that context for callback storage
- route supported OAuth2 callbacks through a Base-owned final dispatcher so custom callbacks cannot bypass state consumption or principal-scoped storage
- preserve legacy site-admin, unscoped OAuth behavior
- relay implicit-flow token and state fragments through a verified server POST

Closes #3230.

## Verification

- `php tests/auth-cli-agent-scoped-oauth-smoke.php`
- `php tests/oauth-agent-callback-authorization-smoke.php`
- `php tests/oauth2-implicit-agent-state-smoke.php`
- `php tests/auth-principal-scoped-smoke.php`
- `php tests/auth-cli-disconnect-alias-smoke.php`
- PHP syntax checks
- `composer validate --no-check-publish`
- `git diff --check`

Focused PHPUnit coverage was added but could not run locally because `vendor/bin/phpunit` is unavailable in the worktree.

## AI assistance disclosure

OpenAI GPT-5.6-sol via OpenCode inspected the OAuth lifecycle, implemented the principal-scoped CLI and callback contract, added deterministic tests, and performed iterative security reviews. Chris Huber directed and reviewed the work.