### PR TITLE
Enforce portable subagent bundle tool policies

### DIFF
--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -816,7 +816,7 @@ class AgentBundler {
 				$this->detect_locally_modified_subagent_artifacts( $slug, $kind, $files, is_array( $existing_root_metadata[ $kind ] ?? null ) ? $existing_root_metadata[ $kind ] : array(), $artifact_file_conflicts );
 			}
 			if ( ! empty( $root_artifacts ) || array_key_exists( 'skill_policy', $agent_data ) || array_key_exists( 'tool_policy', $agent_data ) ) {
-				if ( array_key_exists( 'tool_policy', $agent_data ) ) {
+				if ( ! empty( $agent_data['tool_policy'] ) ) {
 					$incoming_config['tool_policy'] = AgentSubagentGraph::normalize_tool_policy( $agent_data['tool_policy'], sprintf( 'Agent %s', $slug ) );
 				}
 				$incoming_config['datamachine_subagent'] = array_merge(

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -25,6 +25,7 @@ use DataMachine\Engine\Bundle\AgentBundleArtifactDefinitions;
 use DataMachine\Engine\Bundle\AgentBundleArtifactExtensions;
 use DataMachine\Engine\Bundle\AgentBundleArtifactState;
 use DataMachine\Engine\Bundle\AgentBundleAgentConfig;
+use DataMachine\Engine\Bundle\AgentBundleCompatibility;
 use DataMachine\Engine\Bundle\AgentBundleArtifactStatus;
 use DataMachine\Engine\Bundle\AgentBundleMemoryArtifact;
 use DataMachine\Engine\Bundle\BundleStepIdRemapper;
@@ -624,6 +625,19 @@ class AgentBundler {
 			);
 		}
 
+		try {
+			$compatibility = AgentBundleCompatibility::report( AgentPackageProjection::from_array_bundle( $bundle ) )->to_array();
+		} catch ( BundleValidationException $e ) {
+			return array(
+				'success'    => false,
+				'error_code' => 'install_invalid_bundle',
+				'error'      => $e->getMessage(),
+			);
+		}
+		if ( empty( $compatibility['compatible'] ) ) {
+			return self::unsupported_capabilities_result( $compatibility );
+		}
+
 		if ( (string) ( $bundle['bundle_schema_version'] ?? '' ) === (string) BundleSchema::VERSION ) {
 			try {
 				$directory = AgentBundleArrayAdapter::from_array_bundle( $bundle );
@@ -635,21 +649,14 @@ class AgentBundler {
 				);
 			}
 
-			$payload                       = AgentBundleArrayAdapter::to_import_payload( $directory );
-			$payload['abilities_manifest'] = is_array( $bundle['abilities_manifest'] ?? null ) ? $bundle['abilities_manifest'] : array();
-			try {
-				$this->validate_import_file_maps( $payload );
-			} catch ( BundleValidationException $e ) {
-				return array(
-					'success'    => false,
-					'error_code' => 'install_invalid_bundle',
-					'error'      => $e->getMessage(),
-				);
-			}
-			if ( ! empty( $payload['subagents'] ) && empty( $options['_graph_node'] ) ) {
-				return $this->import_subagent_graph( $payload, $new_slug, $owner_id, $dry_run, $options );
-			}
-			return $this->materialize_import_bundle( $payload, $new_slug, $owner_id, $dry_run, $options );
+			return $this->import_directory_materialization(
+				$directory,
+				$new_slug,
+				$owner_id,
+				$dry_run,
+				$options,
+				is_array( $bundle['abilities_manifest'] ?? null ) ? $bundle['abilities_manifest'] : array()
+			);
 		}
 
 		try {
@@ -809,6 +816,9 @@ class AgentBundler {
 				$this->detect_locally_modified_subagent_artifacts( $slug, $kind, $files, is_array( $existing_root_metadata[ $kind ] ?? null ) ? $existing_root_metadata[ $kind ] : array(), $artifact_file_conflicts );
 			}
 			if ( ! empty( $root_artifacts ) || array_key_exists( 'skill_policy', $agent_data ) || array_key_exists( 'tool_policy', $agent_data ) ) {
+				if ( array_key_exists( 'tool_policy', $agent_data ) ) {
+					$incoming_config['tool_policy'] = AgentSubagentGraph::normalize_tool_policy( $agent_data['tool_policy'], sprintf( 'Agent %s', $slug ) );
+				}
 				$incoming_config['datamachine_subagent'] = array_merge(
 					is_array( $incoming_config['datamachine_subagent'] ?? null ) ? $incoming_config['datamachine_subagent'] : array(),
 					array_filter(
@@ -1504,6 +1514,11 @@ class AgentBundler {
 	 * @return array{success: bool, message?: string, error?: string, error_code?: string, summary?: array}
 	 */
 	private function import_directory_materialization( AgentBundleDirectory $directory, ?string $new_slug, int $owner_id, bool $dry_run, array $options, array $abilities_manifest = array() ): array {
+		$compatibility = AgentBundleCompatibility::report( AgentPackageProjection::from_directory( $directory ) )->to_array();
+		if ( empty( $compatibility['compatible'] ) ) {
+			return self::unsupported_capabilities_result( $compatibility );
+		}
+
 		$payload = AgentBundleArrayAdapter::to_import_payload( $directory );
 		try {
 			$this->validate_import_file_maps( $payload );
@@ -1523,6 +1538,16 @@ class AgentBundler {
 		}
 
 		return $this->materialize_import_bundle( $payload, $new_slug, $owner_id, $dry_run, $options );
+	}
+
+	/** @return array<string,mixed> */
+	private static function unsupported_capabilities_result( array $compatibility ): array {
+		return array(
+			'success'       => false,
+			'error_code'    => 'install_unsupported_capabilities',
+			'error'         => 'Agent bundle requires capabilities that are not available on this host.',
+			'compatibility' => $compatibility,
+		);
 	}
 
 	/** Validate every raw legacy file map before an import can mutate the filesystem. */
@@ -1641,6 +1666,7 @@ class AgentBundler {
 							array(
 								'description'          => $child['description'],
 								'subagents'            => $child['subagents'],
+								'tool_policy'          => $child['tool_policy'],
 								'datamachine_subagent' => array(
 									'tool_policy'  => $child['tool_policy'],
 									'skill_policy' => $child['skill_policy'],

--- a/inc/Engine/Agents/AgentSubagentGraph.php
+++ b/inc/Engine/Agents/AgentSubagentGraph.php
@@ -14,6 +14,8 @@ defined( 'ABSPATH' ) || exit;
 
 final class AgentSubagentGraph {
 
+	public const CAPABILITY = 'datamachine/subagent-graph';
+
 	/** @return string[] */
 	public static function edges_from_config( mixed $edges, string $slug = '' ): array {
 		if ( ! is_array( $edges ) || ! array_is_list( $edges ) ) {
@@ -101,7 +103,7 @@ final class AgentSubagentGraph {
 				'description'  => (string) $child['description'],
 				'agent_config' => $child['agent_config'],
 				'memory'       => $memory,
-				'tool_policy'  => $child['tool_policy'],
+				'tool_policy'  => self::normalize_tool_policy( $child['tool_policy'], sprintf( 'Subagent %s', $slug ) ),
 				'skill_policy' => is_array( $child['skill_policy'] ?? null ) ? $child['skill_policy'] : array(),
 				'skills'       => self::normalize_file_map( $child['skills'], $slug, 'skill' ),
 				'references'   => self::normalize_file_map( $child['references'], $slug, 'reference' ),
@@ -118,6 +120,57 @@ final class AgentSubagentGraph {
 		}
 		self::assert_acyclic( $nodes );
 		return array_values( $nodes );
+	}
+
+	/** @return array<string,mixed> */
+	public static function normalize_tool_policy( mixed $policy, string $label = 'Agent' ): array {
+		if ( ! is_array( $policy ) || ( array() !== $policy && array_is_list( $policy ) ) ) {
+			throw new BundleValidationException( sprintf( '%s tool policy must be an object.', esc_html( $label ) ) );
+		}
+		if ( array() === $policy ) {
+			return array();
+		}
+		if ( array_key_exists( 'allow', $policy ) || array_key_exists( 'default', $policy ) ) {
+			$legacy_unknown = array_diff( array_keys( $policy ), array( 'allow', 'default' ) );
+			if ( ! empty( $legacy_unknown ) || ( array_key_exists( 'default', $policy ) && 'deny' !== $policy['default'] ) ) {
+				throw new BundleValidationException( sprintf( '%s legacy tool policy must be an allowlist with a deny default.', esc_html( $label ) ) );
+			}
+			$policy = array(
+				'mode'  => 'allow',
+				'tools' => $policy['allow'] ?? array(),
+			);
+		}
+
+		$unknown = array_diff( array_keys( $policy ), array( 'mode', 'tools', 'categories' ) );
+		if ( ! empty( $unknown ) ) {
+			throw new BundleValidationException( sprintf( '%s tool policy has unsupported fields: %s.', esc_html( $label ), esc_html( implode( ', ', $unknown ) ) ) );
+		}
+
+		$mode = is_string( $policy['mode'] ?? null ) ? $policy['mode'] : '';
+		if ( ! in_array( $mode, array( 'allow', 'deny' ), true ) ) {
+			throw new BundleValidationException( sprintf( '%s tool policy mode must be allow or deny.', esc_html( $label ) ) );
+		}
+
+		$normalized = array( 'mode' => $mode );
+		foreach ( array( 'tools', 'categories' ) as $field ) {
+			$values = $policy[ $field ] ?? array();
+			if ( ! is_array( $values ) || ! array_is_list( $values ) ) {
+				throw new BundleValidationException( sprintf( '%s tool policy %s must be a list.', esc_html( $label ), esc_html( $field ) ) );
+			}
+			$values = array_map( static fn( $value ): string => is_string( $value ) ? trim( $value ) : '', $values );
+			if ( in_array( '', $values, true ) ) {
+				throw new BundleValidationException( sprintf( '%s tool policy %s must contain non-empty strings.', esc_html( $label ), esc_html( $field ) ) );
+			}
+			$values = array_values( array_unique( $values ) );
+			sort( $values, SORT_STRING );
+			$normalized[ $field ] = $values;
+		}
+
+		if ( 'deny' === $mode && empty( $normalized['tools'] ) && empty( $normalized['categories'] ) ) {
+			throw new BundleValidationException( sprintf( '%s deny tool policy must name at least one tool or category.', esc_html( $label ) ) );
+		}
+
+		return $normalized;
 	}
 
 	/** @param string[] $edges @param array<int,array<string,mixed>> $children @return string[] */

--- a/inc/Engine/Bundle/AgentBundleAbilityService.php
+++ b/inc/Engine/Bundle/AgentBundleAbilityService.php
@@ -670,47 +670,12 @@ final class AgentBundleAbilityService {
 	}
 
 	public static function capability_report( \WP_Agent_Package $package ): \WP_Agent_Package_Capability_Report {
-		return \WP_Agent_Package_Capability_Checker::check( $package, self::host_capabilities() );
+		return AgentBundleCompatibility::report( $package );
 	}
 
 	/** @return array<int,string> */
 	public static function host_capabilities(): array {
-		$capabilities = array(
-			'datamachine',
-			'datamachine/agent',
-			'datamachine/agent-bundle',
-			'datamachine/bundle-schema-v1',
-			'datamachine/pipeline',
-			'datamachine/flow',
-			'datamachine/prompt',
-			'datamachine/rubric',
-			'datamachine/tool-policy',
-			'datamachine/auth-ref',
-			'datamachine/queue-seed',
-		);
-
-		/**
-		 * Extend host capability strings used for read-only bundle compatibility checks.
-		 *
-		 * @param array<int,string> $capabilities Data Machine host capabilities.
-		 */
-		$capabilities = function_exists( 'apply_filters' ) ? apply_filters( 'datamachine_agent_bundle_host_capabilities', $capabilities ) : $capabilities;
-		if ( ! is_array( $capabilities ) ) {
-			$capabilities = array();
-		}
-
-		$normalized = array();
-		foreach ( $capabilities as $capability ) {
-			$capability = trim( strtolower( (string) $capability ) );
-			if ( '' !== $capability ) {
-				$normalized[] = $capability;
-			}
-		}
-
-		$normalized = array_values( array_unique( $normalized ) );
-		sort( $normalized, SORT_STRING );
-
-		return $normalized;
+		return AgentBundleCompatibility::host_capabilities();
 	}
 
 	private function add_runtime_drift_to_plan( array $plan, array $bundle, string $slug = '', string $decision = 'preserve_existing' ): array {

--- a/inc/Engine/Bundle/AgentBundleCompatibility.php
+++ b/inc/Engine/Bundle/AgentBundleCompatibility.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Agent bundle host compatibility checks.
+ *
+ * @package DataMachine\Engine\Bundle
+ */
+
+namespace DataMachine\Engine\Bundle;
+
+use DataMachine\Engine\Agents\AgentSubagentGraph;
+
+defined( 'ABSPATH' ) || exit;
+
+final class AgentBundleCompatibility {
+
+	public static function report( \WP_Agent_Package $package ): \WP_Agent_Package_Capability_Report {
+		return \WP_Agent_Package_Capability_Checker::check( $package, self::host_capabilities() );
+	}
+
+	/** @return array<int,string> */
+	public static function host_capabilities(): array {
+		$capabilities = array(
+			'datamachine',
+			'datamachine/agent',
+			'datamachine/agent-bundle',
+			AgentSubagentGraph::CAPABILITY,
+			'datamachine/bundle-schema-v1',
+			'datamachine/pipeline',
+			'datamachine/flow',
+			'datamachine/prompt',
+			'datamachine/rubric',
+			'datamachine/tool-policy',
+			'datamachine/auth-ref',
+			'datamachine/queue-seed',
+		);
+
+		/**
+		 * Extend host capability strings used for bundle compatibility checks.
+		 *
+		 * @param array<int,string> $capabilities Data Machine host capabilities.
+		 */
+		$capabilities = function_exists( 'apply_filters' ) ? apply_filters( 'datamachine_agent_bundle_host_capabilities', $capabilities ) : $capabilities;
+		if ( ! is_array( $capabilities ) ) {
+			$capabilities = array();
+		}
+
+		$normalized = array();
+		foreach ( $capabilities as $capability ) {
+			$capability = trim( strtolower( (string) $capability ) );
+			if ( '' !== $capability ) {
+				$normalized[] = $capability;
+			}
+		}
+
+		$normalized = array_values( array_unique( $normalized ) );
+		sort( $normalized, SORT_STRING );
+
+		return $normalized;
+	}
+}

--- a/inc/Engine/Bundle/AgentBundleCompatibility.php
+++ b/inc/Engine/Bundle/AgentBundleCompatibility.php
@@ -44,17 +44,6 @@ final class AgentBundleCompatibility {
 			$capabilities = array();
 		}
 
-		$normalized = array();
-		foreach ( $capabilities as $capability ) {
-			$capability = trim( strtolower( (string) $capability ) );
-			if ( '' !== $capability ) {
-				$normalized[] = $capability;
-			}
-		}
-
-		$normalized = array_values( array_unique( $normalized ) );
-		sort( $normalized, SORT_STRING );
-
-		return $normalized;
+		return AgentPackageProjection::normalize_capabilities( $capabilities );
 	}
 }

--- a/inc/Engine/Bundle/AgentBundleManifest.php
+++ b/inc/Engine/Bundle/AgentBundleManifest.php
@@ -42,6 +42,9 @@ final class AgentBundleManifest {
 		$this->subagents       = AgentSubagentGraph::normalize( $subagents, (string) $this->agent['slug'] );
 		if ( ! empty( $this->subagents ) ) {
 			$this->agent['subagents'] = AgentSubagentGraph::coordinator_edges( $this->agent['subagents'] ?? array(), $this->subagents, (string) $this->agent['slug'] );
+			$this->capabilities[] = AgentSubagentGraph::CAPABILITY;
+			$this->capabilities   = array_values( array_unique( $this->capabilities ) );
+			sort( $this->capabilities, SORT_STRING );
 		}
 	}
 
@@ -203,10 +206,7 @@ final class AgentBundleManifest {
 			$validated['skill_policy'] = $agent['skill_policy'];
 		}
 		if ( array_key_exists( 'tool_policy', $agent ) ) {
-			if ( ! is_array( $agent['tool_policy'] ) || ( array() !== $agent['tool_policy'] && array_is_list( $agent['tool_policy'] ) ) ) {
-				throw new BundleValidationException( 'manifest.json agent.tool_policy must be an object.' );
-			}
-			$validated['tool_policy'] = $agent['tool_policy'];
+			$validated['tool_policy'] = AgentSubagentGraph::normalize_tool_policy( $agent['tool_policy'], 'manifest.json agent' );
 		}
 
 		// Carry the agent's site scope through the round-trip. `null` means

--- a/inc/Engine/Bundle/AgentPackageProjection.php
+++ b/inc/Engine/Bundle/AgentPackageProjection.php
@@ -53,13 +53,21 @@ final class AgentPackageProjection {
 	 * @return array<string,mixed>
 	 */
 	private static function agent_from_manifest( array $manifest ): array {
-		$agent = is_array( $manifest['agent'] ?? null ) ? $manifest['agent'] : array();
+		$agent          = is_array( $manifest['agent'] ?? null ) ? $manifest['agent'] : array();
+		$default_config = is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array();
+		if ( isset( $agent['tool_policy'] ) && is_array( $agent['tool_policy'] ) ) {
+			$default_config['tool_policy'] = $agent['tool_policy'];
+		}
+		if ( isset( $agent['subagents'] ) && is_array( $agent['subagents'] ) ) {
+			$default_config['subagents'] = $agent['subagents'];
+		}
 
 		return array(
 			'slug'           => (string) ( $agent['slug'] ?? '' ),
 			'label'          => (string) ( $agent['label'] ?? ( $agent['slug'] ?? '' ) ),
 			'description'    => (string) ( $agent['description'] ?? '' ),
-			'default_config' => is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array(),
+			'default_config' => $default_config,
+			'subagents'      => is_array( $agent['subagents'] ?? null ) ? $agent['subagents'] : array(),
 			'meta'           => array(
 				'package_source' => 'data-machine',
 			),

--- a/inc/Engine/Bundle/AgentPackageProjection.php
+++ b/inc/Engine/Bundle/AgentPackageProjection.php
@@ -29,7 +29,7 @@ final class AgentPackageProjection {
 				'slug'         => (string) $manifest['bundle_slug'],
 				'version'      => (string) $manifest['bundle_version'],
 				'agent'        => self::agent_from_manifest( $manifest ),
-				'capabilities' => self::string_list( is_array( $manifest['capabilities'] ?? null ) ? $manifest['capabilities'] : array() ),
+				'capabilities' => self::normalize_capabilities( is_array( $manifest['capabilities'] ?? null ) ? $manifest['capabilities'] : array() ),
 				'artifacts'    => self::artifacts_from_directory( $directory ),
 				'meta'         => self::meta_from_manifest( $manifest ),
 			)
@@ -170,7 +170,7 @@ final class AgentPackageProjection {
 					'extension_artifact_type' => $artifact_type,
 					'payload_kind'            => 'json',
 				),
-				self::string_list( is_array( $artifact['requires'] ?? null ) ? $artifact['requires'] : array() ),
+				self::normalize_capabilities( is_array( $artifact['requires'] ?? null ) ? $artifact['requires'] : array() ),
 				$artifact['payload'] ?? null
 			);
 		}
@@ -211,7 +211,7 @@ final class AgentPackageProjection {
 		);
 
 		if ( ! empty( $requires ) ) {
-			$artifact['requires'] = self::string_list( $requires );
+			$artifact['requires'] = self::normalize_capabilities( $requires );
 		}
 
 		if ( null !== $payload ) {
@@ -227,7 +227,7 @@ final class AgentPackageProjection {
 	 * @param array<int,mixed> $values Raw capability values.
 	 * @return array<int,string>
 	 */
-	private static function string_list( array $values ): array {
+	public static function normalize_capabilities( array $values ): array {
 		$normalized = array();
 		foreach ( $values as $value ) {
 			$value = trim( strtolower( (string) $value ) );

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -38,6 +38,7 @@ use DataMachine\Core\Database\Jobs\Jobs as JobsRepository;
 use DataMachine\Core\Database\Pipelines\Pipelines as PipelinesRepository;
 use DataMachine\Abilities\Engine\RunFlowAbility;
 use DataMachine\Engine\AI\Tools\Global\AgentDailyMemory;
+use DataMachine\Engine\AI\Tools\Policy\DataMachineAgentToolPolicyProvider;
 use DataMachine\Engine\Bundle\AgentBundleArrayAdapter;
 use DataMachine\Engine\Tasks\RecurringScheduler;
 use DataMachine\Engine\Bundle\AgentBundleArtifactState;
@@ -986,6 +987,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 	public function test_subagent_skill_policy_survives_persisted_graph_projection(): void {
 		$bundle                              = $this->fixture_bundle( 'policy-coordinator' );
 		$bundle['agent']['subagents']        = array( 'policy-writer' );
+		$bundle['agent']['tool_policy']      = array( 'mode' => 'allow', 'tools' => array( 'datamachine/search' ) );
 		$bundle['subagents']                 = array(
 			array(
 				'slug'         => 'policy-writer',
@@ -993,7 +995,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 				'description'  => 'Writes with an explicit skill policy.',
 				'agent_config' => array(),
 				'memory'       => array( 'SOUL.md' => "# Policy Writer\n" ),
-				'tool_policy'  => array(),
+				'tool_policy'  => array( 'mode' => 'allow', 'tools' => array( 'datamachine/read' ) ),
 				'skill_policy' => array( 'mode' => 'explicit', 'allowed' => array( 'write.md' ) ),
 				'skills'       => array( 'write.md' => "# Write\n" ),
 				'references'   => array(),
@@ -1008,11 +1010,43 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$projection = PersistedAgentGraphProjector::project( 'policy-coordinator' );
 		$this->assertTrue( (bool) $projection['success'] );
 		$nodes = array_column( $projection['nodes'] ?? array(), null, 'slug' );
+		$root  = $this->agents_repo->get_by_slug( 'policy-coordinator' );
+		$child = $this->agents_repo->get_by_slug( 'policy-writer' );
+		$this->assertSame( array( 'mode' => 'allow', 'tools' => array( 'datamachine/search' ), 'categories' => array() ), $root['agent_config']['tool_policy'] ?? null, 'Root policy is persisted where runtime enforcement reads it.' );
+		$this->assertSame( array( 'mode' => 'allow', 'tools' => array( 'datamachine/read' ), 'categories' => array() ), $child['agent_config']['tool_policy'] ?? null, 'Child policy is persisted where runtime enforcement reads it.' );
+		$policy_provider = new DataMachineAgentToolPolicyProvider();
+		$this->assertSame( $root['agent_config']['tool_policy'], $policy_provider->getForAgent( (int) $root['agent_id'] ), 'Runtime policy provider resolves the imported root policy.' );
+		$this->assertSame( $child['agent_config']['tool_policy'], $policy_provider->getForAgent( (int) $child['agent_id'] ), 'Runtime policy provider resolves the imported child policy.' );
 		$this->assertSame(
 			array( 'mode' => 'explicit', 'allowed' => array( 'write.md' ), 'paths' => array( 'write.md' ) ),
 			$nodes['policy-writer']['skill_policy'] ?? null,
 			'Persisted graph projection retains the child policy and installed skill paths.'
 		);
+	}
+
+	public function test_subagent_graph_import_fails_before_mutation_on_unsupported_host(): void {
+		$bundle                       = $this->fixture_bundle( 'unsupported-coordinator' );
+		$bundle['agent']['subagents'] = array( 'unsupported-writer' );
+		$bundle['subagents']          = array(
+			array(
+				'slug' => 'unsupported-writer', 'label' => 'Writer', 'description' => '', 'agent_config' => array(),
+				'memory' => array(), 'tool_policy' => array(), 'skills' => array(), 'references' => array(), 'subagents' => array(),
+			),
+		);
+		$remove_graph_capability = static fn( array $capabilities ): array => array_values( array_diff( $capabilities, array( 'datamachine/subagent-graph' ) ) );
+		add_filter( 'datamachine_agent_bundle_host_capabilities', $remove_graph_capability );
+
+		try {
+			$result = $this->bundler->import( $bundle, null, $this->owner_id );
+		} finally {
+			remove_filter( 'datamachine_agent_bundle_host_capabilities', $remove_graph_capability );
+		}
+
+		$this->assertFalse( (bool) $result['success'] );
+		$this->assertSame( 'install_unsupported_capabilities', $result['error_code'] ?? null );
+		$this->assertSame( array( 'datamachine/subagent-graph' ), $result['compatibility']['unsupported_capabilities'] ?? null );
+		$this->assertNull( $this->agents_repo->get_by_slug( 'unsupported-coordinator' ), 'Compatibility rejection creates no coordinator row.' );
+		$this->assertNull( $this->agents_repo->get_by_slug( 'unsupported-writer' ), 'Compatibility rejection creates no child row.' );
 	}
 
 	/**

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -47,6 +47,7 @@ use DataMachine\Engine\Bundle\AgentBundleInstalledArtifact;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
 use DataMachine\Engine\Bundle\BundleSchema;
 use DataMachine\Engine\Agents\PersistedAgentGraphProjector;
+use DataMachine\Engine\Agents\AgentSubagentGraph;
 use WP_UnitTestCase;
 
 final class DailyMemoryImportFakeStore implements WP_Agent_Memory_Store {
@@ -1033,7 +1034,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 				'memory' => array(), 'tool_policy' => array(), 'skills' => array(), 'references' => array(), 'subagents' => array(),
 			),
 		);
-		$remove_graph_capability = static fn( array $capabilities ): array => array_values( array_diff( $capabilities, array( 'datamachine/subagent-graph' ) ) );
+		$remove_graph_capability = static fn( array $capabilities ): array => array_values( array_diff( $capabilities, array( AgentSubagentGraph::CAPABILITY ) ) );
 		add_filter( 'datamachine_agent_bundle_host_capabilities', $remove_graph_capability );
 
 		try {
@@ -1044,7 +1045,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 
 		$this->assertFalse( (bool) $result['success'] );
 		$this->assertSame( 'install_unsupported_capabilities', $result['error_code'] ?? null );
-		$this->assertSame( array( 'datamachine/subagent-graph' ), $result['compatibility']['unsupported_capabilities'] ?? null );
+		$this->assertSame( array( AgentSubagentGraph::CAPABILITY ), $result['compatibility']['unsupported_capabilities'] ?? null );
 		$this->assertNull( $this->agents_repo->get_by_slug( 'unsupported-coordinator' ), 'Compatibility rejection creates no coordinator row.' );
 		$this->assertNull( $this->agents_repo->get_by_slug( 'unsupported-writer' ), 'Compatibility rejection creates no child row.' );
 	}

--- a/tests/agent-bundle-subagent-graph-smoke.php
+++ b/tests/agent-bundle-subagent-graph-smoke.php
@@ -32,7 +32,7 @@ function subagent_graph_node( string $slug, array $edges = array() ): array {
 		'slug' => $slug, 'label' => ucfirst( $slug ), 'description' => $slug,
 		'agent_config' => array( 'default_model' => 'generic-model' ),
 		'memory' => array( 'SOUL.md' => "# {$slug}\n", 'MEMORY.md' => '' ),
-		'tool_policy' => array( 'allow' => array( 'generic/tool' ) ),
+		'tool_policy' => array( 'mode' => 'allow', 'tools' => array( 'generic/tool' ) ),
 		'skill_policy' => array( 'mode' => 'explicit' ),
 		'skills' => array( 'skill.md' => "generic-skill\n" ), 'references' => array( 'reference.md' => "generic-ref\n" ), 'subagents' => $edges,
 	);
@@ -48,6 +48,7 @@ subagent_graph_assert( array( 'researcher' ) === $nodes[2]['subagents'], 'child 
 subagent_graph_assert( '# writer' . "\n" === $nodes[2]['memory']['SOUL.md'], 'identity bytes round-trip' );
 subagent_graph_assert( "generic-skill\n" === $nodes[2]['skills']['skill.md'] && "generic-ref\n" === $nodes[2]['references']['reference.md'], 'generic skills and references round-trip as bytes' );
 subagent_graph_assert( array( 'mode' => 'explicit' ) === $nodes[2]['skill_policy'], 'child skill policy round-trips' );
+subagent_graph_assert( array( 'mode' => 'allow', 'tools' => array( 'generic/tool' ), 'categories' => array() ) === $nodes[2]['tool_policy'], 'child tool policy is canonicalized for runtime enforcement' );
 subagent_graph_assert( array( 'writer' ) === AgentSubagentGraph::coordinator_edges( array( 'writer' ), $nodes, 'coordinator' ), 'coordinator edges resolve within bundled children' );
 
 foreach ( array(
@@ -92,6 +93,19 @@ try {
 	AgentSubagentGraph::normalize( array( $invalid ), 'coordinator' );
 } catch ( BundleValidationException $e ) { $rejected = true; }
 subagent_graph_assert( $rejected, 'traversal skill artifact paths are rejected before package path construction' );
+
+$legacy                = subagent_graph_node( 'writer' );
+$legacy['tool_policy'] = array( 'default' => 'deny', 'allow' => array( 'generic/tool' ) );
+$legacy_nodes          = AgentSubagentGraph::normalize( array( $legacy ), 'coordinator' );
+subagent_graph_assert( array( 'mode' => 'allow', 'tools' => array( 'generic/tool' ), 'categories' => array() ) === $legacy_nodes[0]['tool_policy'], 'shipped legacy allowlists migrate to the enforceable policy shape' );
+
+$rejected = false;
+try {
+	$invalid                = subagent_graph_node( 'writer' );
+	$invalid['tool_policy'] = array( 'default' => null, 'allow' => array( 'generic/tool' ) );
+	AgentSubagentGraph::normalize( array( $invalid ), 'coordinator' );
+} catch ( BundleValidationException $e ) { $rejected = true; }
+subagent_graph_assert( $rejected, 'present legacy defaults must be exactly deny' );
 
 if ( $failures ) {
 	exit( 1 );

--- a/tests/agent-bundler-directory-adapter-smoke.php
+++ b/tests/agent-bundler-directory-adapter-smoke.php
@@ -354,7 +354,7 @@ assert_adapter_equals( 'reference bytes survive directory package read', "\0refe
 assert_adapter_equals( 'root skill bytes survive directory package read', "root \0\xFF", $graph_round_trip['agent']['skills']['root.md'] ?? null );
 assert_adapter_equals( 'root reference bytes survive directory package read', "root reference \xC3\xA9", $graph_round_trip['agent']['references']['root-ref.md'] ?? null );
 assert_adapter_equals( 'root skill policy survives directory package read', array( 'mode' => 'explicit' ), $graph_round_trip['agent']['skill_policy'] ?? null );
-assert_adapter_equals( 'root tool policy survives directory package read', array( 'allow' => array( 'datamachine/read-file' ) ), $graph_round_trip['agent']['tool_policy'] ?? null );
+assert_adapter_equals( 'legacy root tool policy migrates during directory package read', array( 'mode' => 'allow', 'tools' => array( 'datamachine/read-file' ), 'categories' => array() ), $graph_round_trip['agent']['tool_policy'] ?? null );
 $child_skill_policy = $graph_round_trip['subagents'][0]['skill_policy'] ?? array();
 assert_adapter(
 	'child skill policy survives directory package read',

--- a/tests/bundle-validate-inspect-smoke.php
+++ b/tests/bundle-validate-inspect-smoke.php
@@ -18,6 +18,7 @@ agents_api_smoke_require_module();
 require_once dirname( __DIR__ ) . '/inc/Engine/Bundle/register-agent-package-artifacts.php';
 
 use DataMachine\Engine\Bundle\AgentBundleAbilityService;
+use DataMachine\Engine\Bundle\AgentBundleCompatibility;
 use DataMachine\Engine\Bundle\AgentBundleDirectory;
 use DataMachine\Engine\Bundle\AgentBundleFlowFile;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
@@ -117,6 +118,44 @@ agents_api_smoke_assert_equals( $report, $repeated_report, 'repeated inspection 
 agents_api_smoke_assert_equals( $artifact_types, $repeated_artifacts, 'repeated inspection preserves registered artifact definitions', $failures, $passes );
 agents_api_smoke_assert_equals( array(), $GLOBALS['__agents_api_smoke_wrong'], 'repeated inspection emits no incorrect-usage notices', $failures, $passes );
 
+$graph_directory = new AgentBundleDirectory(
+	new AgentBundleManifest(
+		'2026-08-18T00:00:00Z',
+		'data-machine/test',
+		'Graph Package',
+		'1.0.0',
+		'',
+		'',
+		array(
+			'slug'         => 'coordinator',
+			'label'        => 'Coordinator',
+			'description'  => '',
+			'agent_config' => array(),
+			'subagents'    => array( 'writer' ),
+			'tool_policy'  => array( 'mode' => 'allow', 'tools' => array( 'datamachine/search' ) ),
+		),
+		array(
+			'memory' => array(), 'pipelines' => array(), 'flows' => array(), 'prompts' => array(),
+			'rubrics' => array(), 'tool_policies' => array(), 'auth_refs' => array(), 'seed_queues' => array(),
+			'extensions' => array(), 'handler_auth' => 'refs',
+		),
+		array(),
+		array( 'datamachine/agent-bundle' ),
+		array(
+			array(
+				'slug' => 'writer', 'label' => 'Writer', 'description' => '', 'agent_config' => array(),
+				'memory' => array(), 'tool_policy' => array( 'mode' => 'allow', 'tools' => array() ),
+				'skills' => array(), 'references' => array(), 'subagents' => array(),
+			),
+		)
+	),
+	array(), array(), array()
+);
+$graph_package = AgentPackageProjection::from_directory( $graph_directory )->to_array();
+agents_api_smoke_assert_equals( array( 'writer' ), $graph_package['agent']['subagents'] ?? null, 'package inspection preserves coordinator edges', $failures, $passes );
+agents_api_smoke_assert_equals( 'allow', $graph_package['agent']['default_config']['tool_policy']['mode'] ?? null, 'package inspection projects enforceable root policy', $failures, $passes );
+agents_api_smoke_assert_equals( true, in_array( 'datamachine/subagent-graph', $graph_package['capabilities'] ?? array(), true ), 'graph packages automatically require graph-capable hosts', $failures, $passes );
+
 echo "\n[2] Projected extension artifact requirements are reported as unsupported:\n";
 add_filter(
 	'datamachine_agent_bundle_artifact_types',
@@ -197,7 +236,7 @@ $unsupported_package = WP_Agent_Package::from_array(
 		),
 	)
 );
-$unsupported_report = WP_Agent_Package_Capability_Checker::check( $unsupported_package, AgentBundleAbilityService::host_capabilities() )->to_array();
+$unsupported_report = WP_Agent_Package_Capability_Checker::check( $unsupported_package, AgentBundleCompatibility::host_capabilities() )->to_array();
 agents_api_smoke_assert_equals( false, $unsupported_report['compatible'] ?? true, 'unsupported package is incompatible', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'intelligence/wiki-brain', 'unknown/runtime' ), $unsupported_report['unsupported_capabilities'] ?? null, 'unsupported capabilities include package and artifact requirements', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'unknown/vendor-artifact' ), $unsupported_report['unknown_artifact_types'] ?? null, 'unknown artifact type is reported', $failures, $passes );

--- a/tests/bundle-validate-inspect-smoke.php
+++ b/tests/bundle-validate-inspect-smoke.php
@@ -25,6 +25,7 @@ use DataMachine\Engine\Bundle\AgentBundleManifest;
 use DataMachine\Engine\Bundle\AgentBundlePipelineFile;
 use DataMachine\Engine\Bundle\AgentPackageProjection;
 use DataMachine\Engine\Bundle\BundleSchema;
+use DataMachine\Engine\Agents\AgentSubagentGraph;
 
 function datamachine_bundle_validate_smoke_reset_registry(): void {
 	do_action( 'init' );
@@ -154,7 +155,7 @@ $graph_directory = new AgentBundleDirectory(
 $graph_package = AgentPackageProjection::from_directory( $graph_directory )->to_array();
 agents_api_smoke_assert_equals( array( 'writer' ), $graph_package['agent']['subagents'] ?? null, 'package inspection preserves coordinator edges', $failures, $passes );
 agents_api_smoke_assert_equals( 'allow', $graph_package['agent']['default_config']['tool_policy']['mode'] ?? null, 'package inspection projects enforceable root policy', $failures, $passes );
-agents_api_smoke_assert_equals( true, in_array( 'datamachine/subagent-graph', $graph_package['capabilities'] ?? array(), true ), 'graph packages automatically require graph-capable hosts', $failures, $passes );
+agents_api_smoke_assert_equals( true, in_array( AgentSubagentGraph::CAPABILITY, $graph_package['capabilities'] ?? array(), true ), 'graph packages automatically require graph-capable hosts', $failures, $passes );
 
 echo "\n[2] Projected extension artifact requirements are reported as unsupported:\n";
 add_filter(


### PR DESCRIPTION
## Summary

- validate and canonicalize coordinator and child tool policies before materialization
- persist imported policies at `agent_config.tool_policy`, where runtime enforcement reads them
- migrate the shipped legacy allowlist shape into the enforceable policy contract
- require and advertise `datamachine/subagent-graph` for graph packages
- reject unsupported package capabilities before any schema-v1, legacy-array, or directory import mutation
- preserve coordinator edges and root policy in read-only package inspection

Closes #3234.

## Verification

- `php tests/agent-bundle-subagent-graph-smoke.php` (19 assertions)
- `php tests/agent-bundler-directory-adapter-smoke.php` (74 assertions)
- `php tests/bundle-validate-inspect-smoke.php` (20 assertions)
- PHPCS on all changed PHP files
- PHP syntax checks on changed production files
- `git diff --check`
- targeted WordPress integration coverage added for policy-provider resolution and rejection-before-mutation; full execution remains a CI environment gate
- independent review completed with no remaining findings

## AI assistance

OpenAI gpt-5.6-sol via OpenCode inspected the bundle import, compatibility, persisted graph, and runtime tool-policy contracts; it helped implement, test, and independently review the repair. Chris Huber reviewed and is responsible for every line.