### PR TITLE
refactor: migrate agent auth and memory ability failures

### DIFF
--- a/inc/Abilities/AI/InspectRequestAbility.php
+++ b/inc/Abilities/AI/InspectRequestAbility.php
@@ -61,12 +61,16 @@ class InspectRequestAbility {
 		return PermissionHelper::can( 'view_logs' ) || PermissionHelper::can_manage();
 	}
 
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$job_id = (int) ( $input['job_id'] ?? 0 );
 		if ( $job_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'Missing or invalid job_id.',
+			return new \WP_Error(
+				'invalid_job_id',
+				'Missing or invalid job_id.',
+				array(
+					'status' => 400,
+					'job_id' => $job_id,
+				)
 			);
 		}
 
@@ -74,6 +78,27 @@ class InspectRequestAbility {
 			? (string) $input['flow_step_id']
 			: null;
 
-		return ( new RequestInspector() )->inspectPipelineJob( $job_id, $flow_step_id );
+		$result = ( new RequestInspector() )->inspectPipelineJob( $job_id, $flow_step_id );
+		if ( ! empty( $result['success'] ) ) {
+			return $result;
+		}
+
+		$message = (string) ( $result['error'] ?? 'AI request inspection failed.' );
+		$code    = 'request_inspection_failed';
+		$status  = 400;
+		if ( str_contains( $message, 'Job ' ) && str_contains( $message, ' not found' ) ) {
+			$code   = 'job_not_found';
+			$status = 404;
+		} elseif ( str_contains( $message, 'not found in job engine snapshot' ) ) {
+			$code   = 'flow_step_not_found';
+			$status = 404;
+		} elseif ( ! empty( $result['missing_required_handler_slugs'] ) ) {
+			$code   = 'required_handler_tools_unavailable';
+			$status = 409;
+		}
+		$data = $result;
+		unset( $data['success'], $data['error'] );
+		$data['status'] = $status;
+		return new \WP_Error( $code, $message, $data );
 	}
 }

