### PR TITLE
fix: avoid missing ability registration probe

### DIFF
--- a/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
+++ b/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php
@@ -29,7 +29,7 @@ class ConfigureFlowStepsAbility {
 
 	private function registerAbility(): void {
 		$register_callback = function () {
-			if ( null !== wp_get_ability( 'datamachine/configure-flow-steps' ) ) {
+			if ( wp_has_ability( 'datamachine/configure-flow-steps' ) ) {
 				return;
 			}
 

--- a/tests/ability-provider-bootstrap-idempotency-smoke.php
+++ b/tests/ability-provider-bootstrap-idempotency-smoke.php
@@ -9,13 +9,17 @@
 
 namespace {
 	if ( function_exists( 'wp_register_ability' ) ) {
-		require_once dirname( __DIR__ ) . '/vendor/autoload.php';
-		require_once dirname( __DIR__ ) . '/inc/Abilities/AbilityCategories.php';
+		if ( ! class_exists( \DataMachine\Abilities\FlowStep\ConfigureFlowStepsAbility::class ) ) {
+			require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+		}
+		if ( ! class_exists( \DataMachine\Abilities\AbilityCategories::class ) ) {
+			require_once dirname( __DIR__ ) . '/inc/Abilities/AbilityCategories.php';
+		}
 		\DataMachine\Abilities\AbilityCategories::ensure_registered();
 
 		$notices = 0;
 		$watch   = static function ( string $function_name, string $message ) use ( &$notices ): void {
-			if ( 'WP_Abilities_Registry::register' === $function_name && str_contains( $message, 'datamachine/' ) ) {
+			if ( str_starts_with( $function_name, 'WP_Abilities_Registry::' ) && str_contains( $message, 'datamachine/' ) ) {
 				++$notices;
 			}
 		};
@@ -24,6 +28,7 @@ namespace {
 		$bootstrap = static function (): void {
 			new \DataMachine\Abilities\Engine\ScheduleNextStepAbility();
 			new \DataMachine\Abilities\Taxonomy\ResolveTermAbility();
+			new \DataMachine\Abilities\FlowStep\ConfigureFlowStepsAbility();
 		};
 
 		$bootstrap();
@@ -31,12 +36,18 @@ namespace {
 		$abilities = array(
 			wp_get_ability( 'datamachine/resolve-term' ),
 			wp_get_ability( 'datamachine/schedule-next-step' ),
+			wp_get_ability( 'datamachine/configure-flow-steps' ),
 		);
 		$bootstrap();
 		$bootstrap();
 		remove_action( 'doing_it_wrong_run', $watch, 10 );
+		$registered = wp_get_abilities();
 
-		if ( in_array( null, $abilities, true ) || 0 !== $notices ) {
+		if (
+			in_array( null, $abilities, true )
+			|| 0 !== $notices
+			|| ( $registered['datamachine/configure-flow-steps'] ?? null ) !== $abilities[2]
+		) {
 			fwrite( STDERR, "FAIL: repeated WordPress bootstrap duplicated or missed affected abilities\n" );
 			exit( 1 );
 		}
@@ -86,6 +97,24 @@ namespace {
 		}
 	}
 
+	if ( ! function_exists( 'wp_has_ability' ) ) {
+		function wp_has_ability( string $name ): bool {
+			return isset( $GLOBALS['datamachine_3066_state']->registrations[ $name ] );
+		}
+	}
+
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		function wp_get_ability( string $name ): ?object {
+			$state = $GLOBALS['datamachine_3066_state'];
+			if ( ! isset( $state->registrations[ $name ] ) ) {
+				++$state->notices;
+				return null;
+			}
+
+			return new \stdClass();
+		}
+	}
+
 	if ( ! function_exists( '__' ) ) {
 		function __( string $text, string $domain = 'default' ): string {
 			unset( $domain );
@@ -118,22 +147,31 @@ namespace DataMachine\Core\Database\ProcessedItems {
 	}
 }
 
+namespace DataMachine\Abilities {
+	if ( ! class_exists( HandlerAbilities::class ) ) {
+		class HandlerAbilities {}
+	}
+}
+
 namespace {
 	require_once dirname( __DIR__ ) . '/inc/Abilities/AbilityRegistration.php';
 	require_once dirname( __DIR__ ) . '/inc/Abilities/Engine/EngineHelpers.php';
 	require_once dirname( __DIR__ ) . '/inc/Abilities/Engine/ScheduleNextStepAbility.php';
 	require_once dirname( __DIR__ ) . '/inc/Abilities/Taxonomy/ResolveTermAbility.php';
+	require_once dirname( __DIR__ ) . '/inc/Abilities/FlowStep/FlowStepHelpers.php';
+	require_once dirname( __DIR__ ) . '/inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php';
 
 	$bootstrap = static function (): void {
 		new \DataMachine\Abilities\Engine\ScheduleNextStepAbility();
 		new \DataMachine\Abilities\Taxonomy\ResolveTermAbility();
+		new \DataMachine\Abilities\FlowStep\ConfigureFlowStepsAbility();
 	};
 
 	$bootstrap();
 	$bootstrap();
 
 	$state = $GLOBALS['datamachine_3066_state'];
-	if ( 2 !== count( $state->actions['wp_abilities_api_init'] ?? array() ) ) {
+	if ( 3 !== count( $state->actions['wp_abilities_api_init'] ?? array() ) ) {
 		fwrite( STDERR, "FAIL: repeated bootstrap attached duplicate provider callbacks\n" );
 		exit( 1 );
 	}
@@ -148,7 +186,7 @@ namespace {
 	$bootstrap();
 	$bootstrap();
 
-	foreach ( array( 'datamachine/resolve-term', 'datamachine/schedule-next-step' ) as $name ) {
+	foreach ( array( 'datamachine/resolve-term', 'datamachine/schedule-next-step', 'datamachine/configure-flow-steps' ) as $name ) {
 		if ( 1 !== ( $state->registrations[ $name ] ?? 0 ) ) {
 			fwrite( STDERR, "FAIL: {$name} did not register exactly once\n" );
 			exit( 1 );


### PR DESCRIPTION
## Summary
- use WordPress core's non-noticing `wp_has_ability()` predicate for the `configure-flow-steps` registration guard
- extend provider bootstrap regression coverage to fail on registry doing-it-wrong notices and prove repeated construction leaves one canonical ability
- make the smoke runnable both standalone and in a representative WP-CLI bootstrap

## Root cause
`ConfigureFlowStepsAbility::registerAbility()` used `wp_get_ability()` to ask whether the ability was absent. In WordPress 7.0, that helper delegates to `WP_Abilities_Registry::get_registered()`, which intentionally emits `_doing_it_wrong()` when the requested ability is missing. The first legitimate registration therefore produced a notice on bootstrap.

Core already provides the intended feature-detection API: `wp_has_ability()` delegates to `WP_Abilities_Registry::is_registered()` and returns `false` for an absent ability without emitting a notice.

## Idempotency
Data Machine's `AbilityRegistration::on_abilities_api_init()` deduplicates callbacks by their concrete provider and declaration location. The core predicate remains as a safe guard if the registration callback itself is invoked repeatedly. Regression coverage constructs the providers repeatedly before and after the lifecycle callback, fails on missing-lookup or duplicate-registration notices, and asserts `datamachine/configure-flow-steps` registers exactly once and resolves to the canonical registry object.

## Verification
- `php tests/ability-provider-bootstrap-idempotency-smoke.php`
- `wp --skip-plugins --url=https://extrachill.com --path=/var/www/extrachill.com eval-file /var/lib/datamachine/workspace/data-machine@fix-3244-configure-flow-registration/tests/ability-provider-bootstrap-idempotency-smoke.php`
- `php tests/flow-step-target-resolver-smoke.php`
- `php tests/frontend-runtime-gate-smoke.php`
- `php tests/bootstrap-service-provider-composition-smoke.php`
- `vendor/bin/phpcs inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php tests/ability-provider-bootstrap-idempotency-smoke.php`
- `vendor/bin/phpcs`
- `php -l inc/Abilities/FlowStep/ConfigureFlowStepsAbility.php`
- `php -l tests/ability-provider-bootstrap-idempotency-smoke.php`
- `git diff --check`

The installed pre-fix plugin reproduced the notice when the WordPress-loaded regression first constructed `ConfigureFlowStepsAbility`; the isolated WP-CLI run loading the candidate worktree passed notice-free. The original representative command also completed without the notice during final verification:

`wp --url=https://extrachill.com --path=/var/www/extrachill.com datamachine-code workspace show data-machine`

PHPStan is not installed in this repository. The WP unit test file could not run outside the configured WordPress test suite because `WP_UnitTestCase` is unavailable; focused standalone and WP-CLI regression coverage passed instead.

## Sibling audit
No other ability registration callback in `inc/Abilities/` uses `wp_get_ability()` as a registration guard, so no broader migration is required.

Closes #3244