### PR TITLE
Add runtime-backed Pipeline Builder fuzz suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ docs/.docs-sync.json
 
 # Build artifacts
 build/
+artifacts/

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -1,0 +1,20 @@
+# Runtime-Backed Pipeline Builder Fuzzing
+
+Run the versioned Pipeline Builder fixture against a disposable WordPress runtime:
+
+```bash
+npm run build
+wp-codebox run-fuzz-suite --runner-mode=runtime-backed --input-file=tests/fuzz/pipeline-builder-runtime.json --format=json
+```
+
+`wp-codebox` is the public executable. The similarly named `wp codebox` WordPress CLI command invokes an in-process ability and cannot execute browser or runtime actions.
+
+Validate the Data Machine-owned fixture contract without booting a runtime:
+
+```bash
+node tests/fuzz/pipeline-builder-runtime-contract.test.mjs
+```
+
+The fixture requires compiled Pipeline Builder assets and a disposable recipe runtime per case. Because the input lives in `tests/fuzz`, its Data Machine mount is `../..`. Each workload activates the mounted plugin, creates and restores a checkpoint inside its own recipe workflow, and creates its own prerequisite pipeline or flow. Its selectors come from the builder source and target concrete controls, including `input[placeholder="Pipeline name"]` and `input[type="file"][accept=".csv,text/csv"]`.
+
+Keep a real regression as a replayable failing case with its artifacts; do not weaken assertions to hide it.

