### PR TITLE
fix: clear compact summary release lint

### DIFF
--- a/inc/Abilities/Job/JobsSummaryAbility.php
+++ b/inc/Abilities/Job/JobsSummaryAbility.php
@@ -109,7 +109,7 @@ class JobsSummaryAbility {
 		}
 		$filters = array_merge( $filters, $ownership_scope );
 
-		$summary     = empty( $input['compact'] ) ? $this->db_jobs->get_jobs_summary( $filters ) : $this->getCompactSummary( $filters );
+		$summary = empty( $input['compact'] ) ? $this->db_jobs->get_jobs_summary( $filters ) : $this->getCompactSummary( $filters );
 		if ( is_wp_error( $summary ) ) {
 			return $summary;
 		}
@@ -193,6 +193,6 @@ class JobsSummaryAbility {
 		$count       = (int) $query();
 		$query_error = $this->jobQueryFailed();
 
-		return $query_error ?: $count;
+		return $query_error ? $query_error : $count;
 	}
 }


### PR DESCRIPTION
## Summary
- align the compact summary assignment with WordPress coding standards
- replace the forbidden short ternary without changing query-error behavior

## Verification
- exact `v0.175.2..HEAD` release lint scope passes PHPCS and PHPStan
- compact summary smoke passes 25 assertions

Closes #3247