### PR TITLE
fix: compute compact stuck job count

### DIFF
--- a/inc/Abilities/Job/JobsSummaryAbility.php
+++ b/inc/Abilities/Job/JobsSummaryAbility.php
@@ -110,6 +110,9 @@ class JobsSummaryAbility {
 		$filters = array_merge( $filters, $ownership_scope );
 
 		$summary     = empty( $input['compact'] ) ? $this->db_jobs->get_jobs_summary( $filters ) : $this->getCompactSummary( $filters );
+		if ( is_wp_error( $summary ) ) {
+			return $summary;
+		}
 		$query_error = $this->jobQueryFailed();
 		if ( $query_error ) {
 			return $query_error;
@@ -126,26 +129,56 @@ class JobsSummaryAbility {
 	 * Get lightweight status counts for polling surfaces.
 	 *
 	 * @param array<string,mixed> $filters Job filters.
-	 * @return array<string,mixed> Compact summary payload.
+	 * @return array<string,mixed>|\WP_Error Compact summary payload or query failure.
 	 */
-	private function getCompactSummary( array $filters ): array {
+	private function getCompactSummary( array $filters ): array|\WP_Error {
+		$total = $this->queryCompactCount( fn() => $this->db_jobs->get_jobs_count( $filters ) );
+		if ( is_wp_error( $total ) ) {
+			return $total;
+		}
+
+		$failed = $this->queryCompactCount( fn() => $this->db_jobs->get_jobs_count( array_merge( $filters, array( 'status' => 'failed' ) ) ) );
+		if ( is_wp_error( $failed ) ) {
+			return $failed;
+		}
+
+		$stuck = $this->queryCompactCount( fn() => $this->db_jobs->get_stuck_processing_count( $filters ) );
+		if ( is_wp_error( $stuck ) ) {
+			return $stuck;
+		}
+
+		$incomplete = $this->queryCompactCount( fn() => $this->db_jobs->count_incomplete_terminal_accounting( $filters ) );
+		if ( is_wp_error( $incomplete ) ) {
+			return $incomplete;
+		}
+
+		$processing = $this->queryCompactCount( fn() => $this->db_jobs->get_jobs_count( array_merge( $filters, array( 'status' => 'processing' ) ) ) );
+		if ( is_wp_error( $processing ) ) {
+			return $processing;
+		}
+
+		$pending = $this->queryCompactCount( fn() => $this->db_jobs->get_jobs_count( array_merge( $filters, array( 'status' => 'pending' ) ) ) );
+		if ( is_wp_error( $pending ) ) {
+			return $pending;
+		}
+
 		return array(
-			'total'                                => $this->db_jobs->get_jobs_count( $filters ),
-			'failed_count'                         => $this->db_jobs->get_jobs_count( array_merge( $filters, array( 'status' => 'failed' ) ) ),
-			'stuck_processing_count'               => $this->db_jobs->get_stuck_processing_count( $filters ),
-			'incomplete_terminal_accounting_count' => $this->db_jobs->count_incomplete_terminal_accounting( $filters ),
+			'total'                                => $total,
+			'failed_count'                         => $failed,
+			'stuck_processing_count'               => $stuck,
+			'incomplete_terminal_accounting_count' => $incomplete,
 			'status'                               => array(
 				array(
 					'status' => 'processing',
-					'count'  => $this->db_jobs->get_jobs_count( array_merge( $filters, array( 'status' => 'processing' ) ) ),
+					'count'  => $processing,
 				),
 				array(
 					'status' => 'pending',
-					'count'  => $this->db_jobs->get_jobs_count( array_merge( $filters, array( 'status' => 'pending' ) ) ),
+					'count'  => $pending,
 				),
 				array(
 					'status' => 'failed',
-					'count'  => $this->db_jobs->get_jobs_count( array_merge( $filters, array( 'status' => 'failed' ) ) ),
+					'count'  => $failed,
 				),
 			),
 			'pipeline'                             => array(),
@@ -153,5 +186,13 @@ class JobsSummaryAbility {
 			'handler'                              => array(),
 			'filters'                              => $filters,
 		);
+	}
+
+	/** Execute one compact count without allowing a later query to erase its error. */
+	private function queryCompactCount( callable $query ): int|\WP_Error {
+		$count       = (int) $query();
+		$query_error = $this->jobQueryFailed();
+
+		return $query_error ?: $count;
 	}
 }

--- a/inc/Abilities/Job/JobsSummaryAbility.php
+++ b/inc/Abilities/Job/JobsSummaryAbility.php
@@ -132,7 +132,7 @@ class JobsSummaryAbility {
 		return array(
 			'total'                                => $this->db_jobs->get_jobs_count( $filters ),
 			'failed_count'                         => $this->db_jobs->get_jobs_count( array_merge( $filters, array( 'status' => 'failed' ) ) ),
-			'stuck_processing_count'               => 0,
+			'stuck_processing_count'               => $this->db_jobs->get_stuck_processing_count( $filters ),
 			'incomplete_terminal_accounting_count' => $this->db_jobs->count_incomplete_terminal_accounting( $filters ),
 			'status'                               => array(
 				array(

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -1154,8 +1154,11 @@ class Jobs extends BaseRepository {
 
 	/**
 	 * Count processing jobs older than the dashboard stuck threshold.
+	 *
+	 * @param array<string,mixed> $args Job filters.
+	 * @return int Stuck processing job count.
 	 */
-	private function get_stuck_processing_count( array $args ): int {
+	public function get_stuck_processing_count( array $args ): int {
 		$stuck_args           = $args;
 		$stuck_args['status'] = 'processing';
 		$where_parts          = $this->build_jobs_summary_where( $stuck_args, 'j' );

--- a/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
+++ b/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
@@ -206,6 +206,34 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'jobs', $operator_summary['summary'] );
 	}
 
+	public function test_compact_summary_reports_authoritative_stuck_count(): void {
+		global $wpdb;
+
+		wp_set_current_user( $this->admin_id );
+		$jobs   = new Jobs();
+		$job_id = $jobs->create_job(
+			array(
+				'pipeline_id' => 'direct',
+				'flow_id'     => 'direct',
+			)
+		);
+		$wpdb->update(
+			$wpdb->prefix . 'datamachine_jobs',
+			array(
+				'status'     => 'processing',
+				'created_at' => gmdate( 'Y-m-d H:i:s', time() - 3 * HOUR_IN_SECONDS ),
+			),
+			array( 'job_id' => $job_id )
+		);
+
+		$compact = ( new JobsSummaryAbility() )->execute( array( 'compact' => true ) );
+		$full    = ( new JobsSummaryAbility() )->execute( array() );
+
+		$this->assertTrue( $compact['success'] );
+		$this->assertGreaterThanOrEqual( 1, $compact['summary']['stuck_processing_count'] );
+		$this->assertSame( $full['summary']['stuck_processing_count'], $compact['summary']['stuck_processing_count'] );
+	}
+
 	public function test_query_validation_and_not_found_use_native_errors(): void {
 		wp_set_current_user( $this->admin_id );
 

--- a/tests/job-status-accounting-smoke.php
+++ b/tests/job-status-accounting-smoke.php
@@ -136,6 +136,8 @@ $summary_ability = file_get_contents( __DIR__ . '/../inc/Abilities/Job/JobsSumma
 $assert( 'jobs summary accepts compact input', str_contains( $summary_ability, "'compact'" ) );
 $assert( 'jobs summary has compact helper', str_contains( $summary_ability, 'getCompactSummary' ) );
 $assert( 'compact summary skips database breakdown helpers', ! str_contains( $summary_ability, 'get_pipeline_summary_rows' ) && ! str_contains( $summary_ability, 'get_flow_summary_rows' ) );
+$assert( 'compact summary queries authoritative stuck count', str_contains( $summary_ability, 'get_stuck_processing_count( $filters )' ) );
+$assert( 'compact summary does not fabricate zero stuck jobs', ! str_contains( $summary_ability, "'stuck_processing_count'               => 0" ) );
 
 echo "\n[6] job status transitions use one terminal primitive\n";
 $recover_ability = file_get_contents( __DIR__ . '/../inc/Abilities/Job/RecoverStuckJobsAbility.php' );


### PR DESCRIPTION
## Summary
- replace the compact jobs summary's synthetic stuck count with the owner repository calculation
- preserve ownership filters and the lightweight compact response
- add regression assertions preventing a hardcoded healthy zero

## Verification
- `job-status-accounting-smoke.php`: 25 assertions pass
- `DirectJobOwnershipTest` passes
- scoped PHPCS and `git diff --check` pass

Closes #3245