--- a/tests/fuzz/pipeline-builder-runtime-contract.test.mjs
+++ b/tests/fuzz/pipeline-builder-runtime-contract.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const directory = dirname(fileURLToPath(import.meta.url));
+const repository = resolve(directory, "../..");
+const fixture = JSON.parse(await readFile(resolve(directory, "pipeline-builder-runtime.json"), "utf8"));
+
+assert.equal(fixture.schema, "wp-codebox/fuzz-suite/v1");
+assert.equal("resetPolicy" in fixture, false, "Recipe-backed component suites reset inside each workload, not through a suite executor.");
+assert.equal(fixture.metadata.runtime_requirements.extra_plugins[0].source, "../..");
+assert.equal(fixture.metadata.runtime_requirements.extra_plugins[0].path, "../..");
+assert.equal("coveragePlan" in fixture, false, "Runtime execution, not static fixture data, owns executable coverage accounting.");
+
+const seeds = new Set();
+for (const fuzzCase of fixture.cases) {
+  assert.match(fuzzCase.id, /^[a-z0-9-]+$/);
+  assert.equal(typeof fuzzCase.metadata.seed, "number");
+  assert.equal(seeds.has(fuzzCase.metadata.seed), false, `duplicate seed for ${fuzzCase.id}`);
+  seeds.add(fuzzCase.metadata.seed);
+  assert.ok(fuzzCase.metadata.dimensions.length > 0, `${fuzzCase.id} must declare exercised dimensions`);
+  assert.equal(fuzzCase.target ?? fixture.target, fixture.target, `${fuzzCase.id} must use the canonical runtime workload target`);
+
+  const setup = fuzzCase.phases?.setup ?? [];
+  const teardown = fuzzCase.phases?.teardown ?? [];
+  assert.ok(setup.some((step) => step.command === "wp-codebox.checkpoint-create"), `${fuzzCase.id} must create its own checkpoint`);
+  assert.ok(teardown.some((step) => step.command === "wp-codebox.checkpoint-restore"), `${fuzzCase.id} must restore its own checkpoint`);
+  assert.ok(setup.some((step) => step.command === "wordpress.ensure-plugin-active"), `${fuzzCase.id} must activate its own component runtime`);
+  assert.ok(Object.values(fuzzCase.phases).flat().some((step) => step.command === "wordpress.browser-actions" || step.command === "wordpress.rest-request" || step.command === "wordpress.run-php"), `${fuzzCase.id} must exercise a real runtime surface`);
+  for (const step of Object.values(fuzzCase.phases).flat()) {
+    assert.equal((step.args ?? []).some((arg) => arg.startsWith("session=")), false, `${fuzzCase.id} must not depend on an undeclared recipe user session`);
+    if (step.command === "wordpress.browser-actions") {
+      const steps = JSON.parse(step.args.find((arg) => arg.startsWith("steps-json="))?.slice("steps-json=".length));
+      assert.equal(steps[0]?.kind, "navigate", `${fuzzCase.id} browser actions must own their page lifecycle`);
+    }
+    if (step.command === "wordpress.run-php" && step.args.some((arg) => arg.includes("rest_do_request"))) {
+      const code = step.args.find((arg) => arg.startsWith("code="));
+      assert.ok(code.includes("datamachine_activate_full_runtime"), `${fuzzCase.id} direct REST dispatch must activate the full runtime`);
+      assert.ok(code.includes("rest_api_init"), `${fuzzCase.id} direct REST dispatch must register routes`);
+    }
+  }
+}
+
+const sourceFiles = await Promise.all([
+  "inc/Core/Admin/Pages/Pipelines/assets/react/PipelinesApp.jsx",
+  "inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/PipelineHeader.jsx",
+  "inc/Core/Admin/Pages/Pipelines/assets/react/components/pipelines/EmptyStepCard.jsx",
+  "inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/EmptyFlowCard.jsx",
+  "inc/Core/Admin/Pages/Pipelines/assets/react/components/flows/FlowsSection.jsx",
+  "inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/StepSelectionModal.jsx",
+  "inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/ImportExportModal.jsx",
+  "inc/Core/Admin/Pages/Pipelines/assets/react/components/modals/import-export/CSVDropzone.jsx",
+  "inc/Core/Admin/Pages/Pipelines/assets/react/stores/uiStore.js",
+  "inc/Engine/Filters/Admin.php",
+].map((path) => readFile(resolve(repository, path), "utf8")));
+const source = sourceFiles.join("\n");
+
+assert.ok(source.includes("'datamachine-' . $slug"), "Admin.php must retain the datamachine- page slug convention used by this fixture.");
+
+for (const expected of [
+  "Add New Pipeline",
+  "Pipeline name",
+  "Delete Pipeline",
+  "datamachine-step-card--empty",
+  "datamachine-flow-card--empty",
+  "datamachine-flows-list",
+  "datamachine-step-selection-modal",
+  "datamachine-modal-card",
+  "Import / Export",
+  "datamachine-import-export-modal",
+  "datamachine-ui-store",
+  "accept=\".csv,text/csv\"",
+]) {
+  assert.ok(source.includes(expected), `fixture selector or label no longer exists in builder source: ${expected}`);
+}
+
+const serializedFixture = JSON.stringify(fixture);
+assert.equal(serializedFixture.includes("page=pipelines"), false, "Pipeline Builder must use the Admin.php datamachine-pipelines slug.");
+assert.ok(serializedFixture.includes("page=datamachine-pipelines"), "Fixture must exercise the registered Pipeline Builder admin route.");
+assert.equal(serializedFixture.includes("/wp-json/"), false, "Runtime REST requests must use WP_REST_Request routes, not HTTP wp-json paths.");
+
+console.log("pipeline builder fuzz fixture contract ok");

