### PR TITLE
Include registered abilities in bundle host capabilities

### DIFF
--- a/inc/Engine/Bundle/AgentBundleCompatibility.php
+++ b/inc/Engine/Bundle/AgentBundleCompatibility.php
@@ -33,6 +33,12 @@ final class AgentBundleCompatibility {
 			'datamachine/auth-ref',
 			'datamachine/queue-seed',
 		);
+		if ( function_exists( 'wp_get_abilities' ) ) {
+			$abilities = wp_get_abilities();
+			if ( is_array( $abilities ) ) {
+				$capabilities = array_merge( $capabilities, array_keys( $abilities ) );
+			}
+		}
 
 		/**
 		 * Extend host capability strings used for bundle compatibility checks.

--- a/tests/bundle-validate-inspect-smoke.php
+++ b/tests/bundle-validate-inspect-smoke.php
@@ -10,6 +10,14 @@
 $failures = array();
 $passes   = 0;
 
+$GLOBALS['datamachine_bundle_validate_smoke_abilities'] = array(
+	'example/registered-report' => new stdClass(),
+);
+
+function wp_get_abilities(): array {
+	return $GLOBALS['datamachine_bundle_validate_smoke_abilities'];
+}
+
 echo "bundle-validate-inspect-smoke\n";
 
 require_once __DIR__ . '/agents-api-smoke-helpers.php';
@@ -225,7 +233,7 @@ $unsupported_package = WP_Agent_Package::from_array(
 			'description'    => '',
 			'default_config' => array(),
 		),
-		'capabilities' => array( 'datamachine/agent-bundle', 'intelligence/wiki-brain' ),
+		'capabilities' => array( 'datamachine/agent-bundle', 'example/registered-report', 'intelligence/wiki-brain' ),
 		'artifacts'    => array(
 			array(
 				'type'     => 'unknown/vendor-artifact',
@@ -239,6 +247,7 @@ $unsupported_package = WP_Agent_Package::from_array(
 );
 $unsupported_report = WP_Agent_Package_Capability_Checker::check( $unsupported_package, AgentBundleCompatibility::host_capabilities() )->to_array();
 agents_api_smoke_assert_equals( false, $unsupported_report['compatible'] ?? true, 'unsupported package is incompatible', $failures, $passes );
+agents_api_smoke_assert_equals( true, in_array( 'example/registered-report', AgentBundleCompatibility::host_capabilities(), true ), 'registered WordPress ability is a host capability', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'intelligence/wiki-brain', 'unknown/runtime' ), $unsupported_report['unsupported_capabilities'] ?? null, 'unsupported capabilities include package and artifact requirements', $failures, $passes );
 agents_api_smoke_assert_equals( array( 'unknown/vendor-artifact' ), $unsupported_report['unknown_artifact_types'] ?? null, 'unknown artifact type is reported', $failures, $passes );
 agents_api_smoke_assert_equals( 'unknown/vendor-artifact:opaque-seed', $unsupported_report['unsupported_artifacts'][0]['artifact_key'] ?? '', 'unsupported artifact carries stable key', $failures, $passes );


### PR DESCRIPTION
## Summary
Let portable agent packages require registered WordPress abilities without provider-specific duplicate declarations.

## What changed
- Merge live WordPress ability names into Data Machine's normalized bundle host capability set before the extension filter.

## How to test
1. Run `php tests/bundle-validate-inspect-smoke.php`; expect 21 assertions pass, including registered and unregistered ability behavior.
2. Run `vendor/bin/phpunit`; expect PHP unit suite exits successfully.
3. Run `composer lint`; expect PHPCS exits successfully.
4. Run `npm run build`; expect Webpack compiles successfully.

## Compatibility
Existing built-in and filter-provided capabilities remain supported; unregistered ability names remain unsupported.

## Evidence
- Base unchanged since verification: main remains at 0d4440e32fd25bc2335780de5777b76576d67b25.
- CI expected: tests
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/data-machine/issues/3250
- Verified finalization base: main at 0d4440e32fd25bc2335780de5777b76576d67b25
- bundle-compatibility-smoke: passed (21 assertions) (Passed)
- frontend-build: passed (Passed)
- phpcs: passed (Passed)
- phpunit: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Identified the duplicate host-capability declaration, implemented registry-derived ability capabilities, and ran deterministic verification.

## Source relationships
- Closes #3250