--- a/inc/Abilities/AgentAbilities.php
+++ b/inc/Abilities/AgentAbilities.php
@@ -893,22 +893,24 @@ class AgentAbilities {
 	 * @param array $input Input parameters with old_slug and new_slug.
 	 * @return array Result.
 	 */
-	public static function renameAgent( array $input ): array {
+	public static function renameAgent( array $input ): array|\WP_Error {
 		$old_slug = sanitize_title( $input['old_slug'] );
 		$new_slug = sanitize_title( $input['new_slug'] );
 
 		if ( $old_slug === $new_slug ) {
-			return array(
-				'success' => false,
-				'message' => 'Old and new slugs are identical.',
+			return new \WP_Error(
+				'invalid_agent_slug',
+				'Old and new slugs are identical.',
+				array(
+					'status'   => 400,
+					'old_slug' => $old_slug,
+					'new_slug' => $new_slug,
+				)
 			);
 		}
 
 		if ( empty( $new_slug ) ) {
-			return array(
-				'success' => false,
-				'message' => 'New slug cannot be empty.',
-			);
+			return new \WP_Error( 'invalid_agent_slug', 'New slug cannot be empty.', array( 'status' => 400 ) );
 		}
 
 		$agents_repo = new Agents();
@@ -917,9 +919,13 @@ class AgentAbilities {
 		$existing = $agents_repo->get_by_slug( $old_slug );
 
 		if ( ! $existing ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Agent with slug "%s" not found.', $old_slug ),
+			return new \WP_Error(
+				'agent_not_found',
+				sprintf( 'Agent with slug "%s" not found.', $old_slug ),
+				array(
+					'status'   => 404,
+					'old_slug' => $old_slug,
+				)
 			);
 		}
 
@@ -927,9 +933,13 @@ class AgentAbilities {
 		$conflict = $agents_repo->get_by_slug( $new_slug );
 
 		if ( $conflict ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'An agent with slug "%s" already exists.', $new_slug ),
+			return new \WP_Error(
+				'agent_slug_conflict',
+				sprintf( 'An agent with slug "%s" already exists.', $new_slug ),
+				array(
+					'status'   => 409,
+					'new_slug' => $new_slug,
+				)
 			);
 		}
 
@@ -943,13 +953,16 @@ class AgentAbilities {
 
 		if ( is_dir( $old_path ) ) {
 			if ( is_dir( $new_path ) ) {
-				return array(
-					'success'  => false,
-					'message'  => sprintf( 'Target directory "%s" already exists.', $new_path ),
-					'old_slug' => $old_slug,
-					'new_slug' => $new_slug,
-					'old_path' => $old_path,
-					'new_path' => $new_path,
+				return new \WP_Error(
+					'agent_directory_conflict',
+					sprintf( 'Target directory "%s" already exists.', $new_path ),
+					array(
+						'status'   => 409,
+						'old_slug' => $old_slug,
+						'new_slug' => $new_slug,
+						'old_path' => $old_path,
+						'new_path' => $new_path,
+					)
 				);
 			}
 
@@ -957,13 +970,16 @@ class AgentAbilities {
 			$dir_moved = rename( $old_path, $new_path );
 
 			if ( ! $dir_moved ) {
-				return array(
-					'success'  => false,
-					'message'  => sprintf( 'Failed to move directory from "%s" to "%s".', $old_path, $new_path ),
-					'old_slug' => $old_slug,
-					'new_slug' => $new_slug,
-					'old_path' => $old_path,
-					'new_path' => $new_path,
+				return new \WP_Error(
+					'agent_directory_move_failed',
+					sprintf( 'Failed to move directory from "%s" to "%s".', $old_path, $new_path ),
+					array(
+						'status'   => 500,
+						'old_slug' => $old_slug,
+						'new_slug' => $new_slug,
+						'old_path' => $old_path,
+						'new_path' => $new_path,
+					)
 				);
 			}
 		}
@@ -978,13 +994,16 @@ class AgentAbilities {
 				rename( $new_path, $old_path );
 			}
 
-			return array(
-				'success'  => false,
-				'message'  => 'Database update failed. Directory change reverted.',
-				'old_slug' => $old_slug,
-				'new_slug' => $new_slug,
-				'old_path' => $old_path,
-				'new_path' => $new_path,
+			return new \WP_Error(
+				'agent_rename_failed',
+				'Database update failed. Directory change reverted.',
+				array(
+					'status'   => 500,
+					'old_slug' => $old_slug,
+					'new_slug' => $new_slug,
+					'old_path' => $old_path,
+					'new_path' => $new_path,
+				)
 			);
 		}
 
@@ -1016,7 +1035,7 @@ class AgentAbilities {
 	 * @param array $input Input parameters (unused).
 	 * @return array Result.
 	 */
-	public static function listAgents( array $input ): array {
+	public static function listAgents( array $input ): array|\WP_Error {
 		// ---- Parameter resolution ----------------------------------------
 		$scope             = isset( $input['scope'] ) ? (string) $input['scope'] : 'mine';
 		$requested_user_id = isset( $input['user_id'] ) ? (int) $input['user_id'] : 0;
@@ -1024,9 +1043,13 @@ class AgentAbilities {
 		$include_role      = ! empty( $input['include_role'] );
 
 		if ( ! in_array( $scope, array( 'mine', 'all' ), true ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Invalid scope. Allowed values: "mine", "all".',
+			return new \WP_Error(
+				'invalid_agent_scope',
+				'Invalid scope. Allowed values: "mine", "all".',
+				array(
+					'status' => 400,
+					'scope'  => $scope,
+				)
 			);
 		}
 
@@ -1035,18 +1058,26 @@ class AgentAbilities {
 
 		// ---- Escalation checks -------------------------------------------
 		if ( 'all' === $scope && ! $is_admin ) {
-			return array(
-				'success' => false,
-				'error'   => 'scope=all requires admin privileges.',
+			return new \WP_Error(
+				'agent_scope_forbidden',
+				'scope=all requires admin privileges.',
+				array(
+					'status' => 403,
+					'scope'  => $scope,
+				)
 			);
 		}
 
 		// Non-admins are always forced to self. Admin omitting user_id also
 		// defaults to self (the intuitive "show me MY accessible agents").
 		if ( $requested_user_id > 0 && $requested_user_id !== $caller_id && ! $is_admin ) {
-			return array(
-				'success' => false,
-				'error'   => 'Querying another user\'s agents requires admin privileges.',
+			return new \WP_Error(
+				'agent_user_scope_forbidden',
+				'Querying another user\'s agents requires admin privileges.',
+				array(
+					'status'  => 403,
+					'user_id' => $requested_user_id,
+				)
 			);
 		}
 
@@ -1161,13 +1192,10 @@ class AgentAbilities {
 	 * @param array $input Ability input.
 	 * @return array<string,mixed>
 	 */
-	public static function getActiveAgent( array $input ): array {
+	public static function getActiveAgent( array $input ): array|\WP_Error {
 		$target_user_id = self::resolve_active_agent_user_id( isset( $input['user_id'] ) ? (int) $input['user_id'] : 0 );
 		if ( is_wp_error( $target_user_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => $target_user_id->get_error_message(),
-			);
+			return $target_user_id;
 		}
 
 		$active = self::resolve_active_agent_for_user( $target_user_id );
@@ -1187,36 +1215,40 @@ class AgentAbilities {
 	 * @param array $input Ability input.
 	 * @return array<string,mixed>
 	 */
-	public static function setActiveAgent( array $input ): array {
+	public static function setActiveAgent( array $input ): array|\WP_Error {
 		$target_user_id = self::resolve_active_agent_user_id( isset( $input['user_id'] ) ? (int) $input['user_id'] : 0 );
 		if ( is_wp_error( $target_user_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => $target_user_id->get_error_message(),
-			);
+			return $target_user_id;
 		}
 
 		$agent_id = self::resolve_agent_input_id( array( 'agent' => (string) ( $input['agent'] ?? '' ) ) );
 		if ( is_wp_error( $agent_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => $agent_id->get_error_message(),
-			);
+			return $agent_id;
 		}
 
 		$agents_repo = new Agents();
 		$agent       = $agents_repo->get_agent( $agent_id );
 		if ( ! $agent ) {
-			return array(
-				'success' => false,
-				'error'   => 'Agent not found.',
+			return new \WP_Error(
+				'agent_not_found',
+				'Agent not found.',
+				array(
+					'status'   => 404,
+					'agent_id' => $agent_id,
+				)
 			);
 		}
 
 		if ( ! self::user_can_access_agent_row( $target_user_id, $agent ) ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'User %d cannot access agent "%s".', $target_user_id, (string) $agent['agent_slug'] ),
+			return new \WP_Error(
+				'agent_access_denied',
+				sprintf( 'User %d cannot access agent "%s".', $target_user_id, (string) $agent['agent_slug'] ),
+				array(
+					'status'     => 403,
+					'user_id'    => $target_user_id,
+					'agent_id'   => $agent_id,
+					'agent_slug' => (string) $agent['agent_slug'],
+				)
 			);
 		}
 
@@ -1241,12 +1273,19 @@ class AgentAbilities {
 		$is_admin  = PermissionHelper::can_manage();
 
 		if ( $requested_user_id > 0 && $requested_user_id !== $caller_id && ! $is_admin ) {
-			return new \WP_Error( 'forbidden_user', 'Changing another user\'s active agent requires admin privileges.' );
+			return new \WP_Error(
+				'forbidden_user',
+				'Changing another user\'s active agent requires admin privileges.',
+				array(
+					'status'  => 403,
+					'user_id' => $requested_user_id,
+				)
+			);
 		}
 
 		$target_user_id = $requested_user_id > 0 ? $requested_user_id : $caller_id;
 		if ( $target_user_id <= 0 ) {
-			return new \WP_Error( 'missing_user', 'Could not determine acting user.' );
+			return new \WP_Error( 'missing_user', 'Could not determine acting user.', array( 'status' => 403 ) );
 		}
 
 		return $target_user_id;
@@ -1406,14 +1445,18 @@ class AgentAbilities {
 	 * @param array $input Import parameters.
 	 * @return array<string,mixed>
 	 */
-	public static function importAgent( array $input ): array {
+	public static function importAgent( array $input ): array|\WP_Error {
 		$has_inline_bundle = isset( $input['bundle'] ) && is_array( $input['bundle'] );
 		$source            = trim( (string) ( $input['source'] ?? '' ) );
 		if ( ! $has_inline_bundle && '' === $source ) {
-			return array(
-				'success'     => false,
-				'error'       => 'Bundle source or inline bundle is required.',
-				'diagnostics' => self::bundle_source_import_diagnostics( $source ),
+			return new \WP_Error(
+				'invalid_agent_bundle_source',
+				'Bundle source or inline bundle is required.',
+				array(
+					'status'      => 400,
+					'source'      => $source,
+					'diagnostics' => self::bundle_source_import_diagnostics( $source ),
+				)
 			);
 		}
 
@@ -1424,10 +1467,17 @@ class AgentAbilities {
 			$context  = self::build_resolve_context( $input );
 			$resolved = BundleSource::resolve( $source, $context );
 			if ( is_wp_error( $resolved ) ) {
-				return array(
-					'success'     => false,
-					'error'       => $resolved->get_error_message(),
-					'diagnostics' => self::bundle_source_import_diagnostics( $source ),
+				return new \WP_Error(
+					$resolved->get_error_code(),
+					$resolved->get_error_message(),
+					array_merge(
+						array(
+							'status'      => 400,
+							'source'      => $source,
+							'diagnostics' => self::bundle_source_import_diagnostics( $source ),
+						),
+						is_array( $resolved->get_error_data() ) ? $resolved->get_error_data() : array()
+					)
 				);
 			}
 
@@ -1441,9 +1491,13 @@ class AgentAbilities {
 			if ( null !== $resolved ) {
 				BundleSource::cleanup( $resolved, $source );
 			}
-			return array(
-				'success' => false,
-				'error'   => 'on_conflict must be one of: error, skip, upgrade.',
+			return new \WP_Error(
+				'invalid_agent_conflict_mode',
+				'on_conflict must be one of: error, skip, upgrade.',
+				array(
+					'status'      => 400,
+					'on_conflict' => $on_conflict,
+				)
 			);
 		}
 
@@ -1452,9 +1506,13 @@ class AgentAbilities {
 			if ( null !== $resolved ) {
 				BundleSource::cleanup( $resolved, $source );
 			}
-			return array(
-				'success' => false,
-				'error'   => 'Unable to resolve import owner. Pass owner_id, authenticate as a user, or set datamachine_default_owner_id.',
+			return new \WP_Error(
+				'agent_owner_unresolved',
+				'Unable to resolve import owner. Pass owner_id, authenticate as a user, or set datamachine_default_owner_id.',
+				array(
+					'status'   => 403,
+					'owner_id' => $owner_id,
+				)
 			);
 		}
 
@@ -1469,10 +1527,14 @@ class AgentAbilities {
 		}
 
 		if ( ! is_array( $bundle ) ) {
-			return array(
-				'success'     => false,
-				'error'       => 'Failed to parse bundle. Use a bundle directory, .json file, or .zip archive.',
-				'diagnostics' => $has_inline_bundle ? array() : self::bundle_source_import_diagnostics( $source ),
+			return new \WP_Error(
+				'agent_bundle_parse_failed',
+				'Failed to parse bundle. Use a bundle directory, .json file, or .zip archive.',
+				array(
+					'status'      => 400,
+					'source'      => $source,
+					'diagnostics' => $has_inline_bundle ? array() : self::bundle_source_import_diagnostics( $source ),
+				)
 			);
 		}
 
@@ -1511,11 +1573,14 @@ class AgentAbilities {
 		}
 
 		if ( $existing && 'upgrade' !== $on_conflict ) {
-			return array(
-				'success'    => false,
-				'agent_id'   => (int) $existing['agent_id'],
-				'agent_slug' => $slug,
-				'error'      => sprintf( 'Agent slug "%s" already exists. Use on_conflict=skip to no-op, on_conflict=upgrade to reconcile bundle artifacts, or import with a new slug.', $slug ),
+			return new \WP_Error(
+				'agent_slug_conflict',
+				sprintf( 'Agent slug "%s" already exists. Use on_conflict=skip to no-op, on_conflict=upgrade to reconcile bundle artifacts, or import with a new slug.', $slug ),
+				array(
+					'status'     => 409,
+					'agent_id'   => (int) $existing['agent_id'],
+					'agent_slug' => $slug,
+				)
 			);
 		}
 
@@ -1531,7 +1596,19 @@ class AgentAbilities {
 		);
 		if ( empty( $result['success'] ) ) {
 			$result['auth_warnings'] = $auth_warnings;
-			return $result;
+			$code                    = sanitize_key( (string) ( $result['error_code'] ?? 'agent_import_failed' ) );
+			$status                  = 500;
+			if ( str_contains( $code, 'invalid' ) || 'install_unsupported_capabilities' === $code ) {
+				$status = 400;
+			} elseif ( str_contains( $code, 'collision' ) || str_contains( $code, 'mismatch' ) || str_contains( $code, 'local_modified' ) ) {
+				$status = 409;
+			}
+
+			return new \WP_Error(
+				$code,
+				(string) ( $result['error'] ?? 'Failed to import agent bundle.' ),
+				array_merge( $result, array( 'status' => $status ) )
+			);
 		}
 
 		$summary  = is_array( $result['summary'] ?? null ) ? $result['summary'] : array();
@@ -2120,7 +2197,7 @@ class AgentAbilities {
 	 * @param array $input { agent_slug, agent_name, owner_id, config? }.
 	 * @return array Result with agent_id on success.
 	 */
-	public static function createAgent( array $input ): array {
+	public static function createAgent( array $input ): array|\WP_Error {
 		$slug     = sanitize_title( $input['agent_slug'] ?? '' );
 		$name     = sanitize_text_field( $input['agent_name'] ?? '' );
 		$owner_id = (int) ( $input['owner_id'] ?? 0 );
@@ -2142,10 +2219,7 @@ class AgentAbilities {
 		}
 
 		if ( empty( $slug ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Agent slug is required.',
-			);
+			return new \WP_Error( 'invalid_agent_slug', 'Agent slug is required.', array( 'status' => 400 ) );
 		}
 
 		if ( empty( $name ) ) {
@@ -2160,10 +2234,7 @@ class AgentAbilities {
 			$owner_id = PermissionHelper::acting_user_id();
 
 			if ( $owner_id <= 0 ) {
-				return array(
-					'success' => false,
-					'error'   => 'Could not determine acting user for self-service agent creation.',
-				);
+				return new \WP_Error( 'agent_owner_unresolved', 'Could not determine acting user for self-service agent creation.', array( 'status' => 403 ) );
 			}
 
 			// Enforce per-user agent limit for non-admins.
@@ -2181,13 +2252,18 @@ class AgentAbilities {
 			$max_agents = (int) apply_filters( 'datamachine_max_agents_per_user', 1, $owner_id );
 
 			if ( $existing && $max_agents <= 1 ) {
-				return array(
-					'success' => false,
-					'error'   => sprintf(
+				return new \WP_Error(
+					'agent_limit_reached',
+					sprintf(
 						'You already have an agent ("%s"). Non-admin users are limited to %d agent.',
 						$existing['agent_name'],
 						$max_agents
 					),
+					array(
+						'status'   => 409,
+						'owner_id' => $owner_id,
+						'limit'    => $max_agents,
+					)
 				);
 			}
 
@@ -2196,30 +2272,36 @@ class AgentAbilities {
 				$owned = $agents_repo->get_all_by_owner_id( $owner_id );
 
 				if ( count( $owned ) >= $max_agents ) {
-					return array(
-						'success' => false,
-						'error'   => sprintf(
+					return new \WP_Error(
+						'agent_limit_reached',
+						sprintf(
 							'You already have %d agent(s). Non-admin users are limited to %d.',
 							count( $owned ),
 							$max_agents
 						),
+						array(
+							'status'   => 409,
+							'owner_id' => $owner_id,
+							'limit'    => $max_agents,
+						)
 					);
 				}
 			}
 		}
 
 		if ( $owner_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'Owner user ID is required (--owner=<user_id>).',
-			);
+			return new \WP_Error( 'invalid_agent_owner', 'Owner user ID is required (--owner=<user_id>).', array( 'status' => 400 ) );
 		}
 
 		$user = get_user_by( 'id', $owner_id );
 		if ( ! $user ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Owner user ID %d not found.', $owner_id ),
+			return new \WP_Error(
+				'agent_owner_not_found',
+				sprintf( 'Owner user ID %d not found.', $owner_id ),
+				array(
+					'status'   => 404,
+					'owner_id' => $owner_id,
+				)
 			);
 		}
 
@@ -2228,18 +2310,28 @@ class AgentAbilities {
 		// Check for conflict.
 		$existing = $agents_repo->get_by_slug( $slug );
 		if ( $existing ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Agent with slug "%s" already exists (ID: %d).', $slug, $existing['agent_id'] ),
+			return new \WP_Error(
+				'agent_slug_conflict',
+				sprintf( 'Agent with slug "%s" already exists (ID: %d).', $slug, $existing['agent_id'] ),
+				array(
+					'status'     => 409,
+					'agent_slug' => $slug,
+					'agent_id'   => (int) $existing['agent_id'],
+				)
 			);
 		}
 
 		$agent_id = $agents_repo->create_if_missing( $slug, $name, $owner_id, $config, $site_scope );
 
 		if ( ! $agent_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to create agent in database.',
+			return new \WP_Error(
+				'agent_creation_failed',
+				'Failed to create agent in database.',
+				array(
+					'status'     => 500,
+					'agent_slug' => $slug,
+					'owner_id'   => $owner_id,
+				)
 			);
 		}
 
@@ -2255,11 +2347,13 @@ class AgentAbilities {
 		// Scaffold agent-layer memory files (SOUL.md, MEMORY.md) with identity context.
 		$scaffold_ability = \DataMachine\Abilities\File\ScaffoldAbilities::get_ability();
 		if ( $scaffold_ability ) {
-			$scaffold_ability->execute( array(
-				'layer'      => 'agent',
-				'agent_slug' => $slug,
-				'agent_id'   => $agent_id,
-			) );
+			$scaffold_ability->execute(
+				array(
+					'layer'      => 'agent',
+					'agent_slug' => $slug,
+					'agent_id'   => $agent_id,
+				)
+			);
 		}
 
 		/**
@@ -2316,14 +2410,14 @@ class AgentAbilities {
 				$context['agent_id']   = $context['agent_id'] ?? $identity->agent_id;
 				$context['agent_slug'] = $context['agent_slug'] ?? $identity->agent_slug;
 			} catch ( \InvalidArgumentException $e ) {
-				return new \WP_Error( 'agent_not_found', $e->getMessage() );
+				return new \WP_Error( 'agent_not_found', $e->getMessage(), array( 'status' => 404 ) );
 			}
 		}
 
 		try {
 			return ( new AgentIdentityResolver() )->resolve_agent_identity( $context )->agent_id;
 		} catch ( \InvalidArgumentException $e ) {
-			return new \WP_Error( 'agent_not_found', $e->getMessage() );
+			return new \WP_Error( 'agent_not_found', $e->getMessage(), array( 'status' => 404 ) );
 		}
 	}
 
@@ -2333,22 +2427,23 @@ class AgentAbilities {
 	 * @param array $input { agent_slug or agent_id }.
 	 * @return array Agent data or error.
 	 */
-	public static function getAgent( array $input ): array {
+	public static function getAgent( array $input ): array|\WP_Error {
 		$agent_id = self::resolve_agent_input_id( $input );
 		if ( is_wp_error( $agent_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => $agent_id->get_error_message(),
-			);
+			return $agent_id;
 		}
 
 		$agents_repo = new Agents();
 		$agent       = $agents_repo->get_agent( $agent_id );
 
 		if ( ! $agent ) {
-			return array(
-				'success' => false,
-				'error'   => 'Agent not found.',
+			return new \WP_Error(
+				'agent_not_found',
+				'Agent not found.',
+				array(
+					'status'   => 404,
+					'agent_id' => $agent_id,
+				)
 			);
 		}
 
@@ -2390,13 +2485,10 @@ class AgentAbilities {
 	 * @param array $input Ability input.
 	 * @return array Result.
 	 */
-	public static function grantAgentAudienceAccess( array $input ): array {
+	public static function grantAgentAudienceAccess( array $input ): array|\WP_Error {
 		$agent_id = self::resolve_agent_input_id( $input );
 		if ( is_wp_error( $agent_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => $agent_id->get_error_message(),
-			);
+			return $agent_id;
 		}
 
 		$principal_type = sanitize_key( (string) ( $input['principal_type'] ?? 'audience' ) );
@@ -2404,18 +2496,29 @@ class AgentAbilities {
 		$role           = (string) ( $input['role'] ?? \WP_Agent_Access_Grant::ROLE_OPERATOR );
 
 		if ( '' === $principal_type || '' === $principal_id || 'user' === $principal_type ) {
-			return array(
-				'success' => false,
-				'error'   => 'A non-user principal_type and principal_id are required.',
+			return new \WP_Error(
+				'invalid_agent_principal',
+				'A non-user principal_type and principal_id are required.',
+				array(
+					'status'         => 400,
+					'principal_type' => $principal_type,
+					'principal_id'   => $principal_id,
+				)
 			);
 		}
 
 		try {
 			$grant = ( new AgentAccess() )->grant_principal_access( (string) $agent_id, $principal_type, $principal_id, $role );
 		} catch ( \Throwable $e ) {
-			return array(
-				'success' => false,
-				'error'   => $e->getMessage(),
+			return new \WP_Error(
+				'agent_access_grant_failed',
+				$e->getMessage(),
+				array(
+					'status'         => 500,
+					'agent_id'       => $agent_id,
+					'principal_type' => $principal_type,
+					'principal_id'   => $principal_id,
+				)
 			);
 		}
 
@@ -2431,22 +2534,23 @@ class AgentAbilities {
 	 * @param array $input { agent_id, agent_name?, agent_config? }.
 	 * @return array Result with updated agent data.
 	 */
-	public static function updateAgent( array $input ): array {
+	public static function updateAgent( array $input ): array|\WP_Error {
 		$agent_id = self::resolve_agent_input_id( $input );
 		if ( is_wp_error( $agent_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => $agent_id->get_error_message(),
-			);
+			return $agent_id;
 		}
 
 		$agents_repo = new Agents();
 		$agent       = $agents_repo->get_agent( $agent_id );
 
 		if ( ! $agent ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Agent ID %d not found.', $agent_id ),
+			return new \WP_Error(
+				'agent_not_found',
+				sprintf( 'Agent ID %d not found.', $agent_id ),
+				array(
+					'status'   => 404,
+					'agent_id' => $agent_id,
+				)
 			);
 		}
 
@@ -2456,9 +2560,13 @@ class AgentAbilities {
 		if ( isset( $input['agent_name'] ) ) {
 			$name = sanitize_text_field( $input['agent_name'] );
 			if ( empty( $name ) ) {
-				return array(
-					'success' => false,
-					'error'   => 'Agent name cannot be empty.',
+				return new \WP_Error(
+					'invalid_agent_name',
+					'Agent name cannot be empty.',
+					array(
+						'status'   => 400,
+						'agent_id' => $agent_id,
+					)
 				);
 			}
 			$update['agent_name'] = $name;
@@ -2469,9 +2577,13 @@ class AgentAbilities {
 		}
 
 		if ( empty( $update ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'No fields to update. Provide agent_name or agent_config.',
+			return new \WP_Error(
+				'invalid_agent_update',
+				'No fields to update. Provide agent_name or agent_config.',
+				array(
+					'status'   => 400,
+					'agent_id' => $agent_id,
+				)
 			);
 		}
 
@@ -2481,9 +2593,13 @@ class AgentAbilities {
 		$ok = $agents_repo->update_agent( $agent_id, $update );
 
 		if ( ! $ok ) {
-			return array(
-				'success' => false,
-				'error'   => 'Database update failed.',
+			return new \WP_Error(
+				'agent_update_failed',
+				'Database update failed.',
+				array(
+					'status'   => 500,
+					'agent_id' => $agent_id,
+				)
 			);
 		}
 
@@ -2602,21 +2718,22 @@ class AgentAbilities {
 	 * @param array $input Export input.
 	 * @return array Result.
 	 */
-	public static function exportAgent( array $input ): array {
+	public static function exportAgent( array $input ): array|\WP_Error {
 		$agent_id = self::resolve_agent_input_id( $input );
 		if ( is_wp_error( $agent_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => $agent_id->get_error_message(),
-			);
+			return $agent_id;
 		}
 
 		$agents_repo = new Agents();
 		$agent       = $agents_repo->get_agent( $agent_id );
 		if ( ! $agent ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Agent ID %d not found.', $agent_id ),
+			return new \WP_Error(
+				'agent_not_found',
+				sprintf( 'Agent ID %d not found.', $agent_id ),
+				array(
+					'status'   => 404,
+					'agent_id' => $agent_id,
+				)
 			);
 		}
 
@@ -2625,17 +2742,27 @@ class AgentAbilities {
 			$format = 'directory';
 		}
 		if ( ! in_array( $format, array( 'directory', 'zip' ), true ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'format must be directory or zip.',
+			return new \WP_Error(
+				'invalid_agent_export_format',
+				'format must be directory or zip.',
+				array(
+					'status'   => 400,
+					'agent_id' => $agent_id,
+					'format'   => $format,
+				)
 			);
 		}
 
 		$profile = (string) ( $input['profile'] ?? 'share' );
 		if ( ! in_array( $profile, array( 'share', 'backup', 'fork' ), true ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'profile must be share, backup, or fork.',
+			return new \WP_Error(
+				'invalid_agent_export_profile',
+				'profile must be share, backup, or fork.',
+				array(
+					'status'   => 400,
+					'agent_id' => $agent_id,
+					'profile'  => $profile,
+				)
 			);
 		}
 
@@ -2656,9 +2783,14 @@ class AgentAbilities {
 		$written_path = $destination;
 
 		if ( empty( $export['success'] ) || ! $directory instanceof AgentBundleDirectory ) {
-			return array(
-				'success' => false,
-				'error'   => (string) ( $export['error'] ?? 'Failed to build export bundle.' ),
+			return new \WP_Error(
+				'agent_export_failed',
+				(string) ( $export['error'] ?? 'Failed to build export bundle.' ),
+				array(
+					'status'     => 500,
+					'agent_id'   => $agent_id,
+					'agent_slug' => $agent_slug,
+				)
 			);
 		}
 
@@ -2669,9 +2801,14 @@ class AgentAbilities {
 				$written_path = self::writeBundleZip( $directory, $destination, $agent_slug, $reproducible );
 			}
 		} catch ( \Throwable $e ) {
-			return array(
-				'success' => false,
-				'error'   => $e->getMessage(),
+			return new \WP_Error(
+				'agent_export_failed',
+				$e->getMessage(),
+				array(
+					'status'     => 500,
+					'agent_id'   => $agent_id,
+					'agent_slug' => $agent_slug,
+				)
 			);
 		}
 
@@ -2790,15 +2927,35 @@ class AgentAbilities {
 			);
 		}
 
-		$deleted = array();
+		$deleted       = array();
+		$delete_errors = array();
 		if ( ! $dry_run ) {
 			foreach ( $candidates as $candidate ) {
 				$result = self::deleteAgent( array( 'agent_id' => $candidate['agent_id'] ) );
-				if ( ! empty( $result['success'] ) ) {
+				if ( is_wp_error( $result ) ) {
+					$delete_errors[] = array(
+						'agent_id' => $candidate['agent_id'],
+						'code'     => $result->get_error_code(),
+						'message'  => $result->get_error_message(),
+						'data'     => $result->get_error_data(),
+					);
+				} elseif ( ! empty( $result['success'] ) ) {
 					self::clear_active_agent_meta_for_owner( (int) $candidate['owner_id'] );
 					$deleted[] = $candidate;
 				}
 			}
+		}
+		if ( ! empty( $delete_errors ) ) {
+			return new \WP_Error(
+				'agent_prune_failed',
+				'One or more orphaned agents could not be pruned.',
+				array(
+					'status'     => 500,
+					'candidates' => $candidates,
+					'deleted'    => $deleted,
+					'errors'     => $delete_errors,
+				)
+			);
 		}
 
 		return array(
@@ -2965,22 +3122,23 @@ class AgentAbilities {
 	 * @param array $input { agent_slug or agent_id, delete_files? }.
 	 * @return array Result.
 	 */
-	public static function deleteAgent( array $input ): array {
+	public static function deleteAgent( array $input ): array|\WP_Error {
 		$agent_id = self::resolve_agent_input_id( $input );
 		if ( is_wp_error( $agent_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => $agent_id->get_error_message(),
-			);
+			return $agent_id;
 		}
 
 		$agents_repo = new Agents();
 		$agent       = $agents_repo->get_agent( $agent_id );
 
 		if ( ! $agent ) {
-			return array(
-				'success' => false,
-				'error'   => 'Agent not found.',
+			return new \WP_Error(
+				'agent_not_found',
+				'Agent not found.',
+				array(
+					'status'   => 404,
+					'agent_id' => $agent_id,
+				)
 			);
 		}
 
@@ -2999,9 +3157,14 @@ class AgentAbilities {
 		$deleted = $wpdb->delete( $agents_table, array( 'agent_id' => $agent_id ) );
 
 		if ( false === $deleted ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to delete agent from database.',
+			return new \WP_Error(
+				'agent_deletion_failed',
+				'Failed to delete agent from database.',
+				array(
+					'status'     => 500,
+					'agent_id'   => $agent_id,
+					'agent_slug' => $slug,
+				)
 			);
 		}
 
@@ -3065,7 +3228,8 @@ class AgentAbilities {
 		if ( ! $ability instanceof \WP_Ability ) {
 			return new \WP_Error(
 				'datamachine_import_agent_unavailable',
-				__( 'The Data Machine import-agent ability is not available inside the runtime site.', 'data-machine' )
+				__( 'The Data Machine import-agent ability is not available inside the runtime site.', 'data-machine' ),
+				array( 'status' => 500 )
 			);
 		}
 
@@ -3146,7 +3310,7 @@ class AgentAbilities {
 		$agent_id        = (int) ( $principal['agent_id'] ?? 1 );
 		$current_user_id = get_current_user_id();
 		if ( $agent_id <= 0 ) {
-			return new \WP_Error( 'datamachine_browser_bundle_import_principal_missing_agent', __( 'Agent bundle import principals require a positive agent_id.', 'data-machine' ) );
+			return new \WP_Error( 'datamachine_browser_bundle_import_principal_missing_agent', __( 'Agent bundle import principals require a positive agent_id.', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		$capabilities = array_values( array_filter( array_map( 'strval', is_array( $principal['capabilities'] ?? null ) ? $principal['capabilities'] : array() ) ) );

--- a/inc/Abilities/AgentCall/AgentCallAbility.php
+++ b/inc/Abilities/AgentCall/AgentCallAbility.php
@@ -110,16 +110,16 @@ class AgentCallAbility {
 	 * @param array $input Canonical target/input/delivery payload.
 	 * @return array Agent-call result envelope.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$target   = is_array( $input['target'] ?? null ) ? $input['target'] : array();
 		$delivery = is_array( $input['delivery'] ?? null ) ? $input['delivery'] : array();
 
 		if ( 'webhook' !== ( $target['type'] ?? '' ) ) {
-			return $this->failure( 'Unsupported agent_call target type: ' . (string) ( $target['type'] ?? '' ) );
+			return $this->failure( 'invalid_agent_call_target', 'Unsupported agent_call target type: ' . (string) ( $target['type'] ?? '' ), array(), 400 );
 		}
 
 		if ( 'fire_and_forget' !== ( $delivery['mode'] ?? '' ) ) {
-			return $this->failure( 'Unsupported agent_call delivery mode: ' . (string) ( $delivery['mode'] ?? '' ) );
+			return $this->failure( 'invalid_agent_call_delivery', 'Unsupported agent_call delivery mode: ' . (string) ( $delivery['mode'] ?? '' ), array(), 400 );
 		}
 
 		return $this->executeWebhookFireAndForget( $input );
@@ -131,14 +131,14 @@ class AgentCallAbility {
 	 * @param array $input Canonical call input.
 	 * @return array Agent-call result envelope.
 	 */
-	private function executeWebhookFireAndForget( array $input ): array {
+	private function executeWebhookFireAndForget( array $input ): array|\WP_Error {
 		$target   = $input['target'];
 		$call     = is_array( $input['input'] ?? null ) ? $input['input'] : array();
 		$delivery = $input['delivery'];
 
 		$webhook_urls = $this->normalizeWebhookUrls( $target['id'] ?? '' );
 		if ( empty( $webhook_urls ) ) {
-			return $this->failure( 'target.id is required for webhook agent_call targets' );
+			return $this->failure( 'invalid_agent_call_target', 'target.id is required for webhook agent_call targets', array(), 400 );
 		}
 
 		$context          = is_array( $call['context'] ?? null ) ? $call['context'] : array();
@@ -176,7 +176,7 @@ class AgentCallAbility {
 			);
 		}
 
-		return $this->failure( implode( '; ', $errors ), array( 'results' => $results ) );
+		return $this->failure( 'agent_call_delivery_failed', implode( '; ', $errors ), array( 'results' => $results ), 500 );
 	}
 
 	/**
@@ -366,14 +366,17 @@ class AgentCallAbility {
 		return $base . implode( '/', $segments );
 	}
 
-	private function failure( string $error, array $output = array() ): array {
-		return array(
-			'status'        => 'failed',
-			'output'        => $output,
-			'messages'      => array(),
-			'remote_run_id' => '',
-			'resume_token'  => '',
-			'error'         => $error,
+	private function failure( string $code, string $message, array $output = array(), int $status = 500 ): \WP_Error {
+		return new \WP_Error(
+			$code,
+			$message,
+			array(
+				'status'        => $status,
+				'output'        => $output,
+				'messages'      => array(),
+				'remote_run_id' => '',
+				'resume_token'  => '',
+			)
 		);
 	}
 }

--- a/inc/Abilities/AgentMemoryAbilities.php
+++ b/inc/Abilities/AgentMemoryAbilities.php
@@ -315,15 +315,15 @@ class AgentMemoryAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result.
 	 */
-	public static function getMemory( array $input ): array {
+	public static function getMemory( array $input ): array|\WP_Error {
 		$memory  = self::resolveMemory( $input );
 		$section = $input['section'] ?? null;
 
 		if ( null === $section || '' === $section ) {
-			return $memory->get_all();
+			return self::memoryResult( $memory->get_all(), 'agent_memory_read_failed' );
 		}
 
-		return $memory->get_section( $section );
+		return self::memoryResult( $memory->get_section( $section ), 'agent_memory_read_failed' );
 	}
 
 	/**
@@ -332,7 +332,7 @@ class AgentMemoryAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result.
 	 */
-	public static function updateMemory( array $input ): array {
+	public static function updateMemory( array $input ): array|\WP_Error {
 		$consent_decision = DataMachineAgentConsentPolicy::get()->can_store_memory(
 			array(
 				'mode'               => 'ability',
@@ -343,10 +343,15 @@ class AgentMemoryAbilities {
 			)
 		);
 		if ( ! $consent_decision->is_allowed() ) {
-			return array(
-				'success'          => false,
-				'message'          => 'Memory write consent denied.',
-				'consent_decision' => $consent_decision->to_array(),
+			return new \WP_Error(
+				'memory_consent_denied',
+				'Memory write consent denied.',
+				array(
+					'status'           => 403,
+					'consent_decision' => $consent_decision->to_array(),
+					'agent_id'         => (int) ( $input['agent_id'] ?? 0 ),
+					'user_id'          => (int) ( $input['user_id'] ?? 0 ),
+				)
 			);
 		}
 
@@ -362,27 +367,36 @@ class AgentMemoryAbilities {
 			if ( ! $editable ) {
 				$edit_cap = \DataMachine\Engine\AI\MemoryFileRegistry::get_edit_capability( $filename );
 				if ( is_string( $edit_cap ) ) {
-					return array(
-						'success' => false,
-						'message' => sprintf(
+					return new \WP_Error(
+						'memory_file_not_editable',
+						sprintf(
 							'File %s requires capability \'%s\' to edit. Pass --user=<admin-id> or run as an authenticated admin.',
 							$filename,
 							$edit_cap
 						),
+						array(
+							'status'              => 403,
+							'file'                => $filename,
+							'required_capability' => $edit_cap,
+						)
 					);
 				}
-				return array(
-					'success' => false,
-					'message' => sprintf( 'File %s is read-only and cannot be edited via section write.', $filename ),
+				return new \WP_Error(
+					'memory_file_read_only',
+					sprintf( 'File %s is read-only and cannot be edited via section write.', $filename ),
+					array(
+						'status' => 403,
+						'file'   => $filename,
+					)
 				);
 			}
 		}
 
 		if ( 'append' === $mode ) {
-			return $memory->append_to_section( $section, $content );
+			return self::memoryResult( $memory->append_to_section( $section, $content ), 'agent_memory_write_failed' );
 		}
 
-		return $memory->set_section( $section, $content );
+		return self::memoryResult( $memory->set_section( $section, $content ), 'agent_memory_write_failed' );
 	}
 
 	/**
@@ -391,7 +405,7 @@ class AgentMemoryAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result.
 	 */
-	public static function deleteMemorySection( array $input ): array {
+	public static function deleteMemorySection( array $input ): array|\WP_Error {
 		$consent_decision = DataMachineAgentConsentPolicy::get()->can_store_memory(
 			array(
 				'mode'               => 'ability',
@@ -402,23 +416,32 @@ class AgentMemoryAbilities {
 			)
 		);
 		if ( ! $consent_decision->is_allowed() ) {
-			return array(
-				'success'          => false,
-				'message'          => 'Memory delete consent denied.',
-				'consent_decision' => $consent_decision->to_array(),
+			return new \WP_Error(
+				'memory_consent_denied',
+				'Memory delete consent denied.',
+				array(
+					'status'           => 403,
+					'consent_decision' => $consent_decision->to_array(),
+					'agent_id'         => (int) ( $input['agent_id'] ?? 0 ),
+					'user_id'          => (int) ( $input['user_id'] ?? 0 ),
+				)
 			);
 		}
 
 		$filename = $input['file'] ?? 'MEMORY.md';
 		if ( 'MEMORY.md' !== $filename && ! \DataMachine\Engine\AI\MemoryFileRegistry::is_editable( $filename ) ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'File %s is read-only and cannot be edited via section delete.', $filename ),
+			return new \WP_Error(
+				'memory_file_read_only',
+				sprintf( 'File %s is read-only and cannot be edited via section delete.', $filename ),
+				array(
+					'status' => 403,
+					'file'   => $filename,
+				)
 			);
 		}
 
 		$memory = self::resolveMemory( $input );
-		return $memory->delete_section( (string) $input['section'] );
+		return self::memoryResult( $memory->delete_section( (string) $input['section'] ), 'agent_memory_delete_failed' );
 	}
 
 	/**
@@ -427,8 +450,23 @@ class AgentMemoryAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result.
 	 */
-	public static function writeSelfMemory( array $input ): array {
-		return SelfMemoryWritePolicy::execute( $input );
+	public static function writeSelfMemory( array $input ): array|\WP_Error {
+		$result = SelfMemoryWritePolicy::execute( $input );
+		if ( ! empty( $result['success'] ) ) {
+			return $result;
+		}
+
+		$code   = sanitize_key( (string) ( $result['error_code'] ?? 'self_memory_write_failed' ) );
+		$status = 'missing_required_input' === $code ? 400 : 403;
+		if ( ! str_ends_with( $code, '_denied' ) && ! in_array( $code, array( 'missing_agent_context', 'cross_agent_denied', 'missing_required_input' ), true ) ) {
+			$status = 500;
+		}
+
+		return new \WP_Error(
+			$code,
+			(string) ( $result['error'] ?? $result['message'] ?? 'Self-memory write failed.' ),
+			array_merge( $result, array( 'status' => $status ) )
+		);
 	}
 
 	/**
@@ -437,12 +475,12 @@ class AgentMemoryAbilities {
 	 * @param array $input Input parameters with 'query' and optional 'section'.
 	 * @return array Search results.
 	 */
-	public static function searchMemory( array $input ): array {
+	public static function searchMemory( array $input ): array|\WP_Error {
 		$memory  = self::resolveMemory( $input );
 		$query   = $input['query'];
 		$section = $input['section'] ?? null;
 
-		return $memory->search( $query, $section );
+		return self::memoryResult( $memory->search( $query, $section ), 'agent_memory_search_failed' );
 	}
 
 	/**
@@ -451,9 +489,21 @@ class AgentMemoryAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result.
 	 */
-	public static function listSections( array $input ): array {
+	public static function listSections( array $input ): array|\WP_Error {
 		$memory = self::resolveMemory( $input );
-		return $memory->get_sections();
+		return self::memoryResult( $memory->get_sections(), 'agent_memory_list_sections_failed' );
+	}
+
+	/** Convert the legacy memory service result at the registered callback boundary. */
+	private static function memoryResult( array $result, string $code ): array|\WP_Error {
+		if ( ! empty( $result['success'] ) ) {
+			return $result;
+		}
+
+		$message = (string) ( $result['message'] ?? 'Agent memory operation failed.' );
+		$status  = str_contains( strtolower( $message ), 'not found' ) || str_contains( strtolower( $message ), 'does not exist' ) ? 404 : 500;
+
+		return new \WP_Error( $code, $message, array_merge( $result, array( 'status' => $status ) ) );
 	}
 
 	/**

--- a/inc/Abilities/AgentTokenAbilities.php
+++ b/inc/Abilities/AgentTokenAbilities.php
@@ -164,17 +164,14 @@ class AgentTokenAbilities {
 	 * @param array $input Input with agent_id, optional label, capabilities, expires_in.
 	 * @return array Result with raw_token (only returned once).
 	 */
-	public function executeCreateToken( array $input ): array {
+	public function executeCreateToken( array $input ): array|\WP_Error {
 		$agent_id     = intval( $input['agent_id'] ?? 0 );
 		$label        = sanitize_text_field( $input['label'] ?? '' );
 		$capabilities = $input['capabilities'] ?? null;
 		$expires_in   = $input['expires_in'] ?? null;
 
 		if ( $agent_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'agent_id is required', 'data-machine' ),
-			);
+			return new \WP_Error( 'invalid_agent_id', __( 'agent_id is required', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		// Verify agent exists and is active.
@@ -182,17 +179,26 @@ class AgentTokenAbilities {
 		$agent       = $agents_repo->get_agent( $agent_id );
 
 		if ( ! $agent ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Agent not found', 'data-machine' ),
+			return new \WP_Error(
+				'agent_not_found',
+				__( 'Agent not found', 'data-machine' ),
+				array(
+					'status'   => 404,
+					'agent_id' => $agent_id,
+				)
 			);
 		}
 
 		// Check access — caller must have admin access to the agent.
 		if ( ! PermissionHelper::can_access_agent( $agent_id, 'admin' ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'You do not have admin access to this agent', 'data-machine' ),
+			return new \WP_Error(
+				'agent_access_denied',
+				__( 'You do not have admin access to this agent', 'data-machine' ),
+				array(
+					'status'     => 403,
+					'agent_id'   => $agent_id,
+					'agent_slug' => $agent['agent_slug'],
+				)
 			);
 		}
 
@@ -212,9 +218,13 @@ class AgentTokenAbilities {
 		);
 
 		if ( ! $result ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Failed to create token', 'data-machine' ),
+			return new \WP_Error(
+				'agent_token_creation_failed',
+				__( 'Failed to create token', 'data-machine' ),
+				array(
+					'status'   => 500,
+					'agent_id' => $agent_id,
+				)
 			);
 		}
 
@@ -247,21 +257,22 @@ class AgentTokenAbilities {
 	 * @param array $input Input with agent_id and token_id.
 	 * @return array Result.
 	 */
-	public function executeRevokeToken( array $input ): array {
+	public function executeRevokeToken( array $input ): array|\WP_Error {
 		$agent_id = intval( $input['agent_id'] ?? 0 );
 		$token_id = intval( $input['token_id'] ?? 0 );
 
 		if ( $agent_id <= 0 || $token_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'agent_id and token_id are required', 'data-machine' ),
-			);
+			return new \WP_Error( 'invalid_agent_token_input', __( 'agent_id and token_id are required', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		if ( ! PermissionHelper::can_access_agent( $agent_id, 'admin' ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'You do not have admin access to this agent', 'data-machine' ),
+			return new \WP_Error(
+				'agent_access_denied',
+				__( 'You do not have admin access to this agent', 'data-machine' ),
+				array(
+					'status'   => 403,
+					'agent_id' => $agent_id,
+				)
 			);
 		}
 
@@ -269,9 +280,14 @@ class AgentTokenAbilities {
 		$revoked     = $tokens_repo->revoke_token( $token_id, $agent_id );
 
 		if ( ! $revoked ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Token not found or does not belong to this agent', 'data-machine' ),
+			return new \WP_Error(
+				'agent_token_not_found',
+				__( 'Token not found or does not belong to this agent', 'data-machine' ),
+				array(
+					'status'   => 404,
+					'agent_id' => $agent_id,
+					'token_id' => $token_id,
+				)
 			);
 		}
 
@@ -297,20 +313,21 @@ class AgentTokenAbilities {
 	 * @param array $input Input with agent_id.
 	 * @return array Result with tokens array.
 	 */
-	public function executeListTokens( array $input ): array {
+	public function executeListTokens( array $input ): array|\WP_Error {
 		$agent_id = intval( $input['agent_id'] ?? 0 );
 
 		if ( $agent_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'agent_id is required', 'data-machine' ),
-			);
+			return new \WP_Error( 'invalid_agent_id', __( 'agent_id is required', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		if ( ! PermissionHelper::can_access_agent( $agent_id, 'operator' ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'You do not have access to this agent', 'data-machine' ),
+			return new \WP_Error(
+				'agent_access_denied',
+				__( 'You do not have access to this agent', 'data-machine' ),
+				array(
+					'status'   => 403,
+					'agent_id' => $agent_id,
+				)
 			);
 		}
 

--- a/inc/Abilities/AuthAbilities.php
+++ b/inc/Abilities/AuthAbilities.php
@@ -485,12 +485,15 @@ class AuthAbilities {
 		}
 
 		// Sort: authenticated first, then alphabetically by label.
-		usort( $data, function ( $a, $b ) {
-			if ( $a['is_authenticated'] !== $b['is_authenticated'] ) {
-				return $a['is_authenticated'] ? -1 : 1;
+		usort(
+			$data,
+			function ( $a, $b ) {
+				if ( $a['is_authenticated'] !== $b['is_authenticated'] ) {
+					return $a['is_authenticated'] ? -1 : 1;
+				}
+				return strcasecmp( $a['label'], $b['label'] );
 			}
-			return strcasecmp( $a['label'], $b['label'] );
-		} );
+		);
 
 		return array(
 			'success'   => true,
@@ -498,15 +501,17 @@ class AuthAbilities {
 		);
 	}
 
-	public function executeGetAuthStatus( array $input ): array {
+	public function executeGetAuthStatus( array $input ): array|\WP_Error {
 		$handler_slug = sanitize_text_field( $input['handler_slug'] ?? '' );
 
 		if ( empty( $handler_slug ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Handler slug is required', 'data-machine' ),
-			);
+			return new \WP_Error( 'invalid_handler_slug', __( 'Handler slug is required', 'data-machine' ), array( 'status' => 400 ) );
 		}
+
+		$bad_request_data = array(
+			'status'       => 400,
+			'handler_slug' => $handler_slug,
+		);
 
 		$handler_info = $this->handler_abilities->getHandler( $handler_slug );
 		if ( $handler_info && ( $handler_info['requires_auth'] ?? false ) === false ) {
@@ -522,23 +527,29 @@ class AuthAbilities {
 		$auth_instance = $this->getProviderForHandler( $handler_slug );
 
 		if ( ! $auth_instance ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Authentication provider not found', 'data-machine' ),
+			return new \WP_Error(
+				'auth_provider_not_found',
+				__( 'Authentication provider not found', 'data-machine' ),
+				array(
+					'status'       => 404,
+					'handler_slug' => $handler_slug,
+				)
 			);
 		}
 
 		if ( ! method_exists( $auth_instance, 'get_authorization_url' ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'This handler does not support OAuth authorization', 'data-machine' ),
+			return new \WP_Error(
+				'auth_authorization_unsupported',
+				__( 'This handler does not support OAuth authorization', 'data-machine' ),
+				$bad_request_data
 			);
 		}
 
 		if ( method_exists( $auth_instance, 'is_configured' ) && ! $auth_instance->is_configured() ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'OAuth credentials not configured. Please provide client ID and secret first.', 'data-machine' ),
+			return new \WP_Error(
+				'auth_provider_not_configured',
+				__( 'OAuth credentials not configured. Please provide client ID and secret first.', 'data-machine' ),
+				$bad_request_data
 			);
 		}
 
@@ -553,44 +564,56 @@ class AuthAbilities {
 				'instructions'  => __( 'Visit this URL to authorize your account. You will be redirected back to Data Machine upon completion.', 'data-machine' ),
 			);
 		} catch ( \Exception $e ) {
-			return array(
-				'success' => false,
-				'error'   => $e->getMessage(),
+			return new \WP_Error(
+				'auth_authorization_failed',
+				$e->getMessage(),
+				array(
+					'status'       => 500,
+					'handler_slug' => $handler_slug,
+				)
 			);
 		}
 	}
 
-	public function executeDisconnectAuth( array $input ): array {
+	public function executeDisconnectAuth( array $input ): array|\WP_Error {
 		$handler_slug = sanitize_text_field( $input['handler_slug'] ?? '' );
 
 		if ( empty( $handler_slug ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Handler slug is required', 'data-machine' ),
-			);
+			return new \WP_Error( 'invalid_handler_slug', __( 'Handler slug is required', 'data-machine' ), array( 'status' => 400 ) );
 		}
+
+		$bad_request_data = array(
+			'status'       => 400,
+			'handler_slug' => $handler_slug,
+		);
 
 		$handler_info = $this->handler_abilities->getHandler( $handler_slug );
 		if ( $handler_info && ( $handler_info['requires_auth'] ?? false ) === false ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Authentication is not required for this handler', 'data-machine' ),
+			return new \WP_Error(
+				'auth_not_required',
+				__( 'Authentication is not required for this handler', 'data-machine' ),
+				$bad_request_data
 			);
 		}
 
 		$auth_instance = $this->getProviderForHandler( $handler_slug );
 
 		if ( ! $auth_instance ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Authentication provider not found', 'data-machine' ),
+			return new \WP_Error(
+				'auth_provider_not_found',
+				__( 'Authentication provider not found', 'data-machine' ),
+				array(
+					'status'       => 404,
+					'handler_slug' => $handler_slug,
+				)
 			);
 		}
 
 		if ( ! method_exists( $auth_instance, 'clear_account' ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'This handler does not support account disconnection', 'data-machine' ),
+			return new \WP_Error(
+				'auth_disconnect_unsupported',
+				__( 'This handler does not support account disconnection', 'data-machine' ),
+				$bad_request_data
 			);
 		}
 
@@ -604,9 +627,13 @@ class AuthAbilities {
 			);
 		}
 
-		return array(
-			'success' => false,
-			'error'   => __( 'Failed to disconnect account', 'data-machine' ),
+		return new \WP_Error(
+			'auth_disconnect_failed',
+			__( 'Failed to disconnect account', 'data-machine' ),
+			array(
+				'status'       => 500,
+				'handler_slug' => $handler_slug,
+			)
 		);
 	}
 
@@ -625,36 +652,38 @@ class AuthAbilities {
 	 * @param array $input { handler_slug, user_id }.
 	 * @return array Standard ability response.
 	 */
-	public function executeRevokeAuthForUser( array $input ): array {
+	public function executeRevokeAuthForUser( array $input ): array|\WP_Error {
 		$handler_slug = sanitize_text_field( $input['handler_slug'] ?? '' );
 		$user_id      = absint( $input['user_id'] ?? 0 );
 
 		if ( '' === $handler_slug ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Handler slug is required', 'data-machine' ),
-			);
+			return new \WP_Error( 'invalid_handler_slug', __( 'Handler slug is required', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		if ( $user_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'A positive user_id is required', 'data-machine' ),
-			);
+			return new \WP_Error( 'invalid_user_id', __( 'A positive user_id is required', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		$auth_instance = $this->getProviderForHandler( $handler_slug );
 		if ( ! $auth_instance ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Authentication provider not found', 'data-machine' ),
+			return new \WP_Error(
+				'auth_provider_not_found',
+				__( 'Authentication provider not found', 'data-machine' ),
+				array(
+					'status'       => 404,
+					'handler_slug' => $handler_slug,
+				)
 			);
 		}
 
 		if ( ! method_exists( $auth_instance, 'delete_account_for_user' ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'This handler does not support per-user revocation', 'data-machine' ),
+			return new \WP_Error(
+				'auth_revoke_unsupported',
+				__( 'This handler does not support per-user revocation', 'data-machine' ),
+				array(
+					'status'       => 400,
+					'handler_slug' => $handler_slug,
+				)
 			);
 		}
 
@@ -712,10 +741,15 @@ class AuthAbilities {
 		);
 
 		if ( ! $deleted ) {
-			return array(
-				'success'          => false,
-				'error'            => __( 'Failed to delete per-user credentials', 'data-machine' ),
-				'upstream_revoked' => (bool) $upstream_revoked,
+			return new \WP_Error(
+				'auth_revoke_failed',
+				__( 'Failed to delete per-user credentials', 'data-machine' ),
+				array(
+					'status'           => 500,
+					'handler_slug'     => $handler_slug,
+					'user_id'          => $user_id,
+					'upstream_revoked' => (bool) $upstream_revoked,
+				)
 			);
 		}
 
@@ -731,32 +765,37 @@ class AuthAbilities {
 		);
 	}
 
-	public function executeSaveAuthConfig( array $input ): array {
+	public function executeSaveAuthConfig( array $input ): array|\WP_Error {
 		$handler_slug      = sanitize_text_field( $input['handler_slug'] ?? '' );
 		$config_input      = $input['config'] ?? array();
 		$principal_context = $this->getPrincipalContext( $input );
 
 		if ( empty( $handler_slug ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Handler slug is required', 'data-machine' ),
-			);
+			return new \WP_Error( 'invalid_handler_slug', __( 'Handler slug is required', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		$handler_info = $this->handler_abilities->getHandler( $handler_slug );
 		if ( $handler_info && ( $handler_info['requires_auth'] ?? false ) === false ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Authentication is not required for this handler', 'data-machine' ),
+			return new \WP_Error(
+				'auth_not_required',
+				__( 'Authentication is not required for this handler', 'data-machine' ),
+				array(
+					'status'       => 400,
+					'handler_slug' => $handler_slug,
+				)
 			);
 		}
 
 		$auth_instance = $this->getProviderForHandler( $handler_slug );
 
 		if ( ! $auth_instance || ! method_exists( $auth_instance, 'get_config_fields' ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Auth provider not found or invalid', 'data-machine' ),
+			return new \WP_Error(
+				'auth_provider_not_found',
+				__( 'Auth provider not found or invalid', 'data-machine' ),
+				array(
+					'status'       => 404,
+					'handler_slug' => $handler_slug,
+				)
 			);
 		}
 
@@ -771,9 +810,13 @@ class AuthAbilities {
 		} elseif ( method_exists( $auth_instance, 'get_account' ) ) {
 			$existing_config = $auth_instance->get_account();
 		} else {
-			return array(
-				'success' => false,
-				'error'   => __( 'Could not retrieve existing configuration', 'data-machine' ),
+			return new \WP_Error(
+				'auth_config_unavailable',
+				__( 'Could not retrieve existing configuration', 'data-machine' ),
+				array(
+					'status'       => 500,
+					'handler_slug' => $handler_slug,
+				)
 			);
 		}
 
@@ -781,10 +824,15 @@ class AuthAbilities {
 			$value = self::sanitizeConfigValue( $config_input[ $field_name ] ?? '', $field_config );
 
 			if ( ( $field_config['required'] ?? false ) && empty( $value ) && empty( $existing_config[ $field_name ] ?? '' ) ) {
-				return array(
-					'success' => false,
-					/* translators: %s: Field label (e.g., API Key, Client ID) */
-					'error'   => sprintf( __( '%s is required', 'data-machine' ), $field_config['label'] ),
+				return new \WP_Error(
+					'invalid_auth_config',
+					/* translators: %s: authentication configuration field label. */
+					sprintf( __( '%s is required', 'data-machine' ), $field_config['label'] ),
+					array(
+						'status'       => 400,
+						'handler_slug' => $handler_slug,
+						'field'        => $field_name,
+					)
 				);
 			}
 
@@ -818,9 +866,13 @@ class AuthAbilities {
 			if ( method_exists( $auth_instance, 'save_config' ) ) {
 				$saved = $auth_instance->save_config( $config_data );
 			} else {
-				return array(
-					'success' => false,
-					'error'   => __( 'Handler does not support saving config', 'data-machine' ),
+				return new \WP_Error(
+					'auth_config_unsupported',
+					__( 'Handler does not support saving config', 'data-machine' ),
+					array(
+						'status'       => 400,
+						'handler_slug' => $handler_slug,
+					)
 				);
 			}
 		} elseif ( method_exists( $auth_instance, 'save_config' ) ) {
@@ -828,9 +880,13 @@ class AuthAbilities {
 		} else {
 			$saved = $this->saveAuthAccountForContext( $auth_instance, $config_data, $principal_context );
 			if ( null === $saved ) {
-				return array(
-					'success' => false,
-					'error'   => __( 'Handler does not support saving account', 'data-machine' ),
+				return new \WP_Error(
+					'auth_account_save_unsupported',
+					__( 'Handler does not support saving account', 'data-machine' ),
+					array(
+						'status'       => 400,
+						'handler_slug' => $handler_slug,
+					)
 				);
 			}
 		}
@@ -842,9 +898,13 @@ class AuthAbilities {
 			);
 		}
 
-		return array(
-			'success' => false,
-			'error'   => __( 'Failed to save configuration', 'data-machine' ),
+		return new \WP_Error(
+			'auth_config_save_failed',
+			__( 'Failed to save configuration', 'data-machine' ),
+			array(
+				'status'       => 500,
+				'handler_slug' => $handler_slug,
+			)
 		);
 	}
 
@@ -911,45 +971,44 @@ class AuthAbilities {
 	 * @param array $input Input with handler_slug and account_data.
 	 * @return array Result.
 	 */
-	public function executeSetAuthToken( array $input ): array {
+	public function executeSetAuthToken( array $input ): array|\WP_Error {
 		$handler_slug      = sanitize_text_field( $input['handler_slug'] ?? '' );
 		$account_data      = $input['account_data'] ?? array();
 		$principal_context = $this->getPrincipalContext( $input );
 
 		if ( empty( $handler_slug ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Handler slug is required', 'data-machine' ),
-			);
+			return new \WP_Error( 'invalid_handler_slug', __( 'Handler slug is required', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		if ( empty( $account_data ) || ! is_array( $account_data ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Account data is required and must be an object', 'data-machine' ),
-			);
+			return new \WP_Error( 'invalid_account_data', __( 'Account data is required and must be an object', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		if ( empty( $account_data['access_token'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'access_token is required in account_data', 'data-machine' ),
-			);
+			return new \WP_Error( 'invalid_access_token', __( 'access_token is required in account_data', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		$auth_instance = $this->getProviderForHandler( $handler_slug );
 
 		if ( ! $auth_instance ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Authentication provider not found', 'data-machine' ),
+			return new \WP_Error(
+				'auth_provider_not_found',
+				__( 'Authentication provider not found', 'data-machine' ),
+				array(
+					'status'       => 404,
+					'handler_slug' => $handler_slug,
+				)
 			);
 		}
 
 		if ( ! $this->supportsAuthAccountSaveForContext( $auth_instance, $principal_context ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'This handler does not support saving account data', 'data-machine' ),
+			return new \WP_Error(
+				'auth_account_save_unsupported',
+				__( 'This handler does not support saving account data', 'data-machine' ),
+				array(
+					'status'       => 400,
+					'handler_slug' => $handler_slug,
+				)
 			);
 		}
 
@@ -990,9 +1049,13 @@ class AuthAbilities {
 			);
 		}
 
-		return array(
-			'success' => false,
-			'error'   => __( 'Failed to save account data', 'data-machine' ),
+		return new \WP_Error(
+			'auth_account_save_failed',
+			__( 'Failed to save account data', 'data-machine' ),
+			array(
+				'status'       => 500,
+				'handler_slug' => $handler_slug,
+			)
 		);
 	}
 
@@ -1007,40 +1070,49 @@ class AuthAbilities {
 	 * @param array $input Input with handler_slug.
 	 * @return array Result with new expiry if available.
 	 */
-	public function executeRefreshAuth( array $input ): array {
+	public function executeRefreshAuth( array $input ): array|\WP_Error {
 		$handler_slug = sanitize_text_field( $input['handler_slug'] ?? '' );
 
 		if ( empty( $handler_slug ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Handler slug is required', 'data-machine' ),
-			);
+			return new \WP_Error( 'invalid_handler_slug', __( 'Handler slug is required', 'data-machine' ), array( 'status' => 400 ) );
 		}
 
 		$auth_instance = $this->getProviderForHandler( $handler_slug );
 
 		if ( ! $auth_instance ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'Authentication provider not found', 'data-machine' ),
+			return new \WP_Error(
+				'auth_provider_not_found',
+				__( 'Authentication provider not found', 'data-machine' ),
+				array(
+					'status'       => 404,
+					'handler_slug' => $handler_slug,
+				)
 			);
 		}
 
 		if ( ! method_exists( $auth_instance, 'is_authenticated' ) || ! $auth_instance->is_authenticated() ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf(
+			return new \WP_Error(
+				'auth_not_authenticated',
+				sprintf(
 					/* translators: %s: Service name (e.g., Twitter, Facebook) */
 					__( '%s is not currently authenticated. Connect first before refreshing.', 'data-machine' ),
 					ucfirst( $handler_slug )
 				),
+				array(
+					'status'       => 409,
+					'handler_slug' => $handler_slug,
+				)
 			);
 		}
 
 		if ( ! method_exists( $auth_instance, 'get_valid_access_token' ) ) {
-			return array(
-				'success' => false,
-				'error'   => __( 'This handler does not support token refresh', 'data-machine' ),
+			return new \WP_Error(
+				'auth_refresh_unsupported',
+				__( 'This handler does not support token refresh', 'data-machine' ),
+				array(
+					'status'       => 400,
+					'handler_slug' => $handler_slug,
+				)
 			);
 		}
 
@@ -1048,13 +1120,17 @@ class AuthAbilities {
 		$new_token = $auth_instance->get_valid_access_token();
 
 		if ( null === $new_token ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf(
+			return new \WP_Error(
+				'auth_refresh_failed',
+				sprintf(
 					/* translators: %s: Service name (e.g., Twitter, Facebook) */
 					__( 'Token refresh failed for %s. Re-authorization may be required.', 'data-machine' ),
 					ucfirst( $handler_slug )
 				),
+				array(
+					'status'       => 500,
+					'handler_slug' => $handler_slug,
+				)
 			);
 		}
 

--- a/inc/Abilities/DailyMemoryAbilities.php
+++ b/inc/Abilities/DailyMemoryAbilities.php
@@ -300,14 +300,18 @@ class DailyMemoryAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result.
 	 */
-	public static function readDaily( array $input ): array {
+	public static function readDaily( array $input ): array|\WP_Error {
 		$date = $input['date'] ?? gmdate( 'Y-m-d' );
 
 		$parts = DailyMemory::parse_date( $date );
 		if ( ! $parts ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Invalid date format: %s. Use YYYY-MM-DD.', $date ),
+			return new \WP_Error(
+				'invalid_memory_date',
+				sprintf( 'Invalid date format: %s. Use YYYY-MM-DD.', $date ),
+				array(
+					'status' => 400,
+					'date'   => $date,
+				)
 			);
 		}
 
@@ -315,7 +319,7 @@ class DailyMemoryAbilities {
 		$agent_id = (int) ( $input['agent_id'] ?? 0 );
 		$storage  = self::resolveStorage( $user_id, $agent_id );
 
-		return $storage->read( $parts['year'], $parts['month'], $parts['day'] );
+		return self::dailyResult( $storage->read( $parts['year'], $parts['month'], $parts['day'] ), 'daily_memory_read_failed', $date );
 	}
 
 	/**
@@ -324,12 +328,9 @@ class DailyMemoryAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result.
 	 */
-	public static function writeDaily( array $input ): array {
+	public static function writeDaily( array $input ): array|\WP_Error {
 		if ( ! PluginSettings::get( 'daily_memory_enabled', false ) ) {
-			return array(
-				'success' => false,
-				'message' => 'Daily memory is disabled. Enable it in Agent > Configuration.',
-			);
+			return new \WP_Error( 'daily_memory_disabled', 'Daily memory is disabled. Enable it in Agent > Configuration.', array( 'status' => 403 ) );
 		}
 
 		$date    = $input['date'] ?? gmdate( 'Y-m-d' );
@@ -338,9 +339,13 @@ class DailyMemoryAbilities {
 
 		$parts = DailyMemory::parse_date( $date );
 		if ( ! $parts ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Invalid date format: %s. Use YYYY-MM-DD.', $date ),
+			return new \WP_Error(
+				'invalid_memory_date',
+				sprintf( 'Invalid date format: %s. Use YYYY-MM-DD.', $date ),
+				array(
+					'status' => 400,
+					'date'   => $date,
+				)
 			);
 		}
 
@@ -349,10 +354,10 @@ class DailyMemoryAbilities {
 		$storage  = self::resolveStorage( $user_id, $agent_id );
 
 		if ( 'write' === $mode ) {
-			return $storage->write( $parts['year'], $parts['month'], $parts['day'], $content );
+			return self::dailyResult( $storage->write( $parts['year'], $parts['month'], $parts['day'], $content ), 'daily_memory_write_failed', $date );
 		}
 
-		return $storage->append( $parts['year'], $parts['month'], $parts['day'], $content );
+		return self::dailyResult( $storage->append( $parts['year'], $parts['month'], $parts['day'], $content ), 'daily_memory_write_failed', $date );
 	}
 
 	/**
@@ -361,12 +366,12 @@ class DailyMemoryAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result.
 	 */
-	public static function listDaily( array $input ): array {
+	public static function listDaily( array $input ): array|\WP_Error {
 		$user_id  = (int) ( $input['user_id'] ?? 0 );
 		$agent_id = (int) ( $input['agent_id'] ?? 0 );
 		$storage  = self::resolveStorage( $user_id, $agent_id );
 
-		return $storage->list_all();
+		return self::dailyResult( $storage->list_all(), 'daily_memory_list_failed' );
 	}
 
 	/**
@@ -375,7 +380,7 @@ class DailyMemoryAbilities {
 	 * @param array $input Input parameters with 'query', optional 'from' and 'to'.
 	 * @return array Search results.
 	 */
-	public static function searchDaily( array $input ): array {
+	public static function searchDaily( array $input ): array|\WP_Error {
 		$user_id  = (int) ( $input['user_id'] ?? 0 );
 		$agent_id = (int) ( $input['agent_id'] ?? 0 );
 		$storage  = self::resolveStorage( $user_id, $agent_id );
@@ -384,7 +389,7 @@ class DailyMemoryAbilities {
 		$from  = $input['from'] ?? null;
 		$to    = $input['to'] ?? null;
 
-		return $storage->search( $query, $from, $to );
+		return self::dailyResult( $storage->search( $query, $from, $to ), 'daily_memory_search_failed' );
 	}
 
 	/**
@@ -395,21 +400,22 @@ class DailyMemoryAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result.
 	 */
-	public static function deleteDaily( array $input ): array {
+	public static function deleteDaily( array $input ): array|\WP_Error {
 		if ( ! PluginSettings::get( 'daily_memory_enabled', false ) ) {
-			return array(
-				'success' => false,
-				'message' => 'Daily memory is disabled. Enable it in Agent > Configuration.',
-			);
+			return new \WP_Error( 'daily_memory_disabled', 'Daily memory is disabled. Enable it in Agent > Configuration.', array( 'status' => 403 ) );
 		}
 
 		$date = $input['date'] ?? gmdate( 'Y-m-d' );
 
 		$parts = DailyMemory::parse_date( $date );
 		if ( ! $parts ) {
-			return array(
-				'success' => false,
-				'message' => sprintf( 'Invalid date format: %s. Use YYYY-MM-DD.', $date ),
+			return new \WP_Error(
+				'invalid_memory_date',
+				sprintf( 'Invalid date format: %s. Use YYYY-MM-DD.', $date ),
+				array(
+					'status' => 400,
+					'date'   => $date,
+				)
 			);
 		}
 
@@ -417,6 +423,22 @@ class DailyMemoryAbilities {
 		$agent_id = (int) ( $input['agent_id'] ?? 0 );
 		$storage  = self::resolveStorage( $user_id, $agent_id );
 
-		return $storage->delete( $parts['year'], $parts['month'], $parts['day'] );
+		return self::dailyResult( $storage->delete( $parts['year'], $parts['month'], $parts['day'] ), 'daily_memory_delete_failed', $date );
+	}
+
+	/** Convert the legacy daily-memory service result at the registered callback boundary. */
+	private static function dailyResult( array $result, string $code, string $date = '' ): array|\WP_Error {
+		if ( ! empty( $result['success'] ) ) {
+			return $result;
+		}
+
+		$message = (string) ( $result['message'] ?? 'Daily memory operation failed.' );
+		$status  = str_contains( strtolower( $message ), 'no daily memory' ) ? 404 : 500;
+
+		$data = array_merge( $result, array( 'status' => $status ) );
+		if ( '' !== $date ) {
+			$data['date'] = $date;
+		}
+		return new \WP_Error( $code, $message, $data );
 	}
 }

--- a/inc/Api/AgentFiles.php
+++ b/inc/Api/AgentFiles.php
@@ -418,6 +418,10 @@ class AgentFiles {
 
 		$result = DailyMemoryAbilities::readDaily( $input );
 
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'daily_file_not_found' );
+		}
+
 		if ( ! $result['success'] ) {
 			return new WP_Error( 'daily_file_not_found', $result['message'], array( 'status' => 404 ) );
 		}
@@ -454,6 +458,10 @@ class AgentFiles {
 
 		$result = DailyMemoryAbilities::writeDaily( $input );
 
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'daily_file_write_error' );
+		}
+
 		if ( ! $result['success'] ) {
 			$status = false !== strpos( $result['message'] ?? '', 'disabled' ) ? 403 : 500;
 			return new WP_Error( 'daily_file_write_error', $result['message'], array( 'status' => $status ) );
@@ -480,6 +488,10 @@ class AgentFiles {
 
 		$result = DailyMemoryAbilities::deleteDaily( $input );
 
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'daily_file_delete_error' );
+		}
+
 		if ( ! $result['success'] ) {
 			$status = false !== strpos( $result['message'] ?? '', 'disabled' ) ? 403 : 404;
 			return new WP_Error( 'daily_file_delete_error', $result['message'], array( 'status' => $status ) );
@@ -490,8 +502,6 @@ class AgentFiles {
 			'message' => $result['message'],
 		) );
 	}
-
-
 
 	/**
 	 * Get file context array from flow ID.

--- a/inc/Api/Agents.php
+++ b/inc/Api/Agents.php
@@ -452,6 +452,10 @@ class Agents {
 
 		$result = AgentAbilities::listAgents( $input );
 
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'list_agents_failed' );
+		}
+
 		if ( empty( $result['success'] ) ) {
 			return new WP_Error(
 				'list_agents_failed',
@@ -510,6 +514,10 @@ class Agents {
 			)
 		);
 
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'agent_create_failed' );
+		}
+
 		if ( empty( $result['success'] ) ) {
 			return new WP_Error(
 				'agent_create_failed',
@@ -541,6 +549,10 @@ class Agents {
 		$result = AgentAbilities::getAgent(
 			array( 'agent_id' => $agent_id )
 		);
+
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'agent_not_found' );
+		}
 
 		if ( empty( $result['success'] ) ) {
 			return new WP_Error(
@@ -584,6 +596,10 @@ class Agents {
 
 		$result = AgentAbilities::updateAgent( $input );
 
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'agent_update_failed' );
+		}
+
 		if ( empty( $result['success'] ) ) {
 			$status = 400;
 			if ( isset( $result['error'] ) && str_contains( $result['error'], 'not found' ) ) {
@@ -623,6 +639,10 @@ class Agents {
 				'delete_files' => (bool) $request->get_param( 'delete_files' ),
 			)
 		);
+
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'agent_delete_failed' );
+		}
 
 		if ( empty( $result['success'] ) ) {
 			return new WP_Error(
@@ -837,6 +857,10 @@ class Agents {
 			array( 'agent_id' => $agent_id )
 		);
 
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'list_tokens_failed' );
+		}
+
 		if ( empty( $result['success'] ) ) {
 			return new WP_Error( 'list_tokens_failed', $result['error'] ?? 'Failed', array( 'status' => 400 ) );
 		}
@@ -866,6 +890,10 @@ class Agents {
 			)
 		);
 
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'create_token_failed' );
+		}
+
 		if ( empty( $result['success'] ) ) {
 			$status = str_contains( $result['error'] ?? '', 'not found' ) ? 404 : 400;
 			return new WP_Error( 'create_token_failed', $result['error'] ?? 'Failed', array( 'status' => $status ) );
@@ -893,6 +921,10 @@ class Agents {
 				'token_id' => (int) $request->get_param( 'token_id' ),
 			)
 		);
+
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'revoke_token_failed' );
+		}
 
 		if ( empty( $result['success'] ) ) {
 			$status = str_contains( $result['error'] ?? '', 'not found' ) ? 404 : 400;

--- a/inc/Api/Auth.php
+++ b/inc/Api/Auth.php
@@ -167,7 +167,7 @@ class Auth {
 			array( 'handler_slug' => $handler_slug )
 		);
 
-		if ( ! $result['success'] ) {
+		if ( is_wp_error( $result ) || empty( $result['success'] ) ) {
 			return self::ability_to_response( $result, 'get_auth_status_error' );
 		}
 
@@ -268,11 +268,17 @@ class Auth {
 	 * Success results are returned as 200 with the ability's data.
 	 * Failure results are returned as WP_Error with an inferred HTTP status.
 	 *
-	 * @param array  $result     Ability result array.
+	 * @param array|\WP_Error $result     Ability result.
 	 * @param string $error_code WP_Error code for failures.
 	 * @return \WP_REST_Response|\WP_Error
 	 */
-	private static function ability_to_response( array $result, string $error_code ) {
+	private static function ability_to_response( array|\WP_Error $result, string $error_code ) {
+		if ( is_wp_error( $result ) ) {
+			$data                       = is_array( $result->get_error_data() ) ? $result->get_error_data() : array();
+			$data['ability_error_code'] = $result->get_error_code();
+			return new \WP_Error( $error_code, $result->get_error_message(), $data );
+		}
+
 		if ( ! empty( $result['success'] ) ) {
 			return rest_ensure_response( $result );
 		}

--- a/inc/Api/Chat/Tools/AuthenticateHandler.php
+++ b/inc/Api/Chat/Tools/AuthenticateHandler.php
@@ -126,6 +126,9 @@ ACTIONS:
 		}
 
 		$handlers_result = $handlers_ability->execute( array() );
+		if ( is_wp_error( $handlers_result ) ) {
+			return $this->error( $handlers_result->get_error_message() );
+		}
 		if ( ! ( $handlers_result['success'] ?? false ) ) {
 			return $this->error( $handlers_result['error'] ?? 'Failed to get handlers' );
 		}
@@ -145,7 +148,7 @@ ACTIONS:
 
 			if ( $auth_status_ability ) {
 				$status_result = $auth_status_ability->execute( array( 'handler_slug' => $slug ) );
-				if ( $status_result['success'] ?? false ) {
+				if ( ! is_wp_error( $status_result ) && ( $status_result['success'] ?? false ) ) {
 					$is_authenticated = ! empty( $status_result['oauth_url'] ) || ( $status_result['authenticated'] ?? false );
 					$auth_type        = ! empty( $status_result['oauth_url'] ) ? 'oauth' : 'simple';
 				}

--- a/inc/Api/RestResultSpec.php
+++ b/inc/Api/RestResultSpec.php
@@ -61,6 +61,13 @@ class RestResultSpec {
 		return new self( $data_callback, $extra_callback, $default_code, $default_message, $default_status, $failure_status_callback );
 	}
 
+	/** Preserve a legacy REST code while retaining native ability diagnostics. */
+	public static function legacy_error( \WP_Error $error, string $rest_code ): \WP_Error {
+		$data                       = is_array( $error->get_error_data() ) ? $error->get_error_data() : array();
+		$data['ability_error_code'] = $error->get_error_code();
+		return new \WP_Error( $rest_code, $error->get_error_message(), $data );
+	}
+
 	/**
 	 * Convert an ability result to a REST response or error.
 	 *

--- a/inc/Cli/Commands/AICommand.php
+++ b/inc/Cli/Commands/AICommand.php
@@ -62,6 +62,11 @@ class AICommand extends BaseCommand {
 			)
 		);
 
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
 		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( $result['error'] ?? 'Request inspection failed.' );
 			return;

--- a/inc/Cli/Commands/AgentsCommand.php
+++ b/inc/Cli/Commands/AgentsCommand.php
@@ -77,6 +77,23 @@ class AgentsCommand extends AgentBundleCommand {
 
 		if ( 'get' === $action ) {
 			$result = AgentAbilities::getActiveAgent( $input );
+		} else {
+			$agent = isset( $args[1] ) ? (string) $args[1] : '';
+			if ( '' === $agent ) {
+				WP_CLI::error( 'Agent is required. Usage: wp datamachine agent active set <agent>' );
+				return;
+			}
+
+			$input['agent'] = $agent;
+			$result         = AgentAbilities::setActiveAgent( $input );
+		}
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		if ( 'get' === $action ) {
 			if ( empty( $result['success'] ) ) {
 				WP_CLI::error( $result['error'] ?? 'Failed to get active agent.' );
 				return;
@@ -97,14 +114,6 @@ class AgentsCommand extends AgentBundleCommand {
 			return;
 		}
 
-		$agent = isset( $args[1] ) ? (string) $args[1] : '';
-		if ( '' === $agent ) {
-			WP_CLI::error( 'Agent is required. Usage: wp datamachine agent active set <agent>' );
-			return;
-		}
-
-		$input['agent'] = $agent;
-		$result         = AgentAbilities::setActiveAgent( $input );
 		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to set active agent.' );
 			return;
@@ -176,6 +185,11 @@ class AgentsCommand extends AgentBundleCommand {
 		}
 
 		$result = AgentAbilities::listAgents( $input );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
 
 		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to list agents.' );
@@ -272,6 +286,11 @@ class AgentsCommand extends AgentBundleCommand {
 			)
 		);
 
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
 		if ( $result['success'] ) {
 			WP_CLI::success( $result['message'] );
 		} else {
@@ -355,6 +374,11 @@ class AgentsCommand extends AgentBundleCommand {
 			)
 		);
 
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to create agent.' );
 			return;
@@ -406,6 +430,11 @@ class AgentsCommand extends AgentBundleCommand {
 			: array( 'agent_slug' => $identifier );
 
 		$result = AgentAbilities::getAgent( $input );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Agent not found.' );
@@ -487,6 +516,10 @@ class AgentsCommand extends AgentBundleCommand {
 
 		// Get agent info for confirmation.
 		$info = AgentAbilities::getAgent( $input );
+		if ( is_wp_error( $info ) ) {
+			WP_CLI::error( $info->get_error_message() );
+			return;
+		}
 		if ( ! $info['success'] ) {
 			WP_CLI::error( $info['error'] ?? 'Agent not found.' );
 			return;
@@ -508,6 +541,11 @@ class AgentsCommand extends AgentBundleCommand {
 
 		$input['delete_files'] = $delete_files;
 		$result                = AgentAbilities::deleteAgent( $input );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to delete agent.' );
@@ -939,6 +977,11 @@ class AgentsCommand extends AgentBundleCommand {
 			)
 		);
 
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to create token.' );
 			return;
@@ -975,6 +1018,11 @@ class AgentsCommand extends AgentBundleCommand {
 	 */
 	private function tokenList( $abilities, int $agent_id, array $assoc_args ): void {
 		$result = $abilities->executeListTokens( array( 'agent_id' => $agent_id ) );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to list tokens.' );
@@ -1030,6 +1078,11 @@ class AgentsCommand extends AgentBundleCommand {
 				'token_id' => $token_id,
 			)
 		);
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to revoke token.' );
@@ -1352,6 +1405,10 @@ class AgentsCommand extends AgentBundleCommand {
 
 		WP_CLI::log( sprintf( 'Exporting agent "%s"...', $agent['agent_slug'] ) );
 		$result = AgentAbilities::exportAgent( $input );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
 		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( (string) ( $result['error'] ?? 'Failed to export agent.' ) );
 			return;
@@ -1483,6 +1540,11 @@ class AgentsCommand extends AgentBundleCommand {
 		}
 
 		$result = $ability->execute( $ability_input );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to import agent bundle.' );

--- a/inc/Cli/Commands/AuthCommand.php
+++ b/inc/Cli/Commands/AuthCommand.php
@@ -126,7 +126,7 @@ class AuthCommand extends BaseCommand {
 			// Provider not registered — check if handler exists but doesn't require auth.
 			$result = $this->abilities->executeGetAuthStatus( array( 'handler_slug' => $handler_slug ) );
 
-			if ( ! empty( $result['success'] ) && ( $result['requires_auth'] ?? true ) === false ) {
+			if ( ! is_wp_error( $result ) && ! empty( $result['success'] ) && ( $result['requires_auth'] ?? true ) === false ) {
 				WP_CLI::success( sprintf( '%s does not require authentication.', ucfirst( $handler_slug ) ) );
 				return;
 			}
@@ -232,6 +232,7 @@ class AuthCommand extends BaseCommand {
 		}
 
 		$user_id = isset( $assoc_args['user'] ) ? absint( $assoc_args['user'] ) : 0;
+		$message = '';
 
 		// Per-user revoke path.
 		if ( $user_id > 0 ) {
@@ -252,38 +253,38 @@ class AuthCommand extends BaseCommand {
 				)
 			);
 
-			if ( ! empty( $result['success'] ) ) {
-				$msg = $result['message'] ?? sprintf( '%s credentials revoked for user %d.', ucfirst( $handler_slug ), $user_id );
-				if ( array_key_exists( 'upstream_revoked', $result ) ) {
-					$msg .= $result['upstream_revoked']
-						? ' (upstream revoke succeeded)'
-						: ' (upstream revoke skipped or failed; local delete completed)';
-				}
-				WP_CLI::success( $msg );
+			$message = sprintf( '%s credentials revoked for user %d.', ucfirst( $handler_slug ), $user_id );
+		} else {
+			// Site-wide revoke path (delegates to the existing disconnect ability).
+			$auth_status = $this->abilities->getAuthStatus( $handler_slug );
+			if ( ! $auth_status['authenticated'] ) {
+				WP_CLI::warning( sprintf( '%s is not currently authenticated at site scope.', ucfirst( $handler_slug ) ) );
 				return;
 			}
 
-			WP_CLI::error( $result['error'] ?? 'Failed to revoke per-user credentials.' );
+			if ( ! isset( $assoc_args['yes'] ) ) {
+				WP_CLI::confirm( sprintf( 'Revoke site-wide %s credentials? This will clear stored account data.', ucfirst( $handler_slug ) ) );
+			}
+
+			$result  = $this->abilities->executeDisconnectAuth( array( 'handler_slug' => $handler_slug ) );
+			$message = sprintf( '%s site-wide credentials revoked.', ucfirst( $handler_slug ) );
+		}
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
 			return;
 		}
-
-		// Site-wide revoke path (delegates to the existing disconnect ability).
-		$auth_status = $this->abilities->getAuthStatus( $handler_slug );
-		if ( ! $auth_status['authenticated'] ) {
-			WP_CLI::warning( sprintf( '%s is not currently authenticated at site scope.', ucfirst( $handler_slug ) ) );
-			return;
-		}
-
-		if ( ! isset( $assoc_args['yes'] ) ) {
-			WP_CLI::confirm( sprintf( 'Revoke site-wide %s credentials? This will clear stored account data.', ucfirst( $handler_slug ) ) );
-		}
-
-		$result = $this->abilities->executeDisconnectAuth( array( 'handler_slug' => $handler_slug ) );
 
 		if ( ! empty( $result['success'] ) ) {
-			WP_CLI::success( $result['message'] ?? sprintf( '%s site-wide credentials revoked.', ucfirst( $handler_slug ) ) );
+			$message = $result['message'] ?? $message;
+			if ( $user_id > 0 && array_key_exists( 'upstream_revoked', $result ) ) {
+				$message .= $result['upstream_revoked']
+					? ' (upstream revoke succeeded)'
+					: ' (upstream revoke skipped or failed; local delete completed)';
+			}
+			WP_CLI::success( $message );
 		} else {
-			WP_CLI::error( $result['error'] ?? 'Failed to revoke.' );
+			WP_CLI::error( $result['error'] ?? ( $user_id > 0 ? 'Failed to revoke per-user credentials.' : 'Failed to revoke.' ) );
 		}
 	}
 
@@ -464,6 +465,11 @@ class AuthCommand extends BaseCommand {
 			)
 		);
 
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
 		if ( ! empty( $result['success'] ) ) {
 			WP_CLI::success( $result['message'] ?? sprintf( '%s token set.', ucfirst( $handler_slug ) ) );
 
@@ -518,6 +524,11 @@ class AuthCommand extends BaseCommand {
 			array( 'handler_slug' => $handler_slug )
 		);
 
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
 		if ( ! empty( $result['success'] ) ) {
 			WP_CLI::success( $result['message'] ?? sprintf( '%s token refreshed.', ucfirst( $handler_slug ) ) );
 
@@ -567,7 +578,10 @@ class AuthCommand extends BaseCommand {
 
 			$result = $this->abilities->executeRefreshAuth( array( 'handler_slug' => $key ) );
 
-			if ( ! empty( $result['success'] ) ) {
+			if ( is_wp_error( $result ) ) {
+				WP_CLI::log( sprintf( '  %s: FAILED — %s', $key, $result->get_error_message() ) );
+				++$failed;
+			} elseif ( ! empty( $result['success'] ) ) {
 				$expiry_info = ! empty( $result['expires_at'] ) ? " (expires: {$result['expires_at']})" : '';
 				WP_CLI::log( sprintf( '  %s: refreshed%s', $key, $expiry_info ) );
 				++$refreshed;
@@ -776,11 +790,13 @@ class AuthCommand extends BaseCommand {
 	private function connectOAuth( string $handler_slug, object $provider, ?array $agent_context = null ): void {
 		// Check if configured first.
 		if ( method_exists( $provider, 'is_configured' ) && ! $provider->is_configured() ) {
-			WP_CLI::error( sprintf(
-				'%s OAuth credentials not configured. Run "wp datamachine auth config %s --client_id=... --client_secret=..." first.',
-				ucfirst( $handler_slug ),
-				$handler_slug
-			) );
+			WP_CLI::error(
+				sprintf(
+					'%s OAuth credentials not configured. Run "wp datamachine auth config %s --client_id=... --client_secret=..." first.',
+					ucfirst( $handler_slug ),
+					$handler_slug
+				)
+			);
 			return;
 		}
 
@@ -792,6 +808,11 @@ class AuthCommand extends BaseCommand {
 		$result     = null === $agent_context
 			? $get_status()
 			: PermissionHelper::run_as_agent_context( $agent_context['agent_id'], $agent_context['user_id'], $get_status );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
 
 		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to get auth status.' );
@@ -852,8 +873,8 @@ class AuthCommand extends BaseCommand {
 			WP_CLI::error( 'Agent-scoped OAuth connect requires a current WordPress CLI user. Use WP-CLI --user=<id>.' );
 		}
 
-		$is_owner       = $current_user_id === (int) $context['user_id'];
-		$is_site_admin  = current_user_can( 'manage_options' );
+		$is_owner        = $current_user_id === (int) $context['user_id'];
+		$is_site_admin   = current_user_can( 'manage_options' );
 		$has_admin_grant = ! $is_owner && ! $is_site_admin && ( new AgentAccess() )->user_can_access( (int) $context['agent_id'], $current_user_id, \WP_Agent_Access_Grant::ROLE_ADMIN );
 		if ( ! $is_owner && ! $has_admin_grant && ! $is_site_admin ) {
 			WP_CLI::error( sprintf( 'Current CLI user is not authorized to bind OAuth for agent "%s".', $context['agent_slug'] ) );
@@ -903,10 +924,12 @@ class AuthCommand extends BaseCommand {
 		}
 
 		if ( ! empty( $missing ) ) {
-			WP_CLI::error( sprintf(
-				'Missing required fields: %s',
-				implode( ', ', $missing )
-			) );
+			WP_CLI::error(
+				sprintf(
+					'Missing required fields: %s',
+					implode( ', ', $missing )
+				)
+			);
 			return;
 		}
 
@@ -917,6 +940,11 @@ class AuthCommand extends BaseCommand {
 				'config'       => $config_data,
 			)
 		);
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
 
 		if ( ! empty( $result['success'] ) ) {
 			WP_CLI::success( $result['message'] ?? sprintf( '%s credentials saved.', ucfirst( $handler_slug ) ) );
@@ -967,11 +995,13 @@ class AuthCommand extends BaseCommand {
 
 		WP_CLI::log( '' );
 		$cli_key_example = str_replace( '_', '-', array_key_first( $config_fields ) );
-		WP_CLI::log( sprintf(
-			'To update: wp datamachine auth config %s --%s=<value>',
-			$handler_slug,
-			$cli_key_example
-		) );
+		WP_CLI::log(
+			sprintf(
+				'To update: wp datamachine auth config %s --%s=<value>',
+				$handler_slug,
+				$cli_key_example
+			)
+		);
 	}
 
 	/**
@@ -994,6 +1024,11 @@ class AuthCommand extends BaseCommand {
 				'config'       => $config,
 			)
 		);
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
 
 		if ( ! empty( $result['success'] ) ) {
 			WP_CLI::success( $result['message'] ?? sprintf( '%s configuration saved.', ucfirst( $handler_slug ) ) );

--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -97,6 +97,16 @@ class MemoryCommand extends BaseCommand {
 
 		$result = AgentMemoryAbilities::getMemory( $input );
 
+		if ( is_wp_error( $result ) ) {
+			$message = $result->get_error_message();
+			$data    = $result->get_error_data();
+			if ( is_array( $data ) && ! empty( $data['available_sections'] ) ) {
+				$message .= "\nAvailable sections: " . implode( ', ', $data['available_sections'] );
+			}
+			WP_CLI::error( $message );
+			return;
+		}
+
 		if ( ! $result['success'] ) {
 			$message = $result['message'] ?? 'Failed to read file.';
 			if ( ! empty( $result['available_sections'] ) ) {
@@ -156,6 +166,11 @@ class MemoryCommand extends BaseCommand {
 		}
 
 		$result = AgentMemoryAbilities::listSections( $scoping );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['message'] ?? 'Failed to list sections.' );
@@ -354,6 +369,11 @@ class MemoryCommand extends BaseCommand {
 
 		$result = AgentMemoryAbilities::updateMemory( $input );
 
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['message'] ?? 'Failed to write.' );
 			return;
@@ -401,6 +421,10 @@ class MemoryCommand extends BaseCommand {
 		}
 
 		$result = AgentMemoryAbilities::deleteMemorySection( $input );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['message'] ?? 'Failed to delete section.' );
 			return;
@@ -479,6 +503,11 @@ class MemoryCommand extends BaseCommand {
 		}
 
 		$result = AgentMemoryAbilities::searchMemory( $input );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['message'] ?? 'Search failed.' );

--- a/inc/Engine/AI/Tools/Global/AgentMemory.php
+++ b/inc/Engine/AI/Tools/Global/AgentMemory.php
@@ -77,7 +77,7 @@ class AgentMemory extends BaseTool {
 		$result = $ability->execute( $input );
 
 		if ( is_wp_error( $result ) ) {
-			return $this->buildErrorResponse( $result->get_error_message(), 'agent_memory' );
+			return $this->memoryErrorResponse( $result );
 		}
 
 		if ( ! $this->isAbilitySuccess( $result ) ) {
@@ -145,7 +145,7 @@ class AgentMemory extends BaseTool {
 		$result = $ability->execute( $input );
 
 		if ( is_wp_error( $result ) ) {
-			return $this->buildErrorResponse( $result->get_error_message(), 'agent_memory' );
+			return $this->memoryErrorResponse( $result );
 		}
 
 		if ( ! $this->isAbilitySuccess( $result ) ) {
@@ -191,7 +191,7 @@ class AgentMemory extends BaseTool {
 		$result = $ability->execute( $input );
 
 		if ( is_wp_error( $result ) ) {
-			return $this->buildErrorResponse( $result->get_error_message(), 'agent_memory' );
+			return $this->memoryErrorResponse( $result );
 		}
 
 		if ( ! $this->isAbilitySuccess( $result ) ) {
@@ -288,6 +288,14 @@ class AgentMemory extends BaseTool {
 			'user_id'  => $user_id,
 			'agent_id' => $agent_id,
 		);
+	}
+
+	/** Preserve structured ability diagnostics in the curated tool failure envelope. */
+	private function memoryErrorResponse( \WP_Error $error ): array {
+		$response               = $this->buildErrorResponse( $error->get_error_message(), 'agent_memory' );
+		$response['error_code'] = $error->get_error_code();
+		$response['error_data'] = $error->get_error_data();
+		return $response;
 	}
 
 	/**

--- a/tests/Unit/Abilities/AgentAbilitiesTest.php
+++ b/tests/Unit/Abilities/AgentAbilitiesTest.php
@@ -50,8 +50,8 @@ class AgentAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'slug', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertStringContainsString( 'slug', $result->get_error_message() );
 	}
 
 	public function test_createAgent_requires_owner(): void {
@@ -61,8 +61,8 @@ class AgentAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'Owner', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertStringContainsString( 'Owner', $result->get_error_message() );
 	}
 
 	public function test_createAgent_rejects_duplicate_slug(): void {
@@ -82,8 +82,8 @@ class AgentAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'already exists', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertStringContainsString( 'already exists', $result->get_error_message() );
 	}
 
 	public function test_createAgent_rejects_invalid_owner(): void {
@@ -94,8 +94,8 @@ class AgentAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'not found', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertStringContainsString( 'not found', $result->get_error_message() );
 	}
 
 	public function test_getAgent_by_slug(): void {
@@ -148,8 +148,8 @@ class AgentAbilitiesTest extends WP_UnitTestCase {
 	public function test_getAgent_not_found(): void {
 		$result = AgentAbilities::getAgent( array( 'agent_slug' => 'nonexistent-bot' ) );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'not found', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertStringContainsString( 'not found', $result->get_error_message() );
 	}
 
 	public function test_deleteAgent_success(): void {
@@ -167,14 +167,14 @@ class AgentAbilitiesTest extends WP_UnitTestCase {
 
 		// Verify it's gone.
 		$lookup = AgentAbilities::getAgent( array( 'agent_slug' => 'delete-me-bot' ) );
-		$this->assertFalse( $lookup['success'] );
+		$this->assertInstanceOf( \WP_Error::class, $lookup );
 	}
 
 	public function test_deleteAgent_not_found(): void {
 		$result = AgentAbilities::deleteAgent( array( 'agent_slug' => 'ghost-bot' ) );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'not found', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertStringContainsString( 'not found', $result->get_error_message() );
 	}
 
 	public function test_createAgent_bootstraps_owner_access(): void {
@@ -313,8 +313,8 @@ class AgentAbilitiesTest extends WP_UnitTestCase {
 	public function test_updateAgent_requires_agent_identity(): void {
 		$result = AgentAbilities::updateAgent( array( 'agent_name' => 'Orphan' ) );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'Agent identity', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertStringContainsString( 'Agent identity', $result->get_error_message() );
 	}
 
 	public function test_exportAgent_accepts_agent_slug_alias(): void {
@@ -344,8 +344,8 @@ class AgentAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'not found', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertStringContainsString( 'not found', $result->get_error_message() );
 	}
 
 	public function test_updateAgent_rejects_empty_name(): void {
@@ -363,8 +363,8 @@ class AgentAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'empty', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertStringContainsString( 'empty', $result->get_error_message() );
 	}
 
 	public function test_updateAgent_rejects_no_fields(): void {
@@ -379,7 +379,7 @@ class AgentAbilitiesTest extends WP_UnitTestCase {
 			array( 'agent_id' => $created['agent_id'] )
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'No fields', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertStringContainsString( 'No fields', $result->get_error_message() );
 	}
 }

--- a/tests/Unit/Abilities/AgentPruneResurrectionTest.php
+++ b/tests/Unit/Abilities/AgentPruneResurrectionTest.php
@@ -94,7 +94,7 @@ class AgentPruneResurrectionTest extends WP_UnitTestCase {
 
 		// The agent row must stay deleted.
 		$lookup = AgentAbilities::getAgent( array( 'agent_slug' => 'stale-meta-bot' ) );
-		$this->assertFalse( $lookup['success'] );
+		$this->assertInstanceOf( \WP_Error::class, $lookup );
 	}
 
 	public function test_pruneAgents_clears_owner_active_agent_meta(): void {

--- a/tests/Unit/Abilities/AuthAbilitiesTest.php
+++ b/tests/Unit/Abilities/AuthAbilitiesTest.php
@@ -102,9 +102,9 @@ class AuthAbilitiesTest extends WP_UnitTestCase {
 			array( 'handler_slug' => '' )
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'required', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_handler_slug', $result->get_error_code() );
+		$this->assertStringContainsString( 'required', $result->get_error_message() );
 	}
 
 	public function test_get_auth_status_returns_error_for_unknown_handler(): void {
@@ -112,8 +112,8 @@ class AuthAbilitiesTest extends WP_UnitTestCase {
 			array( 'handler_slug' => 'nonexistent_handler' )
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'auth_provider_not_found', $result->get_error_code() );
 	}
 
 	public function test_disconnect_auth_returns_error_for_missing_handler_slug(): void {
@@ -121,9 +121,9 @@ class AuthAbilitiesTest extends WP_UnitTestCase {
 			array( 'handler_slug' => '' )
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'required', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_handler_slug', $result->get_error_code() );
+		$this->assertStringContainsString( 'required', $result->get_error_message() );
 	}
 
 	public function test_disconnect_auth_returns_error_for_unknown_handler(): void {
@@ -131,8 +131,8 @@ class AuthAbilitiesTest extends WP_UnitTestCase {
 			array( 'handler_slug' => 'nonexistent_handler' )
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'auth_provider_not_found', $result->get_error_code() );
 	}
 
 	public function test_save_auth_config_returns_error_for_missing_handler_slug(): void {
@@ -143,9 +143,9 @@ class AuthAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'required', $result['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_handler_slug', $result->get_error_code() );
+		$this->assertStringContainsString( 'required', $result->get_error_message() );
 	}
 
 	public function test_save_auth_config_returns_error_for_unknown_handler(): void {
@@ -156,8 +156,8 @@ class AuthAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'auth_provider_not_found', $result->get_error_code() );
 	}
 
 	public function test_save_auth_config_preserves_opaque_credential_fields(): void {
@@ -213,6 +213,17 @@ class AuthAbilitiesTest extends WP_UnitTestCase {
 
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( $token, $provider->get_account_for_user( get_current_user_id() )['access_token'] );
+	}
+
+	public function test_refresh_unauthenticated_provider_returns_conflict(): void {
+		$provider = new AuthAbilitiesAccountScopeProvider( 'scope_provider' );
+		$this->registerAccountScopeProvider( $provider );
+
+		$result = $this->auth_abilities->executeRefreshAuth( array( 'handler_slug' => 'scope_handler' ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'auth_not_authenticated', $result->get_error_code() );
+		$this->assertSame( 409, $result->get_error_data()['status'] );
 	}
 
 	public function test_set_auth_token_saves_user_account_without_site_fallback(): void {

--- a/tests/Unit/Abilities/DailyMemoryAbilitiesTest.php
+++ b/tests/Unit/Abilities/DailyMemoryAbilitiesTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Daily memory ability boundary tests.
+ *
+ * @package DataMachine\Tests\Unit\Abilities
+ */
+
+namespace DataMachine\Tests\Unit\Abilities;
+
+use DataMachine\Abilities\DailyMemoryAbilities;
+use DataMachine\Core\FilesRepository\DailyMemoryStorage;
+use WP_UnitTestCase;
+
+class DailyMemoryAbilitiesTest extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		add_filter( 'datamachine_daily_memory_storage', array( $this, 'failureStorage' ) );
+	}
+
+	public function tear_down(): void {
+		remove_filter( 'datamachine_daily_memory_storage', array( $this, 'failureStorage' ) );
+		parent::tear_down();
+	}
+
+	public function failureStorage(): DailyMemoryStorage {
+		return new class() implements DailyMemoryStorage {
+			public function read( string $year, string $month, string $day ): array {
+				return array( 'success' => true );
+			}
+
+			public function write( string $year, string $month, string $day, string $content ): array {
+				return array( 'success' => true, 'message' => '' );
+			}
+
+			public function append( string $year, string $month, string $day, string $content ): array {
+				return array( 'success' => true, 'message' => '' );
+			}
+
+			public function delete( string $year, string $month, string $day ): array {
+				return array( 'success' => true, 'message' => '' );
+			}
+
+			public function list_all(): array {
+				return array( 'success' => false, 'message' => 'List backend unavailable.', 'backend' => 'test' );
+			}
+
+			public function search( string $query, ?string $from = null, ?string $to = null, int $context_lines = 2 ): array {
+				return array( 'success' => false, 'message' => 'Search backend unavailable.', 'query' => $query );
+			}
+		};
+	}
+
+	public function test_list_backend_failure_returns_wp_error(): void {
+		$result = DailyMemoryAbilities::listDaily( array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'daily_memory_list_failed', $result->get_error_code() );
+		$this->assertSame( 'test', $result->get_error_data()['backend'] );
+	}
+
+	public function test_search_backend_failure_returns_wp_error(): void {
+		$result = DailyMemoryAbilities::searchDaily( array( 'query' => 'needle' ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'daily_memory_search_failed', $result->get_error_code() );
+		$this->assertSame( 'needle', $result->get_error_data()['query'] );
+	}
+}

--- a/tests/Unit/Abilities/InspectRequestAbilityTest.php
+++ b/tests/Unit/Abilities/InspectRequestAbilityTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Inspect AI request ability tests.
+ *
+ * @package DataMachine\Tests\Unit\Abilities
+ */
+
+namespace DataMachine\Tests\Unit\Abilities;
+
+use DataMachine\Abilities\AI\InspectRequestAbility;
+use WP_UnitTestCase;
+
+class InspectRequestAbilityTest extends WP_UnitTestCase {
+
+	public function test_invalid_job_id_returns_validation_error(): void {
+		$result = ( new InspectRequestAbility() )->execute( array( 'job_id' => 0 ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_job_id', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	public function test_missing_job_returns_not_found_error(): void {
+		$result = ( new InspectRequestAbility() )->execute( array( 'job_id' => 999999 ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'job_not_found', $result->get_error_code() );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
+	}
+}

--- a/tests/Unit/Abilities/ListAgentsAbilityTest.php
+++ b/tests/Unit/Abilities/ListAgentsAbilityTest.php
@@ -135,8 +135,9 @@ class ListAgentsAbilityTest extends WP_UnitTestCase {
 		wp_set_current_user( $this->granted_user );
 		$result = AgentAbilities::listAgents( array( 'scope' => 'all' ) );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'admin', strtolower( $result['error'] ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+		$this->assertStringContainsString( 'admin', strtolower( $result->get_error_message() ) );
 	}
 
 	public function test_scope_all_returns_all_agents_for_admin(): void {
@@ -185,7 +186,8 @@ class ListAgentsAbilityTest extends WP_UnitTestCase {
 		wp_set_current_user( $this->granted_user );
 		$result = AgentAbilities::listAgents( array( 'user_id' => $this->owner_user ) );
 
-		$this->assertFalse( $result['success'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
 	}
 
 	public function test_non_admin_can_explicitly_query_self(): void {
@@ -283,7 +285,8 @@ class ListAgentsAbilityTest extends WP_UnitTestCase {
 		wp_set_current_user( $this->owner_user );
 		$result = AgentAbilities::listAgents( array( 'scope' => 'garbage' ) );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'scope', strtolower( $result['error'] ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+		$this->assertStringContainsString( 'scope', strtolower( $result->get_error_message() ) );
 	}
 }

--- a/tests/Unit/Abilities/MultiAgentScopingTest.php
+++ b/tests/Unit/Abilities/MultiAgentScopingTest.php
@@ -15,6 +15,7 @@
 namespace DataMachine\Tests\Unit\Abilities;
 
 use DataMachine\Abilities\AgentMemoryAbilities;
+use DataMachine\Abilities\DailyMemoryAbilities;
 use DataMachine\Abilities\File\AgentFileAbilities;
 use DataMachine\Abilities\Job\GetJobsAbility;
 use DataMachine\Abilities\Pipeline\GetPipelinesAbility;
@@ -22,6 +23,7 @@ use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\FilesRepository\DirectoryManager;
+use DataMachine\Engine\AI\Tools\Global\AgentMemory as AgentMemoryTool;
 use WP_UnitTestCase;
 
 /**
@@ -153,6 +155,57 @@ class MultiAgentScopingTest extends WP_UnitTestCase {
 		$explicit_result = AgentMemoryAbilities::getMemory( array( 'user_id' => 0 ) );
 
 		$this->assertSame( $default_result['success'], $explicit_result['success'] );
+	}
+
+	public function test_memory_callback_converts_not_found_result_with_diagnostics(): void {
+		$result = AgentMemoryAbilities::getMemory(
+			array(
+				'user_id' => $this->agent_a_id,
+				'file'    => 'MISSING.md',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
+		$this->assertFalse( $result->get_error_data()['success'] );
+	}
+
+	public function test_self_memory_callback_converts_policy_denial(): void {
+		$result = AgentMemoryAbilities::writeSelfMemory(
+			array(
+				'section' => 'Notes',
+				'content' => 'Test',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'missing_agent_context', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+		$this->assertSame( 'missing_agent_context', $result->get_error_data()['error_code'] );
+	}
+
+	public function test_daily_memory_callback_validation_status(): void {
+		$result = DailyMemoryAbilities::readDaily( array( 'date' => 'not-a-date' ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	public function test_agent_memory_tool_preserves_wp_error_data(): void {
+		$error = new \WP_Error(
+			'memory_consent_denied',
+			'Memory write consent denied.',
+			array(
+				'status'           => 403,
+				'consent_decision' => array( 'reason' => 'opt_out' ),
+			)
+		);
+		$method = new \ReflectionMethod( AgentMemoryTool::class, 'memoryErrorResponse' );
+		$result = $method->invoke( new AgentMemoryTool(), $error );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'memory_consent_denied', $result['error_code'] );
+		$this->assertSame( 'opt_out', $result['error_data']['consent_decision']['reason'] );
 	}
 
 	// =========================================================================

--- a/tests/Unit/Abilities/SelfServiceAgentCreationTest.php
+++ b/tests/Unit/Abilities/SelfServiceAgentCreationTest.php
@@ -116,9 +116,9 @@ class SelfServiceAgentCreationTest extends WP_UnitTestCase {
 		$this->assertTrue( $first['success'] );
 
 		$second = AgentAbilities::createAgent( array( 'agent_slug' => 'second-bot' ) );
-		$this->assertFalse( $second['success'] );
-		$this->assertStringContainsString( 'already have an agent', $second['error'] );
-		$this->assertStringContainsString( 'first-bot', $second['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $second );
+		$this->assertStringContainsString( 'already have an agent', $second->get_error_message() );
+		$this->assertStringContainsString( 'first-bot', $second->get_error_message() );
 	}
 
 	/**
@@ -139,8 +139,8 @@ class SelfServiceAgentCreationTest extends WP_UnitTestCase {
 		$this->assertTrue( $a['success'] );
 		$this->assertTrue( $b['success'] );
 		$this->assertTrue( $c['success'] );
-		$this->assertFalse( $d['success'], 'The 4th creation must be rejected with limit=3' );
-		$this->assertStringContainsString( '3', $d['error'] );
+		$this->assertInstanceOf( \WP_Error::class, $d, 'The 4th creation must be rejected with limit=3' );
+		$this->assertStringContainsString( '3', $d->get_error_message() );
 	}
 
 	/**
@@ -257,7 +257,8 @@ class SelfServiceAgentCreationTest extends WP_UnitTestCase {
 		// Missing slug → failure path.
 		$result = AgentAbilities::createAgent( array( 'agent_slug' => '' ) );
 
-		$this->assertFalse( $result['success'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
 		$this->assertSame( 0, $fired, 'Hook must not fire when creation fails' );
 	}
 

--- a/tests/agent-prune-resurrection-smoke.php
+++ b/tests/agent-prune-resurrection-smoke.php
@@ -72,7 +72,7 @@ if ( function_exists( 'wp_get_ability' ) ) {
 			$assert( 'stale active-agent meta is cleared', '' === get_user_meta( $owner_id, $meta_key, true ) );
 
 			$lookup = \DataMachine\Abilities\AgentAbilities::getAgent( array( 'agent_slug' => $created['agent_slug'] ) );
-			$assert( 'pruned agent row stays deleted', empty( $lookup['success'] ) );
+			$assert( 'pruned agent row stays deleted', is_wp_error( $lookup ) );
 
 			$access_repo = new \DataMachine\Core\Database\Agents\AgentAccess();
 			$grants      = $access_repo->get_users_for_agent( (string) $created['agent_id'] );

--- a/tests/auth-cli-agent-scoped-oauth-smoke.php
+++ b/tests/auth-cli-agent-scoped-oauth-smoke.php
@@ -115,6 +115,12 @@ namespace {
 		define( 'ABSPATH', dirname( __DIR__ ) . '/' );
 	}
 
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $value ): bool {
+			return $value instanceof WP_Error;
+		}
+	}
+
 	function sanitize_text_field( $value ): string { return trim( (string) $value ); }
 	function get_current_user_id(): int { return (int) $GLOBALS['auth_cli_user_id']; }
 	function current_user_can( string $capability ): bool { return (bool) $GLOBALS['auth_cli_site_admin']; }

--- a/tests/auth-cli-disconnect-alias-smoke.php
+++ b/tests/auth-cli-disconnect-alias-smoke.php
@@ -57,6 +57,12 @@ namespace {
 		}
 	}
 
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( $value ): bool {
+			return $value instanceof WP_Error;
+		}
+	}
+
 	class WP_CLI {
 		public static array $warnings = array();
 		public static array $successes = array();

--- a/tests/import-agent-ability-smoke.php
+++ b/tests/import-agent-ability-smoke.php
@@ -33,10 +33,12 @@ namespace {
 	class WP_Error {
 		private string $code;
 		private string $message;
+		private mixed $data;
 
-		public function __construct( string $code, string $message ) {
+		public function __construct( string $code, string $message, mixed $data = null ) {
 			$this->code    = $code;
 			$this->message = $message;
+			$this->data    = $data;
 		}
 
 		public function get_error_code(): string {
@@ -45,6 +47,10 @@ namespace {
 
 		public function get_error_message(): string {
 			return $this->message;
+		}
+
+		public function get_error_data(): mixed {
+			return $this->data;
 		}
 	}
 
@@ -74,6 +80,12 @@ namespace {
 			$title = strtolower( trim( $title ) );
 			$title = preg_replace( '/[^a-z0-9]+/', '-', $title ) ?? '';
 			return trim( $title, '-' );
+		}
+	}
+
+	if ( ! function_exists( 'sanitize_key' ) ) {
+		function sanitize_key( string $key ): string {
+			return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', $key ) ?? '' );
 		}
 	}
 
@@ -128,6 +140,7 @@ namespace {
 			public static int $from_directory_calls = 0;
 			public static int $from_zip_calls = 0;
 			public static int $from_json_calls = 0;
+			public static ?array $next_result = null;
 
 			public function from_directory( string $source ): ?array {
 				++self::$from_directory_calls;
@@ -147,6 +160,11 @@ namespace {
 
 			public function import( array $bundle, ?string $new_slug = null, int $owner_id = 0, bool $dry_run = false, array $options = array() ): array {
 				self::$last_import = compact( 'bundle', 'new_slug', 'owner_id', 'dry_run', 'options' );
+				if ( null !== self::$next_result ) {
+					$result            = self::$next_result;
+					self::$next_result = null;
+					return $result;
+				}
 
 				return array(
 					'success' => true,
@@ -277,6 +295,7 @@ namespace {
 		AgentBundler::$from_directory_calls          = 0;
 		AgentBundler::$from_zip_calls                = 0;
 		AgentBundler::$from_json_calls               = 0;
+		AgentBundler::$next_result                   = null;
 		// @phpstan-ignore-next-line smoke-test stub property shadows production class.
 		Agents::$by_slug                             = array();
 		WP_Ability::$last_execute                    = array();
@@ -303,7 +322,7 @@ namespace {
 			'on_conflict' => 'error',
 		)
 	);
-	$assert( 'conflict error fails', false === $result['success'] );
+	$assert( 'conflict error returns WP_Error', is_wp_error( $result ) && 'agent_slug_conflict' === $result->get_error_code() );
 	// @phpstan-ignore-next-line smoke-test stub property shadows production class.
 	$assert( 'conflict error happens before import writes', array() === AgentBundler::$last_import );
 
@@ -324,8 +343,8 @@ namespace {
 			'on_conflict' => 'overwrite',
 		)
 	);
-	$assert( 'unsupported overwrite policy is rejected', false === $result['success'] );
-	$assert( 'overwrite policy is not claimed', str_contains( $result['error'], 'error, skip, upgrade' ) );
+	$assert( 'unsupported overwrite policy is rejected', is_wp_error( $result ) );
+	$assert( 'overwrite policy is not claimed', str_contains( $result->get_error_message(), 'error, skip, upgrade' ) );
 
 	$result = AgentAbilities::importAgent(
 		array(
@@ -364,11 +383,12 @@ namespace {
 	$reset();
 	$missing_source = sys_get_temp_dir() . '/datamachine-missing-runtime-bundle-' . uniqid() . '.json';
 	$result         = AgentAbilities::importAgent( array( 'source' => $missing_source ) );
-	$assert( 'missing source import fails', false === $result['success'] );
-	$assert( 'missing source diagnostic reports attempted source', $missing_source === ( $result['diagnostics']['source'] ?? '' ) );
-	$assert( 'missing source diagnostic reports cwd', isset( $result['diagnostics']['cwd'] ) && is_string( $result['diagnostics']['cwd'] ) );
-	$assert( 'missing source diagnostic reports context', 'local_path' === ( $result['diagnostics']['context'] ?? '' ) );
-	$assert( 'missing source diagnostic reports expected shape', 'Readable local directory, .zip, or JSON file, or remote .zip/.json URL containing a Data Machine agent bundle.' === ( $result['diagnostics']['expected_shape'] ?? '' ) );
+	$assert( 'missing source import fails', is_wp_error( $result ) );
+	$error_data = $result->get_error_data();
+	$assert( 'missing source diagnostic reports attempted source', $missing_source === ( $error_data['diagnostics']['source'] ?? '' ) );
+	$assert( 'missing source diagnostic reports cwd', isset( $error_data['diagnostics']['cwd'] ) && is_string( $error_data['diagnostics']['cwd'] ) );
+	$assert( 'missing source diagnostic reports context', 'local_path' === ( $error_data['diagnostics']['context'] ?? '' ) );
+	$assert( 'missing source diagnostic reports expected shape', 'Readable local directory, .zip, or JSON file, or remote .zip/.json URL containing a Data Machine agent bundle.' === ( $error_data['diagnostics']['expected_shape'] ?? '' ) );
 
 	$reset();
 	$invalid_json_temp = tempnam( sys_get_temp_dir(), 'datamachine-invalid-runtime-bundle-' );
@@ -376,10 +396,24 @@ namespace {
 	rename( $invalid_json_temp, $invalid_json_path );
 	file_put_contents( $invalid_json_path, '{not valid json' );
 	$result = AgentAbilities::importAgent( array( 'source' => $invalid_json_path ) );
-	$assert( 'invalid source import fails', false === $result['success'] );
-	$assert( 'invalid source diagnostic reports attempted source', $invalid_json_path === ( $result['diagnostics']['source'] ?? '' ) );
-	$assert( 'invalid source diagnostic reports expected shape', 'Readable local directory, .zip, or JSON file, or remote .zip/.json URL containing a Data Machine agent bundle.' === ( $result['diagnostics']['expected_shape'] ?? '' ) );
+	$assert( 'invalid source import fails', is_wp_error( $result ) );
+	$error_data = $result->get_error_data();
+	$assert( 'invalid source diagnostic reports attempted source', $invalid_json_path === ( $error_data['diagnostics']['source'] ?? '' ) );
+	$assert( 'invalid source diagnostic reports expected shape', 'Readable local directory, .zip, or JSON file, or remote .zip/.json URL containing a Data Machine agent bundle.' === ( $error_data['diagnostics']['expected_shape'] ?? '' ) );
 	@unlink( $invalid_json_path );
+
+	$reset();
+	AgentBundler::$next_result = array(
+		'success'       => false,
+		'error_code'    => 'install_unsupported_capabilities',
+		'error'         => 'Required capabilities are unavailable.',
+		'compatibility' => array( 'missing' => array( 'example/capability' ) ),
+	);
+	$result                    = AgentAbilities::importAgent( array( 'bundle' => $base_bundle(), 'owner_id' => 99 ) );
+	$assert( 'bundler failure is converted at callback boundary', is_wp_error( $result ) && 'install_unsupported_capabilities' === $result->get_error_code() );
+	$error_data = $result->get_error_data();
+	$assert( 'bundler diagnostics survive callback conversion', array( 'example/capability' ) === ( $error_data['compatibility']['missing'] ?? array() ) );
+	$assert( 'bundler validation failure has status 400', 400 === ( $error_data['status'] ?? 0 ) );
 
 	echo "\n[3] Inline bundle import path\n";
 	$reset();


### PR DESCRIPTION
## Summary
- return native `WP_Error` failures from agent, auth, token, memory, daily-memory, request-inspection, and agent-call ability callbacks
- preserve existing REST, CLI, chat-tool, and AI-tool response contracts at presentation boundaries
- cover backend failures, status metadata, agent scoping, import diagnostics, and prune behavior with focused tests and smokes

## Verification
- `homeboy review lint data-machine --changed-since origin/main`
- `homeboy review audit data-machine --changed-since origin/main` (0 introduced findings)
- focused Agent/Auth/DailyMemory/InspectRequest PHPUnit suites
- import-agent, ability-result, agent-prune, auth CLI, and agent-memory event smokes
- `git diff --check origin/main...HEAD`

Closes #3237