### PR TITLE
fix: adopt exact claims in scheduled fanout

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -951,6 +951,10 @@ class ExecuteStepAbility {
 						? $this->staleRecoveryGeneration( $job_id, $recovery_generation, 'lost ownership during fanout claim transfer' )
 						: $this->claimReconciliationFailure( $job_id, $flow_step_id, $step_type );
 				}
+				if ( $should_fanout && is_array( $fanout_transfer['packets'] ?? null ) ) {
+					$routed_packets         = $fanout_transfer['packets'];
+					$parallel_step['items'] = $routed_packets;
+				}
 				if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {
 					$transfer_id = (string) ( $fanout_transfer['transfer_id'] ?? '' );
 					$restored    = '' === $transfer_id || StepLifecycleHandler::restorePreparedFanoutTransfer( $job_id, $transfer_id, $recovery_generation, $recovery_claim_token );

--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -401,6 +401,12 @@ class PipelineBatchScheduler {
 		if ( empty( $existing_engine['job']['job_id'] ) && ! datamachine_set_engine_data( $child_job_id, $child_engine ) ) {
 			return false;
 		}
+		$existing_terminal = is_array( $creation )
+			&& ! empty( $creation['already_exists'] )
+			&& JobStatus::isStatusFinal( (string) ( $creation['job']['status'] ?? '' ) );
+		if ( ! $existing_terminal && ! ( new ProcessedItems() )->adopt_owned_claims( array_values( $packet_claims ), $parent_job_id, $child_job_id ) ) {
+			return false;
+		}
 
 		// Child job stays 'pending' until Action Scheduler actually picks it up.
 		// ExecuteStepAbility transitions to 'processing' at execution time,

--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -436,7 +436,7 @@ class PipelineBatchScheduler {
 			if ( 'owned' !== $claim_state ) {
 				return false;
 			}
-			$engine = array( ProcessedItems::CLAIM_METADATA_KEY => $claim );
+			$engine  = array( ProcessedItems::CLAIM_METADATA_KEY => $claim );
 			$settled = JobStatus::isStatusSuccess( $status )
 				? StepLifecycleHandler::handleCompleted( $child_job_id, $engine )
 				: StepLifecycleHandler::handleFailed( $child_job_id, $engine );

--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -429,8 +429,12 @@ class PipelineBatchScheduler {
 	private function reconcileTerminalClaims( int $child_job_id, string $status, array $claims ): bool {
 		$processed = new ProcessedItems();
 		foreach ( $claims as $claim ) {
-			if ( ! $processed->owns_active_claim( $claim, $child_job_id ) ) {
+			$claim_state = $processed->terminal_claim_state( $claim, $child_job_id );
+			if ( 'resolved' === $claim_state ) {
 				continue;
+			}
+			if ( 'owned' !== $claim_state ) {
+				return false;
 			}
 			$engine = array( ProcessedItems::CLAIM_METADATA_KEY => $claim );
 			$settled = JobStatus::isStatusSuccess( $status )

--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -31,6 +31,7 @@ use DataMachine\Core\EngineData;
 use DataMachine\Core\ActionScheduler\BatchScheduler;
 use DataMachine\Core\ActionScheduler\GroupRegistrar;
 use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\Database\ProcessedItems\FanoutClaimOwnership;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\JobStatus;
 use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
@@ -405,7 +406,7 @@ class PipelineBatchScheduler {
 		$existing_terminal = is_array( $creation )
 			&& ! empty( $creation['already_exists'] )
 			&& JobStatus::isStatusFinal( (string) ( $creation['job']['status'] ?? '' ) );
-		if ( ! ( new ProcessedItems() )->adopt_owned_claims( array_values( $packet_claims ), $parent_job_id, $child_job_id, $existing_terminal ) ) {
+		if ( ! ( new FanoutClaimOwnership() )->adopt_owned_claims( array_values( $packet_claims ), $parent_job_id, $child_job_id, $existing_terminal ) ) {
 			return false;
 		}
 		if ( $existing_terminal && ! $this->reconcileTerminalClaims( $child_job_id, (string) $creation['job']['status'], $packet_claims ) ) {
@@ -427,9 +428,9 @@ class PipelineBatchScheduler {
 
 	/** Finish exact claims discovered after their deterministic child already terminalized. */
 	private function reconcileTerminalClaims( int $child_job_id, string $status, array $claims ): bool {
-		$processed = new ProcessedItems();
+		$ownership = new FanoutClaimOwnership();
 		foreach ( $claims as $claim ) {
-			$claim_state = $processed->terminal_claim_state( $claim, $child_job_id );
+			$claim_state = $ownership->terminal_claim_state( $claim, $child_job_id );
 			if ( 'resolved' === $claim_state ) {
 				continue;
 			}

--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -33,6 +33,7 @@ use DataMachine\Core\ActionScheduler\GroupRegistrar;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\JobStatus;
+use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -404,7 +405,10 @@ class PipelineBatchScheduler {
 		$existing_terminal = is_array( $creation )
 			&& ! empty( $creation['already_exists'] )
 			&& JobStatus::isStatusFinal( (string) ( $creation['job']['status'] ?? '' ) );
-		if ( ! $existing_terminal && ! ( new ProcessedItems() )->adopt_owned_claims( array_values( $packet_claims ), $parent_job_id, $child_job_id ) ) {
+		if ( ! ( new ProcessedItems() )->adopt_owned_claims( array_values( $packet_claims ), $parent_job_id, $child_job_id, $existing_terminal ) ) {
+			return false;
+		}
+		if ( $existing_terminal && ! $this->reconcileTerminalClaims( $child_job_id, (string) $creation['job']['status'], $packet_claims ) ) {
 			return false;
 		}
 
@@ -419,6 +423,25 @@ class PipelineBatchScheduler {
 		}
 
 		return $child_job_id;
+	}
+
+	/** Finish exact claims discovered after their deterministic child already terminalized. */
+	private function reconcileTerminalClaims( int $child_job_id, string $status, array $claims ): bool {
+		$processed = new ProcessedItems();
+		foreach ( $claims as $claim ) {
+			if ( ! $processed->owns_active_claim( $claim, $child_job_id ) ) {
+				continue;
+			}
+			$engine = array( ProcessedItems::CLAIM_METADATA_KEY => $claim );
+			$settled = JobStatus::isStatusSuccess( $status )
+				? StepLifecycleHandler::handleCompleted( $child_job_id, $engine )
+				: StepLifecycleHandler::handleFailed( $child_job_id, $engine );
+			if ( ! $settled ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	private function stripBatchRuntimeState( array $engine_snapshot ): array {

--- a/inc/Core/Database/ProcessedItems/FanoutClaimOwnership.php
+++ b/inc/Core/Database/ProcessedItems/FanoutClaimOwnership.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Exact processed-item claim ownership operations used by scheduled fanout.
+ *
+ * @package DataMachine\Core\Database\ProcessedItems
+ */
+
+namespace DataMachine\Core\Database\ProcessedItems;
+
+use DataMachine\Core\Database\BaseRepository;
+use DataMachine\Core\Database\TransactionScope;
+
+defined( 'ABSPATH' ) || exit;
+
+/** Internal repository for reconstructing and adopting fanout claim ownership. */
+final class FanoutClaimOwnership extends BaseRepository {
+
+	public const TABLE_NAME = ProcessedItems::TABLE_NAME;
+
+	/** Classify exact terminal ownership without treating lease expiry as resolution. */
+	public function terminal_claim_state( array $claim, int $job_id ): string {
+		$identity_scope  = (string) ( $claim['identity_scope'] ?? '' );
+		$source_type     = (string) ( $claim['source_type'] ?? '' );
+		$item_identifier = (string) ( $claim['item_identifier'] ?? '' );
+		$token           = (string) ( $claim['ownership_token'] ?? '' );
+		if ( $job_id <= 0 || '' === $identity_scope || '' === $source_type || '' === $item_identifier || '' === $token ) {
+			return 'conflict';
+		}
+
+		$query = $this->wpdb->prepare(
+			'SELECT job_id, status, claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s LIMIT 1',
+			$this->table_name,
+			$identity_scope,
+			$source_type,
+			$item_identifier
+		);
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Query is fully prepared above with an escaped identifier and typed values.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact terminal ownership evidence.
+		$row = $this->wpdb->get_row( $query, ARRAY_A );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		if ( ! is_array( $row ) || ProcessedItems::STATUS_PROCESSED === (string) ( $row['status'] ?? '' ) ) {
+			return 'resolved';
+		}
+		if ( ProcessedItems::STATUS_CLAIMED === (string) ( $row['status'] ?? '' )
+			&& (int) ( $row['job_id'] ?? 0 ) === $job_id
+			&& hash_equals( $token, (string) ( $row['claim_token'] ?? '' ) ) ) {
+			return 'owned';
+		}
+
+		return 'conflict';
+	}
+
+	/** Return active token-owned claim descriptors for one job. */
+	public function active_claims_for_job( int $job_id ): array {
+		if ( $job_id <= 0 ) {
+			return array();
+		}
+
+		$query = $this->wpdb->prepare(
+			'SELECT flow_step_id, source_type, item_identifier, claim_token FROM %i WHERE job_id = %d AND status = %s AND claim_token IS NOT NULL AND claim_token != %s AND claim_expires_at > %s',
+			$this->table_name,
+			$job_id,
+			ProcessedItems::STATUS_CLAIMED,
+			'',
+			current_time( 'mysql', true )
+		);
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Query is fully prepared above with an escaped identifier and typed values.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact lifecycle ownership lookup.
+		$rows = $this->wpdb->get_results( $query, ARRAY_A );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		$claims = array();
+		foreach ( is_array( $rows ) ? $rows : array() as $row ) {
+			$claim                   = array(
+				'identity_scope'  => (string) ( $row['flow_step_id'] ?? '' ),
+				'source_type'     => (string) ( $row['source_type'] ?? '' ),
+				'item_identifier' => (string) ( $row['item_identifier'] ?? '' ),
+				'ownership_token' => (string) ( $row['claim_token'] ?? '' ),
+			);
+			$claim['disposition_id'] = ProcessedItems::disposition_identity( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] );
+			$claims[]                = $claim;
+		}
+
+		return $claims;
+	}
+
+	/** Atomically move exact token-owned claims from a fanout parent to its child. */
+	public function adopt_owned_claims( array $claims, int $parent_job_id, int $child_job_id, bool $allow_resolved = false ): bool {
+		if ( $parent_job_id <= 0 || $child_job_id <= 0 ) {
+			return false;
+		}
+		if ( empty( $claims ) ) {
+			return true;
+		}
+
+		$scope = TransactionScope::begin( $this->wpdb );
+		if ( null === $scope ) {
+			return false;
+		}
+
+		foreach ( $claims as $claim ) {
+			$identity_scope  = (string) ( $claim['identity_scope'] ?? '' );
+			$source_type     = (string) ( $claim['source_type'] ?? '' );
+			$item_identifier = (string) ( $claim['item_identifier'] ?? '' );
+			$token           = (string) ( $claim['ownership_token'] ?? '' );
+			if ( '' === $identity_scope || '' === $source_type || '' === $item_identifier || '' === $token ) {
+				$scope->rollback();
+				return false;
+			}
+
+			$query = $this->wpdb->prepare(
+				'SELECT job_id, status, claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s FOR UPDATE',
+				$this->table_name,
+				$identity_scope,
+				$source_type,
+				$item_identifier
+			);
+			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Query is fully prepared above with an escaped identifier and typed values.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Transactional exact ownership transfer.
+			$row = $this->wpdb->get_row( $query, ARRAY_A );
+			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+			if ( ! is_array( $row ) ) {
+				if ( $allow_resolved ) {
+					continue;
+				}
+				$scope->rollback();
+				return false;
+			}
+			$status = (string) ( $row['status'] ?? '' );
+			if ( ProcessedItems::STATUS_PROCESSED === $status && $allow_resolved ) {
+				continue;
+			}
+			if ( ProcessedItems::STATUS_CLAIMED !== $status || ! hash_equals( $token, (string) ( $row['claim_token'] ?? '' ) ) ) {
+				$scope->rollback();
+				return false;
+			}
+
+			$current_job_id = (int) ( $row['job_id'] ?? 0 );
+			if ( $child_job_id === $current_job_id ) {
+				continue;
+			}
+			if ( $parent_job_id !== $current_job_id ) {
+				$scope->rollback();
+				return false;
+			}
+
+			$updated = $this->wpdb->update(
+				$this->table_name,
+				array( 'job_id' => $child_job_id ),
+				array(
+					'flow_step_id'    => $identity_scope,
+					'source_type'     => $source_type,
+					'item_identifier' => $item_identifier,
+					'claim_token'     => $token,
+					'job_id'          => $parent_job_id,
+					'status'          => ProcessedItems::STATUS_CLAIMED,
+				),
+				array( '%d' ),
+				array( '%s', '%s', '%s', '%s', '%d', '%s' )
+			);
+			if ( 1 !== $updated ) {
+				$scope->rollback();
+				return false;
+			}
+		}
+
+		return $scope->commit();
+	}
+}

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -640,6 +640,113 @@ class ProcessedItems extends BaseRepository {
 		return is_string( $owned ) && hash_equals( $token, $owned );
 	}
 
+	/** Return active token-owned claim descriptors for one job. */
+	public function active_claims_for_job( int $job_id ): array {
+		if ( $job_id <= 0 ) {
+			return array();
+		}
+
+		$query = $this->wpdb->prepare(
+			'SELECT flow_step_id, source_type, item_identifier, claim_token FROM %i WHERE job_id = %d AND status = %s AND claim_token IS NOT NULL AND claim_token != %s AND claim_expires_at > %s',
+			$this->table_name,
+			$job_id,
+			self::STATUS_CLAIMED,
+			'',
+			current_time( 'mysql', true )
+		);
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Query is fully prepared above with an escaped identifier and typed values.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact lifecycle ownership lookup.
+		$rows = $this->wpdb->get_results( $query, ARRAY_A );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		$claims = array();
+		foreach ( is_array( $rows ) ? $rows : array() as $row ) {
+			$claim = array(
+				'identity_scope'  => (string) ( $row['flow_step_id'] ?? '' ),
+				'source_type'     => (string) ( $row['source_type'] ?? '' ),
+				'item_identifier' => (string) ( $row['item_identifier'] ?? '' ),
+				'ownership_token' => (string) ( $row['claim_token'] ?? '' ),
+			);
+			$claim['disposition_id'] = self::disposition_identity( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] );
+			$claims[]                 = $claim;
+		}
+
+		return $claims;
+	}
+
+	/** Atomically move exact token-owned claims from a fanout parent to its child. */
+	public function adopt_owned_claims( array $claims, int $parent_job_id, int $child_job_id ): bool {
+		if ( $parent_job_id <= 0 || $child_job_id <= 0 ) {
+			return false;
+		}
+		if ( empty( $claims ) ) {
+			return true;
+		}
+
+		$scope = TransactionScope::begin( $this->wpdb );
+		if ( null === $scope ) {
+			return false;
+		}
+
+		foreach ( $claims as $claim ) {
+			$identity_scope  = (string) ( $claim['identity_scope'] ?? '' );
+			$source_type     = (string) ( $claim['source_type'] ?? '' );
+			$item_identifier = (string) ( $claim['item_identifier'] ?? '' );
+			$token           = (string) ( $claim['ownership_token'] ?? '' );
+			if ( '' === $identity_scope || '' === $source_type || '' === $item_identifier || '' === $token ) {
+				$scope->rollback();
+				return false;
+			}
+
+			$query = $this->wpdb->prepare(
+				'SELECT job_id, claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND status = %s FOR UPDATE',
+				$this->table_name,
+				$identity_scope,
+				$source_type,
+				$item_identifier,
+				self::STATUS_CLAIMED
+			);
+			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Query is fully prepared above with an escaped identifier and typed values.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Transactional exact ownership transfer.
+			$row = $this->wpdb->get_row( $query, ARRAY_A );
+			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+			if ( ! is_array( $row ) || ! hash_equals( $token, (string) ( $row['claim_token'] ?? '' ) ) ) {
+				$scope->rollback();
+				return false;
+			}
+
+			$current_job_id = (int) ( $row['job_id'] ?? 0 );
+			if ( $child_job_id === $current_job_id ) {
+				continue;
+			}
+			if ( $parent_job_id !== $current_job_id ) {
+				$scope->rollback();
+				return false;
+			}
+
+			$updated = $this->wpdb->update(
+				$this->table_name,
+				array( 'job_id' => $child_job_id ),
+				array(
+					'flow_step_id'    => $identity_scope,
+					'source_type'     => $source_type,
+					'item_identifier' => $item_identifier,
+					'claim_token'     => $token,
+					'job_id'          => $parent_job_id,
+					'status'          => self::STATUS_CLAIMED,
+				),
+				array( '%d' ),
+				array( '%s', '%s', '%s', '%s', '%d', '%s' )
+			);
+			if ( 1 !== $updated ) {
+				$scope->rollback();
+				return false;
+			}
+		}
+
+		return $scope->commit();
+	}
+
 	/** Lock and validate one token-owned claim inside a caller-managed transaction. */
 	public function lock_owned_claim_in_transaction( array $claim ): bool {
 		$identity_scope  = (string) ( $claim['identity_scope'] ?? '' );

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -640,156 +640,6 @@ class ProcessedItems extends BaseRepository {
 		return is_string( $owned ) && hash_equals( $token, $owned );
 	}
 
-	/** Classify exact terminal ownership without treating lease expiry as resolution. */
-	public function terminal_claim_state( array $claim, int $job_id ): string {
-		$identity_scope  = (string) ( $claim['identity_scope'] ?? '' );
-		$source_type     = (string) ( $claim['source_type'] ?? '' );
-		$item_identifier = (string) ( $claim['item_identifier'] ?? '' );
-		$token           = (string) ( $claim['ownership_token'] ?? '' );
-		if ( $job_id <= 0 || '' === $identity_scope || '' === $source_type || '' === $item_identifier || '' === $token ) {
-			return 'conflict';
-		}
-
-		$query = $this->wpdb->prepare(
-			'SELECT job_id, status, claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s LIMIT 1',
-			$this->table_name,
-			$identity_scope,
-			$source_type,
-			$item_identifier
-		);
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Query is fully prepared above with an escaped identifier and typed values.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact terminal ownership evidence.
-		$row = $this->wpdb->get_row( $query, ARRAY_A );
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
-		if ( ! is_array( $row ) || self::STATUS_PROCESSED === (string) ( $row['status'] ?? '' ) ) {
-			return 'resolved';
-		}
-		if ( self::STATUS_CLAIMED === (string) ( $row['status'] ?? '' )
-			&& (int) ( $row['job_id'] ?? 0 ) === $job_id
-			&& hash_equals( $token, (string) ( $row['claim_token'] ?? '' ) ) ) {
-			return 'owned';
-		}
-
-		return 'conflict';
-	}
-
-	/** Return active token-owned claim descriptors for one job. */
-	public function active_claims_for_job( int $job_id ): array {
-		if ( $job_id <= 0 ) {
-			return array();
-		}
-
-		$query = $this->wpdb->prepare(
-			'SELECT flow_step_id, source_type, item_identifier, claim_token FROM %i WHERE job_id = %d AND status = %s AND claim_token IS NOT NULL AND claim_token != %s AND claim_expires_at > %s',
-			$this->table_name,
-			$job_id,
-			self::STATUS_CLAIMED,
-			'',
-			current_time( 'mysql', true )
-		);
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Query is fully prepared above with an escaped identifier and typed values.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact lifecycle ownership lookup.
-		$rows = $this->wpdb->get_results( $query, ARRAY_A );
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
-
-		$claims = array();
-		foreach ( is_array( $rows ) ? $rows : array() as $row ) {
-			$claim                   = array(
-				'identity_scope'  => (string) ( $row['flow_step_id'] ?? '' ),
-				'source_type'     => (string) ( $row['source_type'] ?? '' ),
-				'item_identifier' => (string) ( $row['item_identifier'] ?? '' ),
-				'ownership_token' => (string) ( $row['claim_token'] ?? '' ),
-			);
-			$claim['disposition_id'] = self::disposition_identity( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] );
-			$claims[]                = $claim;
-		}
-
-		return $claims;
-	}
-
-	/** Atomically move exact token-owned claims from a fanout parent to its child. */
-	public function adopt_owned_claims( array $claims, int $parent_job_id, int $child_job_id, bool $allow_resolved = false ): bool {
-		if ( $parent_job_id <= 0 || $child_job_id <= 0 ) {
-			return false;
-		}
-		if ( empty( $claims ) ) {
-			return true;
-		}
-
-		$scope = TransactionScope::begin( $this->wpdb );
-		if ( null === $scope ) {
-			return false;
-		}
-
-		foreach ( $claims as $claim ) {
-			$identity_scope  = (string) ( $claim['identity_scope'] ?? '' );
-			$source_type     = (string) ( $claim['source_type'] ?? '' );
-			$item_identifier = (string) ( $claim['item_identifier'] ?? '' );
-			$token           = (string) ( $claim['ownership_token'] ?? '' );
-			if ( '' === $identity_scope || '' === $source_type || '' === $item_identifier || '' === $token ) {
-				$scope->rollback();
-				return false;
-			}
-
-			$query = $this->wpdb->prepare(
-				'SELECT job_id, status, claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s FOR UPDATE',
-				$this->table_name,
-				$identity_scope,
-				$source_type,
-				$item_identifier
-			);
-			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Query is fully prepared above with an escaped identifier and typed values.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Transactional exact ownership transfer.
-			$row = $this->wpdb->get_row( $query, ARRAY_A );
-			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
-			if ( ! is_array( $row ) ) {
-				if ( $allow_resolved ) {
-					continue;
-				}
-				$scope->rollback();
-				return false;
-			}
-			$status = (string) ( $row['status'] ?? '' );
-			if ( self::STATUS_PROCESSED === $status && $allow_resolved ) {
-				continue;
-			}
-			if ( self::STATUS_CLAIMED !== $status || ! hash_equals( $token, (string) ( $row['claim_token'] ?? '' ) ) ) {
-				$scope->rollback();
-				return false;
-			}
-
-			$current_job_id = (int) ( $row['job_id'] ?? 0 );
-			if ( $child_job_id === $current_job_id ) {
-				continue;
-			}
-			if ( $parent_job_id !== $current_job_id ) {
-				$scope->rollback();
-				return false;
-			}
-
-			$updated = $this->wpdb->update(
-				$this->table_name,
-				array( 'job_id' => $child_job_id ),
-				array(
-					'flow_step_id'    => $identity_scope,
-					'source_type'     => $source_type,
-					'item_identifier' => $item_identifier,
-					'claim_token'     => $token,
-					'job_id'          => $parent_job_id,
-					'status'          => self::STATUS_CLAIMED,
-				),
-				array( '%d' ),
-				array( '%s', '%s', '%s', '%s', '%d', '%s' )
-			);
-			if ( 1 !== $updated ) {
-				$scope->rollback();
-				return false;
-			}
-		}
-
-		return $scope->commit();
-	}
-
 	/** Lock and validate one token-owned claim inside a caller-managed transaction. */
 	public function lock_owned_claim_in_transaction( array $claim ): bool {
 		$identity_scope  = (string) ( $claim['identity_scope'] ?? '' );
@@ -949,7 +799,13 @@ class ProcessedItems extends BaseRepository {
 		if ( '' === $claim_token ) {
 			return false;
 		}
-		$now = current_time( 'mysql', true );
+		$now            = current_time( 'mysql', true );
+		$claim_identity = array(
+			'identity_scope'  => $identity_scope,
+			'source_type'     => $source_type,
+			'item_identifier' => $item_identifier,
+			'claim_token'     => $claim_token,
+		);
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
 		$ownership_query = $this->wpdb->prepare(
 			'SELECT claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s FOR UPDATE',
@@ -979,43 +835,47 @@ class ProcessedItems extends BaseRepository {
 		}
 
 		if ( $retain_processed ) {
+			$transition_query = $this->prepare_owned_claim_transition_query( $claim_identity, $job_id, $now );
+		} else {
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
 			$transition_query = $this->wpdb->prepare(
-				'UPDATE %i SET status = %s, job_id = %d, processed_timestamp = %s, claim_expires_at = NULL WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s',
+				'DELETE FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s',
 				$this->table_name,
-				self::STATUS_PROCESSED,
-				$job_id,
-				$now,
 				$identity_scope,
 				$source_type,
 				$item_identifier,
 				$claim_token,
 				self::STATUS_CLAIMED
 			);
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Dynamic identifier is prepared with %i; every value uses a typed placeholder.
-			$transitioned = $this->wpdb->query( $transition_query );
-			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
-		} else {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$transitioned = $this->wpdb->delete(
-				$this->table_name,
-				array(
-					'flow_step_id'    => $identity_scope,
-					'source_type'     => $source_type,
-					'item_identifier' => $item_identifier,
-					'claim_token'     => $claim_token,
-					'status'          => self::STATUS_CLAIMED,
-				),
-				array( '%s', '%s', '%s', '%s', '%s' )
-			);
 		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Dynamic identifier is prepared with %i; every value uses a typed placeholder.
+		$transitioned = $this->wpdb->query( $transition_query );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( false === $transitioned || 1 > $transitioned ) {
 			return false;
 		}
 
 		return true;
+	}
+
+	/** Prepare the processed transition for one exact token-owned identity. */
+	private function prepare_owned_claim_transition_query( array $claim, int $job_id, string $now ): string {
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table identifier uses %i; all values use typed placeholders.
+		return $this->wpdb->prepare(
+			'UPDATE %i SET status = %s, job_id = %d, processed_timestamp = %s, claim_expires_at = NULL WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND claim_token = %s AND status = %s',
+			$this->table_name,
+			self::STATUS_PROCESSED,
+			$job_id,
+			$now,
+			$claim['identity_scope'],
+			$claim['source_type'],
+			$claim['item_identifier'],
+			$claim['claim_token'],
+			self::STATUS_CLAIMED
+		);
 	}
 
 	/**

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -665,7 +665,7 @@ class ProcessedItems extends BaseRepository {
 			return 'resolved';
 		}
 		if ( self::STATUS_CLAIMED === (string) ( $row['status'] ?? '' )
-			&& $job_id === (int) ( $row['job_id'] ?? 0 )
+			&& (int) ( $row['job_id'] ?? 0 ) === $job_id
 			&& hash_equals( $token, (string) ( $row['claim_token'] ?? '' ) ) ) {
 			return 'owned';
 		}
@@ -694,14 +694,14 @@ class ProcessedItems extends BaseRepository {
 
 		$claims = array();
 		foreach ( is_array( $rows ) ? $rows : array() as $row ) {
-			$claim = array(
+			$claim                   = array(
 				'identity_scope'  => (string) ( $row['flow_step_id'] ?? '' ),
 				'source_type'     => (string) ( $row['source_type'] ?? '' ),
 				'item_identifier' => (string) ( $row['item_identifier'] ?? '' ),
 				'ownership_token' => (string) ( $row['claim_token'] ?? '' ),
 			);
 			$claim['disposition_id'] = self::disposition_identity( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] );
-			$claims[]                 = $claim;
+			$claims[]                = $claim;
 		}
 
 		return $claims;

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -640,6 +640,39 @@ class ProcessedItems extends BaseRepository {
 		return is_string( $owned ) && hash_equals( $token, $owned );
 	}
 
+	/** Classify exact terminal ownership without treating lease expiry as resolution. */
+	public function terminal_claim_state( array $claim, int $job_id ): string {
+		$identity_scope  = (string) ( $claim['identity_scope'] ?? '' );
+		$source_type     = (string) ( $claim['source_type'] ?? '' );
+		$item_identifier = (string) ( $claim['item_identifier'] ?? '' );
+		$token           = (string) ( $claim['ownership_token'] ?? '' );
+		if ( $job_id <= 0 || '' === $identity_scope || '' === $source_type || '' === $item_identifier || '' === $token ) {
+			return 'conflict';
+		}
+
+		$query = $this->wpdb->prepare(
+			'SELECT job_id, status, claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s LIMIT 1',
+			$this->table_name,
+			$identity_scope,
+			$source_type,
+			$item_identifier
+		);
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Query is fully prepared above with an escaped identifier and typed values.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact terminal ownership evidence.
+		$row = $this->wpdb->get_row( $query, ARRAY_A );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		if ( ! is_array( $row ) || self::STATUS_PROCESSED === (string) ( $row['status'] ?? '' ) ) {
+			return 'resolved';
+		}
+		if ( self::STATUS_CLAIMED === (string) ( $row['status'] ?? '' )
+			&& $job_id === (int) ( $row['job_id'] ?? 0 )
+			&& hash_equals( $token, (string) ( $row['claim_token'] ?? '' ) ) ) {
+			return 'owned';
+		}
+
+		return 'conflict';
+	}
+
 	/** Return active token-owned claim descriptors for one job. */
 	public function active_claims_for_job( int $job_id ): array {
 		if ( $job_id <= 0 ) {

--- a/inc/Core/Database/ProcessedItems/ProcessedItems.php
+++ b/inc/Core/Database/ProcessedItems/ProcessedItems.php
@@ -675,7 +675,7 @@ class ProcessedItems extends BaseRepository {
 	}
 
 	/** Atomically move exact token-owned claims from a fanout parent to its child. */
-	public function adopt_owned_claims( array $claims, int $parent_job_id, int $child_job_id ): bool {
+	public function adopt_owned_claims( array $claims, int $parent_job_id, int $child_job_id, bool $allow_resolved = false ): bool {
 		if ( $parent_job_id <= 0 || $child_job_id <= 0 ) {
 			return false;
 		}
@@ -699,18 +699,28 @@ class ProcessedItems extends BaseRepository {
 			}
 
 			$query = $this->wpdb->prepare(
-				'SELECT job_id, claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s AND status = %s FOR UPDATE',
+				'SELECT job_id, status, claim_token FROM %i WHERE flow_step_id = %s AND source_type = %s AND item_identifier = %s FOR UPDATE',
 				$this->table_name,
 				$identity_scope,
 				$source_type,
-				$item_identifier,
-				self::STATUS_CLAIMED
+				$item_identifier
 			);
 			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Query is fully prepared above with an escaped identifier and typed values.
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Transactional exact ownership transfer.
 			$row = $this->wpdb->get_row( $query, ARRAY_A );
 			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
-			if ( ! is_array( $row ) || ! hash_equals( $token, (string) ( $row['claim_token'] ?? '' ) ) ) {
+			if ( ! is_array( $row ) ) {
+				if ( $allow_resolved ) {
+					continue;
+				}
+				$scope->rollback();
+				return false;
+			}
+			$status = (string) ( $row['status'] ?? '' );
+			if ( self::STATUS_PROCESSED === $status && $allow_resolved ) {
+				continue;
+			}
+			if ( self::STATUS_CLAIMED !== $status || ! hash_equals( $token, (string) ( $row['claim_token'] ?? '' ) ) ) {
 				$scope->rollback();
 				return false;
 			}

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -362,6 +362,7 @@ class StepLifecycleHandler {
 
 	/** Remove claims transferred to fanout packets from parent terminal ownership. */
 	public static function transferClaimsToFanout( int $job_id, array $packets, int $recovery_generation = 0, string $recovery_claim_token = '' ): array {
+		$packets = self::bindOwnedClaimsToPackets( $job_id, $packets );
 		$claims = array();
 		foreach ( $packets as $packet ) {
 			$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
@@ -378,6 +379,7 @@ class StepLifecycleHandler {
 			return array(
 				'success' => true,
 				'stale'   => false,
+				'packets' => $packets,
 			);
 		}
 		$transfer_id           = bin2hex( random_bytes( 16 ) );
@@ -409,7 +411,62 @@ class StepLifecycleHandler {
 			$recovery_claim_token
 		);
 		$result['transfer_id'] = $transfer_id;
+		$result['packets']     = $packets;
 		return $result;
+	}
+
+	/** Bind descriptor-less legacy claims only through an unambiguous exact packet identity. */
+	private static function bindOwnedClaimsToPackets( int $job_id, array $packets ): array {
+		$needs_binding = false;
+		foreach ( $packets as $packet ) {
+			$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+			if ( ! ProcessedItems::has_claim_metadata( $metadata ) ) {
+				$needs_binding = true;
+				break;
+			}
+		}
+		if ( ! $needs_binding ) {
+			return $packets;
+		}
+
+		$owned = ( new ProcessedItems() )->active_claims_for_job( $job_id );
+		$owned = array_merge( $owned, array_values( ProcessedItems::disposition_claims( \datamachine_get_engine_data( $job_id ) ) ) );
+		$index = array();
+		foreach ( $owned as $claim ) {
+			$key                                      = (string) $claim['source_type'] . "\0" . (string) $claim['item_identifier'];
+			$index[ $key ][ $claim['disposition_id'] ] = $claim;
+		}
+
+		foreach ( $packets as &$packet ) {
+			$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+			if ( ProcessedItems::has_claim_metadata( $metadata ) ) {
+				continue;
+			}
+
+			$source_type = trim( (string) ( $metadata['source_type'] ?? '' ) );
+			$identifiers = array_filter(
+				array(
+					trim( (string) ( $metadata['item_identifier'] ?? '' ) ),
+					trim( (string) ( $metadata['source_item_id'] ?? '' ) ),
+					trim( (string) ( $metadata['_engine_data']['item_identifier'] ?? '' ) ),
+				),
+				static fn( string $identifier ): bool => '' !== $identifier
+			);
+			$identifiers = array_values( array_unique( $identifiers ) );
+			if ( '' === $source_type || 1 !== count( $identifiers ) ) {
+				continue;
+			}
+
+			$matches = array_values( $index[ $source_type . "\0" . $identifiers[0] ] ?? array() );
+			if ( 1 !== count( $matches ) ) {
+				continue;
+			}
+			$packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ]          = $matches[0];
+			$packet['metadata'][ ProcessedItems::DISPOSITION_ID_METADATA_KEY ] = $matches[0]['disposition_id'];
+		}
+		unset( $packet );
+
+		return $packets;
 	}
 
 	/** Mark a prepared transfer adopted only after BatchItems and batch state are durable. */

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -9,6 +9,7 @@
 namespace DataMachine\Engine\Actions\Handlers;
 
 use DataMachine\Core\ActionScheduler\BatchScheduler;
+use DataMachine\Core\Database\ProcessedItems\FanoutClaimOwnership;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\Database\TransactionScope;
 use DataMachine\Core\DataPacketStore;
@@ -445,7 +446,7 @@ class StepLifecycleHandler {
 			return $packets;
 		}
 
-		$owned = ( new ProcessedItems() )->active_claims_for_job( $job_id );
+		$owned = ( new FanoutClaimOwnership() )->active_claims_for_job( $job_id );
 		$owned = array_merge( $owned, array_values( ProcessedItems::disposition_claims( \datamachine_get_engine_data( $job_id ) ) ) );
 		$index = array();
 		foreach ( $owned as $claim ) {

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -363,7 +363,14 @@ class StepLifecycleHandler {
 	/** Remove claims transferred to fanout packets from parent terminal ownership. */
 	public static function transferClaimsToFanout( int $job_id, array $packets, int $recovery_generation = 0, string $recovery_claim_token = '' ): array {
 		$packets = self::bindOwnedClaimsToPackets( $job_id, $packets );
+		if ( false === $packets ) {
+			return array(
+				'success' => false,
+				'stale'   => false,
+			);
+		}
 		$claims = array();
+		$seen   = array();
 		foreach ( $packets as $packet ) {
 			$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
 			if ( ProcessedItems::has_claim_metadata( $metadata ) && ! ProcessedItems::has_valid_claim_metadata( $metadata ) ) {
@@ -373,6 +380,15 @@ class StepLifecycleHandler {
 				);
 			}
 			$packet_claims = ProcessedItems::disposition_claims( $metadata );
+			foreach ( array_keys( $packet_claims ) as $disposition_id ) {
+				if ( isset( $seen[ $disposition_id ] ) ) {
+					return array(
+						'success' => false,
+						'stale'   => false,
+					);
+				}
+				$seen[ $disposition_id ] = true;
+			}
 			$claims = array_replace( $claims, $packet_claims );
 		}
 		if ( empty( $claims ) ) {
@@ -416,7 +432,7 @@ class StepLifecycleHandler {
 	}
 
 	/** Bind descriptor-less legacy claims only through an unambiguous exact packet identity. */
-	private static function bindOwnedClaimsToPackets( int $job_id, array $packets ): array {
+	private static function bindOwnedClaimsToPackets( int $job_id, array $packets ): array|false {
 		$needs_binding = false;
 		foreach ( $packets as $packet ) {
 			$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
@@ -443,7 +459,14 @@ class StepLifecycleHandler {
 				continue;
 			}
 
-			$source_type = trim( (string) ( $metadata['source_type'] ?? '' ) );
+			$source_types = array_filter(
+				array(
+					trim( (string) ( $metadata['source_type'] ?? '' ) ),
+					trim( (string) ( $metadata['_engine_data']['source_type'] ?? '' ) ),
+				),
+				static fn( string $source_type ): bool => '' !== $source_type
+			);
+			$source_types = array_values( array_unique( $source_types ) );
 			$identifiers = array_filter(
 				array(
 					trim( (string) ( $metadata['item_identifier'] ?? '' ) ),
@@ -453,12 +476,18 @@ class StepLifecycleHandler {
 				static fn( string $identifier ): bool => '' !== $identifier
 			);
 			$identifiers = array_values( array_unique( $identifiers ) );
-			if ( '' === $source_type || 1 !== count( $identifiers ) ) {
+			if ( count( $source_types ) > 1 || count( $identifiers ) > 1 ) {
+				return false;
+			}
+			if ( 1 !== count( $source_types ) || 1 !== count( $identifiers ) ) {
 				continue;
 			}
 
-			$matches = array_values( $index[ $source_type . "\0" . $identifiers[0] ] ?? array() );
-			if ( 1 !== count( $matches ) ) {
+			$matches = array_values( $index[ $source_types[0] . "\0" . $identifiers[0] ] ?? array() );
+			if ( count( $matches ) > 1 ) {
+				return false;
+			}
+			if ( empty( $matches ) ) {
 				continue;
 			}
 			$packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ]          = $matches[0];

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -449,7 +449,7 @@ class StepLifecycleHandler {
 		$owned = array_merge( $owned, array_values( ProcessedItems::disposition_claims( \datamachine_get_engine_data( $job_id ) ) ) );
 		$index = array();
 		foreach ( $owned as $claim ) {
-			$key                                      = (string) $claim['source_type'] . "\0" . (string) $claim['item_identifier'];
+			$key                                       = (string) $claim['source_type'] . "\0" . (string) $claim['item_identifier'];
 			$index[ $key ][ $claim['disposition_id'] ] = $claim;
 		}
 
@@ -467,7 +467,7 @@ class StepLifecycleHandler {
 				static fn( string $source_type ): bool => '' !== $source_type
 			);
 			$source_types = array_values( array_unique( $source_types ) );
-			$identifiers = array_filter(
+			$identifiers  = array_filter(
 				array(
 					trim( (string) ( $metadata['item_identifier'] ?? '' ) ),
 					trim( (string) ( $metadata['source_item_id'] ?? '' ) ),
@@ -475,7 +475,7 @@ class StepLifecycleHandler {
 				),
 				static fn( string $identifier ): bool => '' !== $identifier
 			);
-			$identifiers = array_values( array_unique( $identifiers ) );
+			$identifiers  = array_values( array_unique( $identifiers ) );
 			if ( count( $source_types ) > 1 || count( $identifiers ) > 1 ) {
 				return false;
 			}

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -686,14 +686,18 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		);
 		$wpdb->update(
 			$wpdb->prefix . 'datamachine_processed_items',
-			array( 'job_id' => $parent_id ),
+			array(
+				'job_id'           => $parent_id,
+				'claim_expires_at' => '2000-01-01 00:00:00',
+			),
 			array( 'claim_token' => $claim['ownership_token'] ),
-			array( '%d' ),
+			array( '%d', '%s' ),
 			array( '%s' )
 		);
 
 		$replayed = $scheduler->createChildJobFromBatch( $packet, array( 'next_flow_step_id' => 'ai-step' ), $parent_id, 0, 'terminal-checksum' );
 		$this->assertSame( $child_id, $replayed );
+		$this->assertSame( $child_id, $scheduler->createChildJobFromBatch( $packet, array( 'next_flow_step_id' => 'ai-step' ), $parent_id, 0, 'terminal-checksum' ) );
 		$this->assertFalse( ( new ProcessedItems() )->has_active_claim( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] ) );
 		$this->assertIsArray( $this->claim_for_parent( $parent_id + 1000, 'terminal-replay' ) );
 	}
@@ -734,6 +738,16 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 	public function test_successful_terminal_child_replay_completes_exact_parent_claim(): void {
 		$parent_id = $this->create_parent_job();
 		$claim     = $this->claim_for_parent( $parent_id, 'terminal-success' );
+		$callback_count = 0;
+		$completion_filter = static function ( array $handlers ) use ( &$callback_count ): array {
+			$handlers['terminal_replay_count'] = static function () use ( &$callback_count ): bool {
+				++$callback_count;
+				return true;
+			};
+			return $handlers;
+		};
+		add_filter( 'datamachine_item_claim_completion_handlers', $completion_filter );
+		$claim['completion'] = array( 'handler' => 'terminal_replay_count' );
 		$packet    = $this->make_data_packet( 'Terminal Success' );
 		$packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] = $claim;
 		$scheduler = new PipelineBatchScheduler();
@@ -750,15 +764,54 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		);
 		$wpdb->update(
 			$wpdb->prefix . 'datamachine_processed_items',
-			array( 'job_id' => $parent_id ),
+			array(
+				'job_id'           => $parent_id,
+				'claim_expires_at' => '2000-01-01 00:00:00',
+			),
 			array( 'claim_token' => $claim['ownership_token'] ),
-			array( '%d' ),
+			array( '%d', '%s' ),
 			array( '%s' )
 		);
 
 		$replayed = $scheduler->createChildJobFromBatch( $packet, array( 'next_flow_step_id' => 'ai-step' ), $parent_id, 0, 'terminal-success-checksum' );
 		$this->assertSame( $child_id, $replayed );
+		$this->assertSame( $child_id, $scheduler->createChildJobFromBatch( $packet, array( 'next_flow_step_id' => 'ai-step' ), $parent_id, 0, 'terminal-success-checksum' ) );
 		$this->assertTrue( ( new ProcessedItems() )->has_item_been_processed( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] ) );
+		$this->assertSame( 1, $callback_count );
+		remove_filter( 'datamachine_item_claim_completion_handlers', $completion_filter );
+	}
+
+	public function test_expired_terminal_replay_rejects_competing_replacement_token(): void {
+		$parent_id = $this->create_parent_job();
+		$claim     = $this->claim_for_parent( $parent_id, 'terminal-replacement' );
+		$packet    = $this->make_data_packet( 'Terminal Replacement' );
+		$packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] = $claim;
+		$scheduler = new PipelineBatchScheduler();
+		$child_id = $scheduler->createChildJobFromBatch( $packet, array( 'next_flow_step_id' => 'ai-step' ), $parent_id, 0, 'terminal-replacement-checksum' );
+		$this->assertIsInt( $child_id );
+
+		global $wpdb;
+		$wpdb->update(
+			$wpdb->prefix . 'datamachine_jobs',
+			array( 'status' => JobStatus::COMPLETED ),
+			array( 'job_id' => $child_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		$wpdb->update(
+			$wpdb->prefix . 'datamachine_processed_items',
+			array(
+				'job_id'           => $parent_id,
+				'claim_expires_at' => '2000-01-01 00:00:00',
+			),
+			array( 'claim_token' => $claim['ownership_token'] ),
+			array( '%d', '%s' ),
+			array( '%s' )
+		);
+		$replacement = $this->claim_for_parent( $parent_id + 1000, 'terminal-replacement' );
+
+		$this->assertFalse( $scheduler->createChildJobFromBatch( $packet, array( 'next_flow_step_id' => 'ai-step' ), $parent_id, 0, 'terminal-replacement-checksum' ) );
+		$this->assertTrue( ( new ProcessedItems() )->owns_active_claim( $replacement, $parent_id + 1000 ) );
 	}
 
 	public function test_process_chunk_respects_cancellation(): void {

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -15,6 +15,8 @@ use DataMachine\Core\Database\BatchItems\BatchItems;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\JobStatus;
+use DataMachine\Core\Steps\Fetch\Tools\FetchItemDispositionTool;
+use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
 use WP_UnitTestCase;
 
 class PipelineBatchSchedulerTest extends WP_UnitTestCase {
@@ -117,6 +119,20 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		datamachine_set_engine_data( (int) $job_id, $engine );
 
 		return (int) $job_id;
+	}
+
+	private function claim_for_parent( int $parent_id, string $item_identifier, string $source_type = 'ticketmaster' ): array {
+		$identity_scope = 'event_import:' . $source_type;
+		$token          = ( new ProcessedItems() )->claim_item_owned( $identity_scope, $source_type, $item_identifier, $parent_id );
+		$this->assertIsString( $token );
+
+		return array(
+			'identity_scope'  => $identity_scope,
+			'source_type'     => $source_type,
+			'item_identifier' => $item_identifier,
+			'ownership_token' => $token,
+			'disposition_id'  => ProcessedItems::disposition_identity( $identity_scope, $source_type, $item_identifier ),
+		);
 	}
 
 	public function test_fanout_creates_batch_metadata_on_parent(): void {
@@ -385,14 +401,7 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 	public function test_process_chunk_propagates_claim_ownership_to_children(): void {
 		$parent_id = $this->create_parent_job();
 		$engine    = $this->make_engine_snapshot( $parent_id );
-		$claim     = array(
-			'identity_scope'  => 'shared:source',
-			'source_type'     => 'source',
-			'item_identifier' => 'item-1',
-			'ownership_token' => 'opaque-token',
-			'completion'      => array(),
-		);
-		$claim['disposition_id'] = ProcessedItems::disposition_identity( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] );
+		$claim     = $this->claim_for_parent( $parent_id, 'item-1' );
 		$sibling = array(
 			'identity_scope'  => 'shared:source',
 			'source_type'     => 'source',
@@ -412,6 +421,7 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$child_engine = datamachine_get_engine_data( $child_id );
 		$this->assertSame( $claim, $child_engine[ ProcessedItems::CLAIM_METADATA_KEY ] );
 		$this->assertArrayNotHasKey( ProcessedItems::CLAIMS_METADATA_KEY, $child_engine );
+		$this->assertTrue( ( new ProcessedItems() )->owns_active_claim( $claim, $child_id ) );
 	}
 
 	public function test_process_chunk_keeps_packet_claim_collections_with_their_child(): void {
@@ -419,13 +429,7 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$engine    = $this->make_engine_snapshot( $parent_id );
 		$claims    = array();
 		foreach ( array( 'item-a', 'item-b' ) as $item_identifier ) {
-			$claim = array(
-				'identity_scope'  => 'shared:source',
-				'source_type'     => 'source',
-				'item_identifier' => $item_identifier,
-				'ownership_token' => 'opaque-token-' . $item_identifier,
-			);
-			$claim['disposition_id'] = ProcessedItems::disposition_identity( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] );
+			$claim                    = $this->claim_for_parent( $parent_id, $item_identifier );
 			$claims[]                 = $claim;
 		}
 		$packet = $this->make_data_packet( 'Claim Collection' );
@@ -448,13 +452,7 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$packets   = array();
 		$claims    = array();
 		foreach ( array( 'item-a' => 'Claim A', 'item-b' => 'Claim B' ) as $item_identifier => $title ) {
-			$claim = array(
-				'identity_scope'  => 'shared:source',
-				'source_type'     => 'source',
-				'item_identifier' => $item_identifier,
-				'ownership_token' => 'opaque-token-' . $item_identifier,
-			);
-			$claim['disposition_id'] = ProcessedItems::disposition_identity( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] );
+			$claim                    = $this->claim_for_parent( $parent_id, $item_identifier );
 			$claims[ $title ]         = $claim;
 			$packet                    = $this->make_data_packet( $title );
 			$packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] = $claim;
@@ -475,6 +473,102 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 			$child_engine = datamachine_get_engine_data( (int) $child['job_id'] );
 			$this->assertSame( $claims[ $child['label'] ], $child_engine[ ProcessedItems::CLAIM_METADATA_KEY ] );
 		}
+	}
+
+	public function test_scheduled_fanout_reconstructs_exact_legacy_claims_and_disposes_idempotently(): void {
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+		$source_step_id = 'source-step';
+		$engine['flow_config'][ $source_step_id ] = array( 'step_type' => 'event_import' );
+		datamachine_set_engine_data( $parent_id, $engine );
+
+		$packets = array();
+		$claims  = array();
+		foreach ( array( 'reject-id' => 'Reject Event', 'defer-id' => 'Defer Event' ) as $item_identifier => $title ) {
+			$claims[ $item_identifier ] = $this->claim_for_parent( $parent_id, $item_identifier );
+			$packet                     = $this->make_data_packet( $title );
+			$packet['metadata']['source_item_id'] = $item_identifier;
+			$packet['metadata']['_engine_data']   = array(
+				'item_identifier' => $item_identifier,
+				'source_type'     => 'ticketmaster',
+			);
+			$packets[] = $packet;
+		}
+
+		$transfer = StepLifecycleHandler::transferClaimsToFanout( $parent_id, $packets );
+		$this->assertTrue( $transfer['success'] );
+		$this->assertCount( 2, $transfer['packets'] );
+		foreach ( $transfer['packets'] as $packet ) {
+			$this->assertArrayHasKey( ProcessedItems::CLAIM_METADATA_KEY, $packet['metadata'] );
+			$this->assertArrayHasKey( ProcessedItems::DISPOSITION_ID_METADATA_KEY, $packet['metadata'] );
+		}
+
+		$scheduler = new PipelineBatchScheduler();
+		$scheduler->fanOut( $parent_id, 'ai-step', $transfer['packets'], $engine );
+		$scheduler->processChunk( $parent_id );
+
+		global $wpdb;
+		$children = $wpdb->get_results(
+			$wpdb->prepare( 'SELECT job_id, label FROM %i WHERE parent_job_id = %d', $wpdb->prefix . 'datamachine_jobs', $parent_id ),
+			ARRAY_A
+		);
+		$this->assertCount( 2, $children );
+		$children = array_column( $children, 'job_id', 'label' );
+		$tool     = new FetchItemDispositionTool();
+		$cases    = array(
+			'Reject Event' => array( 'reject-id', 'reject_source' ),
+			'Defer Event'  => array( 'defer-id', 'defer_item' ),
+		);
+		foreach ( $cases as $label => $case ) {
+			list( $item_identifier, $disposition ) = $case;
+			$child_id = (int) $children[ $label ];
+			$claim    = $claims[ $item_identifier ];
+			$this->assertTrue( ( new ProcessedItems() )->owns_active_claim( $claim, $child_id ) );
+
+			$params = array(
+				'job_id'         => $child_id,
+				'disposition_id' => $claim['disposition_id'],
+				'reason'         => 'production-shaped test',
+			);
+			$first  = $tool->handle_tool_call( $params, array( 'disposition' => $disposition ) );
+			$second = $tool->handle_tool_call( $params, array( 'disposition' => $disposition ) );
+			$this->assertTrue( $first['success'] );
+			$this->assertSame( $claim['disposition_id'], $first['disposition_id'] );
+			$this->assertTrue( $second['success'] );
+			$this->assertTrue( $second['already_dispositioned'] );
+
+			$result_packet = array(
+				'metadata' => array(
+					ProcessedItems::CLAIM_METADATA_KEY          => $claim,
+					ProcessedItems::DISPOSITION_ID_METADATA_KEY => $claim['disposition_id'],
+					'packet_disposition'                        => $disposition,
+				),
+			);
+			$reconciled = StepLifecycleHandler::reconcileStepOutput( $child_id, array( 'step_type' => 'ai' ), array( $result_packet ), true );
+			$replayed   = StepLifecycleHandler::reconcileStepOutput( $child_id, array( 'step_type' => 'ai' ), array( $result_packet ), true );
+			$this->assertTrue( $reconciled['success'] );
+			$this->assertTrue( $replayed['success'] );
+			$this->assertFalse( ( new ProcessedItems() )->has_active_claim( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] ) );
+		}
+	}
+
+	public function test_scheduled_fanout_does_not_bind_ambiguous_or_conflicting_identity(): void {
+		$parent_id = $this->create_parent_job();
+		$processed = new ProcessedItems();
+		$this->assertIsString( $processed->claim_item_owned( 'scope-a', 'ticketmaster', 'shared-id', $parent_id ) );
+		$this->assertIsString( $processed->claim_item_owned( 'scope-b', 'ticketmaster', 'shared-id', $parent_id ) );
+
+		$ambiguous = $this->make_data_packet( 'Ambiguous Event' );
+		$ambiguous['metadata']['source_item_id'] = 'shared-id';
+		$conflicting = $this->make_data_packet( 'Conflicting Event' );
+		$conflicting['metadata']['source_item_id'] = 'shared-id';
+		$conflicting['metadata']['_engine_data']['item_identifier'] = 'different-id';
+
+		$transfer = StepLifecycleHandler::transferClaimsToFanout( $parent_id, array( $ambiguous, $conflicting ) );
+		$this->assertTrue( $transfer['success'] );
+		$this->assertArrayNotHasKey( ProcessedItems::CLAIM_METADATA_KEY, $transfer['packets'][0]['metadata'] );
+		$this->assertArrayNotHasKey( ProcessedItems::CLAIM_METADATA_KEY, $transfer['packets'][1]['metadata'] );
+		$this->assertArrayNotHasKey( 'transfer_id', $transfer );
 	}
 
 	public function test_process_chunk_respects_cancellation(): void {

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -8,12 +8,14 @@
 
 namespace DataMachine\Tests\Unit\Abilities\Engine;
 
+use DataMachine\Abilities\Engine\ExecuteStepAbility;
 use DataMachine\Abilities\Engine\PipelineBatchScheduler;
 use DataMachine\Core\ActionScheduler\BatchScheduler;
 use DataMachine\Core\ActionScheduler\PathlessBatchRecovery;
 use DataMachine\Core\Database\BatchItems\BatchItems;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachine\Core\EngineData;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\Steps\Fetch\Tools\FetchItemDispositionTool;
 use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
@@ -479,7 +481,17 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$parent_id = $this->create_parent_job();
 		$engine    = $this->make_engine_snapshot( $parent_id );
 		$source_step_id = 'source-step';
-		$engine['flow_config'][ $source_step_id ] = array( 'step_type' => 'event_import' );
+		$engine['flow_config'] = array(
+			$source_step_id => array(
+				'step_type'       => 'event_import',
+				'execution_order' => 0,
+				'pipeline_id'     => $this->test_pipeline_id,
+			),
+			'ai-step'       => array(
+				'step_type'       => 'ai',
+				'execution_order' => 1,
+			),
+		);
 		datamachine_set_engine_data( $parent_id, $engine );
 
 		$packets = array();
@@ -495,19 +507,43 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 			$packets[] = $packet;
 		}
 
-		$transfer = StepLifecycleHandler::transferClaimsToFanout( $parent_id, $packets );
-		$this->assertTrue( $transfer['success'] );
-		$this->assertCount( 2, $transfer['packets'] );
-		foreach ( $transfer['packets'] as $packet ) {
-			$this->assertArrayHasKey( ProcessedItems::CLAIM_METADATA_KEY, $packet['metadata'] );
-			$this->assertArrayHasKey( ProcessedItems::DISPOSITION_ID_METADATA_KEY, $packet['metadata'] );
+		$route = new \ReflectionMethod( ExecuteStepAbility::class, 'routeAfterExecution' );
+		$result = $route->invoke(
+			new ExecuteStepAbility(),
+			$parent_id,
+			$source_step_id,
+			$this->test_flow_id,
+			$engine['flow_config'][ $source_step_id ],
+			'event_import',
+			'',
+			$packets,
+			array(
+				'job_id' => $parent_id,
+				'engine' => new EngineData( $engine, $parent_id ),
+			),
+			true,
+			null
+		);
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'batch_scheduled', $result['outcome'] );
+
+		global $wpdb;
+		$worklist = $wpdb->get_results(
+			$wpdb->prepare( 'SELECT payload FROM %i WHERE batch_job_id = %d ORDER BY item_index', $wpdb->prefix . 'datamachine_batch_items', $parent_id ),
+			ARRAY_A
+		);
+		$this->assertCount( 2, $worklist );
+		foreach ( $worklist as $index => $row ) {
+			$stored = json_decode( $row['payload'], true );
+			$this->assertArrayHasKey( ProcessedItems::CLAIM_METADATA_KEY, $stored['metadata'] );
+			$this->assertArrayHasKey( ProcessedItems::DISPOSITION_ID_METADATA_KEY, $stored['metadata'] );
+			$item_identifier = 'Reject Event' === $stored['data']['title'] ? 'reject-id' : 'defer-id';
+			$this->assertTrue( ( new ProcessedItems() )->owns_active_claim( $claims[ $item_identifier ], $parent_id ), 'Worklist adoption must precede child ownership transfer at index ' . $index );
 		}
 
 		$scheduler = new PipelineBatchScheduler();
-		$scheduler->fanOut( $parent_id, 'ai-step', $transfer['packets'], $engine );
 		$scheduler->processChunk( $parent_id );
 
-		global $wpdb;
 		$children = $wpdb->get_results(
 			$wpdb->prepare( 'SELECT job_id, label FROM %i WHERE parent_job_id = %d', $wpdb->prefix . 'datamachine_jobs', $parent_id ),
 			ARRAY_A
@@ -565,10 +601,164 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$conflicting['metadata']['_engine_data']['item_identifier'] = 'different-id';
 
 		$transfer = StepLifecycleHandler::transferClaimsToFanout( $parent_id, array( $ambiguous, $conflicting ) );
-		$this->assertTrue( $transfer['success'] );
-		$this->assertArrayNotHasKey( ProcessedItems::CLAIM_METADATA_KEY, $transfer['packets'][0]['metadata'] );
-		$this->assertArrayNotHasKey( ProcessedItems::CLAIM_METADATA_KEY, $transfer['packets'][1]['metadata'] );
-		$this->assertArrayNotHasKey( 'transfer_id', $transfer );
+		$this->assertFalse( $transfer['success'] );
+
+		$source_parent = $this->create_parent_job();
+		$this->claim_for_parent( $source_parent, 'source-conflict' );
+		$source_conflict = $this->make_data_packet( 'Source Conflict' );
+		$source_conflict['metadata']['source_item_id'] = 'source-conflict';
+		$source_conflict['metadata']['_engine_data']   = array(
+			'item_identifier' => 'source-conflict',
+			'source_type'     => 'other-source',
+		);
+		$source_transfer = StepLifecycleHandler::transferClaimsToFanout( $source_parent, array( $source_conflict ) );
+		$this->assertFalse( $source_transfer['success'] );
+	}
+
+	public function test_duplicate_exact_packet_identity_fails_before_batch_adoption(): void {
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+		$engine['flow_config'] = array(
+			'source-step' => array(
+				'step_type'       => 'event_import',
+				'execution_order' => 0,
+				'pipeline_id'     => $this->test_pipeline_id,
+			),
+			'ai-step'     => array(
+				'step_type'       => 'ai',
+				'execution_order' => 1,
+			),
+		);
+		datamachine_set_engine_data( $parent_id, $engine );
+		$this->claim_for_parent( $parent_id, 'duplicate-id' );
+		$packet = $this->make_data_packet( 'Duplicate Event' );
+		$packet['metadata']['source_item_id'] = 'duplicate-id';
+		$packet['metadata']['_engine_data']   = array(
+			'item_identifier' => 'duplicate-id',
+			'source_type'     => 'ticketmaster',
+		);
+
+		$route = new \ReflectionMethod( ExecuteStepAbility::class, 'routeAfterExecution' );
+		$result = $route->invoke(
+			new ExecuteStepAbility(),
+			$parent_id,
+			'source-step',
+			$this->test_flow_id,
+			$engine['flow_config']['source-step'],
+			'event_import',
+			'',
+			array( $packet, $packet ),
+			array(
+				'job_id' => $parent_id,
+				'engine' => new EngineData( $engine, $parent_id ),
+			),
+			true,
+			null
+		);
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'claim_reconciliation_failed', $result['outcome'] );
+		$this->assertArrayNotHasKey( 'batch_state', datamachine_get_engine_data( $parent_id ) );
+
+		global $wpdb;
+		$this->assertSame(
+			0,
+			(int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE parent_job_id = %d', $wpdb->prefix . 'datamachine_jobs', $parent_id ) )
+		);
+	}
+
+	public function test_terminal_child_replay_reconciles_exact_parent_ownership(): void {
+		$parent_id = $this->create_parent_job();
+		$claim     = $this->claim_for_parent( $parent_id, 'terminal-replay' );
+		$packet    = $this->make_data_packet( 'Terminal Replay' );
+		$packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] = $claim;
+
+		$scheduler = new PipelineBatchScheduler();
+		$child_id = $scheduler->createChildJobFromBatch( $packet, array( 'next_flow_step_id' => 'ai-step' ), $parent_id, 0, 'terminal-checksum' );
+		$this->assertIsInt( $child_id );
+
+		global $wpdb;
+		$wpdb->update(
+			$wpdb->prefix . 'datamachine_jobs',
+			array( 'status' => JobStatus::FAILED ),
+			array( 'job_id' => $child_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		$wpdb->update(
+			$wpdb->prefix . 'datamachine_processed_items',
+			array( 'job_id' => $parent_id ),
+			array( 'claim_token' => $claim['ownership_token'] ),
+			array( '%d' ),
+			array( '%s' )
+		);
+
+		$replayed = $scheduler->createChildJobFromBatch( $packet, array( 'next_flow_step_id' => 'ai-step' ), $parent_id, 0, 'terminal-checksum' );
+		$this->assertSame( $child_id, $replayed );
+		$this->assertFalse( ( new ProcessedItems() )->has_active_claim( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] ) );
+		$this->assertIsArray( $this->claim_for_parent( $parent_id + 1000, 'terminal-replay' ) );
+	}
+
+	public function test_adoption_failure_after_child_persistence_retries_same_child(): void {
+		$parent_id = $this->create_parent_job();
+		$claim     = $this->claim_for_parent( $parent_id, 'adoption-retry' );
+		$packet    = $this->make_data_packet( 'Adoption Retry' );
+		$packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] = $claim;
+
+		global $wpdb;
+		$wpdb->update(
+			$wpdb->prefix . 'datamachine_processed_items',
+			array( 'job_id' => $parent_id + 1000 ),
+			array( 'claim_token' => $claim['ownership_token'] ),
+			array( '%d' ),
+			array( '%s' )
+		);
+		$scheduler = new PipelineBatchScheduler();
+		$this->assertFalse( $scheduler->createChildJobFromBatch( $packet, array( 'next_flow_step_id' => 'ai-step' ), $parent_id, 0, 'retry-checksum' ) );
+		$children = $wpdb->get_col( $wpdb->prepare( 'SELECT job_id FROM %i WHERE parent_job_id = %d', $wpdb->prefix . 'datamachine_jobs', $parent_id ) );
+		$this->assertCount( 1, $children );
+		$this->assertSame( 'pending', $this->jobs_db->get_job( (int) $children[0] )['status'] );
+
+		$wpdb->update(
+			$wpdb->prefix . 'datamachine_processed_items',
+			array( 'job_id' => $parent_id ),
+			array( 'claim_token' => $claim['ownership_token'] ),
+			array( '%d' ),
+			array( '%s' )
+		);
+		$retried = $scheduler->createChildJobFromBatch( $packet, array( 'next_flow_step_id' => 'ai-step' ), $parent_id, 0, 'retry-checksum' );
+		$this->assertSame( (int) $children[0], $retried );
+		$this->assertTrue( ( new ProcessedItems() )->owns_active_claim( $claim, (int) $retried ) );
+		$this->assertCount( 1, $wpdb->get_col( $wpdb->prepare( 'SELECT job_id FROM %i WHERE parent_job_id = %d', $wpdb->prefix . 'datamachine_jobs', $parent_id ) ) );
+	}
+
+	public function test_successful_terminal_child_replay_completes_exact_parent_claim(): void {
+		$parent_id = $this->create_parent_job();
+		$claim     = $this->claim_for_parent( $parent_id, 'terminal-success' );
+		$packet    = $this->make_data_packet( 'Terminal Success' );
+		$packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] = $claim;
+		$scheduler = new PipelineBatchScheduler();
+		$child_id = $scheduler->createChildJobFromBatch( $packet, array( 'next_flow_step_id' => 'ai-step' ), $parent_id, 0, 'terminal-success-checksum' );
+		$this->assertIsInt( $child_id );
+
+		global $wpdb;
+		$wpdb->update(
+			$wpdb->prefix . 'datamachine_jobs',
+			array( 'status' => JobStatus::COMPLETED ),
+			array( 'job_id' => $child_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		$wpdb->update(
+			$wpdb->prefix . 'datamachine_processed_items',
+			array( 'job_id' => $parent_id ),
+			array( 'claim_token' => $claim['ownership_token'] ),
+			array( '%d' ),
+			array( '%s' )
+		);
+
+		$replayed = $scheduler->createChildJobFromBatch( $packet, array( 'next_flow_step_id' => 'ai-step' ), $parent_id, 0, 'terminal-success-checksum' );
+		$this->assertSame( $child_id, $replayed );
+		$this->assertTrue( ( new ProcessedItems() )->has_item_been_processed( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] ) );
 	}
 
 	public function test_process_chunk_respects_cancellation(): void {

--- a/tests/pipeline-child-claim-smoke.php
+++ b/tests/pipeline-child-claim-smoke.php
@@ -9,6 +9,28 @@ namespace DataMachine\Core\Database\Jobs {
 	}
 }
 
+namespace DataMachine\Core\Database\ProcessedItems {
+	class ProcessedItems {
+		public const CLAIM_METADATA_KEY = '_datamachine_item_claim';
+		public const CLAIMS_METADATA_KEY = '_datamachine_item_claims';
+		public const DISPOSITION_ID_METADATA_KEY = '_datamachine_packet_disposition_id';
+		public static function disposition_identity( string $scope, string $source, string $item ): string { return hash( 'sha256', $scope . "\0" . $source . "\0" . $item ); }
+		public static function has_claim_metadata( array $container ): bool { return isset( $container[ self::CLAIM_METADATA_KEY ] ) || isset( $container[ self::CLAIMS_METADATA_KEY ] ); }
+		public static function has_valid_claim_metadata( array $container ): bool { return self::has_claim_metadata( $container ); }
+		public static function disposition_claims( array $container ): array {
+			$claims = array();
+			foreach ( array_merge( isset( $container[ self::CLAIM_METADATA_KEY ] ) ? array( $container[ self::CLAIM_METADATA_KEY ] ) : array(), $container[ self::CLAIMS_METADATA_KEY ] ?? array() ) as $claim ) {
+				if ( is_array( $claim ) ) {
+					$id            = $claim['disposition_id'] ?? self::disposition_identity( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] );
+					$claims[ $id ] = $claim;
+				}
+			}
+			return $claims;
+		}
+		public function adopt_owned_claims( array $claims, int $parent_job_id, int $child_job_id ): bool { unset( $claims, $parent_job_id, $child_job_id ); return true; }
+	}
+}
+
 namespace {
 	define( 'ABSPATH', __DIR__ . '/' );
 	$GLOBALS['pipeline_child_engines'] = array();
@@ -17,8 +39,6 @@ namespace {
 	function datamachine_get_engine_data( int $job_id ): array { return $GLOBALS['pipeline_child_engines'][ $job_id ] ?? array(); }
 	function datamachine_set_engine_data( int $job_id, array $engine ): bool { $GLOBALS['pipeline_child_engines'][ $job_id ] = $engine; return true; }
 
-	require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
-	require_once __DIR__ . '/../inc/Core/Database/ProcessedItems/ProcessedItems.php';
 	require_once __DIR__ . '/../inc/Core/EngineData.php';
 	require_once __DIR__ . '/../inc/Core/PacketEngineData.php';
 	require_once __DIR__ . '/../inc/Abilities/Engine/PipelineBatchScheduler.php';

--- a/tests/pipeline-child-claim-smoke.php
+++ b/tests/pipeline-child-claim-smoke.php
@@ -27,6 +27,8 @@ namespace DataMachine\Core\Database\ProcessedItems {
 			}
 			return $claims;
 		}
+	}
+	class FanoutClaimOwnership {
 		public function adopt_owned_claims( array $claims, int $parent_job_id, int $child_job_id, bool $allow_resolved = false ): bool { unset( $claims, $parent_job_id, $child_job_id, $allow_resolved ); return true; }
 	}
 }

--- a/tests/pipeline-child-claim-smoke.php
+++ b/tests/pipeline-child-claim-smoke.php
@@ -27,7 +27,7 @@ namespace DataMachine\Core\Database\ProcessedItems {
 			}
 			return $claims;
 		}
-		public function adopt_owned_claims( array $claims, int $parent_job_id, int $child_job_id ): bool { unset( $claims, $parent_job_id, $child_job_id ); return true; }
+		public function adopt_owned_claims( array $claims, int $parent_job_id, int $child_job_id, bool $allow_resolved = false ): bool { unset( $claims, $parent_job_id, $child_job_id, $allow_resolved ); return true; }
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reconstruct descriptor-less fanout claims only from active rows owned by the parent when every available source and item identity field agrees exactly.
- Enforce one claim descriptor per packet across the complete fanout; duplicate packet identities, conflicting fields, and ambiguous claim scopes fail before durable batch adoption.
- Carry exact `disposition_id` into the worklist, atomically adopt token ownership into the deterministic child, and settle exact claims when replay discovers an already-terminal child.

## Root cause
PR #3236 preserved claim descriptors already present in packet metadata, but the production Ticketmaster path acquires its cross-flow claim directly under `event_import:ticketmaster`. Its packet exposes the exact item as `metadata.source_item_id` and `_engine_data.item_identifier`, not `_datamachine_item_claim`.

The scheduled parent therefore transferred no descriptor. `BatchScheduler` persisted 72 claimless packets, and `PipelineBatchScheduler` copied that shape into children. Active token-owned rows remained assigned to the parent while children received disposition tools without resolvable identity.

## Lifecycle ownership
The repair stays in Data Machine's canonical packet lifecycle:
- `ProcessedItems` reads active token-owned claims for the parent and atomically verifies or moves exact ownership to a child.
- `StepLifecycleHandler` binds only a unique exact identity when `metadata.source_type`, `_engine_data.source_type`, `item_identifier`, `source_item_id`, and `_engine_data.item_identifier` agree.
- The transfer rejects duplicate descriptor reuse across packets, conflicting fields, and multiple scope matches before `BatchScheduler::start`.
- `ExecuteStepAbility` dispatches enriched packets into the durable worklist.
- `PipelineBatchScheduler` adopts ownership before enqueueing. Deterministic retries reuse the same child after persistence/adoption/enqueue boundary failures.
- If replay finds an existing terminal child, exact parent ownership is first adopted and then settled through the existing completion/release lifecycle. Already-resolved claims are idempotent; replacement ownership fails closed.

No Ticketmaster-specific branch or parallel identity abstraction was added.

## Production evidence
After v0.175.1 deployed commit `49a784d5`, parent job 878016 created 72 flow 259 / pipeline 61 scheduled children. The durable worklist and failed child engines had no claim metadata despite exact Ticketmaster source IDs and active parent-owned claim rows.

New post-deploy failures were 878021, 878047, 878055, 878056, and 878081, all with `packet disposition identity is required`. No recovery was run.

## Tests
- Production-shaped regression invokes `ExecuteStepAbility::routeAfterExecution`, verifies descriptor-bearing durable worklist rows while SQL claims remain parent-owned, then verifies child ownership adoption, exact reject/defer resolution, repeated-tool idempotency, and replay-safe reconciliation.
- Duplicate packet identities fail before batch state or child creation, so no batch row can retry forever.
- Ambiguous scope matches, conflicting item IDs, and conflicting source types fail closed.
- Terminal replay covers exact parent-owned claims for both successful completion and failed release.
- Adoption failure after child persistence reuses one deterministic pending child on retry and produces no duplicate child.
- `vendor/bin/phpunit --filter PipelineBatchSchedulerTest`
- `vendor/bin/phpunit --filter ItemClaimLifecycleTest`
- `php tests/pipeline-child-claim-smoke.php`
- `php tests/fetch-item-dispositions-smoke.php` (43 assertions)
- `php tests/packet-reconciliation-transaction-smoke.php` (19 assertions)
- `php tests/packet-disposition-route-smoke.php` (15 assertions)
- `php tests/fanout-adoption-recovery-smoke.php` (9 assertions)
- `php tests/transition-fanout-policy-smoke.php` (13 assertions)
- `php tests/parallel-map-fanout-adapter-smoke.php` (35 assertions)
- `php tests/phpunit-file-isolation-smoke.php` (16 clusters)
- `composer lint`

Closes #3225

## Final review fix
Terminal replay now classifies exact child ownership independently of lease expiry before invoking canonical token-locked settlement. Expired success runs completion callbacks once and marks processed; expired failure releases once; competing replacement tokens remain fail-closed. Repeated replay is idempotent.