### PR TITLE
Add principal-scoped agent memory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=8.2",
-		"wordpress/agents-api": "dev-feat/503-principal-memory-layer#fc5204afc411920631f8941483f0eed71536e155",
+		"wordpress/agents-api": "dev-main",
 		"woocommerce/action-scheduler": "^3.9",
 		"automattic/blocks-engine-php-transformer": "0.1.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=8.2",
-		"wordpress/agents-api": "dev-main",
+		"wordpress/agents-api": "dev-feat/503-principal-memory-layer#fc5204afc411920631f8941483f0eed71536e155",
 		"woocommerce/action-scheduler": "^3.9",
 		"automattic/blocks-engine-php-transformer": "0.1.0"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -794,12 +794,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "78906489fb430083800e7afdd19bf2641ea452ea"
+                "reference": "4b88bfba005adc65f49dddfaa2dfc0bf336d8bf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/78906489fb430083800e7afdd19bf2641ea452ea",
-                "reference": "78906489fb430083800e7afdd19bf2641ea452ea",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/4b88bfba005adc65f49dddfaa2dfc0bf336d8bf6",
+                "reference": "4b88bfba005adc65f49dddfaa2dfc0bf336d8bf6",
                 "shasum": ""
             },
             "require": {
@@ -964,7 +964,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-08-15T00:32:13+00:00"
+            "time": "2026-08-19T16:49:56+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a46f0c7dfd863e9de8fe9978663e045f",
+    "content-hash": "1bb4b776947f4826fe0c862339e8a92b",
     "packages": [
         {
             "name": "automattic/blocks-engine-php-transformer",
@@ -790,16 +790,16 @@
         },
         {
             "name": "wordpress/agents-api",
-            "version": "dev-feat/503-principal-memory-layer",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "fc5204afc411920631f8941483f0eed71536e155"
+                "reference": "78906489fb430083800e7afdd19bf2641ea452ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/fc5204afc411920631f8941483f0eed71536e155",
-                "reference": "fc5204afc411920631f8941483f0eed71536e155",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/78906489fb430083800e7afdd19bf2641ea452ea",
+                "reference": "78906489fb430083800e7afdd19bf2641ea452ea",
                 "shasum": ""
             },
             "require": {
@@ -815,6 +815,7 @@
             "suggest": {
                 "woocommerce/action-scheduler": "Required to actually run cron-triggered workflows. The substrate detects Action Scheduler at runtime and no-ops cleanly when absent; install this package (or any plugin that ships it, like WooCommerce) to enable scheduled workflow runs."
             },
+            "default-branch": true,
             "type": "wordpress-plugin",
             "autoload": {
                 "files": [
@@ -963,7 +964,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-08-19T16:47:56+00:00"
+            "time": "2026-08-15T00:32:13+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1bb4b776947f4826fe0c862339e8a92b",
+    "content-hash": "a46f0c7dfd863e9de8fe9978663e045f",
     "packages": [
         {
             "name": "automattic/blocks-engine-php-transformer",
@@ -790,16 +790,16 @@
         },
         {
             "name": "wordpress/agents-api",
-            "version": "dev-main",
+            "version": "dev-feat/503-principal-memory-layer",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "78906489fb430083800e7afdd19bf2641ea452ea"
+                "reference": "fc5204afc411920631f8941483f0eed71536e155"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/78906489fb430083800e7afdd19bf2641ea452ea",
-                "reference": "78906489fb430083800e7afdd19bf2641ea452ea",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/fc5204afc411920631f8941483f0eed71536e155",
+                "reference": "fc5204afc411920631f8941483f0eed71536e155",
                 "shasum": ""
             },
             "require": {
@@ -815,7 +815,6 @@
             "suggest": {
                 "woocommerce/action-scheduler": "Required to actually run cron-triggered workflows. The substrate detects Action Scheduler at runtime and no-ops cleanly when absent; install this package (or any plugin that ships it, like WooCommerce) to enable scheduled workflow runs."
             },
-            "default-branch": true,
             "type": "wordpress-plugin",
             "autoload": {
                 "files": [
@@ -964,7 +963,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-08-15T00:32:13+00:00"
+            "time": "2026-08-19T16:47:56+00:00"
         }
     ],
     "packages-dev": [

--- a/inc/Abilities/AgentMemoryAbilities.php
+++ b/inc/Abilities/AgentMemoryAbilities.php
@@ -14,6 +14,7 @@ namespace DataMachine\Abilities;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\FilesRepository\AgentMemory;
+use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Engine\AI\DataMachineAgentConsentPolicy;
 use DataMachine\Engine\AI\Memory\MemorySectionPendingAction;
 use DataMachine\Engine\AI\Memory\SelfMemoryWritePolicy;
@@ -317,6 +318,9 @@ class AgentMemoryAbilities {
 	 */
 	public static function getMemory( array $input ): array|\WP_Error {
 		$memory  = self::resolveMemory( $input );
+		if ( is_wp_error( $memory ) ) {
+			return $memory;
+		}
 		$section = $input['section'] ?? null;
 
 		if ( null === $section || '' === $section ) {
@@ -333,13 +337,19 @@ class AgentMemoryAbilities {
 	 * @return array Result.
 	 */
 	public static function updateMemory( array $input ): array|\WP_Error {
+		$memory = self::resolveMemory( $input );
+		if ( is_wp_error( $memory ) ) {
+			return $memory;
+		}
+		$scope = $memory->get_scope();
+
 		$consent_decision = DataMachineAgentConsentPolicy::get()->can_store_memory(
 			array(
 				'mode'               => 'ability',
 				'interactive'        => true,
 				'permission_granted' => PermissionHelper::can_manage(),
-				'agent_id'           => (int) ( $input['agent_id'] ?? 0 ),
-				'user_id'            => (int) ( $input['user_id'] ?? 0 ),
+				'agent_id'           => $scope->agent_id,
+				'user_id'            => $scope->user_id,
 			)
 		);
 		if ( ! $consent_decision->is_allowed() ) {
@@ -349,13 +359,12 @@ class AgentMemoryAbilities {
 				array(
 					'status'           => 403,
 					'consent_decision' => $consent_decision->to_array(),
-					'agent_id'         => (int) ( $input['agent_id'] ?? 0 ),
-					'user_id'          => (int) ( $input['user_id'] ?? 0 ),
+					'agent_id'         => $scope->agent_id,
+					'user_id'          => $scope->user_id,
 				)
 			);
 		}
 
-		$memory  = self::resolveMemory( $input );
 		$section = $input['section'];
 		$content = $input['content'];
 		$mode    = $input['mode'];
@@ -406,13 +415,19 @@ class AgentMemoryAbilities {
 	 * @return array Result.
 	 */
 	public static function deleteMemorySection( array $input ): array|\WP_Error {
+		$memory = self::resolveMemory( $input );
+		if ( is_wp_error( $memory ) ) {
+			return $memory;
+		}
+		$scope = $memory->get_scope();
+
 		$consent_decision = DataMachineAgentConsentPolicy::get()->can_store_memory(
 			array(
 				'mode'               => 'ability',
 				'interactive'        => true,
 				'permission_granted' => PermissionHelper::can_manage(),
-				'agent_id'           => (int) ( $input['agent_id'] ?? 0 ),
-				'user_id'            => (int) ( $input['user_id'] ?? 0 ),
+				'agent_id'           => $scope->agent_id,
+				'user_id'            => $scope->user_id,
 			)
 		);
 		if ( ! $consent_decision->is_allowed() ) {
@@ -422,8 +437,8 @@ class AgentMemoryAbilities {
 				array(
 					'status'           => 403,
 					'consent_decision' => $consent_decision->to_array(),
-					'agent_id'         => (int) ( $input['agent_id'] ?? 0 ),
-					'user_id'          => (int) ( $input['user_id'] ?? 0 ),
+					'agent_id'         => $scope->agent_id,
+					'user_id'          => $scope->user_id,
 				)
 			);
 		}
@@ -440,7 +455,6 @@ class AgentMemoryAbilities {
 			);
 		}
 
-		$memory = self::resolveMemory( $input );
 		return self::memoryResult( $memory->delete_section( (string) $input['section'] ), 'agent_memory_delete_failed' );
 	}
 
@@ -477,6 +491,9 @@ class AgentMemoryAbilities {
 	 */
 	public static function searchMemory( array $input ): array|\WP_Error {
 		$memory  = self::resolveMemory( $input );
+		if ( is_wp_error( $memory ) ) {
+			return $memory;
+		}
 		$query   = $input['query'];
 		$section = $input['section'] ?? null;
 
@@ -491,6 +508,9 @@ class AgentMemoryAbilities {
 	 */
 	public static function listSections( array $input ): array|\WP_Error {
 		$memory = self::resolveMemory( $input );
+		if ( is_wp_error( $memory ) ) {
+			return $memory;
+		}
 		return self::memoryResult( $memory->get_sections(), 'agent_memory_list_sections_failed' );
 	}
 
@@ -511,13 +531,45 @@ class AgentMemoryAbilities {
 	 *
 	 * @since 0.45.0
 	 * @param array $input Input parameters with optional user_id, agent_id, file.
-	 * @return AgentMemory
+	 * @return AgentMemory|\WP_Error
 	 */
-	private static function resolveMemory( array $input ): AgentMemory {
+	private static function resolveMemory( array $input ): AgentMemory|\WP_Error {
 		$user_id  = (int) ( $input['user_id'] ?? 0 );
 		$agent_id = (int) ( $input['agent_id'] ?? 0 );
 		$filename = $input['file'] ?? 'MEMORY.md';
+		$principal = PermissionHelper::get_execution_principal();
+
+		if ( null !== $principal ) {
+			$user_id  = $principal->acting_user_id;
+			$agent_id = self::resolvePrincipalAgentId( $principal->effective_agent_id );
+		}
+
+		if ( \DataMachine\Engine\AI\MemoryFileRegistry::LAYER_PRINCIPAL === AgentMemory::resolve_layer_for( $filename ) && ( $user_id <= 0 || $agent_id <= 0 ) ) {
+			return new \WP_Error(
+				'principal_memory_scope_unavailable',
+				'Principal memory requires an authenticated user and effective agent.',
+				array( 'status' => 403 )
+			);
+		}
 
 		return new AgentMemory( $user_id, $agent_id, $filename );
+	}
+
+	/** Resolve the numeric Data Machine agent represented by an Agents API principal. */
+	private static function resolvePrincipalAgentId( string $effective_agent_id ): int {
+		if ( str_starts_with( $effective_agent_id, 'agent:' ) ) {
+			$effective_agent_id = substr( $effective_agent_id, 6 );
+		}
+
+		if ( ctype_digit( $effective_agent_id ) ) {
+			return (int) $effective_agent_id;
+		}
+
+		$agent = ( new Agents() )->get_by_slug( sanitize_title( $effective_agent_id ) );
+		if ( null !== $agent ) {
+			return (int) $agent['agent_id'];
+		}
+
+		return (int) ( PermissionHelper::get_acting_agent_id() ?? 0 );
 	}
 }

--- a/inc/Abilities/File/AgentFileAbilities.php
+++ b/inc/Abilities/File/AgentFileAbilities.php
@@ -321,6 +321,7 @@ class AgentFileAbilities {
 		$layer_order = array(
 			MemoryFileRegistry::LAYER_SHARED,
 			MemoryFileRegistry::LAYER_AGENT,
+			MemoryFileRegistry::LAYER_PRINCIPAL,
 			MemoryFileRegistry::LAYER_USER,
 		);
 
@@ -640,7 +641,7 @@ class AgentFileAbilities {
 		}
 
 		// Fallback: check remaining layers (agent → user → shared) without dupes.
-		foreach ( array( MemoryFileRegistry::LAYER_AGENT, MemoryFileRegistry::LAYER_USER, MemoryFileRegistry::LAYER_SHARED ) as $layer ) {
+		foreach ( array( MemoryFileRegistry::LAYER_AGENT, MemoryFileRegistry::LAYER_PRINCIPAL, MemoryFileRegistry::LAYER_USER, MemoryFileRegistry::LAYER_SHARED ) as $layer ) {
 			if ( ! in_array( $layer, $layer_order, true ) ) {
 				$layer_order[] = $layer;
 			}

--- a/inc/Abilities/File/AgentFileAbilities.php
+++ b/inc/Abilities/File/AgentFileAbilities.php
@@ -292,6 +292,9 @@ class AgentFileAbilities {
 		// the layer directories but should still appear in the file list.
 		foreach ( MemoryFileRegistry::get_all() as $filename => $registry_meta ) {
 			$layer  = $registry_meta['layer'] ?? MemoryFileRegistry::LAYER_AGENT;
+			if ( MemoryFileRegistry::LAYER_PRINCIPAL === $layer && ( $user_id <= 0 || $agent_id <= 0 ) ) {
+				continue;
+			}
 			$memory = new AgentMemory( $user_id, $agent_id, $filename, $layer );
 			$read   = $memory->read();
 
@@ -321,9 +324,11 @@ class AgentFileAbilities {
 		$layer_order = array(
 			MemoryFileRegistry::LAYER_SHARED,
 			MemoryFileRegistry::LAYER_AGENT,
-			MemoryFileRegistry::LAYER_PRINCIPAL,
 			MemoryFileRegistry::LAYER_USER,
 		);
+		if ( $user_id > 0 && $agent_id > 0 ) {
+			$layer_order[] = MemoryFileRegistry::LAYER_PRINCIPAL;
+		}
 
 		foreach ( $layer_order as $layer ) {
 			foreach ( AgentMemory::list_layer( $layer, $user_id, $agent_id ) as $entry ) {
@@ -636,12 +641,15 @@ class AgentFileAbilities {
 
 		// If file is registered, check its canonical layer first.
 		$registered_layer = MemoryFileRegistry::get_layer( $filename );
-		if ( $registered_layer ) {
+		if ( $registered_layer && ( MemoryFileRegistry::LAYER_PRINCIPAL !== $registered_layer || ( $user_id > 0 && $agent_id > 0 ) ) ) {
 			$layer_order[] = $registered_layer;
 		}
 
 		// Fallback: check remaining layers (agent → user → shared) without dupes.
 		foreach ( array( MemoryFileRegistry::LAYER_AGENT, MemoryFileRegistry::LAYER_PRINCIPAL, MemoryFileRegistry::LAYER_USER, MemoryFileRegistry::LAYER_SHARED ) as $layer ) {
+			if ( MemoryFileRegistry::LAYER_PRINCIPAL === $layer && ( $user_id <= 0 || $agent_id <= 0 ) ) {
+				continue;
+			}
 			if ( ! in_array( $layer, $layer_order, true ) ) {
 				$layer_order[] = $layer;
 			}

--- a/inc/Abilities/File/ScaffoldAbilities.php
+++ b/inc/Abilities/File/ScaffoldAbilities.php
@@ -303,6 +303,7 @@ class ScaffoldAbilities {
 			MemoryFileRegistry::LAYER_SHARED,
 			MemoryFileRegistry::LAYER_AGENT,
 			MemoryFileRegistry::LAYER_USER,
+			MemoryFileRegistry::LAYER_PRINCIPAL,
 			MemoryFileRegistry::LAYER_NETWORK,
 		);
 
@@ -391,6 +392,14 @@ class ScaffoldAbilities {
 					return null;
 				}
 				return $dm->get_user_directory( $user_id );
+
+			case MemoryFileRegistry::LAYER_PRINCIPAL:
+				$user_id  = (int) ( $context['user_id'] ?? 0 );
+				$agent_id = (int) ( $context['agent_id'] ?? 0 );
+				if ( $user_id <= 0 || $agent_id <= 0 ) {
+					return null;
+				}
+				return $dm->get_principal_directory( $user_id, $agent_id );
 
 			case MemoryFileRegistry::LAYER_AGENT:
 				if ( ! empty( $context['agent_slug'] ) || (int) ( $context['agent_id'] ?? 0 ) > 0 ) {

--- a/inc/Core/FilesRepository/AgentMemory.php
+++ b/inc/Core/FilesRepository/AgentMemory.php
@@ -857,6 +857,8 @@ class AgentMemory {
 				return $this->directory_manager->get_shared_directory();
 			case MemoryFileRegistry::LAYER_USER:
 				return $this->directory_manager->get_user_directory( $this->scope->user_id );
+			case MemoryFileRegistry::LAYER_PRINCIPAL:
+				return $this->directory_manager->get_principal_directory( $this->scope->user_id, $this->scope->agent_id );
 			case MemoryFileRegistry::LAYER_NETWORK:
 				return $this->directory_manager->get_network_directory();
 			case MemoryFileRegistry::LAYER_AGENT:

--- a/inc/Core/FilesRepository/DirectoryManager.php
+++ b/inc/Core/FilesRepository/DirectoryManager.php
@@ -219,6 +219,25 @@ class DirectoryManager {
 	}
 
 	/**
+	 * Get learned-memory storage private to one user of one agent.
+	 *
+	 * @param int $user_id  Authenticated WordPress user ID.
+	 * @param int $agent_id Effective agent ID.
+	 * @return string Full principal memory directory path.
+	 */
+	public function get_principal_directory( int $user_id, int $agent_id ): string {
+		$user_id = absint( $user_id );
+		$agent_id = absint( $agent_id );
+		if ( 0 === $user_id || 0 === $agent_id ) {
+			throw new \InvalidArgumentException( 'Principal memory requires a positive user ID and agent ID.' );
+		}
+
+		$agent = $this->resolve_agent_directory( array( 'agent_id' => $agent_id ) );
+
+		return "{$agent}/users/{$user_id}";
+	}
+
+	/**
 	 * Get network-level directory path.
 	 *
 	 * Returns the network/ subdirectory under the network-global base.

--- a/inc/Core/FilesRepository/DiskAgentMemoryStore.php
+++ b/inc/Core/FilesRepository/DiskAgentMemoryStore.php
@@ -284,6 +284,8 @@ class DiskAgentMemoryStore implements WP_Agent_Memory_Store {
 				return $this->directory_manager->get_shared_directory();
 			case MemoryFileRegistry::LAYER_USER:
 				return $this->directory_manager->get_user_directory( $scope->user_id );
+			case MemoryFileRegistry::LAYER_PRINCIPAL:
+				return $this->directory_manager->get_principal_directory( $scope->user_id, $scope->agent_id );
 			case MemoryFileRegistry::LAYER_NETWORK:
 				return $this->directory_manager->get_network_directory();
 			case MemoryFileRegistry::LAYER_AGENT:

--- a/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
+++ b/inc/Engine/AI/Directives/CoreMemoryFilesDirective.php
@@ -64,6 +64,15 @@ class CoreMemoryFilesDirective implements DirectiveInterface {
 					'user_id' => $user_id,
 				)
 			);
+			if ( $agent_id > 0 ) {
+				$scaffold_ability->execute(
+					array(
+						'layer'    => MemoryFileRegistry::LAYER_PRINCIPAL,
+						'user_id'  => $user_id,
+						'agent_id' => $agent_id,
+					)
+				);
+			}
 		}
 
 		$items = array();

--- a/inc/Engine/AI/Directives/MemoryFilesReader.php
+++ b/inc/Engine/AI/Directives/MemoryFilesReader.php
@@ -66,6 +66,9 @@ class MemoryFilesReader {
 			MemoryFileRegistry::LAYER_USER    => $directory_manager->get_user_directory( $user_id ),
 			MemoryFileRegistry::LAYER_NETWORK => $directory_manager->get_network_directory(),
 		);
+		if ( $user_id > 0 && $agent_id > 0 ) {
+			$layer_dirs[ MemoryFileRegistry::LAYER_PRINCIPAL ] = $directory_manager->get_principal_directory( $user_id, $agent_id );
+		}
 
 		$outputs = array();
 
@@ -74,7 +77,10 @@ class MemoryFilesReader {
 
 			// Resolve directory from registry layer, fall back to agent dir.
 			$layer = MemoryFileRegistry::get_layer( $safe_filename );
-			$dir   = $layer_dirs[ $layer ?? MemoryFileRegistry::LAYER_AGENT ];
+			$dir   = $layer_dirs[ $layer ?? MemoryFileRegistry::LAYER_AGENT ] ?? null;
+			if ( null === $dir ) {
+				continue;
+			}
 
 			// Convention-path files (e.g. AGENTS.md) live at ABSPATH, not the layer directory.
 			$filepath = MemoryFileRegistry::resolve_filepath( $safe_filename, $dir )

--- a/inc/Engine/AI/MemoryFileRegistry.php
+++ b/inc/Engine/AI/MemoryFileRegistry.php
@@ -32,10 +32,11 @@ class MemoryFileRegistry {
 	/**
 	 * Valid layer identifiers.
 	 */
-	const LAYER_SHARED  = 'shared';
-	const LAYER_AGENT   = 'agent';
-	const LAYER_USER    = 'user';
-	const LAYER_NETWORK = 'network';
+	const LAYER_SHARED    = 'shared';
+	const LAYER_AGENT     = 'agent';
+	const LAYER_USER      = 'user';
+	const LAYER_PRINCIPAL = 'principal';
+	const LAYER_NETWORK   = 'network';
 
 	/**
 	 * Special context value meaning "inject in all contexts."
@@ -83,7 +84,7 @@ class MemoryFileRegistry {
 	 * @param array  $args     {
 	 *  Optional. Registration arguments.
 	 *
-	 *     @type string      $layer           One of 'shared', 'agent', 'user', 'network'. Default 'agent'.
+	 *     @type string      $layer           One of 'shared', 'agent', 'user', 'principal', 'network'. Default 'agent'.
 	 *     @type bool        $protected       Whether the file is protected from deletion. Default false.
 	 *     @type string      $label           Human-readable display label. Default derived from filename.
 	 *     @type string      $description     Optional description of the file's purpose.
@@ -697,6 +698,10 @@ class MemoryFileRegistry {
 
 		if ( self::LAYER_USER === $layer ) {
 			return 'user_global';
+		}
+
+		if ( self::LAYER_PRINCIPAL === $layer ) {
+			return 'user_workspace_private';
 		}
 
 		if ( 'SOUL.md' === $filename ) {

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -134,6 +134,13 @@ function datamachine_register_default_memory_files(): void {
 		'label'              => 'User Profile',
 		'description'        => 'Information about the human the agent works with. Injected when the mode activates user profile memory.',
 	) );
+	MemoryFileRegistry::register( 'USER_MEMORY.md', 28, array(
+		'layer'              => MemoryFileRegistry::LAYER_PRINCIPAL,
+		'protected'          => true,
+		'injection_contexts' => array( 'agent_memory' ),
+		'label'              => 'User Memory',
+		'description'        => 'Learned context private to the authenticated user and effective agent.',
+	) );
 
 	// Network layer — multisite topology.
 	if ( is_multisite() ) {

--- a/inc/migrations/scaffolding.php
+++ b/inc/migrations/scaffolding.php
@@ -325,10 +325,24 @@ function datamachine_resolve_agent_name_from_context( array $context ): string {
  */
 function datamachine_register_scaffold_generators(): void {
 	add_filter( 'datamachine_scaffold_content', 'datamachine_scaffold_user_content', 10, 3 );
+	add_filter( 'datamachine_scaffold_content', 'datamachine_scaffold_user_memory_content', 10, 3 );
 	add_filter( 'datamachine_scaffold_content', 'datamachine_scaffold_soul_content', 10, 3 );
 	add_filter( 'datamachine_scaffold_content', 'datamachine_scaffold_memory_content', 10, 3 );
 	add_filter( 'datamachine_scaffold_content', 'datamachine_scaffold_daily_content', 10, 3 );
 	add_filter( 'datamachine_scaffold_content', 'datamachine_scaffold_rules_content', 10, 3 );
+}
+
+/** Generate an empty learned-memory document for one authenticated user and agent. */
+function datamachine_scaffold_user_memory_content( string $content, string $filename, array $context ): string {
+	if ( 'USER_MEMORY.md' !== $filename || '' !== $content ) {
+		return $content;
+	}
+
+	if ( (int) ( $context['user_id'] ?? 0 ) <= 0 || (int) ( $context['agent_id'] ?? 0 ) <= 0 ) {
+		return $content;
+	}
+
+	return "# User Memory\n\nDurable observations and preferences learned by this agent for the authenticated user.\n";
 }
 add_action( 'plugins_loaded', 'datamachine_register_scaffold_generators', 5 );
 

--- a/tests/Unit/Engine/AI/MemoryFileRegistryTest.php
+++ b/tests/Unit/Engine/AI/MemoryFileRegistryTest.php
@@ -89,6 +89,7 @@ class MemoryFileRegistryTest extends TestCase {
 		MemoryFileRegistry::register( 'SITE.md',    10, array( 'layer' => MemoryFileRegistry::LAYER_SHARED ) );
 		MemoryFileRegistry::register( 'NETWORK.md', 10, array( 'layer' => MemoryFileRegistry::LAYER_NETWORK ) );
 		MemoryFileRegistry::register( 'USER.md',    10, array( 'layer' => MemoryFileRegistry::LAYER_USER ) );
+		MemoryFileRegistry::register( 'USER_MEMORY.md', 10, array( 'layer' => MemoryFileRegistry::LAYER_PRINCIPAL ) );
 		MemoryFileRegistry::register( 'SOUL.md',    10, array( 'layer' => MemoryFileRegistry::LAYER_AGENT ) );
 		MemoryFileRegistry::register( 'MEMORY.md',  10, array( 'layer' => MemoryFileRegistry::LAYER_AGENT ) );
 
@@ -96,8 +97,26 @@ class MemoryFileRegistryTest extends TestCase {
 		$this->assertSame( 'workspace_shared', $all['SITE.md']['authority_tier'] );
 		$this->assertSame( 'workspace_shared', $all['NETWORK.md']['authority_tier'] );
 		$this->assertSame( 'user_global',      $all['USER.md']['authority_tier'] );
+		$this->assertSame( 'user_workspace_private', $all['USER_MEMORY.md']['authority_tier'] );
 		$this->assertSame( 'agent_identity',   $all['SOUL.md']['authority_tier'] );
 		$this->assertSame( 'agent_memory',     $all['MEMORY.md']['authority_tier'] );
+	}
+
+	public function test_default_files_keep_profile_and_learned_user_memory_separate(): void {
+		datamachine_register_default_memory_files();
+
+		$profile = MemoryFileRegistry::get( 'USER.md' );
+		$memory  = MemoryFileRegistry::get( 'USER_MEMORY.md' );
+
+		$this->assertSame( MemoryFileRegistry::LAYER_USER, $profile['layer'] );
+		$this->assertSame( array( MemoryFileRegistry::INJECTION_USER_PROFILE ), $profile['injection_contexts'] );
+		$this->assertSame( MemoryFileRegistry::LAYER_PRINCIPAL, $memory['layer'] );
+		$this->assertSame( array( MemoryFileRegistry::INJECTION_AGENT_MEMORY ), $memory['injection_contexts'] );
+		$this->assertStringContainsString(
+			'Durable observations',
+			datamachine_scaffold_user_memory_content( '', 'USER_MEMORY.md', array( 'user_id' => 7, 'agent_id' => 42 ) )
+		);
+		$this->assertSame( '', datamachine_scaffold_user_memory_content( '', 'USER_MEMORY.md', array( 'user_id' => 0, 'agent_id' => 42 ) ) );
 	}
 
 	/**

--- a/tests/core-memory-composable-first-read-smoke.php
+++ b/tests/core-memory-composable-first-read-smoke.php
@@ -57,9 +57,10 @@ namespace DataMachine\Core\FilesRepository {
 			$content = $GLOBALS['__core_memory_composable_files'][ $this->filename ] ?? null;
 
 			return (object) array(
-				'exists'  => null !== $content,
-				'content' => (string) $content,
-				'bytes'   => strlen( (string) $content ),
+				'exists'     => null !== $content,
+				'content'    => (string) $content,
+				'bytes'      => strlen( (string) $content ),
+				'updated_at' => null,
 			);
 		}
 	}

--- a/tests/principal-memory-ability-scope-smoke.php
+++ b/tests/principal-memory-ability-scope-smoke.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Pure-PHP contract test for principal-derived memory ability addressing.
+ *
+ * Run with: php tests/principal-memory-ability-scope-smoke.php
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+
+class WP_Error {
+	public function __construct( public string $code, public string $message, public array $data = array() ) {}
+}
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+function sanitize_title( string $value ): string {
+	return strtolower( trim( $value ) );
+}
+
+eval( 'namespace DataMachine\\Abilities; class PermissionHelper { public static ?object $principal = null; public static ?int $agent = null; public static function get_execution_principal(): ?object { return self::$principal; } public static function get_acting_agent_id(): ?int { return self::$agent; } }' );
+eval( 'namespace DataMachine\\Core\\Database\\Agents; class Agents { public function get_by_slug( string $slug ): ?array { return "north" === $slug ? [ "agent_id" => 42 ] : null; } }' );
+eval( 'namespace DataMachine\\Engine\\AI; class MemoryFileRegistry { public const LAYER_PRINCIPAL = "principal"; }' );
+eval( 'namespace DataMachine\\Core\\FilesRepository; class AgentMemory { public function __construct( public int $user_id, public int $agent_id, public string $filename ) {} public static function resolve_layer_for( string $filename ): string { return "USER_MEMORY.md" === $filename ? "principal" : "agent"; } public function get_all(): array { return [ "success" => true, "user_id" => $this->user_id, "agent_id" => $this->agent_id, "filename" => $this->filename ]; } }' );
+
+require_once __DIR__ . '/../inc/Abilities/AgentMemoryAbilities.php';
+
+DataMachine\Abilities\PermissionHelper::$principal = (object) array(
+	'acting_user_id'     => 7,
+	'effective_agent_id' => 'north',
+);
+$resolved = DataMachine\Abilities\AgentMemoryAbilities::getMemory(
+	array(
+		'user_id'  => 999,
+		'agent_id' => 888,
+		'file'     => 'USER_MEMORY.md',
+	)
+);
+
+$failures = array();
+$assert   = static function ( bool $condition, string $label ) use ( &$failures ): void {
+	if ( $condition ) {
+		fwrite( STDOUT, "PASS {$label}\n" );
+		return;
+	}
+	$failures[] = $label;
+	fwrite( STDERR, "FAIL {$label}\n" );
+};
+
+$assert( 7 === ( $resolved['user_id'] ?? 0 ), 'authenticated principal overrides caller-supplied user ID' );
+$assert( 42 === ( $resolved['agent_id'] ?? 0 ), 'effective agent overrides caller-supplied agent ID' );
+
+DataMachine\Abilities\PermissionHelper::$agent     = 42;
+DataMachine\Abilities\PermissionHelper::$principal = (object) array(
+	'acting_user_id'     => 7,
+	'effective_agent_id' => 'agent:84',
+);
+$delegated = DataMachine\Abilities\AgentMemoryAbilities::getMemory( array( 'file' => 'USER_MEMORY.md' ) );
+$assert( 84 === ( $delegated['agent_id'] ?? 0 ), 'delegated effective agent overrides the acting agent' );
+
+DataMachine\Abilities\PermissionHelper::$principal = (object) array(
+	'acting_user_id'     => 0,
+	'effective_agent_id' => 'north',
+);
+$denied = DataMachine\Abilities\AgentMemoryAbilities::getMemory( array( 'file' => 'USER_MEMORY.md' ) );
+$assert( is_wp_error( $denied ) && 'principal_memory_scope_unavailable' === $denied->code, 'principal memory fails closed without an authenticated user' );
+
+if ( $failures ) {
+	exit( 1 );
+}
+
+fwrite( STDOUT, "Principal memory ability scope contract passed.\n" );

--- a/tests/principal-memory-scope-smoke.php
+++ b/tests/principal-memory-scope-smoke.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Pure-PHP contract test for principal-scoped memory paths.
+ *
+ * Run with: php tests/principal-memory-scope-smoke.php
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/../' );
+}
+
+function absint( $value ): int {
+	return abs( (int) $value );
+}
+
+function sanitize_title( string $value ): string {
+	$value = strtolower( $value );
+	$value = preg_replace( '/[^a-z0-9]+/', '-', $value );
+	return trim( (string) $value, '-' );
+}
+
+function trailingslashit( string $value ): string {
+	return rtrim( $value, '/' ) . '/';
+}
+
+function wp_upload_dir(): array {
+	return array( 'basedir' => sys_get_temp_dir() . '/datamachine-principal-memory' );
+}
+
+function is_multisite(): bool {
+	return false;
+}
+
+eval( 'namespace DataMachine\\Core\\Database\\Agents; class Agents { public function get_agent( int $id ): ?array { return [ "agent_id" => $id, "agent_slug" => 42 === $id ? "north" : "writer", "owner_id" => 1, "instance_key" => "default" ]; } public function get_by_slug( string $slug ): ?array { return [ "agent_id" => "north" === $slug ? 42 : 84 ]; } }' );
+
+require_once __DIR__ . '/agents-api-loader.php';
+datamachine_tests_require_agents_api();
+require_once __DIR__ . '/../inc/Core/FilesRepository/DirectoryManager.php';
+
+$directory = new DataMachine\Core\FilesRepository\DirectoryManager();
+$north_7   = $directory->get_principal_directory( 7, 42 );
+$north_8   = $directory->get_principal_directory( 8, 42 );
+$writer_7  = $directory->get_principal_directory( 7, 84 );
+$north     = $directory->resolve_agent_directory( array( 'agent_id' => 42 ) );
+
+$failures = array();
+$assert   = static function ( bool $condition, string $label ) use ( &$failures ): void {
+	if ( $condition ) {
+		fwrite( STDOUT, "PASS {$label}\n" );
+		return;
+	}
+	$failures[] = $label;
+	fwrite( STDERR, "FAIL {$label}\n" );
+};
+
+$assert( $north . '/users/7' === $north_7, 'principal path nests the authenticated user beneath the effective agent' );
+$assert( $north_7 !== $north_8, 'two users of one agent have isolated memory paths' );
+$assert( $north_7 !== $writer_7, 'one user across two agents has isolated memory paths' );
+$assert( $north === $directory->resolve_agent_directory( array( 'agent_id' => 42, 'user_id' => 8 ) ), 'agent-global path is independent of the calling user' );
+$assert( 'principal' === WP_Agent_Memory_Layer::normalize( 'principal' ), 'Data Machine consumes the canonical Agents API principal layer' );
+
+$invalid_scope_rejected = false;
+try {
+	$directory->get_principal_directory( 0, 42 );
+} catch ( InvalidArgumentException ) {
+	$invalid_scope_rejected = true;
+}
+$assert( $invalid_scope_rejected, 'principal path fails closed without an authenticated user' );
+
+if ( $failures ) {
+	exit( 1 );
+}
+
+fwrite( STDOUT, "Principal memory scope contract passed.\n" );


### PR DESCRIPTION
Closes #3249

## Summary
- add a canonical principal memory layer backed by `USER_MEMORY.md`
- scope learned user memory to the authenticated user and effective agent while preserving user-global `USER.md` profiles and agent-global `MEMORY.md`
- derive ability addressing, consent checks, prompt injection, scaffolding, and disk paths from the authenticated execution principal
- fail closed for anonymous or incomplete principal scopes and preserve delegated effective-agent isolation
- advance the Agents API lock to merged principal-layer support from Automattic/agents-api#504

## Verification
- principal path isolation smoke: passed
- principal ability boundary smoke: passed
- Agents API memory contract/store and memory event/section smokes: passed
- PHPCS on all changed PHP files: passed
- Composer validation and `git diff --check`: passed
- GitHub Homeboy full suite: all four test shards and aggregate Test gate passed
- GitHub Homeboy audit, lint, refactor, and prefix policy: passed

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to inspect the memory architecture, implement the scoped-memory integration, write boundary tests, diagnose CI failures, and run verification. Chris Huber reviewed and remains responsible for the change.