### PR TITLE
refactor: migrate flow and pipeline failures to WP_Error

### DIFF
--- a/inc/Abilities/Flow/CreateFlowAbility.php
+++ b/inc/Abilities/Flow/CreateFlowAbility.php
@@ -121,7 +121,7 @@ class CreateFlowAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with flow data on success.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		if ( ! empty( $input['flows'] ) && is_array( $input['flows'] ) ) {
 			return $this->executeBulk( $input );
 		}
@@ -135,14 +135,11 @@ class CreateFlowAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with flow data.
 	 */
-	private function executeSingle( array $input ): array {
+	private function executeSingle( array $input ): array|\WP_Error {
 		$pipeline_id = $input['pipeline_id'] ?? null;
 
 		if ( ! is_numeric( $pipeline_id ) || (int) $pipeline_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'pipeline_id is required and must be a positive integer',
-			);
+			return new \WP_Error( 'invalid_pipeline_id', 'pipeline_id is required and must be a positive integer', array( 'status' => 400 ) );
 		}
 
 		$pipeline_id = (int) $pipeline_id;
@@ -150,12 +147,7 @@ class CreateFlowAbility {
 
 		if ( ! $pipeline ) {
 			do_action( 'datamachine_log', 'error', 'Pipeline not found for flow creation', array( 'pipeline_id' => $pipeline_id ) );
-			return array(
-				'success'    => false,
-				'error'      => 'Pipeline not found',
-				'error_code' => 'pipeline_not_found',
-				'status'     => 404,
-			);
+			return new \WP_Error( 'pipeline_not_found', 'Pipeline not found', array( 'status' => 404 ) );
 		}
 
 		$flow_name = sanitize_text_field( wp_unslash( $input['flow_name'] ?? 'Flow' ) );
@@ -170,32 +162,20 @@ class CreateFlowAbility {
 		$validate_only     = ! empty( $input['validate_only'] );
 
 		if ( ! is_array( $scheduling_config ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'scheduling_config must be an object',
-			);
+			return new \WP_Error( 'invalid_scheduling_config', 'scheduling_config must be an object', array( 'status' => 400 ) );
 		}
 
 		if ( ! is_array( $flow_config ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_config must be an object',
-			);
+			return new \WP_Error( 'invalid_flow_config', 'flow_config must be an object', array( 'status' => 400 ) );
 		}
 
 		if ( ! is_array( $step_configs ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'step_configs must be an object',
-			);
+			return new \WP_Error( 'invalid_step_configs', 'step_configs must be an object', array( 'status' => 400 ) );
 		}
 
 		$step_config_validation = $this->validateCreateStepConfigs( $step_configs );
 		if ( true !== $step_config_validation ) {
-			return array(
-				'success' => false,
-				'error'   => $step_config_validation,
-			);
+			return new \WP_Error( 'invalid_step_configs', (string) $step_config_validation, array( 'status' => 400 ) );
 		}
 
 		// Resolve the owning agent when the caller did not supply one. Agent-first
@@ -218,10 +198,7 @@ class CreateFlowAbility {
 		// Validate and resolve interval aliases before storing.
 		$validation = datamachine_validate_interval( $scheduling_config['interval'] ?? 'manual', $scheduling_config );
 		if ( ! $validation['valid'] ) {
-			return array(
-				'success' => false,
-				'error'   => $validation['error'],
-			);
+			return new \WP_Error( 'invalid_schedule', $validation['error'], array( 'status' => 400 ) );
 		}
 		$scheduling_config['interval'] = $validation['resolved'];
 
@@ -241,10 +218,7 @@ class CreateFlowAbility {
 
 		$transaction_scope = $this->beginCreationTransactionScope();
 		if ( null === $transaction_scope ) {
-			return array(
-				'success' => false,
-				'error'   => 'Unable to start flow creation transaction',
-			);
+			return new \WP_Error( 'flow_creation_transaction_failed', 'Unable to start flow creation transaction', array( 'status' => 500 ) );
 		}
 
 		$flow_id = $this->db_flows->create_flow( $flow_data );
@@ -259,10 +233,7 @@ class CreateFlowAbility {
 					'flow_name'   => $flow_name,
 				)
 			);
-			return array(
-				'success' => false,
-				'error'   => 'Failed to create flow',
-			);
+			return new \WP_Error( 'flow_creation_failed', 'Failed to create flow', array( 'status' => 500 ) );
 		}
 
 		$pipeline_config = $pipeline['pipeline_config'] ?? array();
@@ -332,10 +303,7 @@ class CreateFlowAbility {
 			RecurringScheduler::invalidateGenerationCache( FlowScheduling::FLOW_HOOK, array( $flow_id ) );
 			$schedule_error = $this->compensateFlowSchedule( $flow_id );
 			if ( $schedule_error ) {
-				return array_merge(
-					array( 'success' => false ),
-					RecurringScheduler::errorMetadata( $schedule_error )
-				);
+				return new \WP_Error( 'flow_schedule_cleanup_failed', $schedule_error->get_error_message(), array( 'status' => 500 ) + RecurringScheduler::errorMetadata( $schedule_error ) );
 			}
 
 			return array(
@@ -396,24 +364,20 @@ class CreateFlowAbility {
 	 * @param array  $configuration_errors Optional structured configuration errors.
 	 * @return array Failure result.
 	 */
-	private function rollbackCreation( TransactionScope $transaction_scope, int $flow_id, string $error, array $configuration_errors = array() ): array {
+	private function rollbackCreation( TransactionScope $transaction_scope, int $flow_id, string $error, array $configuration_errors = array() ): \WP_Error {
 		$this->rollbackCreationTransactionScope( $transaction_scope );
 		RecurringScheduler::invalidateGenerationCache( FlowScheduling::FLOW_HOOK, array( $flow_id ) );
 		$schedule_error = $this->compensateFlowSchedule( $flow_id );
 
-		$result = array(
-			'success' => false,
-			'error'   => $error,
-		);
-
+		$data = array( 'status' => 500 );
 		if ( ! empty( $configuration_errors ) ) {
-			$result['configuration_errors'] = $configuration_errors;
+			$data['configuration_errors'] = $configuration_errors;
 		}
 		if ( $schedule_error ) {
-			$result['schedule_cleanup'] = RecurringScheduler::errorMetadata( $schedule_error );
+			$data['schedule_cleanup'] = RecurringScheduler::errorMetadata( $schedule_error );
 		}
 
-		return $result;
+		return new \WP_Error( 'flow_creation_failed', $error, $data );
 	}
 
 	/**
@@ -465,16 +429,13 @@ class CreateFlowAbility {
 	 * @param array $input Input parameters including flows array and optional shared_step_config.
 	 * @return array Result with created flows data and error tracking.
 	 */
-	private function executeBulk( array $input ): array {
+	private function executeBulk( array $input ): array|\WP_Error {
 		$flows              = $input['flows'];
 		$shared_step_config = $input['shared_step_config'] ?? array();
 		$validate_only      = ! empty( $input['validate_only'] );
 
 		if ( ! is_array( $shared_step_config ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'shared_step_config must be an object',
-			);
+			return new \WP_Error( 'invalid_shared_step_config', 'shared_step_config must be an object', array( 'status' => 400 ) );
 		}
 
 		$validation_errors = array();
@@ -527,11 +488,7 @@ class CreateFlowAbility {
 		}
 
 		if ( ! empty( $validation_errors ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Validation failed for ' . count( $validation_errors ) . ' flow(s)',
-				'errors'  => $validation_errors,
-			);
+			return new \WP_Error( 'invalid_flows', 'Validation failed for ' . count( $validation_errors ) . ' flow(s)', array( 'status' => 400, 'errors' => $validation_errors ) );
 		}
 
 		$preview = array();
@@ -541,10 +498,7 @@ class CreateFlowAbility {
 			$scheduling_config = $flow_config['scheduling_config'] ?? array( 'interval' => 'manual' );
 			$step_configs      = $flow_config['step_configs'] ?? array();
 			if ( ! is_array( $step_configs ) ) {
-				return array(
-					'success' => false,
-					'error'   => sprintf( 'Validation failed for flow %d: step_configs must be an object', $index ),
-				);
+				return new \WP_Error( 'invalid_step_configs', sprintf( 'Validation failed for flow %d: step_configs must be an object', $index ), array( 'status' => 400 ) );
 			}
 
 			$single_input = array(
@@ -561,12 +515,11 @@ class CreateFlowAbility {
 			}
 
 			$single_result = $this->executeSingle( $single_input );
-			if ( ! $single_result['success'] ) {
-				return array(
-					'success' => false,
-					'error'   => sprintf( 'Validation failed for flow %d: %s', $index, $single_result['error'] ?? 'unknown error' ),
-					'errors'  => $single_result['configuration_errors'] ?? array(),
-				);
+			if ( is_wp_error( $single_result ) ) {
+				return $single_result;
+			}
+			if ( empty( $single_result['success'] ) ) {
+				return new \WP_Error( 'invalid_flows', sprintf( 'Validation failed for flow %d', $index ), array( 'status' => 400 ) );
 			}
 
 			$preview[] = $single_result['would_create'][0];
@@ -608,13 +561,13 @@ class CreateFlowAbility {
 				)
 			);
 
-			if ( ! $single_result['success'] ) {
+			if ( ! is_array( $single_result ) || empty( $single_result['success'] ) ) {
 				++$failed_count;
 				$errors[] = array(
 					'index'       => $index,
 					'pipeline_id' => $pipeline_id,
 					'flow_name'   => $flow_name,
-					'error'       => $single_result['error'],
+					'error'       => is_wp_error( $single_result ) ? $single_result->get_error_message() : ( $single_result['error'] ?? 'Flow creation failed' ),
 					'remediation' => 'Check the error message and fix the flow configuration',
 				);
 				continue;
@@ -653,12 +606,15 @@ class CreateFlowAbility {
 		);
 
 		if ( 0 === $created_count ) {
-			return array(
-				'success'       => false,
-				'error'         => 'All flow creations failed',
-				'created_count' => 0,
-				'failed_count'  => $failed_count,
-				'errors'        => $errors,
+			return new \WP_Error(
+				'flow_creation_failed',
+				'All flow creations failed',
+				array(
+					'status'        => 500,
+					'created_count' => 0,
+					'failed_count'  => $failed_count,
+					'errors'        => $errors,
+				)
 			);
 		}
 

--- a/inc/Abilities/Flow/CreateFlowAbility.php
+++ b/inc/Abilities/Flow/CreateFlowAbility.php
@@ -488,7 +488,14 @@ class CreateFlowAbility {
 		}
 
 		if ( ! empty( $validation_errors ) ) {
-			return new \WP_Error( 'invalid_flows', 'Validation failed for ' . count( $validation_errors ) . ' flow(s)', array( 'status' => 400, 'errors' => $validation_errors ) );
+			return new \WP_Error(
+				'invalid_flows',
+				'Validation failed for ' . count( $validation_errors ) . ' flow(s)',
+				array(
+					'status' => 400,
+					'errors' => $validation_errors,
+				)
+			);
 		}
 
 		$preview = array();

--- a/inc/Abilities/Flow/DeleteFlowAbility.php
+++ b/inc/Abilities/Flow/DeleteFlowAbility.php
@@ -66,14 +66,11 @@ class DeleteFlowAbility {
 	 * @param array $input Input parameters with flow_id.
 	 * @return array Result with success status.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$flow_id = $input['flow_id'] ?? null;
 
 		if ( ! is_numeric( $flow_id ) || (int) $flow_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_id is required and must be a positive integer',
-			);
+			return new \WP_Error( 'invalid_flow_id', 'flow_id is required and must be a positive integer', array( 'status' => 400 ) );
 		}
 
 		$flow_id = (int) $flow_id;
@@ -81,12 +78,7 @@ class DeleteFlowAbility {
 
 		if ( ! $flow ) {
 			do_action( 'datamachine_log', 'error', 'Flow not found for deletion', array( 'flow_id' => $flow_id ) );
-			return array(
-				'success'    => false,
-				'error'      => 'Flow not found',
-				'error_code' => 'flow_not_found',
-				'status'     => 404,
-			);
+			return new \WP_Error( 'flow_not_found', 'Flow not found', array( 'status' => 404 ) );
 		}
 
 		$pipeline_id = (int) ( $flow['pipeline_id'] ?? 0 );
@@ -114,13 +106,7 @@ class DeleteFlowAbility {
 			}
 		);
 		if ( is_wp_error( $schedule_result ) ) {
-			return array_merge(
-				array(
-					'success'                 => false,
-					'desired_state_committed' => null === $this->db_flows->get_flow( $flow_id ),
-				),
-				\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $schedule_result )
-			);
+			return new \WP_Error( $schedule_result->get_error_code(), $schedule_result->get_error_message(), array_merge( array( 'status' => 500, 'desired_state_committed' => null === $this->db_flows->get_flow( $flow_id ) ), \DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $schedule_result ) ) );
 		}
 
 		do_action(

--- a/inc/Abilities/Flow/DeleteFlowAbility.php
+++ b/inc/Abilities/Flow/DeleteFlowAbility.php
@@ -106,7 +106,17 @@ class DeleteFlowAbility {
 			}
 		);
 		if ( is_wp_error( $schedule_result ) ) {
-			return new \WP_Error( $schedule_result->get_error_code(), $schedule_result->get_error_message(), array_merge( array( 'status' => 500, 'desired_state_committed' => null === $this->db_flows->get_flow( $flow_id ) ), \DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $schedule_result ) ) );
+			return new \WP_Error(
+				$schedule_result->get_error_code(),
+				$schedule_result->get_error_message(),
+				array_merge(
+					array(
+						'status'                  => 500,
+						'desired_state_committed' => null === $this->db_flows->get_flow( $flow_id ),
+					),
+					\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $schedule_result )
+				)
+			);
 		}
 
 		do_action(

--- a/inc/Abilities/Flow/DuplicateFlowAbility.php
+++ b/inc/Abilities/Flow/DuplicateFlowAbility.php
@@ -88,14 +88,11 @@ class DuplicateFlowAbility {
 	 * @param array $input Input parameters with source_flow_id, optional target_pipeline_id, flow_name, etc.
 	 * @return array Result with duplicated flow data.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$source_flow_id = $input['source_flow_id'] ?? null;
 
 		if ( ! is_numeric( $source_flow_id ) || (int) $source_flow_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'source_flow_id is required and must be a positive integer',
-			);
+			return new \WP_Error( 'invalid_source_flow_id', 'source_flow_id is required and must be a positive integer', array( 'status' => 400 ) );
 		}
 
 		$source_flow_id = (int) $source_flow_id;
@@ -103,12 +100,7 @@ class DuplicateFlowAbility {
 
 		if ( ! $source_flow ) {
 			do_action( 'datamachine_log', 'error', 'Source flow not found for copy', array( 'source_flow_id' => $source_flow_id ) );
-			return array(
-				'success'    => false,
-				'error'      => 'Source flow not found',
-				'error_code' => 'flow_not_found',
-				'status'     => 404,
-			);
+			return new \WP_Error( 'flow_not_found', 'Source flow not found', array( 'status' => 404 ) );
 		}
 
 		$source_pipeline_id = (int) $source_flow['pipeline_id'];
@@ -117,22 +109,12 @@ class DuplicateFlowAbility {
 
 		$source_pipeline = $this->db_pipelines->get_pipeline( $source_pipeline_id );
 		if ( ! $source_pipeline ) {
-			return array(
-				'success'    => false,
-				'error'      => 'Source pipeline not found',
-				'error_code' => 'pipeline_not_found',
-				'status'     => 404,
-			);
+			return new \WP_Error( 'pipeline_not_found', 'Source pipeline not found', array( 'status' => 404 ) );
 		}
 
 		$target_pipeline = $this->db_pipelines->get_pipeline( $target_pipeline_id );
 		if ( ! $target_pipeline ) {
-			return array(
-				'success'    => false,
-				'error'      => 'Target pipeline not found',
-				'error_code' => 'pipeline_not_found',
-				'status'     => 404,
-			);
+			return new \WP_Error( 'pipeline_not_found', 'Target pipeline not found', array( 'status' => 404 ) );
 		}
 
 		if ( $is_cross_pipeline ) {
@@ -151,10 +133,7 @@ class DuplicateFlowAbility {
 						'error'              => $compatibility['error'],
 					)
 				);
-				return array(
-					'success' => false,
-					'error'   => $compatibility['error'],
-				);
+				return new \WP_Error( 'incompatible_pipelines', $compatibility['error'], array( 'status' => 400 ) );
 			}
 		}
 
@@ -191,10 +170,7 @@ class DuplicateFlowAbility {
 					'target_pipeline_id' => $target_pipeline_id,
 				)
 			);
-			return array(
-				'success' => false,
-				'error'   => 'Failed to create new flow',
-			);
+			return new \WP_Error( 'flow_duplication_failed', 'Failed to create new flow', array( 'status' => 500 ) );
 		}
 
 		$new_flow_config = $this->buildCopiedFlowConfig(

--- a/inc/Abilities/Flow/FlowHelpers.php
+++ b/inc/Abilities/Flow/FlowHelpers.php
@@ -528,7 +528,16 @@ trait FlowHelpers {
 
 			$result = $update_flow_step_ability->execute( $update_input );
 
-			if ( $result['success'] ) {
+			if ( is_wp_error( $result ) ) {
+				$errors[] = array(
+					'step_type'    => $step_type,
+					'flow_step_id' => $flow_step_id,
+					'error'        => $result->get_error_message(),
+				);
+				continue;
+			}
+
+			if ( ! empty( $result['success'] ) ) {
 				$applied[] = $flow_step_id;
 			} else {
 				$errors[] = array(
@@ -667,7 +676,17 @@ trait FlowHelpers {
 				)
 			);
 
-			if ( $result['success'] ) {
+			if ( is_wp_error( $result ) ) {
+				$errors[] = array(
+					'flow_step_id' => $flow_step_id,
+					'step_type'    => $step_type,
+					'handler'      => $default_handler_slug,
+					'error'        => $result->get_error_message(),
+				);
+				continue;
+			}
+
+			if ( ! empty( $result['success'] ) ) {
 				$applied[] = $flow_step_id;
 			} else {
 				$errors[] = array(

--- a/inc/Abilities/Flow/PauseFlowAbility.php
+++ b/inc/Abilities/Flow/PauseFlowAbility.php
@@ -82,25 +82,19 @@ class PauseFlowAbility {
 	 * @param array $input Input with flow_id, pipeline_id, or agent_id.
 	 * @return array Result with pause counts and affected flow IDs.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$flow_id     = isset( $input['flow_id'] ) ? (int) $input['flow_id'] : null;
 		$pipeline_id = isset( $input['pipeline_id'] ) ? (int) $input['pipeline_id'] : null;
 		$agent_id    = isset( $input['agent_id'] ) ? (int) $input['agent_id'] : null;
 
 		if ( null === $flow_id && null === $pipeline_id && null === $agent_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'Must provide flow_id, pipeline_id, or agent_id.',
-			);
+			return new \WP_Error( 'invalid_flow_scope', 'Must provide flow_id, pipeline_id, or agent_id.', array( 'status' => 400 ) );
 		}
 
 		$flows = $this->resolveFlows( $flow_id, $pipeline_id, $agent_id );
 
 		if ( empty( $flows ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'No flows found matching the specified criteria.',
-			);
+			return new \WP_Error( 'flows_not_found', 'No flows found matching the specified criteria.', array( 'status' => 404 ) );
 		}
 
 		$paused  = 0;
@@ -156,14 +150,19 @@ class PauseFlowAbility {
 			)
 		);
 
-		return array(
-			'success' => 0 === $errors,
+		$result = array(
+			'success' => true,
 			'paused'  => $paused,
 			'skipped' => $skipped,
 			'errors'  => $errors,
+			'partial' => $paused > 0 && $errors > 0,
 			'flows'   => $details,
 			'message' => sprintf( 'Paused %d flow(s), skipped %d (already paused).', $paused, $skipped ),
 		);
+		if ( $errors > 0 && 0 === $paused ) {
+			return new \WP_Error( 'flow_pause_failed', 'Failed to pause the requested flows.', array( 'status' => 500 ) + $result );
+		}
+		return $result;
 	}
 
 	/**

--- a/inc/Abilities/Flow/QueueAbility.php
+++ b/inc/Abilities/Flow/QueueAbility.php
@@ -38,6 +38,7 @@ use DataMachine\Core\Database\Pipelines\Pipelines as DB_Pipelines;
 use DataMachine\Abilities\DuplicateCheck\DuplicateCheckAbility;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Engine\ExecutionPlan;
+use DataMachine\Core\AbilityResult;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -753,7 +754,11 @@ class QueueAbility {
 	 * @param array $input Input with flow_id, flow_step_id, prompt.
 	 * @return array Result.
 	 */
-	public function executeQueueAdd( array $input ): array {
+	public function executeQueueAdd( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->executeQueueAddLegacy( $input ), 'queue_add_failed' );
+	}
+
+	private function executeQueueAddLegacy( array $input ): array {
 		$flow_id      = $input['flow_id'] ?? null;
 		$flow_step_id = $input['flow_step_id'] ?? null;
 		$prompt       = $input['prompt'] ?? null;
@@ -859,8 +864,8 @@ class QueueAbility {
 	 * @param array $input Input with flow_id, flow_step_id.
 	 * @return array Result.
 	 */
-	public function executeQueueList( array $input ): array {
-		return $this->listQueueSlot( $input, self::SLOT_PROMPT_QUEUE );
+	public function executeQueueList( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->listQueueSlot( $input, self::SLOT_PROMPT_QUEUE ), 'queue_list_failed' );
 	}
 
 	/**
@@ -869,8 +874,8 @@ class QueueAbility {
 	 * @param array $input Input with flow_id, flow_step_id.
 	 * @return array Result.
 	 */
-	public function executeQueueClear( array $input ): array {
-		return $this->clearQueueSlot( $input, self::SLOT_PROMPT_QUEUE );
+	public function executeQueueClear( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->clearQueueSlot( $input, self::SLOT_PROMPT_QUEUE ), 'queue_clear_failed' );
 	}
 
 	/**
@@ -879,8 +884,8 @@ class QueueAbility {
 	 * @param array $input Input with flow_id, flow_step_id, index.
 	 * @return array Result.
 	 */
-	public function executeQueueRemove( array $input ): array {
-		return $this->removeQueueSlot( $input, self::SLOT_PROMPT_QUEUE, self::FIELD_PROMPT );
+	public function executeQueueRemove( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->removeQueueSlot( $input, self::SLOT_PROMPT_QUEUE, self::FIELD_PROMPT ), 'queue_remove_failed' );
 	}
 
 	/**
@@ -891,7 +896,11 @@ class QueueAbility {
 	 * @param array $input Input with flow_id, flow_step_id, index, prompt.
 	 * @return array Result.
 	 */
-	public function executeQueueUpdate( array $input ): array {
+	public function executeQueueUpdate( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->executeQueueUpdateLegacy( $input ), 'queue_update_failed' );
+	}
+
+	private function executeQueueUpdateLegacy( array $input ): array {
 		$value = $input['prompt'] ?? null;
 		if ( ! is_string( $value ) ) {
 			return array(
@@ -910,8 +919,8 @@ class QueueAbility {
 	 * @param array $input Input with flow_id, flow_step_id, from_index, to_index.
 	 * @return array Result.
 	 */
-	public function executeQueueMove( array $input ): array {
-		return $this->moveQueueSlot( $input, self::SLOT_PROMPT_QUEUE );
+	public function executeQueueMove( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->moveQueueSlot( $input, self::SLOT_PROMPT_QUEUE ), 'queue_move_failed' );
 	}
 
 	/**
@@ -920,7 +929,11 @@ class QueueAbility {
 	 * @param array $input Input with flow_id, flow_step_id, patch.
 	 * @return array Result.
 	 */
-	public function executeConfigPatchAdd( array $input ): array {
+	public function executeConfigPatchAdd( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->executeConfigPatchAddLegacy( $input ), 'config_patch_add_failed' );
+	}
+
+	private function executeConfigPatchAddLegacy( array $input ): array {
 		$flow_id      = $input['flow_id'] ?? null;
 		$flow_step_id = $input['flow_step_id'] ?? null;
 		$patch        = $input['patch'] ?? null;
@@ -998,28 +1011,32 @@ class QueueAbility {
 	/**
 	 * List all config patches in the fetch queue.
 	 */
-	public function executeConfigPatchList( array $input ): array {
-		return $this->listQueueSlot( $input, self::SLOT_CONFIG_PATCH_QUEUE );
+	public function executeConfigPatchList( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->listQueueSlot( $input, self::SLOT_CONFIG_PATCH_QUEUE ), 'config_patch_list_failed' );
 	}
 
 	/**
 	 * Clear all config patches from the fetch queue.
 	 */
-	public function executeConfigPatchClear( array $input ): array {
-		return $this->clearQueueSlot( $input, self::SLOT_CONFIG_PATCH_QUEUE );
+	public function executeConfigPatchClear( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->clearQueueSlot( $input, self::SLOT_CONFIG_PATCH_QUEUE ), 'config_patch_clear_failed' );
 	}
 
 	/**
 	 * Remove a specific config patch from the queue by index.
 	 */
-	public function executeConfigPatchRemove( array $input ): array {
-		return $this->removeQueueSlot( $input, self::SLOT_CONFIG_PATCH_QUEUE, self::FIELD_PATCH );
+	public function executeConfigPatchRemove( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->removeQueueSlot( $input, self::SLOT_CONFIG_PATCH_QUEUE, self::FIELD_PATCH ), 'config_patch_remove_failed' );
 	}
 
 	/**
 	 * Update a config patch at a specific index in the queue.
 	 */
-	public function executeConfigPatchUpdate( array $input ): array {
+	public function executeConfigPatchUpdate( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->executeConfigPatchUpdateLegacy( $input ), 'config_patch_update_failed' );
+	}
+
+	private function executeConfigPatchUpdateLegacy( array $input ): array {
 		$value = $input['patch'] ?? null;
 		if ( ! is_array( $value ) ) {
 			return array(
@@ -1040,8 +1057,8 @@ class QueueAbility {
 	/**
 	 * Move a config patch from one position to another in the queue.
 	 */
-	public function executeConfigPatchMove( array $input ): array {
-		return $this->moveQueueSlot( $input, self::SLOT_CONFIG_PATCH_QUEUE );
+	public function executeConfigPatchMove( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->moveQueueSlot( $input, self::SLOT_CONFIG_PATCH_QUEUE ), 'config_patch_move_failed' );
 	}
 
 	/**
@@ -1055,7 +1072,11 @@ class QueueAbility {
 	 * @param array $input Input with flow_id, flow_step_id, and mode.
 	 * @return array Result.
 	 */
-	public function executeQueueMode( array $input ): array {
+	public function executeQueueMode( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->executeQueueModeLegacy( $input ), 'queue_mode_failed' );
+	}
+
+	private function executeQueueModeLegacy( array $input ): array {
 		$flow_id      = $input['flow_id'] ?? null;
 		$flow_step_id = $input['flow_step_id'] ?? null;
 		$mode         = $input['mode'] ?? null;
@@ -1530,6 +1551,37 @@ class QueueAbility {
 			'queue_length' => $queue_length,
 			'message'      => sprintf( 'Moved item from index %d to %d.', $from_index, $to_index ),
 		);
+	}
+
+	/**
+	 * Convert a legacy queue failure at the registered callback boundary.
+	 *
+	 * Queue storage and consumption helpers intentionally continue to use their
+	 * domain arrays; only registered ability executors expose WP_Error.
+	 *
+	 * @param mixed  $result Result from a queue helper.
+	 * @param string $default_code Stable fallback error code.
+	 * @return array|\WP_Error
+	 */
+	private function callbackResult( $result, string $default_code ): array|\WP_Error {
+		$message = is_array( $result ) ? (string) ( $result['error'] ?? '' ) : '';
+		$code    = $default_code;
+		if ( str_contains( $message, 'flow_id' ) ) {
+			$code = 'invalid_flow_id';
+		} elseif ( str_contains( $message, 'not found' ) ) {
+			$code = str_contains( $message, 'Flow step' ) ? 'flow_step_not_found' : 'flow_not_found';
+		} elseif ( str_contains( $message, 'Flow step' ) || str_contains( $message, 'flow_step_id' ) ) {
+			$code = 'invalid_flow_step_id';
+		}
+		$error = AbilityResult::legacy_failure_to_wp_error( $result, $code, 'Queue operation failed.' );
+		if ( ! $error ) {
+			return $result;
+		}
+
+		$data = is_array( $result ) ? $result : array();
+		unset( $data['success'] );
+		$data['status'] = ( in_array( $code, array( 'flow_not_found', 'flow_step_not_found' ), true ) || ( isset( $result['error_type'] ) && 'not_found' === $result['error_type'] ) ) ? 404 : ( str_ends_with( $code, '_failed' ) ? 500 : 400 );
+		return new \WP_Error( $error->get_error_code(), $error->get_error_message(), $data );
 	}
 
 	/**

--- a/inc/Abilities/Flow/ResumeFlowAbility.php
+++ b/inc/Abilities/Flow/ResumeFlowAbility.php
@@ -82,25 +82,19 @@ class ResumeFlowAbility {
 	 * @param array $input Input with flow_id, pipeline_id, or agent_id.
 	 * @return array Result with resume counts and affected flow IDs.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$flow_id     = isset( $input['flow_id'] ) ? (int) $input['flow_id'] : null;
 		$pipeline_id = isset( $input['pipeline_id'] ) ? (int) $input['pipeline_id'] : null;
 		$agent_id    = isset( $input['agent_id'] ) ? (int) $input['agent_id'] : null;
 
 		if ( null === $flow_id && null === $pipeline_id && null === $agent_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'Must provide flow_id, pipeline_id, or agent_id.',
-			);
+			return new \WP_Error( 'invalid_flow_scope', 'Must provide flow_id, pipeline_id, or agent_id.', array( 'status' => 400 ) );
 		}
 
 		$flows = $this->resolveFlows( $flow_id, $pipeline_id, $agent_id );
 
 		if ( empty( $flows ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'No flows found matching the specified criteria.',
-			);
+			return new \WP_Error( 'flows_not_found', 'No flows found matching the specified criteria.', array( 'status' => 404 ) );
 		}
 
 		$resumed = 0;
@@ -157,14 +151,19 @@ class ResumeFlowAbility {
 			)
 		);
 
-		return array(
+		$result = array(
 			'success' => true,
 			'resumed' => $resumed,
 			'skipped' => $skipped,
 			'errors'  => $errors,
+			'partial' => $resumed > 0 && $errors > 0,
 			'flows'   => $details,
 			'message' => sprintf( 'Resumed %d flow(s), skipped %d (not paused), %d error(s).', $resumed, $skipped, $errors ),
 		);
+		if ( $errors > 0 && 0 === $resumed ) {
+			return new \WP_Error( 'flow_resume_failed', 'Failed to resume the requested flows.', array( 'status' => 500 ) + $result );
+		}
+		return $result;
 	}
 
 	/**

--- a/inc/Abilities/Flow/WebhookTriggerAbility.php
+++ b/inc/Abilities/Flow/WebhookTriggerAbility.php
@@ -12,6 +12,8 @@
 
 namespace DataMachine\Abilities\Flow;
 
+use DataMachine\Core\AbilityResult;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -374,7 +376,11 @@ class WebhookTriggerAbility {
 	 * @param array $input
 	 * @return array
 	 */
-	public function executeEnable( array $input ): array {
+	public function executeEnable( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->executeEnableLegacy( $input ), 'webhook_enable_failed' );
+	}
+
+	private function executeEnableLegacy( array $input ): array {
 		$flow_id = (int) ( $input['flow_id'] ?? 0 );
 		if ( $flow_id <= 0 ) {
 			return array(
@@ -589,7 +595,11 @@ class WebhookTriggerAbility {
 	 * @param array $input flow_id, secret|generate, optional secret_id.
 	 * @return array
 	 */
-	public function executeSetSecret( array $input ): array {
+	public function executeSetSecret( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->executeSetSecretLegacy( $input ), 'webhook_set_secret_failed' );
+	}
+
+	private function executeSetSecretLegacy( array $input ): array {
 		$flow_id = (int) ( $input['flow_id'] ?? 0 );
 		if ( $flow_id <= 0 ) {
 			return array(
@@ -679,7 +689,11 @@ class WebhookTriggerAbility {
 	 * @param array $input Input with flow_id.
 	 * @return array Result with success status.
 	 */
-	public function executeDisable( array $input ): array {
+	public function executeDisable( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->executeDisableLegacy( $input ), 'webhook_disable_failed' );
+	}
+
+	private function executeDisableLegacy( array $input ): array {
 		$flow_id = (int) ( $input['flow_id'] ?? 0 );
 
 		if ( $flow_id <= 0 ) {
@@ -739,7 +753,11 @@ class WebhookTriggerAbility {
 	 * @param array $input Input with flow_id.
 	 * @return array Result with new token and webhook URL.
 	 */
-	public function executeRegenerate( array $input ): array {
+	public function executeRegenerate( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->executeRegenerateLegacy( $input ), 'webhook_regenerate_failed' );
+	}
+
+	private function executeRegenerateLegacy( array $input ): array {
 		$flow_id = (int) ( $input['flow_id'] ?? 0 );
 
 		if ( $flow_id <= 0 ) {
@@ -815,7 +833,11 @@ class WebhookTriggerAbility {
 	 * @param array $input Input with flow_id, max, window.
 	 * @return array Result with updated rate limit config.
 	 */
-	public function executeSetRateLimit( array $input ): array {
+	public function executeSetRateLimit( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->executeSetRateLimitLegacy( $input ), 'webhook_rate_limit_failed' );
+	}
+
+	private function executeSetRateLimitLegacy( array $input ): array {
 		$flow_id = (int) ( $input['flow_id'] ?? 0 );
 
 		if ( $flow_id <= 0 ) {
@@ -917,7 +939,11 @@ class WebhookTriggerAbility {
 	 * @param array $input Input with flow_id.
 	 * @return array Result with webhook status including rate limit config.
 	 */
-	public function executeStatus( array $input ): array {
+	public function executeStatus( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->executeStatusLegacy( $input ), 'webhook_status_failed' );
+	}
+
+	private function executeStatusLegacy( array $input ): array {
 		$flow_id = (int) ( $input['flow_id'] ?? 0 );
 
 		if ( $flow_id <= 0 ) {
@@ -971,6 +997,36 @@ class WebhookTriggerAbility {
 	}
 
 	/**
+	 * Convert a legacy webhook failure at the registered callback boundary.
+	 *
+	 * @param mixed  $result Legacy callback result.
+	 * @param string $default_code Stable fallback error code.
+	 * @return array|\WP_Error
+	 */
+	private function callbackResult( $result, string $default_code ): array|\WP_Error {
+		$message = is_array( $result ) ? (string) ( $result['error'] ?? '' ) : '';
+		$code    = $default_code;
+		if ( str_contains( $message, 'flow_id' ) ) {
+			$code = 'invalid_flow_id';
+		} elseif ( str_contains( $message, 'not found' ) ) {
+			$code = 'flow_not_found';
+		} elseif ( str_contains( $message, 'not enabled' ) ) {
+			$code = 'webhook_not_enabled';
+		} elseif ( str_starts_with( $message, 'Failed to update' ) ) {
+			$code = 'webhook_update_failed';
+		}
+		$error = AbilityResult::legacy_failure_to_wp_error( $result, $code, 'Webhook operation failed.' );
+		if ( ! $error ) {
+			return $result;
+		}
+
+		$data = is_array( $result ) ? $result : array();
+		unset( $data['success'] );
+		$data['status'] = ( 'flow_not_found' === $code || ( isset( $result['error_type'] ) && 'not_found' === $result['error_type'] ) ) ? 404 : ( 'webhook_update_failed' === $code ? 500 : 400 );
+		return new \WP_Error( $error->get_error_code(), $error->get_error_message(), $data );
+	}
+
+	/**
 	 * Generate a cryptographically secure webhook token.
 	 *
 	 * @return string 64-character hex token.
@@ -1008,7 +1064,11 @@ class WebhookTriggerAbility {
 	 * @param array $input flow_id, optional secret|generate|previous_ttl_seconds.
 	 * @return array
 	 */
-	public function executeRotateSecret( array $input ): array {
+	public function executeRotateSecret( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->executeRotateSecretLegacy( $input ), 'webhook_rotate_secret_failed' );
+	}
+
+	private function executeRotateSecretLegacy( array $input ): array {
 		$flow_id = (int) ( $input['flow_id'] ?? 0 );
 		if ( $flow_id <= 0 ) {
 			return array(
@@ -1120,7 +1180,11 @@ class WebhookTriggerAbility {
 	 * @param array $input flow_id, secret_id.
 	 * @return array
 	 */
-	public function executeForgetSecret( array $input ): array {
+	public function executeForgetSecret( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->executeForgetSecretLegacy( $input ), 'webhook_forget_secret_failed' );
+	}
+
+	private function executeForgetSecretLegacy( array $input ): array {
 		$flow_id   = (int) ( $input['flow_id'] ?? 0 );
 		$secret_id = isset( $input['secret_id'] ) ? (string) $input['secret_id'] : '';
 

--- a/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
+++ b/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
@@ -510,7 +510,7 @@ class ConfigureFlowStepsAbility {
 		$data = is_array( $result ) ? $result : array();
 		unset( $data['success'] );
 		$operational_failure = str_starts_with( $message, 'No steps were updated' ) || str_starts_with( $message, 'Failed to' );
-		$data['status']       = ( 'pipeline_not_found' === $code || 'handler_not_found' === $code || 'not_found' === ( $result['error_type'] ?? '' ) ) ? 404 : ( $operational_failure ? 500 : 400 );
+		$data['status']      = ( 'pipeline_not_found' === $code || 'handler_not_found' === $code || 'not_found' === ( $result['error_type'] ?? '' ) ) ? 404 : ( $operational_failure ? 500 : 400 );
 		return new \WP_Error( $error->get_error_code(), $error->get_error_message(), $data );
 	}
 

--- a/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
+++ b/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
@@ -13,6 +13,7 @@ namespace DataMachine\Abilities\FlowStep;
 
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\FlowStepTargetResolver;
+use DataMachine\Core\AbilityResult;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -141,7 +142,11 @@ class ConfigureFlowStepsAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with configuration status.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
+		return $this->callbackResult( $this->executeLegacy( $input ) );
+	}
+
+	private function executeLegacy( array $input ): array {
 		// Check for cross-pipeline mode
 		if ( ! empty( $input['updates'] ) && is_array( $input['updates'] ) ) {
 			return $this->executeCrossPipeline( $input );
@@ -479,6 +484,34 @@ class ConfigureFlowStepsAbility {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Convert a legacy configure failure at the registered callback boundary.
+	 *
+	 * @param mixed $result Legacy callback result.
+	 * @return array|\WP_Error
+	 */
+	private function callbackResult( $result ): array|\WP_Error {
+		$message = is_array( $result ) ? (string) ( $result['error'] ?? '' ) : '';
+		$code    = 'configure_flow_steps_failed';
+		if ( str_contains( $message, 'pipeline_id' ) ) {
+			$code = 'invalid_pipeline_id';
+		} elseif ( str_contains( $message, 'Pipeline not found' ) ) {
+			$code = 'pipeline_not_found';
+		} elseif ( str_contains( $message, 'handler' ) && str_contains( $message, 'not found' ) ) {
+			$code = 'handler_not_found';
+		}
+		$error = AbilityResult::legacy_failure_to_wp_error( $result, $code, 'Flow step configuration failed.' );
+		if ( ! $error ) {
+			return $result;
+		}
+
+		$data = is_array( $result ) ? $result : array();
+		unset( $data['success'] );
+		$operational_failure = str_starts_with( $message, 'No steps were updated' ) || str_starts_with( $message, 'Failed to' );
+		$data['status']       = ( 'pipeline_not_found' === $code || 'handler_not_found' === $code || 'not_found' === ( $result['error_type'] ?? '' ) ) ? 404 : ( $operational_failure ? 500 : 400 );
+		return new \WP_Error( $error->get_error_code(), $error->get_error_message(), $data );
 	}
 
 	/**

--- a/inc/Abilities/FlowStep/GetFlowStepsAbility.php
+++ b/inc/Abilities/FlowStep/GetFlowStepsAbility.php
@@ -69,17 +69,14 @@ class GetFlowStepsAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with steps data.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$flow_id      = $input['flow_id'] ?? null;
 		$flow_step_id = $input['flow_step_id'] ?? null;
 
 		// Direct step lookup by ID - bypasses flow_id requirement.
 		if ( null !== $flow_step_id ) {
 			if ( ! is_string( $flow_step_id ) || empty( $flow_step_id ) ) {
-				return array(
-					'success' => false,
-					'error'   => 'flow_step_id must be a non-empty string',
-				);
+				return new \WP_Error( 'invalid_flow_step_id', 'flow_step_id must be a non-empty string', array( 'status' => 400 ) );
 			}
 
 			$step_config = $this->db_flows->get_flow_step_config( $flow_step_id );
@@ -102,20 +99,14 @@ class GetFlowStepsAbility {
 		}
 
 		if ( ! is_numeric( $flow_id ) || (int) $flow_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_id is required and must be a positive integer',
-			);
+			return new \WP_Error( 'invalid_flow_id', 'flow_id is required and must be a positive integer', array( 'status' => 400 ) );
 		}
 
 		$flow_id = (int) $flow_id;
 		$flow    = $this->db_flows->get_flow( $flow_id );
 
 		if ( ! $flow ) {
-			return array(
-				'success' => false,
-				'error'   => 'Flow not found',
-			);
+			return new \WP_Error( 'flow_not_found', 'Flow not found', array( 'status' => 404 ) );
 		}
 
 		$flow_config = $flow['flow_config'] ?? array();

--- a/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
+++ b/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
@@ -99,7 +99,7 @@ class UpdateFlowStepAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with update status.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$flow_step_id       = $input['flow_step_id'] ?? null;
 		$handler_slug       = $input['handler_slug'] ?? null;
 		$handler_configs    = is_array( $input['handler_configs'] ?? null ) ? $input['handler_configs'] : array();
@@ -108,10 +108,7 @@ class UpdateFlowStepAbility {
 		$user_message       = $input['user_message'] ?? null;
 
 		if ( empty( $flow_step_id ) || ! is_string( $flow_step_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_step_id is required and must be a string',
-			);
+			return new \WP_Error( 'invalid_flow_step_id', 'flow_step_id is required and must be a string', array( 'status' => 400 ) );
 		}
 
 		if ( empty( $handler_config ) && ! empty( $handler_configs ) ) {
@@ -128,18 +125,25 @@ class UpdateFlowStepAbility {
 		$has_remove_handler = ! empty( $input['remove_handler'] );
 
 		if ( ! $has_handler_update && ! $has_message_update && ! $has_add_handler && ! $has_remove_handler ) {
-			return array(
-				'success' => false,
-				'error'   => 'At least one of handler_slug, handler_config, user_message, add_handler, or remove_handler is required',
-			);
+			return new \WP_Error( 'invalid_flow_step_update', 'At least one of handler_slug, handler_config, user_message, add_handler, or remove_handler is required', array( 'status' => 400 ) );
 		}
 
 		$validation = $this->validateFlowStepId( $flow_step_id );
 		if ( ! $validation['valid'] ) {
-			return is_array( $validation['error_response'] ?? null ) ? $validation['error_response'] : array(
-				'success' => false,
-				'error'   => 'Invalid flow_step_id',
-			);
+			if ( is_array( $validation['error_response'] ?? null ) ) {
+				$error_response = $validation['error_response'];
+				$not_found      = 'not_found' === ( $error_response['error_type'] ?? '' );
+				return new \WP_Error(
+					$not_found ? 'flow_step_not_found' : 'invalid_flow_step_id',
+					$error_response['error'] ?? 'Invalid flow_step_id',
+					array(
+						'status'      => $not_found ? 404 : 400,
+						'diagnostic'  => $error_response['diagnostic'] ?? array(),
+						'remediation' => $error_response['remediation'] ?? array(),
+					)
+				);
+			}
+			return new \WP_Error( 'invalid_flow_step_id', 'Invalid flow_step_id', array( 'status' => 400 ) );
 		}
 
 		$existing_step = is_array( $validation['step_config'] ?? null ) ? $validation['step_config'] : array();
@@ -150,31 +154,20 @@ class UpdateFlowStepAbility {
 			$effective_slug = FlowStepConfig::getEffectiveSlug( $existing_step, $handler_slug ?? '' );
 
 			if ( empty( $effective_slug ) ) {
-				return array(
-					'success' => false,
-					'error'   => 'Unable to determine handler: no handler_slug provided, stored, or step_type available',
-				);
+				return new \WP_Error( 'invalid_handler', 'Unable to determine handler: no handler_slug provided, stored, or step_type available', array( 'status' => 400 ) );
 			}
 
 			if ( ! empty( $handler_config ) ) {
 				$validation_result = $this->validateHandlerConfig( $effective_slug, $handler_config );
 				if ( true !== $validation_result ) {
-					return array(
-						'success'        => false,
-						'error'          => $validation_result['error'],
-						'unknown_fields' => $validation_result['unknown_fields'],
-						'field_specs'    => $validation_result['field_specs'],
-					);
+					return new \WP_Error( 'invalid_handler_config', $validation_result['error'], array( 'status' => 400, 'unknown_fields' => $validation_result['unknown_fields'], 'field_specs' => $validation_result['field_specs'] ) );
 				}
 			}
 
 			$success = $this->updateHandler( $flow_step_id, $effective_slug, $handler_config );
 
 			if ( ! $success ) {
-				return array(
-					'success' => false,
-					'error'   => 'Failed to update handler configuration',
-				);
+				return new \WP_Error( 'flow_step_update_failed', 'Failed to update handler configuration', array( 'status' => 500 ) );
 			}
 
 			if ( ! empty( $handler_slug ) ) {
@@ -189,31 +182,20 @@ class UpdateFlowStepAbility {
 		$add_handler = $input['add_handler'] ?? null;
 		if ( ! empty( $add_handler ) ) {
 			if ( ! $this->handler_abilities->handlerExists( $add_handler ) ) {
-				return array(
-					'success' => false,
-					'error'   => "Handler '{$add_handler}' not found",
-				);
+				return new \WP_Error( 'handler_not_found', "Handler '{$add_handler}' not found", array( 'status' => 404 ) );
 			}
 
 			$add_handler_config = $input['add_handler_config'] ?? array();
 			if ( ! empty( $add_handler_config ) ) {
 				$validation_result = $this->validateHandlerConfig( $add_handler, $add_handler_config );
 				if ( true !== $validation_result ) {
-					return array(
-						'success'        => false,
-						'error'          => $validation_result['error'],
-						'unknown_fields' => $validation_result['unknown_fields'],
-						'field_specs'    => $validation_result['field_specs'],
-					);
+					return new \WP_Error( 'invalid_handler_config', $validation_result['error'], array( 'status' => 400, 'unknown_fields' => $validation_result['unknown_fields'], 'field_specs' => $validation_result['field_specs'] ) );
 				}
 			}
 
 			$success = $this->addHandler( $flow_step_id, $add_handler, $add_handler_config );
 			if ( ! $success ) {
-				return array(
-					'success' => false,
-					'error'   => "Failed to add handler '{$add_handler}' to step",
-				);
+				return new \WP_Error( 'flow_step_update_failed', "Failed to add handler '{$add_handler}' to step", array( 'status' => 500 ) );
 			}
 			$updated_fields[] = 'add_handler:' . $add_handler;
 		}
@@ -223,10 +205,7 @@ class UpdateFlowStepAbility {
 		if ( ! empty( $remove_handler ) ) {
 			$success = $this->removeHandler( $flow_step_id, $remove_handler );
 			if ( ! $success ) {
-				return array(
-					'success' => false,
-					'error'   => "Failed to remove handler '{$remove_handler}' from step. It may be the only handler.",
-				);
+				return new \WP_Error( 'flow_step_update_failed', "Failed to remove handler '{$remove_handler}' from step. It may be the only handler.", array( 'status' => 500 ) );
 			}
 			$updated_fields[] = 'remove_handler:' . $remove_handler;
 		}
@@ -235,10 +214,7 @@ class UpdateFlowStepAbility {
 			$success = $this->updateUserMessage( $flow_step_id, $user_message );
 
 			if ( ! $success ) {
-				return array(
-					'success' => false,
-					'error'   => 'Failed to update user message. Verify the step exists.',
-				);
+				return new \WP_Error( 'flow_step_update_failed', 'Failed to update user message. Verify the step exists.', array( 'status' => 500 ) );
 			}
 
 			$updated_fields[] = 'user_message';

--- a/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
+++ b/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
@@ -160,7 +160,15 @@ class UpdateFlowStepAbility {
 			if ( ! empty( $handler_config ) ) {
 				$validation_result = $this->validateHandlerConfig( $effective_slug, $handler_config );
 				if ( true !== $validation_result ) {
-					return new \WP_Error( 'invalid_handler_config', $validation_result['error'], array( 'status' => 400, 'unknown_fields' => $validation_result['unknown_fields'], 'field_specs' => $validation_result['field_specs'] ) );
+					return new \WP_Error(
+						'invalid_handler_config',
+						$validation_result['error'],
+						array(
+							'status'         => 400,
+							'unknown_fields' => $validation_result['unknown_fields'],
+							'field_specs'    => $validation_result['field_specs'],
+						)
+					);
 				}
 			}
 
@@ -189,7 +197,15 @@ class UpdateFlowStepAbility {
 			if ( ! empty( $add_handler_config ) ) {
 				$validation_result = $this->validateHandlerConfig( $add_handler, $add_handler_config );
 				if ( true !== $validation_result ) {
-					return new \WP_Error( 'invalid_handler_config', $validation_result['error'], array( 'status' => 400, 'unknown_fields' => $validation_result['unknown_fields'], 'field_specs' => $validation_result['field_specs'] ) );
+					return new \WP_Error(
+						'invalid_handler_config',
+						$validation_result['error'],
+						array(
+							'status'         => 400,
+							'unknown_fields' => $validation_result['unknown_fields'],
+							'field_specs'    => $validation_result['field_specs'],
+						)
+					);
 				}
 			}
 

--- a/inc/Abilities/FlowStep/ValidateFlowStepsConfigAbility.php
+++ b/inc/Abilities/FlowStep/ValidateFlowStepsConfigAbility.php
@@ -109,11 +109,25 @@ class ValidateFlowStepsConfigAbility {
 		$pipeline    = $this->db_pipelines->get_pipeline( $pipeline_id );
 
 		if ( ! $pipeline ) {
-			return new \WP_Error( 'pipeline_not_found', 'Pipeline not found', array( 'status' => 404, 'remediation' => 'Use list_pipelines (api_query) to find valid pipeline IDs.' ) );
+			return new \WP_Error(
+				'pipeline_not_found',
+				'Pipeline not found',
+				array(
+					'status'      => 404,
+					'remediation' => 'Use list_pipelines (api_query) to find valid pipeline IDs.',
+				)
+			);
 		}
 
 		if ( ! empty( $target_handler_slug ) && ! $this->handler_abilities->handlerExists( $target_handler_slug ) ) {
-			return new \WP_Error( 'handler_not_found', "Target handler '{$target_handler_slug}' not found", array( 'status' => 404, 'remediation' => 'Use list_handlers (api_query) to find valid handler slugs.' ) );
+			return new \WP_Error(
+				'handler_not_found',
+				"Target handler '{$target_handler_slug}' not found",
+				array(
+					'status'      => 404,
+					'remediation' => 'Use list_handlers (api_query) to find valid handler slugs.',
+				)
+			);
 		}
 
 		$flows = $this->db_flows->get_flows_for_pipeline( $pipeline_id );
@@ -121,7 +135,18 @@ class ValidateFlowStepsConfigAbility {
 		if ( empty( $flows ) ) {
 			$pipeline_config = $pipeline['pipeline_config'] ?? array();
 
-			return new \WP_Error( 'pipeline_has_no_flows', 'Pipeline has no flows yet', array( 'status' => 400, 'diagnostic' => array( 'pipeline_name' => $pipeline['pipeline_name'] ?? '', 'step_count' => count( $pipeline_config ) ), 'remediation' => 'Create a flow first using create_flow tool.' ) );
+			return new \WP_Error(
+				'pipeline_has_no_flows',
+				'Pipeline has no flows yet',
+				array(
+					'status'      => 400,
+					'diagnostic'  => array(
+						'pipeline_name' => $pipeline['pipeline_name'] ?? '',
+						'step_count'    => count( $pipeline_config ),
+					),
+					'remediation' => 'Create a flow first using create_flow tool.',
+				)
+			);
 		}
 
 		$flow_configs_by_id = array();
@@ -243,7 +268,15 @@ class ValidateFlowStepsConfigAbility {
 		);
 
 		if ( ! empty( $validation_errors ) ) {
-			return new \WP_Error( 'invalid_flow_step_configuration', 'Flow step configuration validation failed', array( 'status' => 400, 'validation_errors' => $validation_errors, 'pipeline_id' => $pipeline_id ) );
+			return new \WP_Error(
+				'invalid_flow_step_configuration',
+				'Flow step configuration validation failed',
+				array(
+					'status'            => 400,
+					'validation_errors' => $validation_errors,
+					'pipeline_id'       => $pipeline_id,
+				)
+			);
 		}
 
 		if ( ! empty( $warnings ) ) {

--- a/inc/Abilities/FlowStep/ValidateFlowStepsConfigAbility.php
+++ b/inc/Abilities/FlowStep/ValidateFlowStepsConfigAbility.php
@@ -93,7 +93,7 @@ class ValidateFlowStepsConfigAbility {
 	 * @param array $input Input parameters.
 	 * @return array Validation result with would_update and validation_errors.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$pipeline_id         = $input['pipeline_id'] ?? null;
 		$step_type           = $input['step_type'] ?? null;
 		$handler_slug        = $input['handler_slug'] ?? null;
@@ -102,44 +102,18 @@ class ValidateFlowStepsConfigAbility {
 		$flow_configs        = $input['flow_configs'] ?? array();
 
 		if ( ! is_numeric( $pipeline_id ) || (int) $pipeline_id <= 0 ) {
-			return array(
-				'valid'             => false,
-				'validation_errors' => array(
-					array(
-						'field' => 'pipeline_id',
-						'error' => 'pipeline_id is required and must be a positive integer',
-					),
-				),
-			);
+			return new \WP_Error( 'invalid_pipeline_id', 'pipeline_id is required and must be a positive integer', array( 'status' => 400 ) );
 		}
 
 		$pipeline_id = (int) $pipeline_id;
 		$pipeline    = $this->db_pipelines->get_pipeline( $pipeline_id );
 
 		if ( ! $pipeline ) {
-			return array(
-				'valid'             => false,
-				'validation_errors' => array(
-					array(
-						'field'       => 'pipeline_id',
-						'error'       => 'Pipeline not found',
-						'remediation' => 'Use list_pipelines (api_query) to find valid pipeline IDs.',
-					),
-				),
-			);
+			return new \WP_Error( 'pipeline_not_found', 'Pipeline not found', array( 'status' => 404, 'remediation' => 'Use list_pipelines (api_query) to find valid pipeline IDs.' ) );
 		}
 
 		if ( ! empty( $target_handler_slug ) && ! $this->handler_abilities->handlerExists( $target_handler_slug ) ) {
-			return array(
-				'valid'             => false,
-				'validation_errors' => array(
-					array(
-						'field'       => 'target_handler_slug',
-						'error'       => "Target handler '{$target_handler_slug}' not found",
-						'remediation' => 'Use list_handlers (api_query) to find valid handler slugs.',
-					),
-				),
-			);
+			return new \WP_Error( 'handler_not_found', "Target handler '{$target_handler_slug}' not found", array( 'status' => 404, 'remediation' => 'Use list_handlers (api_query) to find valid handler slugs.' ) );
 		}
 
 		$flows = $this->db_flows->get_flows_for_pipeline( $pipeline_id );
@@ -147,23 +121,7 @@ class ValidateFlowStepsConfigAbility {
 		if ( empty( $flows ) ) {
 			$pipeline_config = $pipeline['pipeline_config'] ?? array();
 
-			return array(
-				'valid'             => false,
-				'flow_count'        => 0,
-				'matching_steps'    => 0,
-				'would_update'      => array(),
-				'validation_errors' => array(
-					array(
-						'field'       => 'pipeline_id',
-						'error'       => 'Pipeline has no flows yet',
-						'diagnostic'  => array(
-							'pipeline_name' => $pipeline['pipeline_name'] ?? '',
-							'step_count'    => count( $pipeline_config ),
-						),
-						'remediation' => 'Create a flow first using create_flow tool.',
-					),
-				),
-			);
+			return new \WP_Error( 'pipeline_has_no_flows', 'Pipeline has no flows yet', array( 'status' => 400, 'diagnostic' => array( 'pipeline_name' => $pipeline['pipeline_name'] ?? '', 'step_count' => count( $pipeline_config ) ), 'remediation' => 'Create a flow first using create_flow tool.' ) );
 		}
 
 		$flow_configs_by_id = array();
@@ -285,7 +243,7 @@ class ValidateFlowStepsConfigAbility {
 		);
 
 		if ( ! empty( $validation_errors ) ) {
-			$response['validation_errors'] = $validation_errors;
+			return new \WP_Error( 'invalid_flow_step_configuration', 'Flow step configuration validation failed', array( 'status' => 400, 'validation_errors' => $validation_errors, 'pipeline_id' => $pipeline_id ) );
 		}
 
 		if ( ! empty( $warnings ) ) {

--- a/inc/Abilities/InternalLinkingAbilities.php
+++ b/inc/Abilities/InternalLinkingAbilities.php
@@ -1333,9 +1333,9 @@ class InternalLinkingAbilities {
 	 * @since 0.43.0
 	 *
 	 * @param array $input Ability input.
-	 * @return array Ability response.
+	 * @return array|\WP_Error Ability response.
 	 */
-	public static function getLinkOpportunities( array $input = array() ): array {
+	public static function getLinkOpportunities( array $input = array() ): array|\WP_Error {
 		$limit      = absint( $input['limit'] ?? 20 );
 		$category   = sanitize_text_field( $input['category'] ?? '' );
 		$min_clicks = absint( $input['min_clicks'] ?? 5 );
@@ -1347,10 +1347,7 @@ class InternalLinkingAbilities {
 		if ( false === $graph || ! is_array( $graph ) ) {
 			$graph = self::buildLinkGraph( 'post', '', array() );
 			if ( isset( $graph['error'] ) ) {
-				return array(
-					'success' => false,
-					'error'   => 'Failed to build link graph: ' . $graph['error'],
-				);
+				return new \WP_Error( 'link_graph_failed', 'Failed to build link graph: ' . $graph['error'], array( 'status' => 500 ) );
 			}
 			set_transient( self::GRAPH_TRANSIENT_KEY, $graph, self::GRAPH_CACHE_TTL );
 		}
@@ -1409,10 +1406,7 @@ class InternalLinkingAbilities {
 		$gsc_ability = wp_get_ability( 'datamachine/google-search-console' );
 
 		if ( ! $gsc_ability ) {
-			return array(
-				'success' => false,
-				'error'   => 'Google Search Console ability not available. Ensure Data Machine Business is active and Search Console is configured.',
-			);
+			return new \WP_Error( 'gsc_ability_unavailable', 'Google Search Console ability not available. Ensure Data Machine Business is active and Search Console is configured.', array( 'status' => 503 ) );
 		}
 
 		$start_date = gmdate( 'Y-m-d', time() - ( $days * DAY_IN_SECONDS ) );
@@ -1427,11 +1421,12 @@ class InternalLinkingAbilities {
 			)
 		);
 
+		if ( is_wp_error( $gsc_result ) ) {
+			return $gsc_result;
+		}
+
 		if ( empty( $gsc_result['success'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to fetch GSC data: ' . ( $gsc_result['error'] ?? 'Unknown error' ),
-			);
+			return new \WP_Error( 'gsc_query_failed', 'Failed to fetch GSC data: ' . ( $gsc_result['error'] ?? 'Unknown error' ), array( 'status' => 502 ) );
 		}
 
 		$gsc_rows = $gsc_result['results'] ?? array();
@@ -1441,10 +1436,7 @@ class InternalLinkingAbilities {
 		if ( ! empty( $category ) ) {
 			$term = get_term_by( 'slug', $category, 'category' );
 			if ( ! $term ) {
-				return array(
-					'success' => false,
-					'error'   => "Category '{$category}' not found.",
-				);
+				return new \WP_Error( 'category_not_found', "Category '{$category}' not found.", array( 'status' => 404 ) );
 			}
 			$cat_posts         = get_posts(
 				array(

--- a/inc/Abilities/Pipeline/CreatePipelineAbility.php
+++ b/inc/Abilities/Pipeline/CreatePipelineAbility.php
@@ -341,7 +341,14 @@ class CreatePipelineAbility {
 
 			$handler_validation = $this->validateHandlerSlugs( $template_workflow['steps'] );
 			if ( true !== $handler_validation ) {
-				return new \WP_Error( 'invalid_handler_slug', $handler_validation['error'] ?? 'Invalid handler slug', array( 'status' => 400, 'remediation' => $handler_validation['remediation'] ?? '' ) );
+				return new \WP_Error(
+					'invalid_handler_slug',
+					$handler_validation['error'] ?? 'Invalid handler slug',
+					array(
+						'status'      => 400,
+						'remediation' => $handler_validation['remediation'] ?? '',
+					)
+				);
 			}
 		} elseif ( ! empty( $template_steps ) ) {
 			$validation = $this->validateSteps( $template_steps );
@@ -351,7 +358,14 @@ class CreatePipelineAbility {
 
 			$handler_validation = $this->validateHandlerSlugs( $template_steps );
 			if ( true !== $handler_validation ) {
-				return new \WP_Error( 'invalid_handler_slug', $handler_validation['error'] ?? 'Invalid handler slug', array( 'status' => 400, 'remediation' => $handler_validation['remediation'] ?? '' ) );
+				return new \WP_Error(
+					'invalid_handler_slug',
+					$handler_validation['error'] ?? 'Invalid handler slug',
+					array(
+						'status'      => 400,
+						'remediation' => $handler_validation['remediation'] ?? '',
+					)
+				);
 			}
 		}
 
@@ -542,7 +556,16 @@ class CreatePipelineAbility {
 		);
 
 		if ( 0 === $created_count ) {
-			return new \WP_Error( 'pipeline_bulk_creation_failed', 'All pipeline creations failed', array( 'status' => 500, 'created_count' => 0, 'failed_count' => $failed_count, 'errors' => $errors ) );
+			return new \WP_Error(
+				'pipeline_bulk_creation_failed',
+				'All pipeline creations failed',
+				array(
+					'status'        => 500,
+					'created_count' => 0,
+					'failed_count'  => $failed_count,
+					'errors'        => $errors,
+				)
+			);
 		}
 
 		$message = sprintf( 'Created %d pipeline(s).', $created_count );

--- a/inc/Abilities/Pipeline/CreatePipelineAbility.php
+++ b/inc/Abilities/Pipeline/CreatePipelineAbility.php
@@ -110,7 +110,7 @@ class CreatePipelineAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with created pipeline data.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		// Check for bulk mode
 		if ( ! empty( $input['pipelines'] ) && is_array( $input['pipelines'] ) ) {
 			return $this->executeBulk( $input );
@@ -125,22 +125,16 @@ class CreatePipelineAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with created pipeline data.
 	 */
-	private function executeSingle( array $input ): array {
+	private function executeSingle( array $input ): array|\WP_Error {
 		$pipeline_name = $input['pipeline_name'] ?? null;
 
 		if ( empty( $pipeline_name ) || ! is_string( $pipeline_name ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'pipeline_name is required and must be a non-empty string',
-			);
+			return new \WP_Error( 'invalid_pipeline_name', 'pipeline_name is required and must be a non-empty string', array( 'status' => 400 ) );
 		}
 
 		$pipeline_name = sanitize_text_field( wp_unslash( $pipeline_name ) );
 		if ( empty( trim( $pipeline_name ) ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'pipeline_name cannot be empty',
-			);
+			return new \WP_Error( 'invalid_pipeline_name', 'pipeline_name cannot be empty', array( 'status' => 400 ) );
 		}
 
 		$agent_id    = isset( $input['agent_id'] ) ? (int) $input['agent_id'] : null;
@@ -151,10 +145,7 @@ class CreatePipelineAbility {
 			$scheduling_config     = $flow_config['scheduling_config'] ?? array( 'interval' => 'manual' );
 			$scheduling_validation = datamachine_validate_interval( $scheduling_config['interval'] ?? 'manual', $scheduling_config );
 			if ( ! $scheduling_validation['valid'] ) {
-				return array(
-					'success' => false,
-					'error'   => $scheduling_validation['error'],
-				);
+				return new \WP_Error( 'invalid_pipeline_schedule', $scheduling_validation['error'], array( 'status' => 400 ) );
 			}
 			$flow_config['scheduling_config']['interval'] = $scheduling_validation['resolved'];
 		}
@@ -178,18 +169,12 @@ class CreatePipelineAbility {
 		if ( $has_workflow ) {
 			$validation = $this->validateWorkflow( $workflow );
 			if ( true !== $validation ) {
-				return array(
-					'success' => false,
-					'error'   => $validation,
-				);
+				return new \WP_Error( 'invalid_pipeline_workflow', (string) $validation, array( 'status' => 400 ) );
 			}
 		} elseif ( $has_steps ) {
 			$validation = $this->validateSteps( $steps );
 			if ( true !== $validation ) {
-				return array(
-					'success' => false,
-					'error'   => $validation,
-				);
+				return new \WP_Error( 'invalid_pipeline_steps', (string) $validation, array( 'status' => 400 ) );
 			}
 		}
 
@@ -206,10 +191,7 @@ class CreatePipelineAbility {
 
 		if ( ! $pipeline_id ) {
 			do_action( 'datamachine_log', 'error', 'Failed to create pipeline', array( 'pipeline_name' => $pipeline_name ) );
-			return array(
-				'success' => false,
-				'error'   => 'Failed to create pipeline',
-			);
+			return new \WP_Error( 'pipeline_creation_failed', 'Failed to create pipeline', array( 'status' => 500 ) );
 		}
 
 		$pipeline_config = array();
@@ -283,11 +265,11 @@ class CreatePipelineAbility {
 				$flow_result = $create_flow_ability->execute( $flow_input );
 			}
 
-			if ( ! $flow_result || ! $flow_result['success'] ) {
+			if ( ! $flow_result || is_wp_error( $flow_result ) || empty( $flow_result['success'] ) ) {
 				do_action( 'datamachine_log', 'error', "Failed to create flow for pipeline {$pipeline_id}" );
 			}
 
-			if ( $flow_result && $flow_result['success'] && $has_workflow ) {
+			if ( is_array( $flow_result ) && ! empty( $flow_result['success'] ) && $has_workflow ) {
 				$persistent_flow_config = WorkflowConfigFactory::buildPersistentFlowConfig(
 					$workflow,
 					$pipeline_id,
@@ -301,7 +283,7 @@ class CreatePipelineAbility {
 				$flow_result['flow_data']['flow_config'] = $persistent_flow_config;
 			}
 
-			if ( $flow_result && $flow_result['success'] && ! empty( $flow_result['flow_data']['flow_config'] ) ) {
+			if ( is_array( $flow_result ) && ! empty( $flow_result['success'] ) && ! empty( $flow_result['flow_data']['flow_config'] ) ) {
 				$flow_step_ids = array_keys( $flow_result['flow_data']['flow_config'] );
 			}
 		}
@@ -336,7 +318,7 @@ class CreatePipelineAbility {
 	 * @param array $input Input parameters including pipelines array and optional template.
 	 * @return array Result with created pipelines data and error tracking.
 	 */
-	private function executeBulk( array $input ): array {
+	private function executeBulk( array $input ): array|\WP_Error {
 		$pipelines     = $input['pipelines'];
 		$template      = $input['template'] ?? array();
 		$validate_only = ! empty( $input['validate_only'] );
@@ -347,38 +329,29 @@ class CreatePipelineAbility {
 		if ( isset( $template['scheduling_config'] ) ) {
 			$scheduling_validation = datamachine_validate_interval( $template['scheduling_config']['interval'] ?? 'manual', $template['scheduling_config'] );
 			if ( ! $scheduling_validation['valid'] ) {
-				return array(
-					'success' => false,
-					'error'   => 'Template scheduling validation failed: ' . $scheduling_validation['error'],
-				);
+				return new \WP_Error( 'invalid_pipeline_schedule', 'Template scheduling validation failed: ' . $scheduling_validation['error'], array( 'status' => 400 ) );
 			}
 			$template['scheduling_config']['interval'] = $scheduling_validation['resolved'];
 		}
 		if ( ! empty( $template_workflow ) ) {
 			$validation = $this->validateWorkflow( $template_workflow );
 			if ( true !== $validation ) {
-				return array(
-					'success' => false,
-					'error'   => 'Template workflow validation failed: ' . $validation,
-				);
+				return new \WP_Error( 'invalid_pipeline_workflow', 'Template workflow validation failed: ' . $validation, array( 'status' => 400 ) );
 			}
 
 			$handler_validation = $this->validateHandlerSlugs( $template_workflow['steps'] );
 			if ( true !== $handler_validation ) {
-				return $handler_validation;
+				return new \WP_Error( 'invalid_handler_slug', $handler_validation['error'] ?? 'Invalid handler slug', array( 'status' => 400, 'remediation' => $handler_validation['remediation'] ?? '' ) );
 			}
 		} elseif ( ! empty( $template_steps ) ) {
 			$validation = $this->validateSteps( $template_steps );
 			if ( true !== $validation ) {
-				return array(
-					'success' => false,
-					'error'   => 'Template steps validation failed: ' . $validation,
-				);
+				return new \WP_Error( 'invalid_pipeline_steps', 'Template steps validation failed: ' . $validation, array( 'status' => 400 ) );
 			}
 
 			$handler_validation = $this->validateHandlerSlugs( $template_steps );
 			if ( true !== $handler_validation ) {
-				return $handler_validation;
+				return new \WP_Error( 'invalid_handler_slug', $handler_validation['error'] ?? 'Invalid handler slug', array( 'status' => 400, 'remediation' => $handler_validation['remediation'] ?? '' ) );
 			}
 		}
 
@@ -457,10 +430,13 @@ class CreatePipelineAbility {
 		}
 
 		if ( ! empty( $validation_errors ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Validation failed for ' . count( $validation_errors ) . ' pipeline(s)',
-				'errors'  => $validation_errors,
+			return new \WP_Error(
+				'invalid_pipelines',
+				'Validation failed for ' . count( $validation_errors ) . ' pipeline(s)',
+				array(
+					'status' => 400,
+					'errors' => $validation_errors,
+				)
 			);
 		}
 
@@ -531,7 +507,7 @@ class CreatePipelineAbility {
 
 			$single_result = $this->executeSingle( $single_input );
 
-			if ( $single_result['success'] ) {
+			if ( is_array( $single_result ) && ! empty( $single_result['success'] ) ) {
 				++$created_count;
 				$created[] = array(
 					'pipeline_id'   => $single_result['pipeline_id'],
@@ -546,7 +522,7 @@ class CreatePipelineAbility {
 				$errors[] = array(
 					'index'       => $index,
 					'name'        => $entry['name'],
-					'error'       => $single_result['error'],
+					'error'       => is_wp_error( $single_result ) ? $single_result->get_error_message() : ( $single_result['error'] ?? 'Pipeline creation failed' ),
 					'remediation' => 'Check the error message and fix the pipeline configuration',
 				);
 			}
@@ -566,13 +542,7 @@ class CreatePipelineAbility {
 		);
 
 		if ( 0 === $created_count ) {
-			return array(
-				'success'       => false,
-				'error'         => 'All pipeline creations failed',
-				'created_count' => 0,
-				'failed_count'  => $failed_count,
-				'errors'        => $errors,
-			);
+			return new \WP_Error( 'pipeline_bulk_creation_failed', 'All pipeline creations failed', array( 'status' => 500, 'created_count' => 0, 'failed_count' => $failed_count, 'errors' => $errors ) );
 		}
 
 		$message = sprintf( 'Created %d pipeline(s).', $created_count );

--- a/inc/Abilities/Pipeline/DeletePipelineAbility.php
+++ b/inc/Abilities/Pipeline/DeletePipelineAbility.php
@@ -69,14 +69,11 @@ class DeletePipelineAbility {
 	 * @param array $input Input parameters with pipeline_id.
 	 * @return array Result with deletion status.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$pipeline_id = $input['pipeline_id'] ?? null;
 
 		if ( ! is_numeric( $pipeline_id ) || (int) $pipeline_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'pipeline_id is required and must be a positive integer',
-			);
+			return new \WP_Error( 'invalid_pipeline_id', 'pipeline_id is required and must be a positive integer', array( 'status' => 400 ) );
 		}
 
 		$pipeline_id = (int) $pipeline_id;
@@ -84,12 +81,7 @@ class DeletePipelineAbility {
 
 		if ( ! $pipeline ) {
 			do_action( 'datamachine_log', 'error', 'Pipeline not found for deletion', array( 'pipeline_id' => $pipeline_id ) );
-			return array(
-				'success'    => false,
-				'error'      => 'Pipeline not found',
-				'error_code' => 'pipeline_not_found',
-				'status'     => 404,
-			);
+			return new \WP_Error( 'pipeline_not_found', 'Pipeline not found', array( 'status' => 404 ) );
 		}
 
 		$pipeline_name  = $pipeline['pipeline_name'];
@@ -140,13 +132,7 @@ class DeletePipelineAbility {
 			static fn(array $failure): bool => empty( $failure['desired_state_committed'] )
 		);
 		if ( ! empty( $commit_failures ) ) {
-			return array(
-				'success'           => false,
-				'error'             => 'Pipeline deletion did not commit every flow deletion.',
-				'error_code'        => 'pipeline_flow_deletion_incomplete',
-				'schedule_failures' => $schedule_failures,
-				'deleted_flows'     => $deleted_flows,
-			);
+			return new \WP_Error( 'pipeline_flow_deletion_incomplete', 'Pipeline deletion did not commit every flow deletion.', array( 'status' => 500, 'schedule_failures' => $schedule_failures, 'deleted_flows' => $deleted_flows ) );
 		}
 
 		$cleanup            = new FileCleanup();
@@ -165,10 +151,7 @@ class DeletePipelineAbility {
 
 		if ( ! $success ) {
 			do_action( 'datamachine_log', 'error', 'Failed to delete pipeline', array( 'pipeline_id' => $pipeline_id ) );
-			return array(
-				'success' => false,
-				'error'   => 'Failed to delete pipeline',
-			);
+			return new \WP_Error( 'pipeline_deletion_failed', 'Failed to delete pipeline', array( 'status' => 500 ) );
 		}
 
 		do_action(

--- a/inc/Abilities/Pipeline/DeletePipelineAbility.php
+++ b/inc/Abilities/Pipeline/DeletePipelineAbility.php
@@ -132,7 +132,15 @@ class DeletePipelineAbility {
 			static fn(array $failure): bool => empty( $failure['desired_state_committed'] )
 		);
 		if ( ! empty( $commit_failures ) ) {
-			return new \WP_Error( 'pipeline_flow_deletion_incomplete', 'Pipeline deletion did not commit every flow deletion.', array( 'status' => 500, 'schedule_failures' => $schedule_failures, 'deleted_flows' => $deleted_flows ) );
+			return new \WP_Error(
+				'pipeline_flow_deletion_incomplete',
+				'Pipeline deletion did not commit every flow deletion.',
+				array(
+					'status'            => 500,
+					'schedule_failures' => $schedule_failures,
+					'deleted_flows'     => $deleted_flows,
+				)
+			);
 		}
 
 		$cleanup            = new FileCleanup();

--- a/inc/Abilities/Pipeline/DuplicatePipelineAbility.php
+++ b/inc/Abilities/Pipeline/DuplicatePipelineAbility.php
@@ -76,14 +76,11 @@ class DuplicatePipelineAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with duplicated pipeline data.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$pipeline_id = $input['pipeline_id'] ?? null;
 
 		if ( ! is_numeric( $pipeline_id ) || (int) $pipeline_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'pipeline_id is required and must be a positive integer',
-			);
+			return new \WP_Error( 'invalid_pipeline_id', 'pipeline_id is required and must be a positive integer', array( 'status' => 400 ) );
 		}
 
 		$pipeline_id     = (int) $pipeline_id;
@@ -91,10 +88,7 @@ class DuplicatePipelineAbility {
 
 		if ( ! $source_pipeline ) {
 			do_action( 'datamachine_log', 'error', 'Source pipeline not found for duplication', array( 'pipeline_id' => $pipeline_id ) );
-			return array(
-				'success' => false,
-				'error'   => 'Source pipeline not found',
-			);
+			return new \WP_Error( 'pipeline_not_found', 'Source pipeline not found', array( 'status' => 404 ) );
 		}
 
 		$source_name = $source_pipeline['pipeline_name'];
@@ -120,10 +114,7 @@ class DuplicatePipelineAbility {
 		$new_pipeline_id = $this->db_pipelines->create_pipeline( $pipeline_data );
 
 		if ( ! $new_pipeline_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to create new pipeline',
-			);
+			return new \WP_Error( 'pipeline_duplication_failed', 'Failed to create new pipeline', array( 'status' => 500 ) );
 		}
 
 		$source_config   = $source_pipeline['pipeline_config'] ?? array();
@@ -175,7 +166,7 @@ class DuplicatePipelineAbility {
 				$flow_result = $create_flow_ability->execute( $flow_input );
 			}
 
-			if ( $flow_result && $flow_result['success'] ) {
+			if ( is_array( $flow_result ) && ! empty( $flow_result['success'] ) ) {
 				++$flows_created;
 
 				$source_flow_config = $source_flow['flow_config'] ?? array();

--- a/inc/Abilities/Pipeline/ImportExportAbility.php
+++ b/inc/Abilities/Pipeline/ImportExportAbility.php
@@ -116,24 +116,18 @@ class ImportExportAbility {
 	 * @param array $input Input parameters with CSV data.
 	 * @return array Result with import summary.
 	 */
-	public function executeImport( array $input ): array {
+	public function executeImport( array $input ): array|\WP_Error {
 		$data = $input['data'] ?? null;
 
 		if ( empty( $data ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'data is required',
-			);
+			return new \WP_Error( 'invalid_import_data', 'data is required', array( 'status' => 400 ) );
 		}
 
 		$import_export = new ImportExport();
 		$result        = $import_export->handle_import( 'pipelines', $data );
 
 		if ( false === $result ) {
-			return array(
-				'success' => false,
-				'error'   => 'Import failed',
-			);
+			return new \WP_Error( 'pipeline_import_failed', 'Import failed', array( 'status' => 500 ) );
 		}
 
 		$imported = $result['imported'] ?? array();

--- a/inc/Abilities/Pipeline/PipelineConfigurationAbilities.php
+++ b/inc/Abilities/Pipeline/PipelineConfigurationAbilities.php
@@ -144,22 +144,22 @@ class PipelineConfigurationAbilities {
 		return PermissionHelper::can( 'manage_flows' );
 	}
 
-	public function executeGet( array $input ): array {
+	public function executeGet( array $input ): array|\WP_Error {
 		$resolved = $this->resolvePipeline( $input );
-		if ( isset( $resolved['error'] ) ) {
+		if ( is_wp_error( $resolved ) ) {
 			return $resolved;
 		}
 
 		$pipeline = $resolved['pipeline'];
 		$snapshot = $this->pipelineSnapshot( (int) $pipeline['pipeline_id'] );
-		if ( isset( $snapshot['error'] ) ) {
+		if ( is_wp_error( $snapshot ) ) {
 			return $snapshot;
 		}
 
 		$flows = array();
 		foreach ( $this->flows->get_flows_for_pipeline( (int) $pipeline['pipeline_id'] ) as $flow ) {
 			$flow_snapshot = $this->flowSnapshot( (int) $flow['flow_id'] );
-			if ( isset( $flow_snapshot['error'] ) ) {
+			if ( is_wp_error( $flow_snapshot ) ) {
 				return $flow_snapshot;
 			}
 			$flows[] = array(
@@ -183,7 +183,7 @@ class PipelineConfigurationAbilities {
 		);
 	}
 
-	public function executeUpdate( array $input ): array {
+	public function executeUpdate( array $input ): array|\WP_Error {
 		$unknown = array_diff( array_keys( $input ), array( 'target', 'pipeline_id', 'pipeline_name', 'flow_id', 'step_id', 'step_type', 'expected_revision', 'configuration' ) );
 		if ( ! empty( $unknown ) ) {
 			return $this->error( 'unknown_field', 'Unknown input fields: ' . implode( ', ', $unknown ), 400 );
@@ -201,15 +201,15 @@ class PipelineConfigurationAbilities {
 			: $this->updateFlowStep( $input, $expected, $config );
 	}
 
-	private function updatePipelineStep( array $input, string $expected, array $patch ): array {
+	private function updatePipelineStep( array $input, string $expected, array $patch ): array|\WP_Error {
 		$resolved = $this->resolvePipeline( $input );
-		if ( isset( $resolved['error'] ) ) {
+		if ( is_wp_error( $resolved ) ) {
 			return $resolved;
 		}
 
 		$pipeline_id = (int) $resolved['pipeline']['pipeline_id'];
 		$snapshot    = $this->pipelineSnapshot( $pipeline_id );
-		if ( isset( $snapshot['error'] ) ) {
+		if ( is_wp_error( $snapshot ) ) {
 			return $snapshot;
 		}
 		if ( ! hash_equals( $snapshot['revision'], $expected ) ) {
@@ -226,7 +226,7 @@ class PipelineConfigurationAbilities {
 		}
 
 		$step_id = $this->resolveStepId( $snapshot['config'], $input, 'pipeline_step_id' );
-		if ( is_array( $step_id ) ) {
+		if ( is_wp_error( $step_id ) ) {
 			return $step_id;
 		}
 		$step = $snapshot['config'][ $step_id ];
@@ -260,7 +260,7 @@ class PipelineConfigurationAbilities {
 		return $this->updated( 'pipeline', $step_id, $this->pipelines->get_pipeline_config_json( $pipeline_id ) );
 	}
 
-	private function updateFlowStep( array $input, string $expected, array $patch ): array {
+	private function updateFlowStep( array $input, string $expected, array $patch ): array|\WP_Error {
 		$flow_id = isset( $input['flow_id'] ) ? (int) $input['flow_id'] : 0;
 		$flow    = $flow_id > 0 ? $this->flows->get_flow( $flow_id ) : null;
 		if ( ! $flow ) {
@@ -268,7 +268,7 @@ class PipelineConfigurationAbilities {
 		}
 
 		$snapshot = $this->flowSnapshot( $flow_id );
-		if ( isset( $snapshot['error'] ) ) {
+		if ( is_wp_error( $snapshot ) ) {
 			return $snapshot;
 		}
 		if ( ! hash_equals( $snapshot['revision'], $expected ) ) {
@@ -285,7 +285,7 @@ class PipelineConfigurationAbilities {
 		}
 
 		$step_id = $this->resolveStepId( $snapshot['config'], $input, 'flow_step_id' );
-		if ( is_array( $step_id ) ) {
+		if ( is_wp_error( $step_id ) ) {
 			return $step_id;
 		}
 		$step = $snapshot['config'][ $step_id ];
@@ -316,7 +316,7 @@ class PipelineConfigurationAbilities {
 		}
 
 		$handler_result = $this->applyHandlerPatch( $step, $patch );
-		if ( isset( $handler_result['error'] ) ) {
+		if ( is_wp_error( $handler_result ) ) {
 			return $handler_result;
 		}
 		$step = $handler_result['step'];
@@ -329,7 +329,7 @@ class PipelineConfigurationAbilities {
 		return $this->updated( 'flow', $step_id, $this->flows->get_flow_config_json( $flow_id ) );
 	}
 
-	private function applyHandlerPatch( array $step, array $patch ): array {
+	private function applyHandlerPatch( array $step, array $patch ): array|\WP_Error {
 		$has_handler_fields = array_intersect( array_keys( $patch ), array( 'handler_slug', 'handler_config', 'handler_configs', 'flow_step_settings' ) );
 		if ( empty( $has_handler_fields ) ) {
 			return array( 'step' => $step );
@@ -349,7 +349,7 @@ class PipelineConfigurationAbilities {
 			}
 			$slug       = (string) ( $step['step_type'] ?? '' );
 			$validation = $this->validateHandlerConfig( $slug, $patch['flow_step_settings'] );
-			if ( isset( $validation['error'] ) ) {
+			if ( is_wp_error( $validation ) ) {
 				return $validation;
 			}
 			$existing                   = is_array( $step['flow_step_settings'] ?? null ) ? $step['flow_step_settings'] : array();
@@ -383,7 +383,7 @@ class PipelineConfigurationAbilities {
 				return $this->error( 'invalid_configuration', "Handler '{$handler_slug}' is unavailable or has invalid configuration", 400 );
 			}
 			$validation = $this->validateHandlerConfig( $handler_slug, $handler_config );
-			if ( isset( $validation['error'] ) ) {
+			if ( is_wp_error( $validation ) ) {
 				return $validation;
 			}
 			$existing                        = is_array( $stored_configs[ $handler_slug ] ?? null ) ? $stored_configs[ $handler_slug ] : array();
@@ -401,7 +401,7 @@ class PipelineConfigurationAbilities {
 		return array( 'step' => $step );
 	}
 
-	private function validateHandlerConfig( string $slug, array $config ): array {
+	private function validateHandlerConfig( string $slug, array $config ): array|\WP_Error {
 		$fields  = $this->handlers->getConfigFields( $slug );
 		$unknown = array_diff( array_keys( $config ), array_keys( $fields ) );
 		if ( ! empty( $fields ) && ! empty( $unknown ) ) {
@@ -415,7 +415,7 @@ class PipelineConfigurationAbilities {
 		return $class && method_exists( $class, 'sanitize' ) ? $class->sanitize( $config ) : $config;
 	}
 
-	private function resolvePipeline( array $input ): array {
+	private function resolvePipeline( array $input ): array|\WP_Error {
 		$has_id   = isset( $input['pipeline_id'] );
 		$has_name = isset( $input['pipeline_name'] ) && '' !== trim( (string) $input['pipeline_name'] );
 		if ( $has_id === $has_name ) {
@@ -437,17 +437,17 @@ class PipelineConfigurationAbilities {
 		return array( 'pipeline' => $matches[0] );
 	}
 
-	private function pipelineSnapshot( int $pipeline_id ): array {
+	private function pipelineSnapshot( int $pipeline_id ): array|\WP_Error {
 		$raw = $this->pipelines->get_pipeline_config_json( $pipeline_id );
 		return $this->snapshot( $raw, 'pipeline_configuration_unavailable', 'Pipeline configuration is unavailable' );
 	}
 
-	private function flowSnapshot( int $flow_id ): array {
+	private function flowSnapshot( int $flow_id ): array|\WP_Error {
 		$raw = $this->flows->get_flow_config_json( $flow_id );
 		return $this->snapshot( $raw, 'flow_configuration_unavailable', 'Flow configuration is unavailable' );
 	}
 
-	private function snapshot( ?string $raw, string $code, string $message ): array {
+	private function snapshot( ?string $raw, string $code, string $message ): array|\WP_Error {
 		if ( null === $raw ) {
 			return $this->error( $code, $message, 503 );
 		}
@@ -475,7 +475,7 @@ class PipelineConfigurationAbilities {
 		return $steps;
 	}
 
-	private function resolveStepId( array $config, array $input, string $id_field ): string|array {
+	private function resolveStepId( array $config, array $input, string $id_field ): string|\WP_Error {
 		$step_id   = isset( $input['step_id'] ) ? (string) $input['step_id'] : '';
 		$step_type = isset( $input['step_type'] ) ? (string) $input['step_type'] : '';
 		if ( ( '' === $step_id ) === ( '' === $step_type ) ) {
@@ -500,7 +500,7 @@ class PipelineConfigurationAbilities {
 		return $matches[0];
 	}
 
-	private function updated( string $target, string $step_id, ?string $raw ): array {
+	private function updated( string $target, string $step_id, ?string $raw ): array|\WP_Error {
 		if ( null === $raw ) {
 			return $this->error( $target . '_configuration_unavailable', ucfirst( $target ) . ' configuration is unavailable', 503 );
 		}
@@ -520,13 +520,8 @@ class PipelineConfigurationAbilities {
 		return 'sha256:' . hash( 'sha256', $raw );
 	}
 
-	private function error( string $code, string $message, int $status ): array {
-		return array(
-			'success'    => false,
-			'error_code' => $code,
-			'error'      => $message,
-			'status'     => $status,
-		);
+	private function error( string $code, string $message, int $status ): \WP_Error {
+		return new \WP_Error( $code, $message, array( 'status' => $status ) );
 	}
 
 	private function deepMerge( array $existing, array $patch ): array {

--- a/inc/Abilities/Pipeline/PipelineConfigurationAbilities.php
+++ b/inc/Abilities/Pipeline/PipelineConfigurationAbilities.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
 
 class PipelineConfigurationAbilities {
 
-	private const SCHEMA_VERSION = 'datamachine.pipeline_configuration.v1';
+	private const SCHEMA_VERSION    = 'datamachine.pipeline_configuration.v1';
 	private static bool $registered = false;
 
 	private Pipelines $pipelines;

--- a/inc/Abilities/Pipeline/UpdatePipelineAbility.php
+++ b/inc/Abilities/Pipeline/UpdatePipelineAbility.php
@@ -74,35 +74,24 @@ class UpdatePipelineAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with update status.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$pipeline_id   = $input['pipeline_id'] ?? null;
 		$pipeline_name = $input['pipeline_name'] ?? null;
 		$agent_id      = $input['agent_id'] ?? null;
 
 		if ( ! is_numeric( $pipeline_id ) || (int) $pipeline_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'pipeline_id is required and must be a positive integer',
-			);
+			return new \WP_Error( 'invalid_pipeline_id', 'pipeline_id is required and must be a positive integer', array( 'status' => 400 ) );
 		}
 
 		$pipeline_id = (int) $pipeline_id;
 
 		if ( null === $pipeline_name && null === $agent_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'Must provide pipeline_name or agent_id to update',
-			);
+			return new \WP_Error( 'invalid_pipeline_update', 'Must provide pipeline_name or agent_id to update', array( 'status' => 400 ) );
 		}
 
 		$pipeline = $this->db_pipelines->get_pipeline( $pipeline_id );
 		if ( ! $pipeline ) {
-			return array(
-				'success'    => false,
-				'error'      => 'Pipeline not found',
-				'error_code' => 'pipeline_not_found',
-				'status'     => 404,
-			);
+			return new \WP_Error( 'pipeline_not_found', 'Pipeline not found', array( 'status' => 404 ) );
 		}
 
 		$update_data = array();
@@ -110,10 +99,7 @@ class UpdatePipelineAbility {
 		if ( null !== $pipeline_name ) {
 			$pipeline_name = sanitize_text_field( wp_unslash( $pipeline_name ) );
 			if ( empty( trim( $pipeline_name ) ) ) {
-				return array(
-					'success' => false,
-					'error'   => 'Pipeline name cannot be empty',
-				);
+				return new \WP_Error( 'invalid_pipeline_name', 'Pipeline name cannot be empty', array( 'status' => 400 ) );
 			}
 			$update_data['pipeline_name'] = $pipeline_name;
 		}
@@ -128,10 +114,7 @@ class UpdatePipelineAbility {
 		);
 
 		if ( ! $success ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to update pipeline',
-			);
+			return new \WP_Error( 'pipeline_update_failed', 'Failed to update pipeline', array( 'status' => 500 ) );
 		}
 
 		$updated_pipeline = $this->db_pipelines->get_pipeline( $pipeline_id );

--- a/inc/Abilities/PipelineStepAbilities.php
+++ b/inc/Abilities/PipelineStepAbilities.php
@@ -293,17 +293,14 @@ class PipelineStepAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result with steps data.
 	 */
-	public function executeGetPipelineSteps( array $input ): array {
+	public function executeGetPipelineSteps( array $input ): array|\WP_Error {
 		$pipeline_id      = $input['pipeline_id'] ?? null;
 		$pipeline_step_id = $input['pipeline_step_id'] ?? null;
 
 		// Direct step lookup by ID - bypasses pipeline_id requirement.
 		if ( null !== $pipeline_step_id ) {
 			if ( ! is_string( $pipeline_step_id ) || empty( $pipeline_step_id ) ) {
-				return array(
-					'success' => false,
-					'error'   => 'pipeline_step_id must be a non-empty string',
-				);
+				return new \WP_Error( 'invalid_pipeline_step_id', 'pipeline_step_id must be a non-empty string', array( 'status' => 400 ) );
 			}
 
 			$step_config = $this->db_pipelines->get_pipeline_step_config( $pipeline_step_id );
@@ -326,20 +323,14 @@ class PipelineStepAbilities {
 		}
 
 		if ( ! is_numeric( $pipeline_id ) || (int) $pipeline_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'pipeline_id is required and must be a positive integer',
-			);
+			return new \WP_Error( 'invalid_pipeline_id', 'pipeline_id is required and must be a positive integer', array( 'status' => 400 ) );
 		}
 
 		$pipeline_id = (int) $pipeline_id;
 		$pipeline    = $this->db_pipelines->get_pipeline( $pipeline_id );
 
 		if ( ! $pipeline ) {
-			return array(
-				'success' => false,
-				'error'   => 'Pipeline not found',
-			);
+			return new \WP_Error( 'pipeline_not_found', 'Pipeline not found', array( 'status' => 404 ) );
 		}
 
 		$steps = array_values( $this->db_pipelines->get_pipeline_config( $pipeline_id ) );
@@ -358,32 +349,23 @@ class PipelineStepAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result with created step data.
 	 */
-	public function executeAddPipelineStep( array $input ): array {
+	public function executeAddPipelineStep( array $input ): array|\WP_Error {
 		$pipeline_id = $input['pipeline_id'] ?? null;
 		$step_type   = $input['step_type'] ?? null;
 
 		if ( ! is_numeric( $pipeline_id ) || (int) $pipeline_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'pipeline_id is required and must be a positive integer',
-			);
+			return new \WP_Error( 'invalid_pipeline_id', 'pipeline_id is required and must be a positive integer', array( 'status' => 400 ) );
 		}
 
 		if ( empty( $step_type ) || ! is_string( $step_type ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'step_type is required and must be a string',
-			);
+			return new \WP_Error( 'invalid_step_type', 'step_type is required and must be a string', array( 'status' => 400 ) );
 		}
 
 		$step_type_abilities = new StepTypeAbilities();
 		$valid_types         = array_keys( $step_type_abilities->getAllStepTypes() );
 
 		if ( ! in_array( $step_type, $valid_types, true ) ) {
-			return array(
-				'success' => false,
-				'error'   => "Invalid step_type '{$step_type}'. Must be one of: " . implode( ', ', $valid_types ),
-			);
+			return new \WP_Error( 'invalid_step_type', "Invalid step_type '{$step_type}'. Must be one of: " . implode( ', ', $valid_types ), array( 'status' => 400 ) );
 		}
 
 		$pipeline_id = (int) $pipeline_id;
@@ -392,10 +374,7 @@ class PipelineStepAbilities {
 		$step_type_config = $step_type_abilities->getStepType( $step_type );
 		if ( ! $step_type_config ) {
 			do_action( 'datamachine_log', 'error', 'Invalid step type for step creation', array( 'step_type' => $step_type ) );
-			return array(
-				'success' => false,
-				'error'   => 'Invalid step type configuration',
-			);
+			return new \WP_Error( 'invalid_step_type', 'Invalid step type configuration', array( 'status' => 400 ) );
 		}
 
 		$current_steps        = $this->db_pipelines->get_pipeline_config( $pipeline_id );
@@ -457,10 +436,7 @@ class PipelineStepAbilities {
 					'step_type'   => $step_type,
 				)
 			);
-			return array(
-				'success' => false,
-				'error'   => 'Failed to add step. Verify the pipeline_id exists and you have sufficient permissions.',
-			);
+			return new \WP_Error( 'pipeline_step_creation_failed', 'Failed to add step. Verify the pipeline_id exists and you have sufficient permissions.', array( 'status' => 500 ) );
 		}
 
 		$pipeline_step_id = $new_step['pipeline_step_id'];
@@ -513,22 +489,16 @@ class PipelineStepAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result with update status.
 	 */
-	public function executeUpdatePipelineStep( array $input ): array {
+	public function executeUpdatePipelineStep( array $input ): array|\WP_Error {
 		$pipeline_step_id = $input['pipeline_step_id'] ?? null;
 
 		if ( empty( $pipeline_step_id ) || ! is_string( $pipeline_step_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'pipeline_step_id is required and must be a string',
-			);
+			return new \WP_Error( 'invalid_pipeline_step_id', 'pipeline_step_id is required and must be a string', array( 'status' => 400 ) );
 		}
 
 		// Reject handler fields — handlers are flow-scoped, not pipeline-scoped.
 		if ( isset( $input['handler_slug'] ) || isset( $input['handler_slugs'] ) || isset( $input['handler_config'] ) || isset( $input['handler_configs'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'handler_slug(s) and handler_config(s) are flow-scoped. Use datamachine/update-flow-step ability instead.',
-			);
+			return new \WP_Error( 'invalid_pipeline_step_fields', 'handler_slug(s) and handler_config(s) are flow-scoped. Use datamachine/update-flow-step ability instead.', array( 'status' => 400 ) );
 		}
 
 		$system_prompt = $input['system_prompt'] ?? null;
@@ -547,29 +517,20 @@ class PipelineStepAbilities {
 		}
 
 		if ( null === $system_prompt && null === $agent_modes && ! $has_policy_field ) {
-			return array(
-				'success' => false,
-				'error'   => 'At least one of system_prompt, agent_modes, disabled_tools, or tool_categories is required',
-			);
+			return new \WP_Error( 'invalid_pipeline_step_update', 'At least one of system_prompt, agent_modes, disabled_tools, or tool_categories is required', array( 'status' => 400 ) );
 		}
 
 		$step_config = $this->db_pipelines->get_pipeline_step_config( $pipeline_step_id );
 
 		if ( empty( $step_config ) || empty( $step_config['pipeline_id'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Pipeline step not found',
-			);
+			return new \WP_Error( 'pipeline_step_not_found', 'Pipeline step not found', array( 'status' => 404 ) );
 		}
 
 		$pipeline_id = $step_config['pipeline_id'];
 		$pipeline    = $this->db_pipelines->get_pipeline( $pipeline_id );
 
 		if ( ! $pipeline ) {
-			return array(
-				'success' => false,
-				'error'   => 'Pipeline not found',
-			);
+			return new \WP_Error( 'pipeline_not_found', 'Pipeline not found', array( 'status' => 404 ) );
 		}
 
 		$pipeline_config = $pipeline['pipeline_config'] ?? array();
@@ -586,10 +547,7 @@ class PipelineStepAbilities {
 		if ( null !== $agent_modes ) {
 			$sanitized_modes = self::sanitizeStringListField( $agent_modes, 'agent_modes' );
 			if ( is_wp_error( $sanitized_modes ) ) {
-				return array(
-					'success' => false,
-					'error'   => $sanitized_modes->get_error_message(),
-				);
+				return new \WP_Error( $sanitized_modes->get_error_code(), $sanitized_modes->get_error_message(), array( 'status' => 400 ) );
 			}
 			$step_config_data['agent_modes'] = $sanitized_modes;
 			$updated_fields[]                = 'agent_modes';
@@ -602,10 +560,7 @@ class PipelineStepAbilities {
 
 			$sanitized_values = self::sanitizeStringListField( $input[ $field ], $field );
 			if ( is_wp_error( $sanitized_values ) ) {
-				return array(
-					'success' => false,
-					'error'   => $sanitized_values->get_error_message(),
-				);
+				return new \WP_Error( $sanitized_values->get_error_code(), $sanitized_values->get_error_message(), array( 'status' => 400 ) );
 			}
 
 			if ( 'disabled_tools' === $field ) {
@@ -625,10 +580,7 @@ class PipelineStepAbilities {
 		);
 
 		if ( ! $success ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to update pipeline step configuration',
-			);
+			return new \WP_Error( 'pipeline_step_update_failed', 'Failed to update pipeline step configuration', array( 'status' => 500 ) );
 		}
 
 		do_action(
@@ -687,22 +639,16 @@ class PipelineStepAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result with deletion status.
 	 */
-	public function executeDeletePipelineStep( array $input ): array {
+	public function executeDeletePipelineStep( array $input ): array|\WP_Error {
 		$pipeline_id      = $input['pipeline_id'] ?? null;
 		$pipeline_step_id = $input['pipeline_step_id'] ?? null;
 
 		if ( ! is_numeric( $pipeline_id ) || (int) $pipeline_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'pipeline_id is required and must be a positive integer',
-			);
+			return new \WP_Error( 'invalid_pipeline_id', 'pipeline_id is required and must be a positive integer', array( 'status' => 400 ) );
 		}
 
 		if ( empty( $pipeline_step_id ) || ! is_string( $pipeline_step_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'pipeline_step_id is required and must be a string',
-			);
+			return new \WP_Error( 'invalid_pipeline_step_id', 'pipeline_step_id is required and must be a string', array( 'status' => 400 ) );
 		}
 
 		$pipeline_id      = absint( $pipeline_id );
@@ -710,10 +656,7 @@ class PipelineStepAbilities {
 
 		$pipeline = $this->db_pipelines->get_pipeline( $pipeline_id );
 		if ( ! $pipeline ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Pipeline not found.', 'data-machine' ),
-			);
+			return new \WP_Error( 'pipeline_not_found', __( 'Pipeline not found.', 'data-machine' ), array( 'status' => 404 ) );
 		}
 
 		if ( ! isset( $pipeline['pipeline_name'] ) || empty( trim( $pipeline['pipeline_name'] ) ) ) {
@@ -726,10 +669,7 @@ class PipelineStepAbilities {
 					'pipeline_step_id' => $pipeline_step_id,
 				)
 			);
-			return array(
-				'success' => false,
-				'error'   => __( 'Pipeline data is corrupted - missing name.', 'data-machine' ),
-			);
+			return new \WP_Error( 'pipeline_data_invalid', __( 'Pipeline data is corrupted - missing name.', 'data-machine' ), array( 'status' => 500 ) );
 		}
 
 		$pipeline_name  = $pipeline['pipeline_name'];
@@ -749,10 +689,7 @@ class PipelineStepAbilities {
 		}
 
 		if ( ! $step_found ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Step not found in pipeline.', 'data-machine' ),
-			);
+			return new \WP_Error( 'pipeline_step_not_found', __( 'Step not found in pipeline.', 'data-machine' ), array( 'status' => 404 ) );
 		}
 
 		$updated_steps = array();
@@ -770,10 +707,7 @@ class PipelineStepAbilities {
 		);
 
 		if ( ! $success ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Failed to delete step from pipeline.', 'data-machine' ),
-			);
+			return new \WP_Error( 'pipeline_step_deletion_failed', __( 'Failed to delete step from pipeline.', 'data-machine' ), array( 'status' => 500 ) );
 		}
 
 		// Sync deletions to flows
@@ -830,44 +764,29 @@ class PipelineStepAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result with reorder status.
 	 */
-	public function executeReorderPipelineSteps( array $input ): array {
+	public function executeReorderPipelineSteps( array $input ): array|\WP_Error {
 		$pipeline_id = $input['pipeline_id'] ?? null;
 		$step_order  = $input['step_order'] ?? null;
 
 		if ( ! is_numeric( $pipeline_id ) || (int) $pipeline_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'pipeline_id is required and must be a positive integer',
-			);
+			return new \WP_Error( 'invalid_pipeline_id', 'pipeline_id is required and must be a positive integer', array( 'status' => 400 ) );
 		}
 
 		if ( empty( $step_order ) || ! is_array( $step_order ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'step_order is required and must be an array',
-			);
+			return new \WP_Error( 'invalid_step_order', 'step_order is required and must be an array', array( 'status' => 400 ) );
 		}
 
 		foreach ( $step_order as $index => $item ) {
 			if ( ! is_array( $item ) ) {
-				return array(
-					'success' => false,
-					'error'   => "Step order item at index {$index} must be an object",
-				);
+				return new \WP_Error( 'invalid_step_order', "Step order item at index {$index} must be an object", array( 'status' => 400 ) );
 			}
 
 			if ( ! isset( $item['pipeline_step_id'] ) || ! isset( $item['execution_order'] ) ) {
-				return array(
-					'success' => false,
-					'error'   => 'Each step order item must have pipeline_step_id and execution_order',
-				);
+				return new \WP_Error( 'invalid_step_order', 'Each step order item must have pipeline_step_id and execution_order', array( 'status' => 400 ) );
 			}
 
 			if ( ! is_string( $item['pipeline_step_id'] ) || ! is_numeric( $item['execution_order'] ) ) {
-				return array(
-					'success' => false,
-					'error'   => 'pipeline_step_id must be string and execution_order must be numeric',
-				);
+				return new \WP_Error( 'invalid_step_order', 'pipeline_step_id must be string and execution_order must be numeric', array( 'status' => 400 ) );
 			}
 		}
 
@@ -875,10 +794,7 @@ class PipelineStepAbilities {
 		$pipeline_steps = $this->db_pipelines->get_pipeline_config( $pipeline_id );
 
 		if ( empty( $pipeline_steps ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Pipeline not found', 'data-machine' ),
-			);
+			return new \WP_Error( 'pipeline_not_found', __( 'Pipeline not found', 'data-machine' ), array( 'status' => 404 ) );
 		}
 
 		$steps_by_id = array();
@@ -894,26 +810,20 @@ class PipelineStepAbilities {
 			$pipeline_step_id = sanitize_text_field( $item['pipeline_step_id'] );
 
 			if ( isset( $seen_steps[ $pipeline_step_id ] ) ) {
-				return array(
-					'success' => false,
-					'error'   => sprintf(
+				return new \WP_Error( 'duplicate_step_order', sprintf(
 						/* translators: %s: pipeline step ID */
 						__( 'Step %s appears more than once in reorder input', 'data-machine' ),
 						$pipeline_step_id
-					),
-				);
+				), array( 'status' => 400 ) );
 			}
 			$seen_steps[ $pipeline_step_id ] = true;
 
 			if ( ! isset( $steps_by_id[ $pipeline_step_id ] ) ) {
-				return array(
-					'success' => false,
-					'error'   => sprintf(
+				return new \WP_Error( 'pipeline_step_not_found', sprintf(
 						/* translators: %s: pipeline step ID */
 						__( 'Step %s not found in pipeline', 'data-machine' ),
 						$pipeline_step_id
-					),
-				);
+				), array( 'status' => 404 ) );
 			}
 
 			$step                               = $steps_by_id[ $pipeline_step_id ];
@@ -922,10 +832,7 @@ class PipelineStepAbilities {
 		}
 
 		if ( count( $updated_steps ) !== count( $pipeline_steps ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Step count mismatch during reorder', 'data-machine' ),
-			);
+			return new \WP_Error( 'step_order_mismatch', __( 'Step count mismatch during reorder', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		$success = $this->db_pipelines->update_pipeline(
@@ -936,10 +843,7 @@ class PipelineStepAbilities {
 		);
 
 		if ( ! $success ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Failed to save step order', 'data-machine' ),
-			);
+			return new \WP_Error( 'pipeline_step_reorder_failed', __( 'Failed to save step order', 'data-machine' ), array( 'status' => 500 ) );
 		}
 
 		$updated_orders = $this->buildExecutionOrderMap( $updated_steps );

--- a/inc/Abilities/Publish/SendEmailQueuedAbility.php
+++ b/inc/Abilities/Publish/SendEmailQueuedAbility.php
@@ -277,51 +277,23 @@ class SendEmailQueuedAbility {
 			'token_id' => absint( PermissionHelper::get_acting_token_id() ),
 		);
 		if ( $context['user_id'] <= 0 ) {
-			return new \WP_Error(
-				'email_queue_issuer_required',
-				'An identified issuer is required to queue email.',
-				array(
-					'status' => 403,
-					'logs'   => $logs,
-				)
-			);
+			return $this->queueError( 'email_queue_issuer_required', 'An identified issuer is required to queue email.', 403, $logs );
 		}
 		if ( ! empty( $input['auth_ref'] ) ) {
 			$providers = apply_filters( 'datamachine_auth_providers', array() );
 			$auth      = $providers['email_imap'] ?? null;
 			if ( ! $auth || ! method_exists( $auth, 'resolve_mailbox' ) || is_wp_error( $auth->resolve_mailbox( $input['auth_ref'], 'send' ) ) ) {
-				return new \WP_Error(
-					'email_queue_authorization_failed',
-					'Mailbox send authorization failed.',
-					array(
-						'status' => 403,
-						'logs'   => $logs,
-					)
-				);
+				return $this->queueError( 'email_queue_authorization_failed', 'Mailbox send authorization failed.', 403, $logs );
 			}
 		} elseif ( ! $this->canUseLegacySender() ) {
-			return new \WP_Error(
-				'email_queue_mailbox_required',
-				'An authorized mailbox ref is required to queue email.',
-				array(
-					'status' => 403,
-					'logs'   => $logs,
-				)
-			);
+			return $this->queueError( 'email_queue_mailbox_required', 'An authorized mailbox ref is required to queue email.', 403, $logs );
 		}
 
 		// Validate the bare minimum here. The underlying ability re-validates
 		// the full payload when the worker runs.
 		$to = isset( $input['to'] ) ? (string) $input['to'] : '';
 		if ( '' === trim( $to ) ) {
-			return new \WP_Error(
-				'invalid_email_recipient',
-				'Recipient (to) is required.',
-				array(
-					'status' => 400,
-					'logs'   => $logs,
-				)
-			);
+			return $this->queueError( 'invalid_email_recipient', 'Recipient (to) is required.', 400, $logs );
 		}
 
 		$send_at_raw = $input['send_at'] ?? '';
@@ -361,14 +333,7 @@ class SendEmailQueuedAbility {
 				'level'   => 'error',
 				'message' => 'Email queue: Action Scheduler did not return an action id',
 			);
-			return new \WP_Error(
-				'email_queue_failed',
-				'Failed to schedule email action.',
-				array(
-					'status' => 500,
-					'logs'   => $logs,
-				)
-			);
+			return $this->queueError( 'email_queue_failed', 'Failed to schedule email action.', 500, $logs );
 		}
 
 		$logs[] = array(
@@ -500,6 +465,17 @@ class SendEmailQueuedAbility {
 
 		$grant['signature'] = hash_hmac( 'sha256', $this->mailboxGrantPayload( $input, $grant ), wp_salt( 'auth' ) );
 		return $grant;
+	}
+
+	private function queueError( string $code, string $message, int $status, array $logs ): \WP_Error {
+		return new \WP_Error(
+			$code,
+			$message,
+			array(
+				'status' => $status,
+				'logs'   => $logs,
+			)
+		);
 	}
 
 	private function verifyMailboxGrant( array $payload ): array|\WP_Error {

--- a/inc/Abilities/Publish/SendEmailQueuedAbility.php
+++ b/inc/Abilities/Publish/SendEmailQueuedAbility.php
@@ -269,7 +269,7 @@ class SendEmailQueuedAbility {
 	 * @param array $input Send-email payload + send_at/priority.
 	 * @return array Result with success flag, action_id, scheduled_for.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$logs = array();
 		$context = array(
 			'user_id'   => PermissionHelper::acting_user_id(),
@@ -277,39 +277,23 @@ class SendEmailQueuedAbility {
 			'token_id'  => absint( PermissionHelper::get_acting_token_id() ),
 		);
 		if ( $context['user_id'] <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'An identified issuer is required to queue email.',
-				'logs'    => $logs,
-			);
+			return new \WP_Error( 'email_queue_issuer_required', 'An identified issuer is required to queue email.', array( 'status' => 403, 'logs' => $logs ) );
 		}
 		if ( ! empty( $input['auth_ref'] ) ) {
 			$providers = apply_filters( 'datamachine_auth_providers', array() );
 			$auth      = $providers['email_imap'] ?? null;
 			if ( ! $auth || ! method_exists( $auth, 'resolve_mailbox' ) || is_wp_error( $auth->resolve_mailbox( $input['auth_ref'], 'send' ) ) ) {
-				return array(
-					'success' => false,
-					'error'   => 'Mailbox send authorization failed.',
-					'logs'    => $logs,
-				);
+				return new \WP_Error( 'email_queue_authorization_failed', 'Mailbox send authorization failed.', array( 'status' => 403, 'logs' => $logs ) );
 			}
 		} elseif ( ! $this->canUseLegacySender() ) {
-			return array(
-				'success' => false,
-				'error'   => 'An authorized mailbox ref is required to queue email.',
-				'logs'    => $logs,
-			);
+			return new \WP_Error( 'email_queue_mailbox_required', 'An authorized mailbox ref is required to queue email.', array( 'status' => 403, 'logs' => $logs ) );
 		}
 
 		// Validate the bare minimum here. The underlying ability re-validates
 		// the full payload when the worker runs.
 		$to = isset( $input['to'] ) ? (string) $input['to'] : '';
 		if ( '' === trim( $to ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Recipient (to) is required.',
-				'logs'    => $logs,
-			);
+			return new \WP_Error( 'invalid_email_recipient', 'Recipient (to) is required.', array( 'status' => 400, 'logs' => $logs ) );
 		}
 
 		$send_at_raw = $input['send_at'] ?? '';
@@ -329,11 +313,7 @@ class SendEmailQueuedAbility {
 		$timestamp = $this->parseSendAt( $send_at_raw );
 
 		if ( $timestamp instanceof \WP_Error ) {
-			return array(
-				'success' => false,
-				'error'   => $timestamp->get_error_message(),
-				'logs'    => $logs,
-			);
+			return new \WP_Error( $timestamp->get_error_code(), $timestamp->get_error_message(), array_merge( array( 'status' => 400 ), is_array( $timestamp->get_error_data() ) ? $timestamp->get_error_data() : array(), array( 'logs' => $logs ) ) );
 		}
 
 		// Action Scheduler payload — wrap in an indexed array so the hook
@@ -353,11 +333,7 @@ class SendEmailQueuedAbility {
 				'level'   => 'error',
 				'message' => 'Email queue: Action Scheduler did not return an action id',
 			);
-			return array(
-				'success' => false,
-				'error'   => 'Failed to schedule email action.',
-				'logs'    => $logs,
-			);
+			return new \WP_Error( 'email_queue_failed', 'Failed to schedule email action.', array( 'status' => 500, 'logs' => $logs ) );
 		}
 
 		$logs[] = array(
@@ -438,7 +414,7 @@ class SendEmailQueuedAbility {
 			return;
 		}
 
-		$error_msg = is_wp_error( $result ) ? $result->get_error_message() : 'invalid result';
+		$error_msg = is_wp_error( $result ) ? $result->get_error_message() : ( $result['error'] ?? 'invalid result' );
 
 		if ( $attempt >= self::MAX_ATTEMPTS ) {
 			do_action(

--- a/inc/Abilities/Publish/SendEmailQueuedAbility.php
+++ b/inc/Abilities/Publish/SendEmailQueuedAbility.php
@@ -270,30 +270,58 @@ class SendEmailQueuedAbility {
 	 * @return array Result with success flag, action_id, scheduled_for.
 	 */
 	public function execute( array $input ): array|\WP_Error {
-		$logs = array();
+		$logs    = array();
 		$context = array(
-			'user_id'   => PermissionHelper::acting_user_id(),
-			'agent_id'  => absint( PermissionHelper::get_acting_agent_id() ),
-			'token_id'  => absint( PermissionHelper::get_acting_token_id() ),
+			'user_id'  => PermissionHelper::acting_user_id(),
+			'agent_id' => absint( PermissionHelper::get_acting_agent_id() ),
+			'token_id' => absint( PermissionHelper::get_acting_token_id() ),
 		);
 		if ( $context['user_id'] <= 0 ) {
-			return new \WP_Error( 'email_queue_issuer_required', 'An identified issuer is required to queue email.', array( 'status' => 403, 'logs' => $logs ) );
+			return new \WP_Error(
+				'email_queue_issuer_required',
+				'An identified issuer is required to queue email.',
+				array(
+					'status' => 403,
+					'logs'   => $logs,
+				)
+			);
 		}
 		if ( ! empty( $input['auth_ref'] ) ) {
 			$providers = apply_filters( 'datamachine_auth_providers', array() );
 			$auth      = $providers['email_imap'] ?? null;
 			if ( ! $auth || ! method_exists( $auth, 'resolve_mailbox' ) || is_wp_error( $auth->resolve_mailbox( $input['auth_ref'], 'send' ) ) ) {
-				return new \WP_Error( 'email_queue_authorization_failed', 'Mailbox send authorization failed.', array( 'status' => 403, 'logs' => $logs ) );
+				return new \WP_Error(
+					'email_queue_authorization_failed',
+					'Mailbox send authorization failed.',
+					array(
+						'status' => 403,
+						'logs'   => $logs,
+					)
+				);
 			}
 		} elseif ( ! $this->canUseLegacySender() ) {
-			return new \WP_Error( 'email_queue_mailbox_required', 'An authorized mailbox ref is required to queue email.', array( 'status' => 403, 'logs' => $logs ) );
+			return new \WP_Error(
+				'email_queue_mailbox_required',
+				'An authorized mailbox ref is required to queue email.',
+				array(
+					'status' => 403,
+					'logs'   => $logs,
+				)
+			);
 		}
 
 		// Validate the bare minimum here. The underlying ability re-validates
 		// the full payload when the worker runs.
 		$to = isset( $input['to'] ) ? (string) $input['to'] : '';
 		if ( '' === trim( $to ) ) {
-			return new \WP_Error( 'invalid_email_recipient', 'Recipient (to) is required.', array( 'status' => 400, 'logs' => $logs ) );
+			return new \WP_Error(
+				'invalid_email_recipient',
+				'Recipient (to) is required.',
+				array(
+					'status' => 400,
+					'logs'   => $logs,
+				)
+			);
 		}
 
 		$send_at_raw = $input['send_at'] ?? '';
@@ -333,7 +361,14 @@ class SendEmailQueuedAbility {
 				'level'   => 'error',
 				'message' => 'Email queue: Action Scheduler did not return an action id',
 			);
-			return new \WP_Error( 'email_queue_failed', 'Failed to schedule email action.', array( 'status' => 500, 'logs' => $logs ) );
+			return new \WP_Error(
+				'email_queue_failed',
+				'Failed to schedule email action.',
+				array(
+					'status' => 500,
+					'logs'   => $logs,
+				)
+			);
 		}
 
 		$logs[] = array(
@@ -375,7 +410,7 @@ class SendEmailQueuedAbility {
 		}
 
 		$attempt = isset( $payload['_attempt'] ) ? max( 1, (int) $payload['_attempt'] ) : 1;
-		$grant = $this->verifyMailboxGrant( $payload );
+		$grant   = $this->verifyMailboxGrant( $payload );
 		if ( is_wp_error( $grant ) || ! $this->currentIssuerAuthorized( $grant ) ) {
 			do_action( 'datamachine_log', 'error', 'Email worker: queued authorization denied', array( 'attempt' => $attempt ) );
 			return;
@@ -454,14 +489,15 @@ class SendEmailQueuedAbility {
 		$issued_at = time();
 		$nonce     = wp_generate_uuid4();
 		$grant     = array(
-			'user_id'      => (int) $context['user_id'],
-			'agent_id'     => (int) $context['agent_id'],
-			'token_id'     => (int) $context['token_id'],
-			'issuer_type'  => (int) $context['agent_id'] > 0 ? ( (int) $context['token_id'] > 0 ? 'agent_token' : 'agent' ) : 'user',
-			'issued_at'    => $issued_at,
-			'nonce'        => $nonce,
+			'user_id'       => (int) $context['user_id'],
+			'agent_id'      => (int) $context['agent_id'],
+			'token_id'      => (int) $context['token_id'],
+			'issuer_type'   => (int) $context['agent_id'] > 0 ? ( (int) $context['token_id'] > 0 ? 'agent_token' : 'agent' ) : 'user',
+			'issued_at'     => $issued_at,
+			'nonce'         => $nonce,
 			'legacy_sender' => empty( $input['auth_ref'] ),
 		);
+
 		$grant['signature'] = hash_hmac( 'sha256', $this->mailboxGrantPayload( $input, $grant ), wp_salt( 'auth' ) );
 		return $grant;
 	}
@@ -483,6 +519,7 @@ class SendEmailQueuedAbility {
 		unset( $payload['_attempt'], $payload['_mailbox_grant'] );
 		$payload = $this->canonicalizeGrantValue( $payload );
 		return implode( '|', array(
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Existing queued grants depend on this signature payload.
 			hash( 'sha256', serialize( $payload ) ),
 			(string) absint( $grant['user_id'] ?? 0 ),
 			(string) absint( $grant['agent_id'] ?? 0 ),

--- a/inc/Api/Chat/Tools/ConfigureFlowSteps.php
+++ b/inc/Api/Chat/Tools/ConfigureFlowSteps.php
@@ -290,11 +290,7 @@ class ConfigureFlowSteps extends BaseTool {
 		$result = $ability->execute( $input );
 
 		if ( is_wp_error( $result ) ) {
-			return array(
-				'success'   => false,
-				'error'     => $result->get_error_message(),
-				'tool_name' => 'configure_flow_steps',
-			);
+			return $this->abilityErrorResult( $result );
 		}
 
 		$result['tool_name'] = 'configure_flow_steps';
@@ -460,11 +456,7 @@ class ConfigureFlowSteps extends BaseTool {
 		$result = $ability->execute( $input );
 
 		if ( is_wp_error( $result ) ) {
-			return array(
-				'success'   => false,
-				'error'     => $result->get_error_message(),
-				'tool_name' => 'configure_flow_steps',
-			);
+			return $this->abilityErrorResult( $result );
 		}
 
 		$result['tool_name'] = 'configure_flow_steps';
@@ -555,11 +547,7 @@ class ConfigureFlowSteps extends BaseTool {
 		$result = $ability->execute( $input );
 
 		if ( is_wp_error( $result ) ) {
-			return array(
-				'success'   => false,
-				'error'     => $result->get_error_message(),
-				'tool_name' => 'configure_flow_steps',
-			);
+			return $this->abilityErrorResult( $result );
 		}
 
 		$result['tool_name'] = 'configure_flow_steps';
@@ -707,5 +695,18 @@ class ConfigureFlowSteps extends BaseTool {
 		}
 
 		return $result;
+	}
+
+	private function abilityErrorResult( \WP_Error $error ): array {
+		$data = $error->get_error_data();
+		return array_merge(
+			is_array( $data ) ? $data : array(),
+			array(
+				'success'    => false,
+				'error'      => $error->get_error_message(),
+				'error_code' => $error->get_error_code(),
+				'tool_name'  => 'configure_flow_steps',
+			)
+		);
 	}
 }

--- a/inc/Api/Chat/Tools/ConfigureFlowSteps.php
+++ b/inc/Api/Chat/Tools/ConfigureFlowSteps.php
@@ -629,7 +629,20 @@ class ConfigureFlowSteps extends BaseTool {
 			$input['flow_configs'] = $flow_configs;
 		}
 
-		$result              = $ability->execute( $input );
+		$result = $ability->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			$data   = $result->get_error_data();
+			$result = array(
+				'success'           => false,
+				'valid'             => false,
+				'error'             => $result->get_error_message(),
+				'error_code'        => $result->get_error_code(),
+				'validation_errors' => is_array( $data ) ? ( $data['validation_errors'] ?? $data['errors'] ?? array() ) : array(),
+				'flow_count'        => is_array( $data ) ? (int) ( $data['flow_count'] ?? 0 ) : 0,
+				'matching_steps'    => is_array( $data ) ? (int) ( $data['matching_steps'] ?? 0 ) : 0,
+				'would_update'      => is_array( $data ) ? ( $data['would_update'] ?? array() ) : array(),
+			);
+		}
 		$result['tool_name'] = 'configure_flow_steps';
 		$result['mode']      = 'validate_only';
 

--- a/inc/Api/Chat/Tools/CreateFlow.php
+++ b/inc/Api/Chat/Tools/CreateFlow.php
@@ -300,10 +300,10 @@ class CreateFlow extends BaseTool {
 					)
 				);
 
-				if ( ! $result['success'] ) {
+				if ( is_wp_error( $result ) || ! $result['success'] ) {
 					$errors[] = array(
 						'pipeline_step_id' => $pipeline_step_id,
-						'error'            => $result['error'] ?? 'Failed to update handler',
+						'error'            => is_wp_error( $result ) ? $result->get_error_message() : ( $result['error'] ?? 'Failed to update handler' ),
 					);
 					continue;
 				}
@@ -318,10 +318,10 @@ class CreateFlow extends BaseTool {
 					)
 				);
 
-				if ( ! $result['success'] ) {
+				if ( is_wp_error( $result ) || ! $result['success'] ) {
 					$errors[] = array(
 						'pipeline_step_id' => $pipeline_step_id,
-						'error'            => $result['error'] ?? 'Failed to update user_message',
+						'error'            => is_wp_error( $result ) ? $result->get_error_message() : ( $result['error'] ?? 'Failed to update user_message' ),
 					);
 					continue;
 				}

--- a/inc/Api/Flows/FlowSteps.php
+++ b/inc/Api/Flows/FlowSteps.php
@@ -343,6 +343,9 @@ class FlowSteps {
 					'handler_config' => $handler_settings,
 				)
 			);
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
 
 			if ( ! $result['success'] ) {
 				return new \WP_Error(

--- a/inc/Api/Pipelines/PipelineSteps.php
+++ b/inc/Api/Pipelines/PipelineSteps.php
@@ -239,6 +239,9 @@ class PipelineSteps {
 				'step_type'   => $step_type,
 			)
 		);
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
 
 		if ( ! $result['success'] ) {
 			return new \WP_Error(
@@ -294,6 +297,9 @@ class PipelineSteps {
 				'pipeline_step_id' => $step_id,
 			)
 		);
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
 
 		if ( ! $result['success'] ) {
 			return new \WP_Error(
@@ -368,6 +374,9 @@ class PipelineSteps {
 				'step_order'  => $step_order,
 			)
 		);
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
 
 		if ( ! $result['success'] ) {
 			return new \WP_Error(
@@ -402,6 +411,9 @@ class PipelineSteps {
 				'system_prompt'    => $system_prompt,
 			)
 		);
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
 
 		if ( ! $result['success'] ) {
 			return new \WP_Error(

--- a/inc/Api/RestResultSpec.php
+++ b/inc/Api/RestResultSpec.php
@@ -68,6 +68,11 @@ class RestResultSpec {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function response( $result ) {
+		// Native errors already carry the callback's machine code and status.
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
 		$normalized = AbilityResult::normalize( $result );
 
 		if ( is_array( $normalized ) && isset( $normalized['success'] ) && ! $normalized['success'] && ! isset( $normalized['status'] ) && $this->failure_status_callback ) {

--- a/inc/Cli/Commands/Flows/BulkConfigCommand.php
+++ b/inc/Cli/Commands/Flows/BulkConfigCommand.php
@@ -16,6 +16,7 @@ use WP_CLI;
 use DataMachine\Cli\JsonInput;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Abilities\FlowStep\ConfigureFlowStepsAbility;
+use DataMachine\Core\AbilityResult;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -226,7 +227,7 @@ class BulkConfigCommand extends BaseCommand {
 		}
 
 		$ability = new ConfigureFlowStepsAbility();
-		$result  = $ability->execute( $input );
+		$result  = AbilityResult::normalize( $ability->execute( $input ) );
 
 		if ( 'json' === $format ) {
 			WP_CLI::line( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -1254,7 +1254,7 @@ class FlowsCommand extends BaseCommand {
 		}
 
 		$ability = wp_get_ability( 'datamachine/delete-flow' );
-		$result  = $ability->execute( array( 'flow_id' => $flow_id ) );
+		$result  = AbilityResult::normalize( $ability->execute( array( 'flow_id' => $flow_id ) ) );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to delete flow' );
@@ -2245,7 +2245,7 @@ class FlowsCommand extends BaseCommand {
 		}
 
 		$ability = wp_get_ability( 'datamachine/pause-flow' );
-		$result  = $ability->execute( $input );
+		$result  = AbilityResult::normalize( $ability->execute( $input ) );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to pause flows' );
@@ -2285,7 +2285,7 @@ class FlowsCommand extends BaseCommand {
 		}
 
 		$ability = wp_get_ability( 'datamachine/resume-flow' );
-		$result  = $ability->execute( $input );
+		$result  = AbilityResult::normalize( $ability->execute( $input ) );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to resume flows' );

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -23,6 +23,7 @@ use DataMachine\Cli\AgentResolver;
 use DataMachine\Cli\JsonInput;
 use DataMachine\Cli\UserResolver;
 use DataMachine\Cli\Commands\DrainCommand;
+use DataMachine\Core\AbilityResult;
 use DataMachine\Core\Database\Flows\FlowConfigEscaping;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Engine\Debug\SyncRunner;
@@ -1092,7 +1093,7 @@ class FlowsCommand extends BaseCommand {
 		}
 
 		$ability = wp_get_ability( 'datamachine/create-flow' );
-		$result  = $ability->execute( $input );
+		$result  = AbilityResult::normalize( $ability->execute( $input ) );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to create flow' );
@@ -1439,12 +1440,12 @@ class FlowsCommand extends BaseCommand {
 				WP_CLI::log( sprintf( '[dry-run] would update user_message for step %s (%d chars); no changes written', $message_step, mb_strlen( $user_message ) ) );
 			} else {
 				$step_ability = new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility();
-				$step_result  = $step_ability->execute(
+				$step_result  = AbilityResult::normalize( $step_ability->execute(
 					array(
 						'flow_step_id' => $message_step,
 						'user_message' => $user_message,
 					)
-				);
+				) );
 
 				if ( ! $step_result['success'] ) {
 					WP_CLI::error( $step_result['error'] ?? 'Failed to update user_message' );
@@ -1497,7 +1498,7 @@ class FlowsCommand extends BaseCommand {
 				WP_CLI::log( sprintf( '[dry-run] would update handler_config for step %s: %s; no changes written', $handler_step, $updated_keys ) );
 			} else {
 				$step_ability = new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility();
-				$step_result  = $step_ability->execute( $step_input );
+				$step_result  = AbilityResult::normalize( $step_ability->execute( $step_input ) );
 
 				if ( ! $step_result['success'] ) {
 					WP_CLI::error( $step_result['error'] ?? 'Failed to update handler config' );
@@ -1947,7 +1948,7 @@ class FlowsCommand extends BaseCommand {
 			$input['add_handler_config'] = $handler_config;
 		}
 
-		$result = ( new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility() )->execute( $input );
+		$result = AbilityResult::normalize( ( new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility() )->execute( $input ) );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to add handler' );
@@ -1981,12 +1982,12 @@ class FlowsCommand extends BaseCommand {
 			$step_id = $resolved['step_id'];
 		}
 
-		$result = ( new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility() )->execute(
+		$result = AbilityResult::normalize( ( new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility() )->execute(
 			array(
 				'flow_step_id'   => $step_id,
 				'remove_handler' => $handler_slug,
 			)
-		);
+		) );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to remove handler' );

--- a/inc/Cli/Commands/PipelinesCommand.php
+++ b/inc/Cli/Commands/PipelinesCommand.php
@@ -19,6 +19,7 @@ use DataMachine\Abilities\Pipeline\CreatePipelineAbility;
 use DataMachine\Abilities\Pipeline\DeletePipelineAbility;
 use DataMachine\Abilities\Pipeline\GetPipelinesAbility;
 use DataMachine\Abilities\Pipeline\UpdatePipelineAbility;
+use DataMachine\Core\AbilityResult;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Engine\Debug\SyncRunner;
 
@@ -625,7 +626,7 @@ class PipelinesCommand extends BaseCommand {
 			);
 		}
 
-		$result = ( new CreatePipelineAbility() )->execute( $input );
+		$result = AbilityResult::normalize( ( new CreatePipelineAbility() )->execute( $input ) );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to create pipeline' );

--- a/inc/Cli/Commands/PipelinesCommand.php
+++ b/inc/Cli/Commands/PipelinesCommand.php
@@ -730,12 +730,12 @@ class PipelinesCommand extends BaseCommand {
 
 		// Update name if provided.
 		if ( $has_name ) {
-			$result = ( new UpdatePipelineAbility() )->execute(
+			$result = AbilityResult::normalize( ( new UpdatePipelineAbility() )->execute(
 				array(
 					'pipeline_id'   => $pipeline_id,
 					'pipeline_name' => $assoc_args['name'],
 				)
-			);
+			) );
 
 			if ( ! $result['success'] ) {
 				WP_CLI::error( $result['error'] ?? 'Failed to update pipeline name' );
@@ -793,7 +793,7 @@ class PipelinesCommand extends BaseCommand {
 					continue;
 				}
 
-				$step_result = $step_ability->executeUpdatePipelineStep( $step_input );
+				$step_result = AbilityResult::normalize( $step_ability->executeUpdatePipelineStep( $step_input ) );
 
 				if ( ! $step_result['success'] ) {
 					WP_CLI::warning( "Failed to update step {$step_id}: " . ( $step_result['error'] ?? 'Unknown error' ) );
@@ -821,13 +821,13 @@ class PipelinesCommand extends BaseCommand {
 			}
 
 			$step_ability  = new \DataMachine\Abilities\PipelineStepAbilities();
-			$prompt_result = $step_ability->executeUpdatePipelineStep(
+			$prompt_result = AbilityResult::normalize( $step_ability->executeUpdatePipelineStep(
 				array(
 					'pipeline_id'      => $pipeline_id,
 					'pipeline_step_id' => $step_id,
 					'system_prompt'    => $system_prompt,
 				)
-			);
+			) );
 
 			if ( ! $prompt_result['success'] ) {
 				WP_CLI::warning( 'Failed to update system prompt: ' . ( $prompt_result['error'] ?? 'Unknown error' ) );
@@ -1051,7 +1051,7 @@ class PipelinesCommand extends BaseCommand {
 			) );
 		}
 
-		$result = ( new DeletePipelineAbility() )->execute( array( 'pipeline_id' => $pipeline_id ) );
+		$result = AbilityResult::normalize( ( new DeletePipelineAbility() )->execute( array( 'pipeline_id' => $pipeline_id ) ) );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to delete pipeline' );

--- a/tests/Unit/Abilities/FlowAbilitiesTest.php
+++ b/tests/Unit/Abilities/FlowAbilitiesTest.php
@@ -469,9 +469,9 @@ class FlowAbilitiesTest extends WP_UnitTestCase {
 			'flow_name' => 'Should Not Exist'
 		]);
 
-		$this->assertFalse($result['success']);
-		$this->assertArrayHasKey('error', $result);
-		$this->assertStringContainsString('not found', $result['error']);
+		$this->assertWPError($result);
+		$this->assertSame('pipeline_not_found', $result->get_error_code());
+		$this->assertSame(404, $result->get_error_data()['status']);
 	}
 
 	public function test_create_flow_defaults_name_to_flow(): void {

--- a/tests/Unit/Abilities/FlowAbilitiesTest.php
+++ b/tests/Unit/Abilities/FlowAbilitiesTest.php
@@ -427,9 +427,8 @@ class FlowAbilitiesTest extends WP_UnitTestCase {
 			'flow_id' => 999999
 		]);
 
-		$this->assertFalse($result['success']);
-		$this->assertArrayHasKey('error', $result);
-		$this->assertStringContainsString('not found', $result['error']);
+		$this->assertWPError($result);
+		$this->assertStringContainsString('not found', $result->get_error_message());
 	}
 
 	public function test_delete_flow_with_zero_id_returns_error(): void {
@@ -437,9 +436,8 @@ class FlowAbilitiesTest extends WP_UnitTestCase {
 			'flow_id' => 0
 		]);
 
-		$this->assertFalse($result['success']);
-		$this->assertArrayHasKey('error', $result);
-		$this->assertStringContainsString('positive integer', $result['error']);
+		$this->assertWPError($result);
+		$this->assertStringContainsString('positive integer', $result->get_error_message());
 	}
 
 	public function test_create_flow_ability_registered(): void {
@@ -580,9 +578,8 @@ class FlowAbilitiesTest extends WP_UnitTestCase {
 			'source_flow_id' => 999999
 		]);
 
-		$this->assertFalse($result['success']);
-		$this->assertArrayHasKey('error', $result);
-		$this->assertStringContainsString('not found', $result['error']);
+		$this->assertWPError($result);
+		$this->assertStringContainsString('not found', $result->get_error_message());
 	}
 
 	public function test_duplicate_flow_with_invalid_target_pipeline_returns_error(): void {
@@ -591,8 +588,7 @@ class FlowAbilitiesTest extends WP_UnitTestCase {
 			'target_pipeline_id' => 999999
 		]);
 
-		$this->assertFalse($result['success']);
-		$this->assertArrayHasKey('error', $result);
-		$this->assertStringContainsString('not found', $result['error']);
+		$this->assertWPError($result);
+		$this->assertStringContainsString('not found', $result->get_error_message());
 	}
 }

--- a/tests/Unit/Abilities/FlowCreationAtomicityTest.php
+++ b/tests/Unit/Abilities/FlowCreationAtomicityTest.php
@@ -185,8 +185,9 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 
 			$result = wp_get_ability( 'datamachine/create-flow' )->execute( $input );
 
-			$this->assertFalse( $result['success'] );
-			$this->assertStringContainsString( $alias, $result['error'] );
+			$this->assertWPError( $result );
+			$this->assertSame( 'invalid_step_configs', $result->get_error_code() );
+			$this->assertStringContainsString( $alias, $result->get_error_message() );
 			$this->assertSame( $before, $this->flowCount() );
 		}
 	}
@@ -206,8 +207,9 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 
 		$result = wp_get_ability( 'datamachine/create-flow' )->execute( $input );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'Unknown handler_config fields', $result['error'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'flow_creation_failed', $result->get_error_code() );
+		$this->assertStringContainsString( 'Unknown handler_config fields', $result->get_error_message() );
 		$this->assertSame( $before, $this->flowCount() );
 	}
 
@@ -259,7 +261,7 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 
 		$result = wp_get_ability( 'datamachine/create-flow' )->execute( $input );
 
-		$this->assertFalse( $result['success'] );
+		$this->assertWPError( $result );
 		$this->assertSame( $before, $this->scheduledFlowActionCount() );
 	}
 
@@ -271,8 +273,9 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 
 		$result = wp_get_ability( 'datamachine/create-flow' )->execute( $input );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'Timestamp required', $result['error'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_schedule', $result->get_error_code() );
+		$this->assertStringContainsString( 'Timestamp required', $result->get_error_message() );
 		$this->assertSame( $flow_count, $this->flowCount() );
 		$this->assertSame( $action_count, $this->scheduledFlowActionCount() );
 	}
@@ -297,8 +300,9 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 		$result = wp_get_ability( 'datamachine/create-flow' )->execute( $this->validInput( 'Default Failure Flow' ) );
 
 		remove_filter( 'datamachine_flow_config_pre_save', $reject_default );
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'Failed to update handler configuration', $result['error'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'flow_creation_failed', $result->get_error_code() );
+		$this->assertStringContainsString( 'Failed to update handler configuration', $result->get_error_message() );
 		$this->assertSame( $before, $this->flowCount() );
 	}
 
@@ -314,7 +318,7 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
+		$this->assertWPError( $result );
 		$this->assertSame( $before, $this->flowCount() );
 	}
 

--- a/tests/Unit/Abilities/PipelineConfigurationAbilitiesTest.php
+++ b/tests/Unit/Abilities/PipelineConfigurationAbilitiesTest.php
@@ -125,8 +125,8 @@ class PipelineConfigurationAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertSame( 'unknown_field', $result['error_code'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'unknown_field', $result->get_error_code() );
 		$after = $this->abilities->executeGet( array( 'pipeline_id' => $this->pipeline_id ) );
 		$this->assertSame( $current['pipeline']['revision'], $after['pipeline']['revision'] );
 	}
@@ -149,18 +149,18 @@ class PipelineConfigurationAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertSame( 'configuration_conflict', $result['error_code'] );
-		$this->assertSame( 409, $result['status'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'configuration_conflict', $result->get_error_code() );
+		$this->assertSame( 409, $result->get_error_data()['status'] );
 		$this->assertSame( 'Concurrent value', $repository->get_pipeline_config( $this->pipeline_id )[ $step_id ]['system_prompt'] );
 	}
 
 	public function test_missing_pipeline_returns_explicit_not_found_error(): void {
 		$result = $this->abilities->executeGet( array( 'pipeline_id' => 999999 ) );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertSame( 'pipeline_not_found', $result['error_code'] );
-		$this->assertSame( 404, $result['status'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'pipeline_not_found', $result->get_error_code() );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
 	}
 
 	public function test_ability_enforces_manage_flows_authorization(): void {

--- a/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
+++ b/tests/Unit/Abilities/PipelineStepAbilitiesTest.php
@@ -137,9 +137,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 			array( 'pipeline_id' => 999999 )
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'not found', $result['error'] );
+		$this->assertAbilityError( $result, 'not found' );
 	}
 
 	public function test_get_pipeline_steps_invalid_id(): void {
@@ -147,9 +145,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 			array( 'pipeline_id' => 0 )
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'positive integer', $result['error'] );
+		$this->assertAbilityError( $result, 'positive integer' );
 	}
 
 	public function test_add_pipeline_step(): void {
@@ -304,9 +300,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'Invalid step_type', $result['error'] );
+		$this->assertAbilityError( $result, 'Invalid step_type' );
 	}
 
 	public function test_add_pipeline_step_missing_pipeline_id(): void {
@@ -314,9 +308,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 			array( 'step_type' => 'fetch' )
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'pipeline_id', $result['error'] );
+		$this->assertAbilityError( $result, 'pipeline_id' );
 	}
 
 	public function test_add_pipeline_step_missing_step_type(): void {
@@ -324,9 +316,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 			array( 'pipeline_id' => $this->test_pipeline_id )
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'step_type', $result['error'] );
+		$this->assertAbilityError( $result, 'step_type' );
 	}
 
 	public function test_get_pipeline_steps_with_step_id_returns_single_step(): void {
@@ -365,9 +355,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 			array( 'pipeline_step_id' => '' )
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'non-empty', $result['error'] );
+		$this->assertAbilityError( $result, 'non-empty' );
 	}
 
 	public function test_update_pipeline_step_system_prompt(): void {
@@ -435,8 +423,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 				'disabled_tools'   => 'test_disabled_tool',
 			)
 		);
-		$this->assertFalse( $non_array_result['success'] );
-		$this->assertStringContainsString( 'disabled_tools must be an array of strings', $non_array_result['error'] );
+		$this->assertAbilityError( $non_array_result, 'disabled_tools must be an array of strings' );
 
 		$non_string_result = $this->step_abilities->executeUpdatePipelineStep(
 			array(
@@ -444,8 +431,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 				'tool_categories'  => array( 'datamachine-test', 123 ),
 			)
 		);
-		$this->assertFalse( $non_string_result['success'] );
-		$this->assertStringContainsString( 'tool_categories must contain only strings', $non_string_result['error'] );
+		$this->assertAbilityError( $non_string_result, 'tool_categories must contain only strings' );
 	}
 
 	public function test_rest_pipeline_step_config_schema_exposes_tool_policy_fields(): void {
@@ -527,8 +513,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'system_prompt, agent_modes, disabled_tools, or tool_categories', $result['error'] );
+		$this->assertAbilityError( $result, 'system_prompt, agent_modes, disabled_tools, or tool_categories' );
 	}
 
 	public function test_update_pipeline_step_no_fields(): void {
@@ -544,9 +529,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 			array( 'pipeline_step_id' => $pipeline_step_id )
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'At least one', $result['error'] );
+		$this->assertAbilityError( $result, 'At least one' );
 	}
 
 	public function test_update_pipeline_step_not_found(): void {
@@ -557,9 +540,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'not found', $result['error'] );
+		$this->assertAbilityError( $result, 'not found' );
 	}
 
 	public function test_delete_pipeline_step(): void {
@@ -598,8 +579,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
+		$this->assertAbilityError( $result );
 	}
 
 	public function test_delete_pipeline_step_missing_pipeline_id(): void {
@@ -607,9 +587,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 			array( 'pipeline_step_id' => 'some-step-id' )
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'pipeline_id', $result['error'] );
+		$this->assertAbilityError( $result, 'pipeline_id' );
 	}
 
 	public function test_delete_pipeline_step_missing_step_id(): void {
@@ -617,9 +595,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 			array( 'pipeline_id' => $this->test_pipeline_id )
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'pipeline_step_id', $result['error'] );
+		$this->assertAbilityError( $result, 'pipeline_step_id' );
 	}
 
 	public function test_reorder_pipeline_steps(): void {
@@ -811,8 +787,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'appears more than once', $result['error'] );
+		$this->assertAbilityError( $result, 'appears more than once' );
 	}
 
 	public function test_reorder_pipeline_steps_invalid_format(): void {
@@ -823,9 +798,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'object', $result['error'] );
+		$this->assertAbilityError( $result, 'object' );
 	}
 
 	public function test_reorder_pipeline_steps_missing_fields(): void {
@@ -838,9 +811,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'execution_order', $result['error'] );
+		$this->assertAbilityError( $result, 'execution_order' );
 	}
 
 	public function test_reorder_pipeline_steps_empty_array(): void {
@@ -851,9 +822,7 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'required', $result['error'] );
+		$this->assertAbilityError( $result, 'required' );
 	}
 
 	public function test_permission_callback(): void {
@@ -872,6 +841,13 @@ class PipelineStepAbilitiesTest extends WP_UnitTestCase {
 
 		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
+	}
+
+	private function assertAbilityError( $result, string $message_contains = '' ): void {
+		$this->assertWPError( $result );
+		if ( '' !== $message_contains ) {
+			$this->assertStringContainsString( $message_contains, $result->get_error_message() );
+		}
 	}
 
 	public function test_multiple_steps_execution_order(): void {

--- a/tests/Unit/Abilities/ScheduleMutationFailureTest.php
+++ b/tests/Unit/Abilities/ScheduleMutationFailureTest.php
@@ -103,9 +103,9 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 
 		$result = wp_get_ability( 'datamachine/delete-flow' )->execute( array( 'flow_id' => $this->flow_id ) );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertSame( 'schedule_lock_timeout', $result['error_code'] );
-		$this->assertTrue( $result['retryable'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'schedule_lock_timeout', $result->get_error_code() );
+		$this->assertTrue( $result->get_error_data()['retryable'] );
 		$this->assertNotNull( $this->flows->get_flow( $this->flow_id ) );
 		$this->assertTrue( RecurringScheduler::hasLogicalCoverage( self::FLOW_HOOK, array( $this->flow_id ) ) );
 	}
@@ -286,9 +286,9 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 		$result = wp_get_ability( 'datamachine/pause-flow' )->execute( array( 'flow_id' => $this->flow_id ) );
 		$flow   = $this->flows->get_flow( $this->flow_id );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertSame( 1, $result['errors'] );
-		$this->assertSame( 'pause_error', $result['flows'][0]['status'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 1, $result->get_error_data()['errors'] );
+		$this->assertSame( 'pause_error', $result->get_error_data()['flows'][0]['status'] );
 		$this->assertTrue( $flow['scheduling_config']['enabled'] );
 		$this->assertTrue( RecurringScheduler::hasLogicalCoverage( self::FLOW_HOOK, array( $this->flow_id ) ) );
 	}
@@ -331,10 +331,10 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 
 		$result = wp_get_ability( 'datamachine/delete-pipeline' )->execute( array( 'pipeline_id' => $this->pipeline_id ) );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertSame( 'pipeline_flow_deletion_incomplete', $result['error_code'] );
-		$this->assertSame( 1, $result['deleted_flows'] );
-		$this->assertSame( 'schedule_lock_timeout', $result['schedule_failures'][ $blocked_flow_id ]['error_code'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'pipeline_flow_deletion_incomplete', $result->get_error_code() );
+		$this->assertSame( 1, $result->get_error_data()['deleted_flows'] );
+		$this->assertSame( 'schedule_lock_timeout', $result->get_error_data()['schedule_failures'][ $blocked_flow_id ]['error_code'] );
 		$this->assertNotNull( $this->pipelines->get_pipeline( $this->pipeline_id ) );
 		$this->assertNull( $this->flows->get_flow( $this->flow_id ) );
 		$this->assertNotNull( $this->flows->get_flow( $blocked_flow_id ) );

--- a/tests/Unit/Abilities/ScheduleMutationFailureTest.php
+++ b/tests/Unit/Abilities/ScheduleMutationFailureTest.php
@@ -367,8 +367,8 @@ class ScheduleMutationFailureTest extends WP_UnitTestCase {
 
 		$result = ( new ReflectionMethod( $ability, 'rollbackCreation' ) )->invoke( $ability, $scope, $flow_id, 'Forced rollback' );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayNotHasKey( 'schedule_cleanup', $result );
+		$this->assertWPError( $result );
+		$this->assertArrayNotHasKey( 'schedule_cleanup', $result->get_error_data() );
 		$this->assertNull( $this->flows->get_flow( $flow_id ) );
 	}
 

--- a/tests/Unit/Api/WebhookTriggerTest.php
+++ b/tests/Unit/Api/WebhookTriggerTest.php
@@ -65,8 +65,9 @@ class WebhookTriggerTest extends WP_UnitTestCase {
 			'flow_id'   => $this->flow_id,
 			'auth_mode' => 'hmac',
 		) );
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'preset', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'webhook_enable_failed', $result->get_error_code() );
+		$this->assertStringContainsString( 'preset', $result->get_error_message() );
 	}
 
 	public function test_enable_hmac_with_unknown_preset_errors(): void {
@@ -74,8 +75,9 @@ class WebhookTriggerTest extends WP_UnitTestCase {
 			'flow_id' => $this->flow_id,
 			'preset'  => 'does-not-exist',
 		) );
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'Unknown preset', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'webhook_enable_failed', $result->get_error_code() );
+		$this->assertStringContainsString( 'Unknown preset', $result->get_error_message() );
 	}
 
 	public function test_enable_hmac_with_preset_generates_secret(): void {
@@ -159,8 +161,9 @@ class WebhookTriggerTest extends WP_UnitTestCase {
 			'flow_id'  => $this->flow_id,
 			'generate' => true,
 		) );
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'template', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'webhook_set_secret_failed', $result->get_error_code() );
+		$this->assertStringContainsString( 'template', $result->get_error_message() );
 	}
 
 	public function test_rotate_keeps_previous_secret_verifying(): void {

--- a/tests/Unit/Cli/Commands/Flows/BulkConfigCommandTest.php
+++ b/tests/Unit/Cli/Commands/Flows/BulkConfigCommandTest.php
@@ -207,8 +207,9 @@ class BulkConfigCommandTest extends WP_UnitTestCase {
 				'validate_only'  => $validate_only,
 			) );
 
-			$this->assertFalse( $result['success'] );
-			$this->assertStringContainsString( 'Validation failed', $result['error'] );
+			$this->assertInstanceOf( \WP_Error::class, $result );
+			$this->assertSame( 'configure_flow_steps_failed', $result->get_error_code() );
+			$this->assertStringContainsString( 'Validation failed', $result->get_error_message() );
 			$this->assertSame( array(), $ability->handler_updates );
 		}
 	}
@@ -236,8 +237,9 @@ class BulkConfigCommandTest extends WP_UnitTestCase {
 			'handler_config' => array( 'max_items' => 10 ),
 		) );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'No matching steps', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'configure_flow_steps_failed', $result->get_error_code() );
+		$this->assertStringContainsString( 'No matching steps', $result->get_error_message() );
 	}
 
 	public function test_global_scope_dry_run(): void {
@@ -317,8 +319,9 @@ class BulkConfigCommandTest extends WP_UnitTestCase {
 			'handler_config' => array( 'max_items' => 10 ),
 		) );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'not found', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'handler_not_found', $result->get_error_code() );
+		$this->assertStringContainsString( 'not found', $result->get_error_message() );
 	}
 
 	public function test_per_flow_override_in_pipeline_scope(): void {
@@ -358,7 +361,8 @@ class BulkConfigCommandTest extends WP_UnitTestCase {
 		) );
 
 		// No AI steps with rss handler — should find no matches.
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'No matching steps', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'configure_flow_steps_failed', $result->get_error_code() );
+		$this->assertStringContainsString( 'No matching steps', $result->get_error_message() );
 	}
 }

--- a/tests/ability-result-wp-error-smoke.php
+++ b/tests/ability-result-wp-error-smoke.php
@@ -305,6 +305,9 @@ $rest_spec_error = RestResultSpec::item(
 );
 $assert( 'REST result spec applies failure status callback', 404 === ( $rest_spec_error->get_error_data()['status'] ?? null ) );
 
+$native_spec_error = new WP_Error( 'native_queue_denied', 'Queue access denied.', array( 'status' => 403 ) );
+$assert( 'REST result spec preserves native WP_Error unchanged', $native_spec_error === RestResultSpec::item()->response( $native_spec_error ) );
+
 $GLOBALS['datamachine_test_abilities']['datamachine/test-rest'] = new class() {
 	public function execute( array $input ): array {
 		return array(

--- a/tests/send-email-template-smoke.php
+++ b/tests/send-email-template-smoke.php
@@ -241,15 +241,20 @@ if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
 		private string $code;
 		private string $message;
+		private array $data;
 		public function __construct( string $code = '', string $message = '', array $data = array() ) {
 			$this->code    = $code;
 			$this->message = $message;
+			$this->data    = $data;
 		}
 		public function get_error_message(): string {
 			return $this->message;
 		}
 		public function get_error_code(): string {
 			return $this->code;
+		}
+		public function get_error_data(): array {
+			return $this->data;
 		}
 	}
 }
@@ -416,7 +421,7 @@ $queued = wp_get_ability( 'datamachine/send-email-queued' );
 \DataMachine\Abilities\PermissionHelper::$user_id = 0;
 $GLOBALS['ec_scheduled'] = array();
 $res = $queued->execute( array( 'to' => 'user@example.com', 'subject' => 'No issuer', 'body' => 'body' ) );
-ec_assert( 'queued email rejects principal-less ambient execution', false === ( $res['success'] ?? true ) && 0 === count( $GLOBALS['ec_scheduled'] ) );
+ec_assert( 'queued email rejects principal-less ambient execution', is_wp_error( $res ) && 0 === count( $GLOBALS['ec_scheduled'] ) );
 \DataMachine\Abilities\PermissionHelper::$user_id = 1;
 
 $res = $queued->execute( array(
@@ -449,7 +454,7 @@ $res = $queued->execute( array(
 	'from_email' => 'spoof@example.com',
 	'reply_to'   => 'spoof@example.com',
 ) );
-ec_assert( 'tool-only queued spoof requires auth_ref', false === ( $res['success'] ?? true ) );
+ec_assert( 'tool-only queued spoof requires auth_ref', is_wp_error( $res ) );
 ec_assert( 'tool-only queued spoof is not scheduled', 0 === count( $GLOBALS['ec_scheduled'] ) );
 \DataMachine\Abilities\PermissionHelper::$manage  = true;
 \DataMachine\Abilities\PermissionHelper::$user_id = 1;
@@ -483,7 +488,7 @@ $res = $queued->execute( array(
 	'body'    => 'body',
 	'send_at' => 'not-a-date',
 ) );
-ec_assert( 'invalid send_at fails', false === ( $res['success'] ?? true ) );
+ec_assert( 'invalid send_at fails', is_wp_error( $res ) );
 
 /* ---------------------------------------------------------------------------
  * Case 9 — worker invokes underlying ability and re-enqueues on failure


### PR DESCRIPTION
## Summary
- preserve native `WP_Error` through REST and nested ability boundaries
- migrate Flow, FlowStep, Pipeline, PipelineStep, queue, webhook, and queued-email callback failures
- keep CLI/chat presentation envelopes stable while updating direct and adapter tests

## Scope
This is the first bounded tranche of #2522. It does not close the parent issue.

Remaining domains are tracked in:
- #3237 agent, auth, and memory
- #3238 engine and jobs
- #3239 content, files, fetch, and publish
- #3240 remaining system and data abilities

## Verification
- changed-scope Homeboy lint: 0 findings; PHPStan passed
- FlowCreationAtomicityTest: 15/15
- FlowAbilitiesTest: 35/35
- PipelineConfigurationAbilitiesTest: 7/7
- PipelineStepAbilitiesTest: 46/46
- ScheduleMutationFailureTest: 11/11
- WebhookTriggerTest: 17/17
- BulkConfigCommandTest: 13/13
- queued email smoke: 53/53
- queue CLI smoke: 6/6
- ability result, CLI boundary, and ability-native tool smokes passed

Canonical file-isolated CI is the full-suite acceptance gate.