--- a/tests/fuzz/pipeline-builder-runtime.json
+++ b/tests/fuzz/pipeline-builder-runtime.json
@@ -1,0 +1,120 @@
+{
+  "schema": "wp-codebox/fuzz-suite/v1",
+  "id": "data-machine-pipeline-builder-runtime",
+  "version": "1.0.0",
+  "target": { "kind": "runtime", "id": "wordpress.run-workload", "entrypoint": "wordpress.run-workload" },
+  "metadata": {
+    "issue": 3219,
+    "seed": 3219,
+    "owner": "data-machine",
+    "isolation": "Each case is a disposable recipe runtime with an explicit checkpoint workflow.",
+    "runtime_requirements": {
+      "extra_plugins": [{ "slug": "data-machine", "source": "../..", "path": "../..", "loadAs": "plugin", "activate": true }],
+      "component_contracts": [{ "slug": "data-machine", "path": "../..", "loadAs": "plugin", "activate": true }]
+    },
+    "requiredRunnerCapabilities": {
+      "capabilities": ["runtime", "disposable-runtime", "runtime-isolation", "artifact-export"],
+      "targetKinds": ["runtime"],
+      "commands": ["wordpress.browser-actions", "wordpress.rest-request", "wordpress.run-php", "wp-codebox.checkpoint-create", "wp-codebox.checkpoint-restore"]
+    }
+  },
+  "cases": [
+    {
+      "id": "clean-load-desktop",
+      "description": "A clean Data Machine activation loads the Pipeline Builder without browser, page, or PHP errors.",
+      "metadata": { "seed": 321901, "dimensions": ["clean-load", "desktop", "console-page-php-cleanliness"] },
+      "phases": {
+        "setup": [
+          { "command": "wordpress.ensure-plugin-active", "args": ["plugin=data-machine/data-machine.php"] },
+          { "command": "wp-codebox.checkpoint-create", "args": ["name=clean-load-desktop"] }
+        ],
+        "action": [
+          { "command": "wordpress.browser-actions", "args": ["auth=wordpress-admin", "viewport=1440x960", "steps-json=[{\"kind\":\"navigate\",\"url\":\"/wp-admin/admin.php?page=datamachine-pipelines\",\"waitFor\":\"domcontentloaded\"},{\"kind\":\"waitFor\",\"selector\":\"#datamachine-react-root\"},{\"kind\":\"expect\",\"selector\":\".datamachine-pipelines-layout\",\"state\":\"visible\"},{\"kind\":\"screenshot\",\"name\":\"pipeline-builder-clean-load-desktop\"},{\"kind\":\"assertObservation\",\"assertion\":\"no-console-errors\"},{\"kind\":\"assertObservation\",\"assertion\":\"no-page-errors\"}]", "capture=steps,console,errors,html,network,screenshot,dom-snapshot"] }
+        ],
+        "assert": [{ "command": "wordpress.run-php", "args": ["code=wp_set_current_user( 1 ); datamachine_activate_full_runtime( 'fuzz-rest' ); do_action( 'rest_api_init' ); $response = rest_do_request( new WP_REST_Request( 'GET', '/datamachine/v1/step-types' ) ); if ( 200 !== $response->get_status() ) { throw new RuntimeException( 'Step types returned HTTP ' . $response->get_status() ); }"] }],
+        "teardown": [{ "command": "wp-codebox.checkpoint-restore", "args": ["name=clean-load-desktop"] }]
+      }
+    },
+    {
+      "id": "pipeline-create-rename-select-delete",
+      "description": "A case-local pipeline is created, renamed, selected after reload, and deleted through the builder controls.",
+      "metadata": { "seed": 321902, "dimensions": ["create", "rename", "select", "delete", "persistence"] },
+      "phases": {
+        "setup": [
+          { "command": "wordpress.ensure-plugin-active", "args": ["plugin=data-machine/data-machine.php"] },
+          { "command": "wp-codebox.checkpoint-create", "args": ["name=pipeline-create-rename-select-delete"] },
+          { "command": "wordpress.browser-actions", "args": ["auth=wordpress-admin", "step-timeout=30s", "steps-json=[{\"kind\":\"navigate\",\"url\":\"/wp-admin/admin.php?page=datamachine-pipelines\"},{\"kind\":\"waitFor\",\"selector\":\".datamachine-pipelines-layout\"},{\"kind\":\"click\",\"text\":\"Add New Pipeline\"},{\"kind\":\"waitFor\",\"selector\":\"input[placeholder=\\\"Pipeline name\\\"]\"}]", "capture=steps,console,errors,network"] }
+        ],
+        "action": [
+          { "command": "wordpress.browser-actions", "args": ["auth=wordpress-admin", "step-timeout=30s", "steps-json=[{\"kind\":\"navigate\",\"url\":\"/wp-admin/admin.php?page=datamachine-pipelines\"},{\"kind\":\"waitFor\",\"selector\":\"input[placeholder=\\\"Pipeline name\\\"]\"},{\"kind\":\"fill\",\"selector\":\"input[placeholder=\\\"Pipeline name\\\"]\",\"value\":\"Fuzz 3219 renamed pipeline\"},{\"kind\":\"waitFor\",\"waitFor\":\"duration\",\"duration\":\"1s\"},{\"kind\":\"navigate\",\"url\":\"/wp-admin/admin.php?page=datamachine-pipelines\",\"waitFor\":\"networkidle\"},{\"kind\":\"expect\",\"selector\":\"input[placeholder=\\\"Pipeline name\\\"]\",\"state\":\"visible\"},{\"kind\":\"evaluate\",\"expression\":\"window.confirm = () => true\"},{\"kind\":\"click\",\"selector\":\"button[aria-label=\\\"Delete Pipeline\\\"]\"},{\"kind\":\"waitFor\",\"selector\":\".datamachine-empty-state\"},{\"kind\":\"assertObservation\",\"assertion\":\"no-console-errors\"},{\"kind\":\"assertObservation\",\"assertion\":\"no-page-errors\"}]", "capture=steps,console,errors,network"] }
+        ],
+        "teardown": [{ "command": "wp-codebox.checkpoint-restore", "args": ["name=pipeline-create-rename-select-delete"] }]
+      }
+    },
+    {
+      "id": "step-type-add-remove-and-cancel",
+      "description": "A case-local pipeline discovers step types through REST, adds a real modal card, removes it, and cancels a second modal.",
+      "metadata": { "seed": 321903, "dimensions": ["step-type-discovery", "step-add", "step-remove", "modal-cancellation"] },
+      "phases": {
+        "setup": [
+          { "command": "wordpress.ensure-plugin-active", "args": ["plugin=data-machine/data-machine.php"] },
+          { "command": "wp-codebox.checkpoint-create", "args": ["name=step-type-add-remove-and-cancel"] },
+          { "command": "wordpress.browser-actions", "args": ["auth=wordpress-admin", "step-timeout=30s", "steps-json=[{\"kind\":\"navigate\",\"url\":\"/wp-admin/admin.php?page=datamachine-pipelines\"},{\"kind\":\"waitFor\",\"selector\":\".datamachine-pipelines-layout\"},{\"kind\":\"click\",\"text\":\"Add New Pipeline\"},{\"kind\":\"waitFor\",\"selector\":\".datamachine-step-card--empty button\"}]", "capture=steps,console,errors"] }
+        ],
+        "action": [
+          { "command": "wordpress.run-php", "args": ["code=wp_set_current_user( 1 ); datamachine_activate_full_runtime( 'fuzz-rest' ); do_action( 'rest_api_init' ); $response = rest_do_request( new WP_REST_Request( 'GET', '/datamachine/v1/step-types' ) ); if ( 200 !== $response->get_status() ) { throw new RuntimeException( 'Step types returned HTTP ' . $response->get_status() ); }"] },
+          { "command": "wordpress.browser-actions", "args": ["auth=wordpress-admin", "step-timeout=30s", "steps-json=[{\"kind\":\"navigate\",\"url\":\"/wp-admin/admin.php?page=datamachine-pipelines\"},{\"kind\":\"waitFor\",\"selector\":\".datamachine-step-card--empty button\"},{\"kind\":\"click\",\"selector\":\".datamachine-step-card--empty button\"},{\"kind\":\"waitFor\",\"selector\":\".datamachine-step-selection-modal\"},{\"kind\":\"click\",\"selector\":\"button.datamachine-modal-card:first-of-type\"},{\"kind\":\"waitFor\",\"selector\":\".datamachine-pipeline-step-card\"},{\"kind\":\"evaluate\",\"expression\":\"window.confirm = () => true\"},{\"kind\":\"click\",\"text\":\"Delete\"},{\"kind\":\"click\",\"selector\":\".datamachine-step-card--empty button\"},{\"kind\":\"waitFor\",\"selector\":\".datamachine-step-selection-modal\"},{\"kind\":\"click\",\"text\":\"Cancel\"},{\"kind\":\"expect\",\"selector\":\".datamachine-step-selection-modal\",\"state\":\"detached\"},{\"kind\":\"assertObservation\",\"assertion\":\"no-console-errors\"},{\"kind\":\"assertObservation\",\"assertion\":\"no-page-errors\"}]", "capture=steps,console,errors,network"] }
+        ],
+        "teardown": [{ "command": "wp-codebox.checkpoint-restore", "args": ["name=step-type-add-remove-and-cancel"] }]
+      }
+    },
+    {
+      "id": "flow-sibling-preservation",
+      "description": "A case-local pipeline creates two sibling flows and preserves their list after reload, replaying the current flow creation failure.",
+      "metadata": { "seed": 321904, "issue": 3254, "dimensions": ["flow-create", "flow-sibling-preservation", "reload", "known-product-defect-replay"] },
+      "phases": {
+        "setup": [
+          { "command": "wordpress.ensure-plugin-active", "args": ["plugin=data-machine/data-machine.php"] },
+          { "command": "wp-codebox.checkpoint-create", "args": ["name=flow-sibling-preservation"] },
+          { "command": "wordpress.browser-actions", "args": ["auth=wordpress-admin", "step-timeout=30s", "steps-json=[{\"kind\":\"navigate\",\"url\":\"/wp-admin/admin.php?page=datamachine-pipelines\"},{\"kind\":\"waitFor\",\"selector\":\".datamachine-pipelines-layout\"},{\"kind\":\"click\",\"text\":\"Add New Pipeline\"},{\"kind\":\"waitFor\",\"selector\":\".datamachine-flow-card--empty button\"}]", "capture=steps,console,errors"] }
+        ],
+        "action": [{ "command": "wordpress.browser-actions", "args": ["auth=wordpress-admin", "step-timeout=30s", "steps-json=[{\"kind\":\"navigate\",\"url\":\"/wp-admin/admin.php?page=datamachine-pipelines\"},{\"kind\":\"waitFor\",\"selector\":\".datamachine-flow-card--empty button\"},{\"kind\":\"click\",\"selector\":\".datamachine-flow-card--empty button\"},{\"kind\":\"waitFor\",\"waitFor\":\"duration\",\"duration\":\"500ms\"},{\"kind\":\"click\",\"selector\":\".datamachine-flow-card--empty button\"},{\"kind\":\"navigate\",\"url\":\"/wp-admin/admin.php?page=datamachine-pipelines\",\"waitFor\":\"networkidle\"},{\"kind\":\"expect\",\"selector\":\".datamachine-flows-list\",\"state\":\"visible\"},{\"kind\":\"assertObservation\",\"assertion\":\"no-console-errors\"},{\"kind\":\"assertObservation\",\"assertion\":\"no-page-errors\"}]", "capture=steps,console,errors,network,screenshot"] }],
+        "teardown": [{ "command": "wp-codebox.checkpoint-restore", "args": ["name=flow-sibling-preservation"] }]
+      }
+    },
+    {
+      "id": "rest-malformed-oversized-repeated-saves",
+      "description": "A case-local REST pipeline prerequisite is followed by malformed import, bounded oversized title, and repeated saves.",
+      "metadata": { "seed": 321905, "dimensions": ["rest", "malformed-save", "oversized-save", "repeated-save", "persistence"] },
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=data-machine/data-machine.php"] }, { "command": "wp-codebox.checkpoint-create", "args": ["name=rest-malformed-oversized-repeated-saves"] }, { "command": "wordpress.run-php", "args": ["code=wp_set_current_user( 1 ); datamachine_activate_full_runtime( 'fuzz-rest' ); do_action( 'rest_api_init' ); $request = new WP_REST_Request( 'POST', '/datamachine/v1/pipelines' ); $request->set_header( 'content-type', 'application/json' ); $request->set_body( wp_json_encode( array( 'pipeline_name' => 'Fuzz 3219 REST prerequisite' ) ) ); $response = rest_do_request( $request ); if ( 200 !== $response->get_status() ) { throw new RuntimeException( 'Prerequisite pipeline returned HTTP ' . $response->get_status() ); }"] }],
+        "action": [
+          { "command": "wordpress.run-php", "args": ["code=wp_set_current_user( 1 ); datamachine_activate_full_runtime( 'fuzz-rest' ); do_action( 'rest_api_init' ); $request = new WP_REST_Request( 'POST', '/datamachine/v1/pipelines' ); $request->set_header( 'content-type', 'application/json' ); $request->set_body( wp_json_encode( array( 'batch_import' => true, 'format' => 'csv', 'data' => \"not,a,pipeline,csv\\n\\\"unterminated\" ) ) ); $response = rest_do_request( $request ); if ( 400 !== $response->get_status() ) { throw new RuntimeException( 'Malformed CSV returned HTTP ' . $response->get_status() ); }"] },
+          { "command": "wordpress.run-php", "args": ["code=wp_set_current_user( 1 ); datamachine_activate_full_runtime( 'fuzz-rest' ); do_action( 'rest_api_init' ); $request = new WP_REST_Request( 'POST', '/datamachine/v1/pipelines' ); $request->set_header( 'content-type', 'application/json' ); $request->set_body( wp_json_encode( array( 'pipeline_name' => str_repeat( 'Fuzz 3219 bounded oversized title ', 8 ) ) ) ); $response = rest_do_request( $request ); if ( 200 !== $response->get_status() ) { throw new RuntimeException( 'Oversized title returned HTTP ' . $response->get_status() ); }"] },
+          { "command": "wordpress.run-php", "args": ["code=wp_set_current_user( 1 ); datamachine_activate_full_runtime( 'fuzz-rest' ); do_action( 'rest_api_init' ); foreach ( array( 1, 2 ) as $attempt ) { $request = new WP_REST_Request( 'POST', '/datamachine/v1/pipelines' ); $request->set_header( 'content-type', 'application/json' ); $request->set_body( wp_json_encode( array( 'pipeline_name' => 'Fuzz 3219 repeat save' ) ) ); $response = rest_do_request( $request ); if ( 200 !== $response->get_status() ) { throw new RuntimeException( 'Repeated save ' . $attempt . ' returned HTTP ' . $response->get_status() ); } }"] }
+        ],
+        "teardown": [{ "command": "wp-codebox.checkpoint-restore", "args": ["name=rest-malformed-oversized-repeated-saves"] }]
+      }
+    },
+    {
+      "id": "stale-selection-reload-and-import-export-narrow",
+      "description": "A case-local pipeline survives stale selection recovery and exposes the import/export modal at a narrow viewport.",
+      "metadata": { "seed": 321906, "dimensions": ["stale-selection", "reload", "import-export", "narrow-viewport", "modal-cancellation"] },
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=data-machine/data-machine.php"] }, { "command": "wp-codebox.checkpoint-create", "args": ["name=stale-selection-reload-and-import-export-narrow"] }, { "command": "wordpress.browser-actions", "args": ["auth=wordpress-admin", "step-timeout=30s", "steps-json=[{\"kind\":\"navigate\",\"url\":\"/wp-admin/admin.php?page=datamachine-pipelines\"},{\"kind\":\"waitFor\",\"selector\":\".datamachine-pipelines-layout\"},{\"kind\":\"click\",\"text\":\"Add New Pipeline\"},{\"kind\":\"waitFor\",\"selector\":\"input[placeholder=\\\"Pipeline name\\\"]\"}]", "capture=steps,console,errors"] }],
+        "action": [{ "command": "wordpress.browser-actions", "args": ["auth=wordpress-admin", "step-timeout=30s", "viewport=390x844", "is-mobile=true", "steps-json=[{\"kind\":\"navigate\",\"url\":\"/wp-admin/admin.php?page=datamachine-pipelines\"},{\"kind\":\"waitFor\",\"waitFor\":\"networkidle\"},{\"kind\":\"evaluate\",\"expression\":\"return (() => { localStorage.setItem(['datamachine','ui','store'].join('-'), JSON.stringify({state:{selectedPipelineId:'stale-3219'},version:2})); location.reload(); })();\"},{\"kind\":\"waitFor\",\"selector\":\"#datamachine-react-root\"},{\"kind\":\"click\",\"text\":\"Import / Export\"},{\"kind\":\"waitFor\",\"selector\":\".datamachine-import-export-modal\"},{\"kind\":\"click\",\"selector\":\"button[role=\\\"tab\\\"][id$=\\\"-import\\\"]\"},{\"kind\":\"expect\",\"selector\":\"input[type=\\\"file\\\"][accept=\\\".csv,text/csv\\\"]\",\"state\":\"attached\"},{\"kind\":\"click\",\"text\":\"Cancel\"},{\"kind\":\"expect\",\"selector\":\".datamachine-import-export-modal\",\"state\":\"detached\"},{\"kind\":\"assertObservation\",\"assertion\":\"no-console-errors\"},{\"kind\":\"assertObservation\",\"assertion\":\"no-page-errors\"}]", "capture=steps,console,errors,network,screenshot,dom-snapshot"] }],
+        "teardown": [{ "command": "wp-codebox.checkpoint-restore", "args": ["name=stale-selection-reload-and-import-export-narrow"] }]
+      }
+    },
+    {
+      "id": "import-valid-csv-must-succeed",
+      "description": "A case-local prerequisite precedes a replayable failing CSV import contract assertion.",
+      "metadata": { "seed": 321907, "issue": 3255, "dimensions": ["import", "rest", "known-product-defect-replay"] },
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=data-machine/data-machine.php"] }, { "command": "wp-codebox.checkpoint-create", "args": ["name=import-valid-csv-must-succeed"] }, { "command": "wordpress.run-php", "args": ["code=wp_set_current_user( 1 ); datamachine_activate_full_runtime( 'fuzz-rest' ); do_action( 'rest_api_init' ); $request = new WP_REST_Request( 'POST', '/datamachine/v1/pipelines' ); $request->set_header( 'content-type', 'application/json' ); $request->set_body( wp_json_encode( array( 'pipeline_name' => 'Fuzz 3219 import prerequisite' ) ) ); $response = rest_do_request( $request ); if ( 200 !== $response->get_status() ) { throw new RuntimeException( 'Import prerequisite returned HTTP ' . $response->get_status() ); }"] }],
+        "action": [{ "command": "wordpress.run-php", "args": ["code=wp_set_current_user( 1 ); datamachine_activate_full_runtime( 'fuzz-rest' ); do_action( 'rest_api_init' ); $request = new WP_REST_Request( 'POST', '/datamachine/v1/pipelines' ); $request->set_header( 'content-type', 'application/json' ); $request->set_body( wp_json_encode( array( 'batch_import' => true, 'format' => 'csv', 'data' => \"pipeline_name\\nFuzz 3219 import\\n\" ) ) ); $response = rest_do_request( $request ); if ( 200 !== $response->get_status() ) { throw new RuntimeException( 'CSV import returned HTTP ' . $response->get_status() . ': ' . wp_json_encode( $response->get_data() ) ); }"] }],
+        "teardown": [{ "command": "wp-codebox.checkpoint-restore", "args": ["name=import-valid-csv-must-succeed"] }]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add seven deterministic Pipeline Builder runtime workloads with case-local checkpoints
- cover desktop and narrow browser behavior, authenticated REST mutation, persistence, malformed and repeated input, modal workflows, and CSV import
- enforce fixture contracts against live builder routes, selectors, storage keys, and browser lifecycle ownership
- document the canonical `wp-codebox run-fuzz-suite` command and compiled-asset prerequisite
- keep confirmed product regressions replayable under #3254 and #3255

## Verification

```text
npm run build
node tests/fuzz/pipeline-builder-runtime-contract.test.mjs
wp-codebox run-fuzz-suite --runner-mode=runtime-backed --input-file=tests/fuzz/pipeline-builder-runtime.json --format=json --dry-run
wp-codebox run-fuzz-suite --runner-mode=runtime-backed --input-file=tests/fuzz/pipeline-builder-runtime.json --format=json
```

Results:

- fixture contract: passed
- dry-run planning: 7 passed, 0 failed/error/skipped
- completed real runtime run: 5 passed, 2 replayable product failures
- `flow-sibling-preservation`: both flow POSTs return HTTP 500 (`#3254`)
- `import-valid-csv-must-succeed`: valid CSV import returns HTTP 400 `Pipeline name is required` (`#3255`)

The branch was rebased after that completed runtime run. The intervening upstream commits do not touch the Pipeline Builder, REST handlers, transaction scope, or fixture runtime paths. Two post-rebase reruns on the same host were interrupted by outer 20/30-minute limits after bounded browser waits expired under sustained runtime contention; they produced no contradictory aggregate.

Depends on Automattic/wp-codebox#2280 for portable input-file-relative runtime requirement resolution.

Closes #3219.

AI assistance: OpenAI gpt-5.6-sol via OpenCode designed and debugged the fixture, ran runtime-backed verification, classified failures, and prepared the documentation. Chris Huber remains responsible for every line.