### PR TITLE
refactor: migrate engine and job ability failures

### DIFF
--- a/inc/Abilities/Engine/DrainJobAbility.php
+++ b/inc/Abilities/Engine/DrainJobAbility.php
@@ -101,7 +101,7 @@ class DrainJobAbility {
 	 * @param array $input Input with job_id and optional budgets.
 	 * @return array Result with terminal status and drain stats.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$job_id         = (int) ( $input['job_id'] ?? 0 );
 		$step_budget    = max( 1, (int) ( $input['step_budget'] ?? self::DEFAULT_STEP_BUDGET ) );
 		$time_budget_ms = max( 1, (int) ( $input['time_budget_ms'] ?? self::DEFAULT_TIME_BUDGET_MS ) );
@@ -109,28 +109,33 @@ class DrainJobAbility {
 		$last_error     = null;
 
 		if ( $job_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'A valid job_id is required.',
-			);
+			return new \WP_Error( 'invalid_job_id', 'A valid job_id is required.', array( 'status' => 400 ) );
 		}
 
 		$job = $this->db_jobs->get_job( $job_id );
 		if ( ! $job ) {
-			return array(
-				'success' => false,
-				'job_id'  => $job_id,
-				'error'   => sprintf( 'Job %d not found.', $job_id ),
+			return new \WP_Error(
+				'job_not_found',
+				sprintf( 'Job %d not found.', $job_id ),
+				array(
+					'status' => 404,
+					'job_id' => $job_id,
+				)
 			);
 		}
 
 		$guard_error = $this->getActionSchedulerGuardError();
 		if ( null !== $guard_error ) {
-			return array(
-				'success'    => false,
-				'job_id'     => $job_id,
-				'error'      => $guard_error,
-				'error_type' => 'action_scheduler_unavailable',
+			return new \WP_Error(
+				'action_scheduler_unavailable',
+				$guard_error,
+				array(
+					'status'      => 503,
+					'retryable'   => true,
+					'job_id'      => $job_id,
+					'error_type'  => 'action_scheduler_unavailable',
+					'diagnostics' => array( 'boundary' => 'drain' ),
+				)
 			);
 		}
 

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -124,7 +124,7 @@ class ExecuteStepAbility {
 	 * @param array $input Input with job_id and flow_step_id.
 	 * @return array Result with step execution outcome.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$job_id                = (int) ( $input['job_id'] ?? 0 );
 		$flow_step_id          = (string) ( $input['flow_step_id'] ?? '' );
 		$operation_generation  = max( 0, (int) ( $input['operation_generation'] ?? 0 ) );
@@ -135,9 +135,14 @@ class ExecuteStepAbility {
 		$job                   = $this->db_jobs->get_job( $job_id );
 
 		if ( ! $job ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Job %d not found.', $job_id ),
+			return new \WP_Error(
+				'job_not_found',
+				sprintf( 'Job %d not found.', $job_id ),
+				array(
+					'status'    => 404,
+					'job_id'    => $job_id,
+					'retryable' => false,
+				)
 			);
 		}
 		if ( $recovery_generation > 0 && ! $this->recoveryGenerationAdmission( $job, $recovery_generation, $recovery_claim_token ) ) {

--- a/inc/Abilities/Engine/PipelineBatchScheduler.php
+++ b/inc/Abilities/Engine/PipelineBatchScheduler.php
@@ -512,7 +512,7 @@ class PipelineBatchScheduler {
 					'data_packets' => array( $single_packet ),
 				)
 			);
-			$action_id = ! empty( $result['success'] ) ? (int) ( $result['action_id'] ?? 0 ) : 0;
+			$action_id = ! is_wp_error( $result ) && ! empty( $result['success'] ) ? (int) ( $result['action_id'] ?? 0 ) : 0;
 		}
 
 		$state = $action_id > 0 ? 'enqueued' : 'enqueue_failed';

--- a/inc/Abilities/Engine/RunFlowAbility.php
+++ b/inc/Abilities/Engine/RunFlowAbility.php
@@ -112,16 +112,20 @@ class RunFlowAbility {
 	 * @param array $input Input with flow_id, optional job_id, initial_data, and respect_paused.
 	 * @return array Result with success status and execution details.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$flow_id = (int) ( $input['flow_id'] ?? 0 );
 		$job_id  = $input['job_id'] ?? null;
 
 		$flow = $this->db_flows->get_flow( $flow_id );
 		if ( ! $flow ) {
 			do_action( 'datamachine_log', 'error', 'Flow execution failed - flow not found', array( 'flow_id' => $flow_id ) );
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Flow %d not found.', $flow_id ),
+			return new \WP_Error(
+				'flow_not_found',
+				sprintf( 'Flow %d not found.', $flow_id ),
+				array(
+					'status'  => 404,
+					'flow_id' => $flow_id,
+				)
 			);
 		}
 
@@ -137,9 +141,14 @@ class RunFlowAbility {
 				'Flow execution skipped - flow is paused',
 				array( 'flow_id' => $flow_id )
 			);
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Flow %d is paused.', $flow_id ),
+			return new \WP_Error(
+				'flow_paused',
+				sprintf( 'Flow %d is paused.', $flow_id ),
+				array(
+					'status'    => 409,
+					'retryable' => true,
+					'flow_id'   => $flow_id,
+				)
 			);
 		}
 
@@ -225,9 +234,14 @@ class RunFlowAbility {
 						'pipeline_id' => $pipeline_id,
 					)
 				);
-				return array(
-					'success' => false,
-					'error'   => 'Job creation failed - database insert failed.',
+				return new \WP_Error(
+					'job_creation_failed',
+					'Job creation failed - database insert failed.',
+					array(
+						'status'    => 500,
+						'retryable' => true,
+						'flow_id'   => $flow_id,
+					)
 				);
 			}
 			do_action(
@@ -340,11 +354,15 @@ class RunFlowAbility {
 					'error'       => $e->getMessage(),
 				)
 			);
-			return array(
-				'success' => false,
-				'job_id'  => $job_id,
-				'reason'  => 'invalid_execution_plan',
-				'error'   => $e->getMessage(),
+			return new \WP_Error(
+				'invalid_execution_plan',
+				$e->getMessage(),
+				array(
+					'status'    => 400,
+					'job_id'    => $job_id,
+					'flow_id'   => $flow_id,
+					'retryable' => false,
+				)
 			);
 		}
 
@@ -361,11 +379,15 @@ class RunFlowAbility {
 					'flow_id'     => $flow_id,
 				)
 			);
-			return array(
-				'success' => false,
-				'job_id'  => $job_id,
-				'reason'  => 'no_first_step',
-				'error'   => 'Flow execution failed - no first step found.',
+			return new \WP_Error(
+				'no_first_step',
+				'Flow execution failed - no first step found.',
+				array(
+					'status'    => 400,
+					'job_id'    => $job_id,
+					'flow_id'   => $flow_id,
+					'retryable' => false,
+				)
 			);
 		}
 

--- a/inc/Abilities/Engine/ScheduleFlowAbility.php
+++ b/inc/Abilities/Engine/ScheduleFlowAbility.php
@@ -89,9 +89,12 @@ class ScheduleFlowAbility {
 	 * @param array $input Input with flow_id and interval_or_timestamp.
 	 * @return array Result with scheduling details.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$flow_id               = (int) ( $input['flow_id'] ?? 0 );
 		$interval_or_timestamp = $input['interval_or_timestamp'] ?? null;
+		if ( $flow_id <= 0 ) {
+			return new \WP_Error( 'invalid_flow_id', 'flow_id must be a positive integer.', array( 'status' => 400 ) );
+		}
 
 		if ( 'manual' === $interval_or_timestamp ) {
 			return $this->clearSchedule( $flow_id );
@@ -117,7 +120,7 @@ class ScheduleFlowAbility {
 	 * @param int $flow_id Flow ID.
 	 * @return array Result.
 	 */
-	private function clearSchedule( int $flow_id ): array {
+	private function clearSchedule( int $flow_id ): array|\WP_Error {
 		$result = \DataMachine\Api\Flows\FlowScheduling::handle_scheduling_update(
 			$flow_id,
 			array( 'interval' => 'manual' ),
@@ -147,7 +150,7 @@ class ScheduleFlowAbility {
 	 * @param int $timestamp Unix timestamp for execution.
 	 * @return array Result.
 	 */
-	private function scheduleOneTime( int $flow_id, int $timestamp ): array {
+	private function scheduleOneTime( int $flow_id, int $timestamp ): array|\WP_Error {
 		$result = \DataMachine\Api\Flows\FlowScheduling::handle_scheduling_update(
 			$flow_id,
 			array(
@@ -193,7 +196,7 @@ class ScheduleFlowAbility {
 	 * @param string $cron_expression Cron expression string (e.g. "0 9 * * 1-5").
 	 * @return array Result.
 	 */
-	private function scheduleCron( int $flow_id, string $cron_expression ): array {
+	private function scheduleCron( int $flow_id, string $cron_expression ): array|\WP_Error {
 		$result = \DataMachine\Api\Flows\FlowScheduling::handle_scheduling_update(
 			$flow_id,
 			array(
@@ -231,7 +234,7 @@ class ScheduleFlowAbility {
 	 * @param string $interval Interval key from datamachine_scheduler_intervals filter.
 	 * @return array Result.
 	 */
-	private function scheduleRecurring( int $flow_id, string $interval ): array {
+	private function scheduleRecurring( int $flow_id, string $interval ): array|\WP_Error {
 		$result = \DataMachine\Api\Flows\FlowScheduling::handle_scheduling_update(
 			$flow_id,
 			array( 'interval' => $interval )
@@ -258,10 +261,12 @@ class ScheduleFlowAbility {
 	/**
 	 * Preserve scheduler retry/status metadata at the ability boundary.
 	 */
-	private function scheduleError( \WP_Error $error ): array {
-		return array_merge(
-			array( 'success' => false ),
-			\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $error )
+	private function scheduleError( \WP_Error $error ): \WP_Error {
+		$data = $error->get_error_data();
+		return new \WP_Error(
+			$error->get_error_code(),
+			$error->get_error_message(),
+			is_array( $data ) ? $data : array( 'status' => 500 )
 		);
 	}
 }

--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -91,10 +91,13 @@ class ScheduleNextStepAbility {
 	 * @param array $input Input with job_id, flow_step_id, and optional data_packets.
 	 * @return array Result with success status and action_id.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$job_id       = (int) ( $input['job_id'] ?? 0 );
 		$flow_step_id = $input['flow_step_id'] ?? '';
 		$dataPackets  = $input['data_packets'] ?? array();
+		if ( $job_id <= 0 || '' === (string) $flow_step_id ) {
+			return new \WP_Error( 'invalid_next_step_input', 'job_id and flow_step_id are required.', array( 'status' => 400 ) );
+		}
 
 		// Store data by job_id (if present).
 		if ( ! empty( $dataPackets ) ) {
@@ -132,9 +135,15 @@ class ScheduleNextStepAbility {
 						'missing_flow_id_during_data_storage',
 						array( 'packet_count' => count( $dataPackets ) )
 					);
-					return array(
-						'success' => false,
-						'error'   => 'Flow ID missing during data storage.',
+					return new \WP_Error(
+						'missing_flow_id',
+						'Flow ID missing during data storage.',
+						array(
+							'status'       => 500,
+							'retryable'    => true,
+							'job_id'       => $job_id,
+							'flow_step_id' => $flow_step_id,
+						)
 					);
 				}
 
@@ -209,6 +218,21 @@ class ScheduleNextStepAbility {
 						'exception_message' => null !== $schedule_exception ? $schedule_exception->getMessage() : null,
 					),
 					static fn ( $value ): bool => null !== $value
+				)
+			);
+		}
+
+		if ( ! is_numeric( $action_id ) || (int) $action_id <= 0 ) {
+			return new \WP_Error(
+				null !== $schedule_exception ? 'next_step_schedule_exception' : 'next_step_schedule_failed',
+				null !== $schedule_exception ? $schedule_exception->getMessage() : 'Unable to schedule the next workflow step.',
+				array(
+					'status'       => 503,
+					'retryable'    => true,
+					'job_id'       => $job_id,
+					'flow_step_id' => $flow_step_id,
+					'ownership'    => 'scheduler',
+					'diagnostics'  => array( 'packet_count' => count( $dataPackets ) ),
 				)
 			);
 		}

--- a/inc/Abilities/Job/DeleteJobsAbility.php
+++ b/inc/Abilities/Job/DeleteJobsAbility.php
@@ -88,6 +88,10 @@ class DeleteJobsAbility {
 
 		$result = $this->deleteJobs( $criteria, $cleanup_processed );
 
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
 		if ( ! $result['success'] ) {
 			return new \WP_Error( 'delete_failed', 'Failed to delete jobs', array( 'status' => 500 ) );
 		}

--- a/inc/Abilities/Job/ExecuteAgentWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteAgentWorkflowAbility.php
@@ -91,26 +91,40 @@ class ExecuteAgentWorkflowAbility {
 	 * Execute a simple Agents API workflow spec and record it as a Data Machine job.
 	 *
 	 * @param array $input Ability input.
-	 * @return array
+	 * @return array|WP_Error
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|WP_Error {
 		$spec_array = $input['spec'] ?? null;
 		if ( ! is_array( $spec_array ) ) {
-			return $this->error_response( 'invalid_spec', 'spec must be an object.' );
+			return new WP_Error(
+				'invalid_spec',
+				'spec must be an object.',
+				array(
+					'status'    => 400,
+					'retryable' => false,
+				)
+			);
 		}
 
 		$unsupported = $this->validateBridgeableSpec( $spec_array );
 		if ( is_wp_error( $unsupported ) ) {
-			return $this->error_response( $unsupported->get_error_code(), $unsupported->get_error_message(), $unsupported->get_error_data() );
+			return new WP_Error( $unsupported->get_error_code(), $unsupported->get_error_message(), array_merge( array( 'status' => 400 ), is_array( $unsupported->get_error_data() ) ? $unsupported->get_error_data() : array() ) );
 		}
 
 		if ( ! class_exists( WP_Agent_Workflow_Spec::class ) || ! class_exists( WP_Agent_Workflow_Runner::class ) ) {
-			return $this->error_response( 'agents_api_workflows_unavailable', 'Agents API workflow classes are unavailable.' );
+			return new WP_Error(
+				'agents_api_workflows_unavailable',
+				'Agents API workflow classes are unavailable.',
+				array(
+					'status'    => 503,
+					'retryable' => true,
+				)
+			);
 		}
 
 		$spec = WP_Agent_Workflow_Spec::from_array( $spec_array );
 		if ( is_wp_error( $spec ) ) {
-			return $this->error_response( $spec->get_error_code(), $spec->get_error_message(), $spec->get_error_data() );
+			return new WP_Error( $spec->get_error_code(), $spec->get_error_message(), array_merge( array( 'status' => 400 ), is_array( $spec->get_error_data() ) ? $spec->get_error_data() : array() ) );
 		}
 
 		$recorder = new AgentsApiWorkflowJobRecorder(
@@ -136,6 +150,29 @@ class ExecuteAgentWorkflowAbility {
 			is_array( $input['inputs'] ?? null ) ? $input['inputs'] : array(),
 			$options
 		);
+
+		if ( ! $result->is_succeeded() ) {
+			$error = $result->get_error();
+			return new WP_Error(
+				is_array( $error ) ? (string) ( $error['code'] ?? 'agents_api_workflow_failed' ) : 'agents_api_workflow_failed',
+				is_array( $error ) ? (string) ( $error['message'] ?? 'Agents API workflow failed.' ) : 'Agents API workflow failed.',
+				array(
+					'status'          => 500,
+					'retryable'       => false,
+					'job_id'          => $recorder->get_job_id(),
+					'run_id'          => $result->get_run_id(),
+					'workflow_id'     => $result->get_workflow_id(),
+					'workflow_status' => $result->get_status(),
+					'steps'           => $result->get_steps(),
+					'output'          => $result->get_output(),
+					'error'           => $error,
+					'diagnostics'     => array(
+						'workflow_id' => $result->get_workflow_id(),
+						'run_id'      => $result->get_run_id(),
+					),
+				)
+			);
+		}
 
 		return array(
 			'success'     => $result->is_succeeded(),

--- a/inc/Abilities/Job/ExecuteWorkflowAbility.php
+++ b/inc/Abilities/Job/ExecuteWorkflowAbility.php
@@ -108,7 +108,7 @@ class ExecuteWorkflowAbility {
 	 * @param array $input Input parameters with workflow, optional timestamp, initial_data, dry_run.
 	 * @return array Result with job_id and execution info.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		return $this->executeWithAuthority( $input, false );
 	}
 
@@ -118,7 +118,7 @@ class ExecuteWorkflowAbility {
 	 * @param array $input Workflow input.
 	 * @return array
 	 */
-	public function executeInternal( array $input ): array {
+	public function executeInternal( array $input ): array|\WP_Error {
 		return $this->executeWithAuthority( $input, true );
 	}
 
@@ -129,18 +129,23 @@ class ExecuteWorkflowAbility {
 	 * @param bool  $system_context Trusted internal system execution.
 	 * @return array
 	 */
-	private function executeWithAuthority( array $input, bool $system_context ): array {
-		$workflow      = $input['workflow'] ?? null;
-		$timestamp     = $input['timestamp'] ?? null;
-		$initial_data  = is_array( $input['initial_data'] ?? null ) ? $input['initial_data'] : array();
-		$operation_key = is_string( $input['operation_key'] ?? null ) ? trim( $input['operation_key'] ) : '';
+	private function executeWithAuthority( array $input, bool $system_context ): array|\WP_Error {
+		$workflow         = $input['workflow'] ?? null;
+		$timestamp        = $input['timestamp'] ?? null;
+		$initial_data     = is_array( $input['initial_data'] ?? null ) ? $input['initial_data'] : array();
+		$operation_key    = is_string( $input['operation_key'] ?? null ) ? trim( $input['operation_key'] ) : '';
+		$input_error_data = array(
+			'status'    => 400,
+			'retryable' => false,
+		);
 
 		// Validate workflow structure
 		$validation = WorkflowSpecValidator::validate( $workflow );
 		if ( ! $validation['valid'] ) {
-			return array(
-				'success' => false,
-				'error'   => $validation['error'],
+			return new \WP_Error(
+				'invalid_workflow',
+				$validation['error'],
+				$input_error_data
 			);
 		}
 
@@ -149,24 +154,31 @@ class ExecuteWorkflowAbility {
 		try {
 			$first_step_id = ExecutionPlan::from_flow_config( $configs['flow_config'] )->first_step_id();
 		} catch ( \InvalidArgumentException $e ) {
-			return array(
-				'success' => false,
-				'error'   => $e->getMessage(),
+			return new \WP_Error(
+				'invalid_execution_plan',
+				$e->getMessage(),
+				$input_error_data
 			);
 		}
 
 		if ( ! $first_step_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'Could not determine first step in workflow',
+			return new \WP_Error(
+				'no_first_step',
+				'Could not determine first step in workflow',
+				$input_error_data
 			);
 		}
 
 		$ownership = $this->resolveOwnership( $initial_data, $system_context );
 		if ( isset( $ownership['error'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => $ownership['error'],
+			return new \WP_Error(
+				'workflow_ownership_denied',
+				$ownership['error'],
+				array(
+					'status'    => 403,
+					'retryable' => false,
+					'ownership' => 'caller',
+				)
 			);
 		}
 
@@ -248,27 +260,41 @@ class ExecuteWorkflowAbility {
 		$job_id                     = is_array( $creation ) ? (int) ( $creation['job_id'] ?? 0 ) : (int) $creation;
 
 		if ( $job_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to create job record',
+			return new \WP_Error(
+				'job_creation_failed',
+				'Failed to create job record',
+				array(
+					'status'    => 500,
+					'retryable' => true,
+				)
 			);
 		}
 
 		if ( is_array( $creation ) && ! empty( $creation['already_exists'] ) ) {
 			$existing_fingerprint = (string) ( $creation['job']['request_fingerprint'] ?? '' );
 			if ( '' === $existing_fingerprint || ! hash_equals( $existing_fingerprint, $request_fingerprint ) ) {
-				return array(
-					'success' => false,
-					'error'   => 'operation_key has already been used with different workflow input.',
+				return new \WP_Error(
+					'operation_key_conflict',
+					'operation_key has already been used with different workflow input.',
+					array(
+						'status'    => 409,
+						'retryable' => false,
+						'ownership' => 'operation',
+					)
 				);
 			}
 		}
 
 		$job = $this->db_jobs->get_job( $job_id );
 		if ( ! is_array( $job ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to load job record after creation',
+			return new \WP_Error(
+				'job_load_failed',
+				'Failed to load job record after creation',
+				array(
+					'status'    => 500,
+					'retryable' => true,
+					'job_id'    => $job_id,
+				)
 			);
 		}
 
@@ -281,9 +307,15 @@ class ExecuteWorkflowAbility {
 		$existing_engine_data['job']           = is_array( $existing_engine_data['job'] ?? null ) ? $existing_engine_data['job'] : array();
 		$existing_engine_data['job']['job_id'] = $job_id;
 		if ( ! $this->db_jobs->store_engine_data( $job_id, $existing_engine_data ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to persist job execution data; replay may retry the operation.',
+			return new \WP_Error(
+				'engine_data_persist_failed',
+				'Failed to persist job execution data; replay may retry the operation.',
+				array(
+					'status'    => 500,
+					'retryable' => true,
+					'job_id'    => $job_id,
+					'recovery'  => 'replay',
+				)
 			);
 		}
 
@@ -293,11 +325,16 @@ class ExecuteWorkflowAbility {
 			is_numeric( $timestamp ) ? (int) $timestamp : null
 		);
 		if ( empty( $enqueue['success'] ) ) {
-			return array(
-				'success'       => false,
-				'error'         => (string) ( $enqueue['error'] ?? 'enqueue_failed' ),
-				'retryable'     => ! empty( $enqueue['retryable'] ),
-				'enqueue_state' => (string) ( $enqueue['state'] ?? 'enqueue_failed' ),
+			return new \WP_Error(
+				(string) ( $enqueue['error_code'] ?? 'enqueue_failed' ),
+				(string) ( $enqueue['error'] ?? 'enqueue_failed' ),
+				array(
+					'status'        => 503,
+					'retryable'     => ! empty( $enqueue['retryable'] ),
+					'enqueue_state' => (string) ( $enqueue['state'] ?? 'enqueue_failed' ),
+					'job_id'        => $job_id,
+					'ownership'     => 'scheduler',
+				)
 			);
 		}
 

--- a/inc/Abilities/Job/FailJobAbility.php
+++ b/inc/Abilities/Job/FailJobAbility.php
@@ -79,12 +79,9 @@ class FailJobAbility {
 	 * @param array $input Input parameters with job_id and optional reason.
 	 * @return array Result with job_id, previous_status, and new_status.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		if ( empty( $input['job_id'] ) || ! is_numeric( $input['job_id'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'job_id is required and must be a positive integer.',
-			);
+			return new \WP_Error( 'invalid_job_id', 'job_id is required and must be a positive integer.', array( 'status' => 400 ) );
 		}
 
 		$job_id = (int) $input['job_id'];
@@ -93,14 +90,18 @@ class FailJobAbility {
 		$job = $this->db_jobs->get_job( $job_id );
 
 		if ( ! $job ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Job %d not found.', $job_id ),
+			return new \WP_Error(
+				'job_not_found',
+				sprintf( 'Job %d not found.', $job_id ),
+				array(
+					'status' => 404,
+					'job_id' => $job_id,
+				)
 			);
 		}
 
 		if ( ! $this->canAccessJob( $job ) ) {
-			return $this->jobAccessDenied();
+			return $this->jobAccessDeniedError();
 		}
 
 		$previous_status = $job['status'] ?? '';
@@ -118,9 +119,14 @@ class FailJobAbility {
 
 		// Pending jobs are queued but not yet running; cancellation is safest before they start.
 		if ( ! in_array( $previous_status, array( JobStatus::PENDING, JobStatus::PROCESSING ), true ) ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Job %d has status "%s" — only pending or processing jobs can be failed.', $job_id, $previous_status ),
+			return new \WP_Error(
+				'invalid_job_status',
+				sprintf( 'Job %d has status "%s" — only pending or processing jobs can be failed.', $job_id, $previous_status ),
+				array(
+					'status'    => 409,
+					'job_id'    => $job_id,
+					'retryable' => false,
+				)
 			);
 		}
 

--- a/inc/Abilities/Job/GetRunArtifactsAbility.php
+++ b/inc/Abilities/Job/GetRunArtifactsAbility.php
@@ -81,9 +81,9 @@ class GetRunArtifactsAbility {
 	 * Retrieve a job's public run artifact contract.
 	 *
 	 * @param array<string,mixed> $input Ability input.
-	 * @return array<string,mixed>
+	 * @return array<string,mixed>|\WP_Error
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$job_id = (int) ( $input['job_id'] ?? 0 );
 		if ( $job_id <= 0 ) {
 			return $this->error( 'invalid_job_id', 'job_id must be a positive integer.', 400 );
@@ -95,7 +95,7 @@ class GetRunArtifactsAbility {
 		}
 
 		if ( ! $this->canAccessJob( $job ) ) {
-			return $this->jobAccessDenied();
+			return $this->jobAccessDeniedError();
 		}
 
 		$artifact_result = ( new JobArtifacts() )->get( $job_id );
@@ -158,12 +158,14 @@ class GetRunArtifactsAbility {
 	}
 
 	/** @return array{success:false,error_code:string,error:string,status:int} */
-	private function error( string $code, string $message, int $status ): array {
-		return array(
-			'success'    => false,
-			'error_code' => $code,
-			'error'      => $message,
-			'status'     => $status,
+	private function error( string $code, string $message, int $status ): \WP_Error {
+		return new \WP_Error(
+			$code,
+			$message,
+			array(
+				'status'    => $status,
+				'retryable' => $status >= 500,
+			)
 		);
 	}
 }

--- a/inc/Abilities/Job/HydrateJobArtifactAbility.php
+++ b/inc/Abilities/Job/HydrateJobArtifactAbility.php
@@ -67,27 +67,21 @@ class HydrateJobArtifactAbility {
 	 * @param array<string,mixed> $input Ability input.
 	 * @return array<string,mixed>
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$artifact_ref = trim( (string) ( $input['artifact_ref'] ?? '' ) );
 		if ( '' === $artifact_ref ) {
-			return array(
-				'success' => false,
-				'error'   => 'artifact_ref is required.',
-			);
+			return new \WP_Error( 'invalid_artifact_ref', 'artifact_ref is required.', array( 'status' => 400 ) );
 		}
 
 		$artifacts = new JobArtifacts();
 		$job_id    = $artifacts->job_id_from_artifact_ref( $artifact_ref );
 		$job       = $job_id > 0 ? $this->db_jobs->get_job( $job_id ) : null;
 		if ( ! is_array( $job ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'artifact_ref is not associated with an existing job.',
-			);
+			return new \WP_Error( 'job_not_found', 'artifact_ref is not associated with an existing job.', array( 'status' => 404 ) );
 		}
 
 		if ( ! $this->canAccessJob( $job ) ) {
-			return $this->jobAccessDenied();
+			return $this->jobAccessDeniedError();
 		}
 
 		$result = $artifacts->hydrate_artifact_ref( $artifact_ref, is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array() );

--- a/inc/Abilities/Job/JobHelpers.php
+++ b/inc/Abilities/Job/JobHelpers.php
@@ -87,6 +87,20 @@ trait JobHelpers {
 		);
 	}
 
+	/** Native failure for registered job callbacks. */
+	protected function jobAccessDeniedError(): \WP_Error {
+		return new \WP_Error(
+			'job_access_denied',
+			'You do not have permission to access this job.',
+			array(
+				'status'      => 403,
+				'retryable'   => false,
+				'ownership'   => 'caller',
+				'diagnostics' => array( 'resource' => 'job' ),
+			)
+		);
+	}
+
 	/** Return the native failure used by read-only job query abilities. */
 	protected function jobQueryAccessDenied( string $message = 'You do not have permission to access this job.' ): \WP_Error {
 		return new \WP_Error( 'job_access_denied', $message, array( 'status' => 403 ) );

--- a/inc/Abilities/Job/RetryJobAbility.php
+++ b/inc/Abilities/Job/RetryJobAbility.php
@@ -84,12 +84,9 @@ class RetryJobAbility {
 	 * @param array $input Input parameters with job_id and optional force.
 	 * @return array Result with job_id, previous_status, and prompt_requeued flag.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		if ( empty( $input['job_id'] ) || ! is_numeric( $input['job_id'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'job_id is required and must be a positive integer.',
-			);
+			return new \WP_Error( 'invalid_job_id', 'job_id is required and must be a positive integer.', array( 'status' => 400 ) );
 		}
 
 		$job_id = (int) $input['job_id'];
@@ -98,23 +95,32 @@ class RetryJobAbility {
 		$job = $this->db_jobs->get_job( $job_id );
 
 		if ( ! $job ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Job %d not found.', $job_id ),
+			return new \WP_Error(
+				'job_not_found',
+				sprintf( 'Job %d not found.', $job_id ),
+				array(
+					'status' => 404,
+					'job_id' => $job_id,
+				)
 			);
 		}
 
 		if ( ! $this->canAccessJob( $job ) ) {
-			return $this->jobAccessDenied();
+			return $this->jobAccessDeniedError();
 		}
 
 		$previous_status = $job['status'] ?? '';
 
 		// Unless forced, only allow retrying failed or processing jobs.
 		if ( ! $force && ! str_starts_with( $previous_status, 'failed' ) && 'processing' !== $previous_status ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Job %d has status "%s" — use --force to retry non-failed jobs.', $job_id, $previous_status ),
+			return new \WP_Error(
+				'invalid_job_status',
+				sprintf( 'Job %d has status "%s" — use --force to retry non-failed jobs.', $job_id, $previous_status ),
+				array(
+					'status'    => 409,
+					'job_id'    => $job_id,
+					'retryable' => true,
+				)
 			);
 		}
 
@@ -123,17 +129,27 @@ class RetryJobAbility {
 
 		if ( 'direct' === (string) ( $job['flow_id'] ?? '' ) ) {
 			if ( empty( $engine_data['flow_config'] ) ) {
-				return array(
-					'success' => false,
-					'error'   => 'Direct workflow execution data is no longer available for retry.',
+				return new \WP_Error(
+					'retry_data_unavailable',
+					'Direct workflow execution data is no longer available for retry.',
+					array(
+						'status'    => 409,
+						'retryable' => false,
+						'job_id'    => $job_id,
+					)
 				);
 			}
 
 			$flow_step_id = JobRetryPolicy::resolveDirectResumeStepId( $engine_data );
 			if ( '' === $flow_step_id ) {
-				return array(
-					'success' => false,
-					'error'   => 'Direct workflow has no safe resume step.',
+				return new \WP_Error(
+					'retry_resume_unavailable',
+					'Direct workflow has no safe resume step.',
+					array(
+						'status'    => 409,
+						'retryable' => false,
+						'job_id'    => $job_id,
+					)
 				);
 			}
 
@@ -143,13 +159,16 @@ class RetryJobAbility {
 				$enqueuer       = new DirectJobEnqueuer( $this->db_jobs );
 				$live_execution = $generation > 0 && '' !== $token ? $enqueuer->liveGenerationExecution( $job_id, $generation, $token ) : 'none';
 				if ( 'none' !== $live_execution ) {
-					return array(
-						'success'         => false,
-						'job_id'          => $job_id,
-						'previous_status' => $previous_status,
-						'retryable'       => true,
-						'error_code'      => 'job_execution_in_progress',
-						'error'           => sprintf( 'Job %d still has live execution for generation %d; retry after it exits or is recovered.', $job_id, $generation ),
+					return new \WP_Error(
+						'job_execution_in_progress',
+						sprintf( 'Job %d still has live execution for generation %d; retry after it exits or is recovered.', $job_id, $generation ),
+						array(
+							'status'     => 409,
+							'retryable'  => true,
+							'job_id'     => $job_id,
+							'generation' => $generation,
+							'ownership'  => 'operation',
+						)
 					);
 				}
 
@@ -160,13 +179,16 @@ class RetryJobAbility {
 				);
 				if ( is_array( $missing_action ) ) {
 					if ( ! empty( $job['operation_effects_begun_at'] ) ) {
-						return array(
-							'success'         => false,
-							'job_id'          => $job_id,
-							'previous_status' => $previous_status,
-							'retryable'       => false,
-							'error_code'      => 'job_effects_begun',
-							'error'           => sprintf( 'Job %d may have begun operation effects and cannot be safely retried.', $job_id ),
+						return new \WP_Error(
+							'job_effects_begun',
+							sprintf( 'Job %d may have begun operation effects and cannot be safely retried.', $job_id ),
+							array(
+								'status'     => 409,
+								'retryable'  => false,
+								'job_id'     => $job_id,
+								'generation' => $generation,
+								'ownership'  => 'operation',
+							)
 						);
 					}
 
@@ -190,13 +212,16 @@ class RetryJobAbility {
 						)
 					);
 					if ( empty( $requeue['success'] ) ) {
-						return array(
-							'success'         => false,
-							'job_id'          => $job_id,
-							'previous_status' => $previous_status,
-							'retryable'       => true,
-							'error_code'      => (string) ( $requeue['reason'] ?? 'retry_enqueue_failed' ),
-							'error'           => sprintf( 'Job %d retry could not establish durable scheduler ownership.', $job_id ),
+						return new \WP_Error(
+							(string) ( $requeue['reason'] ?? 'retry_enqueue_failed' ),
+							sprintf( 'Job %d retry could not establish durable scheduler ownership.', $job_id ),
+							array(
+								'status'     => 503,
+								'retryable'  => true,
+								'job_id'     => $job_id,
+								'generation' => $missing_action['generation'] ?? 0,
+								'ownership'  => 'scheduler',
+							)
 						);
 					}
 
@@ -213,18 +238,28 @@ class RetryJobAbility {
 				$this->db_jobs->complete_job( $job_id, 'failed - manual_retry' );
 			}
 			if ( ! $this->db_jobs->reopen_failed_job( $job_id ) ) {
-				return array(
-					'success' => false,
-					'error'   => sprintf( 'Job %d could not be reopened for retry.', $job_id ),
+				return new \WP_Error(
+					'job_reopen_failed',
+					sprintf( 'Job %d could not be reopened for retry.', $job_id ),
+					array(
+						'status'    => 500,
+						'retryable' => true,
+						'job_id'    => $job_id,
+					)
 				);
 			}
 
 			$enqueue = ( new DirectJobEnqueuer( $this->db_jobs ) )->enqueue( $job_id, $flow_step_id );
 			if ( empty( $enqueue['success'] ) ) {
 				$this->db_jobs->complete_job( $job_id, 'failed - retry_enqueue_failed' );
-				return array(
-					'success' => false,
-					'error'   => sprintf( 'Job %d retry could not be enqueued.', $job_id ),
+				return new \WP_Error(
+					'retry_enqueue_failed',
+					sprintf( 'Job %d retry could not be enqueued.', $job_id ),
+					array(
+						'status'    => 503,
+						'retryable' => true,
+						'job_id'    => $job_id,
+					)
 				);
 			}
 

--- a/inc/Abilities/Job/RunMetricsAbility.php
+++ b/inc/Abilities/Job/RunMetricsAbility.php
@@ -57,25 +57,26 @@ class RunMetricsAbility {
 		\DataMachine\Abilities\AbilityRegistration::on_abilities_api_init( $register_callback );
 	}
 
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$job_id = (int) ( $input['job_id'] ?? 0 );
 		if ( $job_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'job_id must be a positive integer.',
-			);
+			return new \WP_Error( 'invalid_job_id', 'job_id must be a positive integer.', array( 'status' => 400 ) );
 		}
 
 		$job = $this->db_jobs->get_job( $job_id );
 		if ( ! $job ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Job %d not found.', $job_id ),
+			return new \WP_Error(
+				'job_not_found',
+				sprintf( 'Job %d not found.', $job_id ),
+				array(
+					'status' => 404,
+					'job_id' => $job_id,
+				)
 			);
 		}
 
 		if ( ! $this->canAccessJob( $job ) ) {
-			return $this->jobAccessDenied();
+			return $this->jobAccessDeniedError();
 		}
 
 		$jobs = $this->enrichJobNames( array( $job ) );

--- a/inc/Api/WebhookTrigger.php
+++ b/inc/Api/WebhookTrigger.php
@@ -226,11 +226,7 @@ class WebhookTrigger {
 				)
 			);
 
-			return new \WP_Error(
-				'execution_failed',
-				$result->get_error_message(),
-				array( 'status' => 500 )
-			);
+			return $result;
 		}
 
 		if ( ! ( $result['success'] ?? false ) ) {

--- a/inc/Cli/Commands/CycleCommand.php
+++ b/inc/Cli/Commands/CycleCommand.php
@@ -8,6 +8,7 @@
 namespace DataMachine\Cli\Commands;
 
 use DataMachine\Cli\BaseCommand;
+use DataMachine\Core\AbilityResult;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Flows\CycleFlowSelector;
 use WP_CLI;
@@ -98,7 +99,7 @@ class CycleCommand extends BaseCommand {
 			}
 
 			foreach ( $rows as &$row ) {
-				$result = $ability->execute( array( 'flow_id' => (int) $row['flow_id'] ) );
+				$result = AbilityResult::normalize( $ability->execute( array( 'flow_id' => (int) $row['flow_id'] ) ) );
 				if ( ! ( $result['success'] ?? false ) ) {
 					$row['status'] = 'failed_to_start';
 					$row['error']  = (string) ( $result['error'] ?? 'Failed to run flow' );

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -1163,12 +1163,12 @@ class FlowsCommand extends BaseCommand {
 				return;
 			}
 
-			$result = $ability->execute(
+			$result = AbilityResult::normalize( $ability->execute(
 				array(
 					'flow_id'               => $flow_id,
 					'interval_or_timestamp' => $timestamp,
 				)
-			);
+			) );
 
 			if ( ! ( $result['success'] ?? false ) ) {
 				WP_CLI::error( $result['error'] ?? 'Failed to schedule flow' );
@@ -1189,7 +1189,7 @@ class FlowsCommand extends BaseCommand {
 		$job_ids = array();
 
 		for ( $i = 0; $i < $count; $i++ ) {
-			$result = $ability->execute( array( 'flow_id' => $flow_id ) );
+			$result = AbilityResult::normalize( $ability->execute( array( 'flow_id' => $flow_id ) ) );
 
 			if ( ! ( $result['success'] ?? false ) ) {
 				if ( empty( $job_ids ) ) {

--- a/inc/Cli/Commands/JobsCommand.php
+++ b/inc/Cli/Commands/JobsCommand.php
@@ -2460,7 +2460,7 @@ class JobsCommand extends BaseCommand {
 			return;
 		}
 
-		$result = ( new RunMetricsAbility() )->execute( array( 'job_id' => (int) $args[0] ) );
+		$result = AbilityResult::normalize( ( new RunMetricsAbility() )->execute( array( 'job_id' => (int) $args[0] ) ) );
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Unknown error occurred' );
 			return;
@@ -2543,12 +2543,12 @@ class JobsCommand extends BaseCommand {
 			return;
 		}
 
-		$result = ( new FailJobAbility() )->execute(
+		$result = AbilityResult::normalize( ( new FailJobAbility() )->execute(
 			array(
 				'job_id' => (int) $args[0],
 				'reason' => $assoc_args['reason'] ?? 'manual',
 			)
-		);
+		) );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Unknown error occurred' );
@@ -2588,12 +2588,12 @@ class JobsCommand extends BaseCommand {
 			return;
 		}
 
-		$result = ( new RetryJobAbility() )->execute(
+		$result = AbilityResult::normalize( ( new RetryJobAbility() )->execute(
 			array(
 				'job_id' => (int) $args[0],
 				'force'  => isset( $assoc_args['force'] ),
 			)
-		);
+		) );
 
 		if ( ! $result['success'] ) {
 			WP_CLI::error( $result['error'] ?? 'Unknown error occurred' );

--- a/inc/Cli/Commands/SystemCommand.php
+++ b/inc/Cli/Commands/SystemCommand.php
@@ -16,6 +16,7 @@ use DataMachine\Abilities\Engine\DrainJobAbility;
 use DataMachine\Abilities\SystemAbilities;
 use DataMachine\Core\ActionScheduler\ClaimIndexMigration;
 use DataMachine\Core\ActionScheduler\ActionInsertReadiness;
+use DataMachine\Core\AbilityResult;
 use DataMachine\Core\Bootstrap\DependencyChecker;
 use DataMachine\Engine\Tasks\TaskRegistry;
 use DataMachine\Engine\AI\System\Tasks\SystemTask;
@@ -490,13 +491,13 @@ class SystemCommand extends BaseCommand {
 			$step_budget    = isset( $assoc_args['step-budget'] ) ? max( 1, (int) $assoc_args['step-budget'] ) : 50;
 			$time_budget_ms = isset( $assoc_args['time-budget-ms'] ) ? max( 1, (int) $assoc_args['time-budget-ms'] ) : 300000;
 
-			$result['drain'] = ( new DrainJobAbility() )->execute(
+			$result['drain'] = AbilityResult::normalize( ( new DrainJobAbility() )->execute(
 				array(
 					'job_id'         => (int) ( $result['job_id'] ?? 0 ),
 					'step_budget'    => $step_budget,
 					'time_budget_ms' => $time_budget_ms,
 				)
-			);
+			) );
 		}
 
 		if ( 'json' === $format ) {

--- a/inc/Cli/Commands/WorkerCommand.php
+++ b/inc/Cli/Commands/WorkerCommand.php
@@ -13,6 +13,7 @@ use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Cli\WorkerHealth;
 use DataMachine\Cli\WorkerLock;
+use DataMachine\Core\AbilityResult;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
 use WP_CLI;
@@ -284,7 +285,7 @@ class WorkerCommand extends BaseCommand {
 
 				if ( $recover_stuck && ! $recovery_ran ) {
 					$recovery_ran = true;
-					$recovery = ( new RecoverStuckJobsAbility() )->execute(
+					$recovery = AbilityResult::normalize( ( new RecoverStuckJobsAbility() )->execute(
 						array(
 							'dry_run'       => false,
 							'timeout_hours' => $stuck_timeout,
@@ -292,7 +293,7 @@ class WorkerCommand extends BaseCommand {
 							'limit'         => 5,
 							'recover_pathless_children' => false,
 						)
-					);
+					) );
 
 					if ( empty( $recovery['success'] ) ) {
 						++$warnings;
@@ -446,7 +447,7 @@ class WorkerCommand extends BaseCommand {
 
 			if ( $recover_stuck && ! $recovery_ran ) {
 				$recovery_ran = true;
-				$recovery = ( new RecoverStuckJobsAbility() )->execute(
+				$recovery = AbilityResult::normalize( ( new RecoverStuckJobsAbility() )->execute(
 					array(
 						'dry_run'       => false,
 						'timeout_hours' => $stuck_timeout,
@@ -454,7 +455,7 @@ class WorkerCommand extends BaseCommand {
 						'limit'         => 5,
 						'recover_pathless_children' => false,
 					)
-				);
+				) );
 
 				if ( empty( $recovery['success'] ) ) {
 					++$warnings;
@@ -500,13 +501,13 @@ class WorkerCommand extends BaseCommand {
 			++$job_claims;
 			try {
 				$remaining_seconds = $time_limit > 0 ? max( 1, $time_limit - $stop_before_timeout - ( time() - $started_at ) ) : $drain_time_limit;
-				$result            = $drain_job->execute(
+				$result            = AbilityResult::normalize( $drain_job->execute(
 					array(
 						'job_id'         => $claim['job_id'],
 						'step_budget'    => $job_step_budget,
 						'time_budget_ms' => min( $drain_time_limit, $remaining_seconds ) * 1000,
 					)
-				);
+				) );
 
 				$actions += (int) ( $result['actions_drained'] ?? 0 );
 				if ( ! empty( $result['success'] ) ) {

--- a/inc/Engine/Actions/Engine.php
+++ b/inc/Engine/Actions/Engine.php
@@ -77,6 +77,14 @@ function datamachine_execute_step_action( $job_id, string $flow_step_id, $operat
 				'recovery_claim_token'  => is_string( $recovery_claim_token ) ? $recovery_claim_token : '',
 			)
 		);
+		if ( is_wp_error( $result ) ) {
+			$error_data = $result->get_error_data();
+			if ( is_array( $error_data ) && ! empty( $error_data['retryable'] ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Internal scheduler control flow, not rendered output.
+				throw new \RuntimeException( $result->get_error_message() );
+			}
+			return;
+		}
 		if ( in_array( (string) ( $result['outcome'] ?? '' ), array( 'claim_completion_failed', 'terminal_transition_failed' ), true ) ) {
 			throw new \RuntimeException( 'Data Machine terminal transition failed.' );
 		}

--- a/inc/Engine/Bundle/AgentBundleRunner.php
+++ b/inc/Engine/Bundle/AgentBundleRunner.php
@@ -11,6 +11,7 @@ use DataMachine\Abilities\Job\ExecuteWorkflowAbility;
 use DataMachine\Abilities\Engine\DrainJobAbility;
 use DataMachine\Core\Agents\AgentBundler;
 use DataMachine\Core\Agents\AgentIdentityResolver;
+use DataMachine\Core\AbilityResult;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\DataPath;
 use DataMachine\Core\JobStatus;
@@ -121,11 +122,13 @@ final class AgentBundleRunner {
 		$response = $this->with_runtime_controls(
 			$input,
 			function () use ( $workflow, $initial_data, $input ): array {
-				$result = ( new ExecuteWorkflowAbility() )->execute(
-					array(
-						'workflow'     => $workflow,
-						'initial_data' => $initial_data,
-						'timestamp'    => $input['timestamp'] ?? null,
+				$result = $this->normalize_ability_result(
+					( new ExecuteWorkflowAbility() )->execute(
+						array(
+							'workflow'     => $workflow,
+							'initial_data' => $initial_data,
+							'timestamp'    => $input['timestamp'] ?? null,
+						)
 					)
 				);
 
@@ -630,13 +633,13 @@ final class AgentBundleRunner {
 			return $response;
 		}
 
-		$drain_result = ( new DrainJobAbility() )->execute(
+		$drain_result = $this->normalize_ability_result( ( new DrainJobAbility() )->execute(
 			array(
 				'job_id'         => $job_id,
 				'step_budget'    => max( 1, (int) ( $input['step_budget'] ?? 50 ) ),
 				'time_budget_ms' => max( 1, (int) ( $input['time_budget_ms'] ?? 300000 ) ),
 			)
-		);
+		) );
 
 		$job         = ( new Jobs() )->get_job( $job_id );
 		$job_status  = is_array( $job ) ? (string) ( $job['status'] ?? '' ) : '';
@@ -648,6 +651,22 @@ final class AgentBundleRunner {
 		$response['engine_data']         = $engine_data;
 
 		return $response;
+	}
+
+	/** Preserve durable native-error metadata in the public bundle envelope. */
+	private function normalize_ability_result( $result ): array {
+		$normalized = AbilityResult::normalize( $result );
+		if ( ! is_wp_error( $result ) ) {
+			return $normalized;
+		}
+
+		$error_data = $result->get_error_data();
+		if ( ! is_array( $error_data ) ) {
+			return $normalized;
+		}
+
+		unset( $error_data['status'] );
+		return array_merge( $error_data, $normalized );
 	}
 
 	/** @return array<string,mixed> */
@@ -729,11 +748,11 @@ final class AgentBundleRunner {
 		}
 
 		$owner_id = $this->runtime_import_owner_id( $input );
-		$options = array(
+		$options  = array(
 			'is_upgrade'        => true,
 			'reconcile_runtime' => true,
 		);
-		$result  = empty( $bundle )
+		$result   = empty( $bundle )
 			? $this->bundler->import_directory_object( $directory, null, $owner_id, false, $options )
 			: $this->bundler->import( $bundle, null, $owner_id, false, $options );
 		if ( empty( $result['success'] ) ) {
@@ -856,7 +875,7 @@ final class AgentBundleRunner {
 			);
 		}
 
-		$revision = BundleSource::is_remote( $source ) ? BundleSource::last_resolved_revision() : null;
+		$revision  = BundleSource::is_remote( $source ) ? BundleSource::last_resolved_revision() : null;
 		$bundle    = null;
 		$directory = null;
 		try {

--- a/tests/Unit/Abilities/Engine/RunFlowAbilityLifecycleTest.php
+++ b/tests/Unit/Abilities/Engine/RunFlowAbilityLifecycleTest.php
@@ -67,12 +67,17 @@ class RunFlowAbilityLifecycleTest extends WP_UnitTestCase {
 
 		$result = ( new RunFlowAbility() )->execute( array( 'flow_id' => $flow_id ) );
 
-		$this->assertFalse( $result['success'] ?? true );
-		$this->assertSame( 'no_first_step', $result['reason'] ?? '' );
-		$this->assertIsInt( $result['job_id'] ?? null );
+		$this->assertWPError( $result );
+		$this->assertSame( 'no_first_step', $result->get_error_code() );
+		$this->assertSame( 'Flow execution failed - no first step found.', $result->get_error_message() );
+		$error_data = $result->get_error_data();
+		$this->assertSame( 400, $error_data['status'] );
+		$this->assertFalse( $error_data['retryable'] );
+		$this->assertSame( $flow_id, $error_data['flow_id'] );
+		$this->assertIsInt( $error_data['job_id'] );
 		$this->assertSame( array(), $this->scheduled_steps );
 
-		$job = ( new Jobs() )->get_job( (int) $result['job_id'] );
+		$job = ( new Jobs() )->get_job( $error_data['job_id'] );
 		$this->assertNotEmpty( $job );
 		$this->assertSame( JobStatus::FAILED, $job['status'] ?? '' );
 		$this->assertSame( 'no_first_step', $job['engine_data']['job_status_reason'] ?? '' );
@@ -171,8 +176,12 @@ class RunFlowAbilityLifecycleTest extends WP_UnitTestCase {
 
 		remove_filter( 'datamachine_max_active_jobs', $cap );
 
-		$this->assertNotSame( 'queue_backpressure', $result['reason'] ?? '' );
-		$this->assertIsInt( $result['job_id'] ?? null );
+		$this->assertWPError( $result );
+		$this->assertSame( 'no_first_step', $result->get_error_code() );
+		$error_data = $result->get_error_data();
+		$this->assertSame( 400, $error_data['status'] );
+		$this->assertFalse( $error_data['retryable'] );
+		$this->assertIsInt( $error_data['job_id'] );
 	}
 
 	public function test_completed_parent_run_result_includes_available_child_envelopes(): void {

--- a/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
+++ b/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
@@ -702,10 +702,13 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertNull( $after['terminal_accounting_state'] );
 
 		$duplicate = ( new RetryJobAbility() )->execute( array( 'job_id' => $job_id, 'force' => true ) );
+		$after_duplicate = $jobs->get_job( $job_id );
 		$this->assertWPError( $duplicate );
-		$this->assertSame( 'job_execution_in_progress', $duplicate->get_error_code() );
+		$this->assertSame( 'job_reopen_failed', $duplicate->get_error_code() );
 		$this->assertTrue( $duplicate->get_error_data()['retryable'] );
 		$this->assertSame( $job_count, $jobs->get_jobs_count() );
+		$this->assertSame( (int) $after['operation_action_id'], (int) $after_duplicate['operation_action_id'] );
+		$this->assertSame( (int) $after['operation_generation'], (int) $after_duplicate['operation_generation'] );
 	}
 
 	public function test_missing_direct_action_requeue_rolls_back_unusable_receipt(): void {

--- a/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
+++ b/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
@@ -94,8 +94,12 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 
 		$result = $this->execute( 'missing-caller' );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'authenticated acting caller', $result['error'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'workflow_ownership_denied', $result->get_error_code() );
+		$this->assertStringContainsString( 'authenticated acting caller', $result->get_error_message() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+		$this->assertFalse( $result->get_error_data()['retryable'] );
+		$this->assertSame( 'caller', $result->get_error_data()['ownership'] );
 	}
 
 	public function test_forged_system_context_input_does_not_grant_internal_authority(): void {
@@ -109,8 +113,10 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertStringContainsString( 'authenticated acting caller', $result['error'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'workflow_ownership_denied', $result->get_error_code() );
+		$this->assertStringContainsString( 'authenticated acting caller', $result->get_error_message() );
+		$this->assertSame( 'caller', $result->get_error_data()['ownership'] );
 
 		$internal = ( new ExecuteWorkflowAbility( false ) )->executeInternal(
 			array(
@@ -158,9 +164,15 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$denied = ( new GetJobsAbility() )->execute( array( 'job_id' => $job_id ) );
 		$this->assertWPError( $denied );
 		$this->assertSame( 'job_access_denied', $denied->get_error_code() );
-		$this->assertSame( 'job_access_denied', ( new RunMetricsAbility() )->execute( array( 'job_id' => $job_id ) )['error_code'] );
-		$this->assertFalse( ( new FailJobAbility() )->execute( array( 'job_id' => $job_id ) )['success'] );
-		$this->assertSame( 'job_access_denied', ( new RetryJobAbility() )->execute( array( 'job_id' => $job_id ) )['error_code'] );
+		$metrics_denied = ( new RunMetricsAbility() )->execute( array( 'job_id' => $job_id ) );
+		$this->assertWPError( $metrics_denied );
+		$this->assertSame( 'job_access_denied', $metrics_denied->get_error_code() );
+		$fail_denied = ( new FailJobAbility() )->execute( array( 'job_id' => $job_id ) );
+		$this->assertWPError( $fail_denied );
+		$this->assertSame( 'job_access_denied', $fail_denied->get_error_code() );
+		$retry_denied = ( new RetryJobAbility() )->execute( array( 'job_id' => $job_id ) );
+		$this->assertWPError( $retry_denied );
+		$this->assertSame( 'job_access_denied', $retry_denied->get_error_code() );
 
 		wp_set_current_user( $this->admin_id );
 		$this->assertTrue( ( new GetJobsAbility() )->execute( array( 'job_id' => $job_id ) )['success'] );
@@ -323,7 +335,9 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 
 		wp_set_current_user( $this->other_user_id );
 		$denied = ( new HydrateJobArtifactAbility() )->execute( array( 'artifact_ref' => $artifact_ref ) );
-		$this->assertSame( 'job_access_denied', $denied['error_code'] );
+		$this->assertWPError( $denied );
+		$this->assertSame( 'job_access_denied', $denied->get_error_code() );
+		$this->assertSame( 403, $denied->get_error_data()['status'] );
 		$this->assertSame( 0, $hydrate_count );
 
 		wp_set_current_user( $this->owner_id );
@@ -350,8 +364,12 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertSame( (int) ( new Jobs() )->get_job( (int) $first['job_id'] )['operation_action_id'], (int) ( new Jobs() )->get_job( (int) $replay['job_id'] )['operation_action_id'] );
 
 		$conflict = $this->execute( 'stable-operation', 'different input' );
-		$this->assertFalse( $conflict['success'] );
-		$this->assertStringContainsString( 'different workflow input', $conflict['error'] );
+		$this->assertWPError( $conflict );
+		$this->assertSame( 'operation_key_conflict', $conflict->get_error_code() );
+		$this->assertStringContainsString( 'different workflow input', $conflict->get_error_message() );
+		$this->assertSame( 409, $conflict->get_error_data()['status'] );
+		$this->assertFalse( $conflict->get_error_data()['retryable'] );
+		$this->assertSame( 'operation', $conflict->get_error_data()['ownership'] );
 
 		$distinct = $this->execute( 'distinct-operation' );
 		$this->assertTrue( $distinct['success'] );
@@ -367,7 +385,10 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $invalid['success'] );
+		$this->assertWPError( $invalid );
+		$this->assertSame( 'invalid_workflow', $invalid->get_error_code() );
+		$this->assertSame( 400, $invalid->get_error_data()['status'] );
+		$this->assertFalse( $invalid->get_error_data()['retryable'] );
 		$this->assertTrue( $this->execute( 'validation-before-claim' )['success'] );
 	}
 
@@ -641,9 +662,13 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$retry = ( new RetryJobAbility() )->execute( array( 'job_id' => $created['job_id'] ) );
 		$job   = $jobs->get_job( (int) $created['job_id'] );
 
-		$this->assertFalse( $retry['success'] );
-		$this->assertTrue( $retry['retryable'] );
-		$this->assertSame( 'job_execution_in_progress', $retry['error_code'] );
+		$this->assertWPError( $retry );
+		$this->assertSame( 'job_execution_in_progress', $retry->get_error_code() );
+		$this->assertSame( 409, $retry->get_error_data()['status'] );
+		$this->assertTrue( $retry->get_error_data()['retryable'] );
+		$this->assertSame( (int) $created['job_id'], $retry->get_error_data()['job_id'] );
+		$this->assertSame( $original_generation, $retry->get_error_data()['generation'] );
+		$this->assertSame( 'operation', $retry->get_error_data()['ownership'] );
 		$this->assertSame( 'processing', $job['status'] );
 		$this->assertSame( 'enqueued', $job['operation_state'] );
 		$this->assertSame( $original_action_id, (int) $job['operation_action_id'] );
@@ -677,7 +702,9 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertNull( $after['terminal_accounting_state'] );
 
 		$duplicate = ( new RetryJobAbility() )->execute( array( 'job_id' => $job_id, 'force' => true ) );
-		$this->assertFalse( $duplicate['success'] );
+		$this->assertWPError( $duplicate );
+		$this->assertSame( 'job_execution_in_progress', $duplicate->get_error_code() );
+		$this->assertTrue( $duplicate->get_error_data()['retryable'] );
 		$this->assertSame( $job_count, $jobs->get_jobs_count() );
 	}
 
@@ -724,8 +751,12 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 
 		$retry = ( new RetryJobAbility() )->execute( array( 'job_id' => $job_id ) );
 
-		$this->assertFalse( $retry['success'] );
-		$this->assertSame( 'job_effects_begun', $retry['error_code'] );
+		$this->assertWPError( $retry );
+		$this->assertSame( 'job_effects_begun', $retry->get_error_code() );
+		$this->assertSame( 409, $retry->get_error_data()['status'] );
+		$this->assertFalse( $retry->get_error_data()['retryable'] );
+		$this->assertSame( $job_id, $retry->get_error_data()['job_id'] );
+		$this->assertSame( 'operation', $retry->get_error_data()['ownership'] );
 		$this->assertSame( JobStatus::PROCESSING, $jobs->get_job( $job_id )['status'] );
 	}
 
@@ -748,8 +779,12 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 
 		$retry = ( new RetryJobAbility() )->execute( array( 'job_id' => $job_id ) );
 
-		$this->assertFalse( $retry['success'] );
-		$this->assertSame( 'job_execution_in_progress', $retry['error_code'] );
+		$this->assertWPError( $retry );
+		$this->assertSame( 'job_execution_in_progress', $retry->get_error_code() );
+		$this->assertSame( 409, $retry->get_error_data()['status'] );
+		$this->assertTrue( $retry->get_error_data()['retryable'] );
+		$this->assertSame( $job_id, $retry->get_error_data()['job_id'] );
+		$this->assertSame( 'operation', $retry->get_error_data()['ownership'] );
 		$this->assertSame( 'processing', $jobs->get_job( $job_id )['status'] );
 	}
 
@@ -889,7 +924,7 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertTrue( ( new GetJobsAbility() )->execute( array( 'job_id' => $job_id ) )['success'] );
 	}
 
-	private function execute( string $operation_key, string $prompt = 'input' ): array {
+	private function execute( string $operation_key, string $prompt = 'input' ): array|\WP_Error {
 		return ( new ExecuteWorkflowAbility() )->execute(
 			array(
 				'workflow'      => $this->workflow( $prompt ),

--- a/tests/Unit/Abilities/Job/GetRunArtifactsAbilityTest.php
+++ b/tests/Unit/Abilities/Job/GetRunArtifactsAbilityTest.php
@@ -43,9 +43,11 @@ class GetRunArtifactsAbilityTest extends WP_UnitTestCase {
 		wp_set_current_user( $this->owner_id );
 		$result = ( new GetRunArtifactsAbility() )->execute( array( 'job_id' => PHP_INT_MAX ) );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertSame( 'job_not_found', $result['error_code'] );
-		$this->assertSame( 404, $result['status'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'job_not_found', $result->get_error_code() );
+		$this->assertSame( sprintf( 'Job %d was not found.', PHP_INT_MAX ), $result->get_error_message() );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
+		$this->assertFalse( $result->get_error_data()['retryable'] );
 	}
 
 	public function test_unauthorized_run_is_denied_before_artifact_projection(): void {
@@ -54,9 +56,10 @@ class GetRunArtifactsAbilityTest extends WP_UnitTestCase {
 
 		$result = ( new GetRunArtifactsAbility() )->execute( array( 'job_id' => $job_id ) );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertSame( 'job_access_denied', $result['error_code'] );
-		$this->assertArrayNotHasKey( 'artifacts', $result );
+		$this->assertWPError( $result );
+		$this->assertSame( 'job_access_denied', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+		$this->assertFalse( $result->get_error_data()['retryable'] );
 	}
 
 	public function test_valid_empty_artifacts_and_absent_policy_are_distinct_from_failure(): void {

--- a/tests/Unit/Abilities/PermissionHelperTest.php
+++ b/tests/Unit/Abilities/PermissionHelperTest.php
@@ -340,6 +340,7 @@ class PermissionHelperTest extends WP_UnitTestCase {
 			456
 		);
 
+		$this->setExpectedIncorrectUsage( 'WP_Ability::execute' );
 		$result = $ability->execute( array() );
 
 		$this->assertWPError( $result );

--- a/tests/Unit/Abilities/PermissionHelperTest.php
+++ b/tests/Unit/Abilities/PermissionHelperTest.php
@@ -343,7 +343,8 @@ class PermissionHelperTest extends WP_UnitTestCase {
 		$result = $ability->execute( array() );
 
 		$this->assertWPError( $result );
-		$this->assertSame( 'datamachine_ability_scope_denied', $result->get_error_code() );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
+		$this->assertStringContainsString( 'does not have necessary permission', $result->get_error_message() );
 	}
 
 	public function test_view_analytics_granted_to_manage_flows_holder(): void {

--- a/tests/Unit/Api/WebhookTriggerTest.php
+++ b/tests/Unit/Api/WebhookTriggerTest.php
@@ -239,6 +239,43 @@ class WebhookTriggerTest extends WP_UnitTestCase {
 		$this->assert_is_unauthorized( $res );
 	}
 
+	public function test_native_run_flow_error_preserves_code_status_and_retry_metadata(): void {
+		$enable   = $this->ability->executeEnable( array( 'flow_id' => $this->flow_id ) );
+		$registry = \WP_Abilities_Registry::get_instance();
+		$property = ( new \ReflectionClass( $registry ) )->getProperty( 'registered_abilities' );
+		$abilities = $property->getValue( $registry );
+		$original  = $abilities['datamachine/run-flow'];
+		$abilities['datamachine/run-flow'] = new class() extends \WP_Ability {
+			public function __construct() {}
+			public function execute( $input = null ) {
+				unset( $input );
+				return new \WP_Error(
+					'run_flow_busy',
+					'Run flow is temporarily unavailable.',
+					array(
+						'status'        => 503,
+						'retryable'     => true,
+						'enqueue_state' => 'capacity_wait',
+					)
+				);
+			}
+		};
+		$property->setValue( $registry, $abilities );
+
+		try {
+			$result = WebhookTrigger::handle_trigger( $this->make_request( '', array( 'authorization' => 'Bearer ' . $enable['token'] ) ) );
+		} finally {
+			$abilities['datamachine/run-flow'] = $original;
+			$property->setValue( $registry, $abilities );
+		}
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'run_flow_busy', $result->get_error_code() );
+		$this->assertSame( 503, $result->get_error_data()['status'] );
+		$this->assertTrue( $result->get_error_data()['retryable'] );
+		$this->assertSame( 'capacity_wait', $result->get_error_data()['enqueue_state'] );
+	}
+
 	public function test_hmac_valid_signature_passes(): void {
 		$this->register_example_preset();
 		$enable = $this->ability->executeEnable( array(

--- a/tests/agent-bundle-runner-contract-smoke.php
+++ b/tests/agent-bundle-runner-contract-smoke.php
@@ -13,6 +13,19 @@ $passes   = 0;
 
 defined( 'ABSPATH' ) || define( 'ABSPATH', $root . '/' );
 
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code, private string $message, private $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data() { return $this->data; }
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+}
+
 if ( ! function_exists( 'sanitize_key' ) ) {
 	function sanitize_key( string $key ): string {
 		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $key ) ) ?? '';
@@ -57,6 +70,7 @@ echo "agent-bundle-runner-contract-smoke\n";
 echo "\n[3] Runner exposes semantic outputs while preserving raw engine data\n";
 require_once $root . '/inc/Core/JobStatus.php';
 require_once $root . '/inc/Core/DataPath.php';
+require_once $root . '/inc/Core/AbilityResult.php';
 require_once $root . '/inc/Engine/AI/Tools/HostToolPolicy.php';
 require_once $root . '/inc/Engine/Bundle/AgentBundleRunner.php';
 require_once $root . '/inc/Abilities/Flow/FlowHelpers.php';
@@ -66,6 +80,32 @@ require_once $root . '/inc/Core/Steps/FlowStepConfigFactory.php';
 require_once $root . '/inc/Core/Steps/WorkflowConfigFactory.php';
 $runner_reflection = new ReflectionClass( DataMachine\Engine\Bundle\AgentBundleRunner::class );
 $runner_instance   = $runner_reflection->newInstanceWithoutConstructor();
+
+$normalize_ability_result = $runner_reflection->getMethod( 'normalize_ability_result' );
+$native_failure           = $normalize_ability_result->invoke(
+	$runner_instance,
+	new WP_Error(
+		'enqueue_failed',
+		'Could not enqueue workflow.',
+		array(
+			'status'        => 503,
+			'job_id'        => 77,
+			'retryable'     => true,
+			'enqueue_state' => 'insert_failed',
+			'ownership'     => 'scheduler',
+			'recovery'      => 'replay',
+			'diagnostics'   => array( 'action_id' => 91 ),
+		)
+	)
+);
+datamachine_bundle_runner_assert( false === $native_failure['success'], 'native workflow failure normalizes to bundle envelope', $failures, $passes );
+datamachine_bundle_runner_assert( 77 === $native_failure['job_id'], 'bundle failure keeps job id top-level', $failures, $passes );
+datamachine_bundle_runner_assert( true === $native_failure['retryable'], 'bundle failure keeps retryability top-level', $failures, $passes );
+datamachine_bundle_runner_assert( 'insert_failed' === $native_failure['enqueue_state'], 'bundle failure keeps enqueue state top-level', $failures, $passes );
+datamachine_bundle_runner_assert( 'scheduler' === $native_failure['ownership'], 'bundle failure keeps ownership top-level', $failures, $passes );
+datamachine_bundle_runner_assert( 'replay' === $native_failure['recovery'], 'bundle failure keeps recovery top-level', $failures, $passes );
+datamachine_bundle_runner_assert( 91 === $native_failure['diagnostics']['action_id'], 'bundle failure keeps diagnostics top-level', $failures, $passes );
+datamachine_bundle_runner_assert( 503 === $native_failure['wp_error_data']['status'], 'bundle failure retains complete native error data', $failures, $passes );
 
 echo "\n[2a] Runner accepts direct workflow overrides\n";
 $workflow_override = $runner_reflection->getMethod( 'workflow_override_from_input' );

--- a/tests/agents-api-workflow-bridge-smoke.php
+++ b/tests/agents-api-workflow-bridge-smoke.php
@@ -290,7 +290,13 @@ defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
 		)
 	);
 
-	assert_agent_workflow_bridge_equals( false, $missing_input['success'], 'missing input workflow fails', $failures, $passes );
+	assert_agent_workflow_bridge_equals( true, is_wp_error( $missing_input ), 'missing input workflow returns a native error', $failures, $passes );
+	$missing_input_data = $missing_input->get_error_data();
+	assert_agent_workflow_bridge_equals( 102, $missing_input_data['job_id'], 'failed workflow error preserves job id', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'failed', $missing_input_data['workflow_status'], 'failed workflow error preserves runner status', $failures, $passes );
+	assert_agent_workflow_bridge_equals( array(), $missing_input_data['steps'], 'failed workflow error preserves completed steps', $failures, $passes );
+	assert_agent_workflow_bridge_equals( array(), $missing_input_data['output'], 'failed workflow error preserves partial output', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'missing_required_input', $missing_input_data['error']['code'], 'failed workflow error preserves full runner error', $failures, $passes );
 	assert_agent_workflow_bridge_equals( 'failed - missing_required_input', $jobs->jobs[102]['status'], 'failed workflow maps to failed job reason', $failures, $passes );
 	assert_agent_workflow_bridge_equals( 'failed', $recorder->find( 'run-missing-input' )?->get_status(), 'recorder find reconstructs failed status', $failures, $passes );
 
@@ -312,8 +318,8 @@ defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
 		)
 	);
 
-	assert_agent_workflow_bridge_equals( false, $unsupported['success'], 'unsupported foreach workflow fails clearly', $failures, $passes );
-	assert_agent_workflow_bridge_equals( 'agents_api_workflow_step_unsupported', $unsupported['error']['code'], 'unsupported step error is typed', $failures, $passes );
+	assert_agent_workflow_bridge_equals( true, is_wp_error( $unsupported ), 'unsupported foreach workflow fails clearly', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'agents_api_workflow_step_unsupported', $unsupported->get_error_code(), 'unsupported step error is typed', $failures, $passes );
 
 	$trigger_unsupported = $bridge->execute(
 		array(
@@ -325,8 +331,8 @@ defined( 'ABSPATH' ) || define( 'ABSPATH', __DIR__ . '/' );
 		)
 	);
 
-	assert_agent_workflow_bridge_equals( false, $trigger_unsupported['success'], 'unsupported trigger workflow fails clearly', $failures, $passes );
-	assert_agent_workflow_bridge_equals( 'agents_api_workflow_trigger_unsupported', $trigger_unsupported['error']['code'], 'unsupported trigger error is typed', $failures, $passes );
+	assert_agent_workflow_bridge_equals( true, is_wp_error( $trigger_unsupported ), 'unsupported trigger workflow fails clearly', $failures, $passes );
+	assert_agent_workflow_bridge_equals( 'agents_api_workflow_trigger_unsupported', $trigger_unsupported->get_error_code(), 'unsupported trigger error is typed', $failures, $passes );
 
 	if ( $failures ) {
 		echo "\nFAILED: " . count( $failures ) . " agents-api workflow bridge assertions failed.\n";

--- a/tests/drain-job-ability-smoke.php
+++ b/tests/drain-job-ability-smoke.php
@@ -37,7 +37,7 @@ assert_drain_job_contains( 'DEFAULT_STEP_BUDGET = 50', $ability_source, 'sane de
 assert_drain_job_contains( 'DEFAULT_TIME_BUDGET_MS = 300000', $ability_source, 'sane default wall-clock budget is declared' );
 assert_drain_job_contains( "'step_budget'", $ability_source, 'step budget is exposed in input schema' );
 assert_drain_job_contains( "'time_budget_ms'", $ability_source, 'wall-clock budget is exposed in input schema' );
-assert_drain_job_contains( "'error_type' => 'action_scheduler_unavailable'", $ability_source, 'AS unavailability returns a typed error' );
+assert_drain_job_true( 1 === preg_match( "/'error_type'\s*=>\s*'action_scheduler_unavailable'/", $ability_source ), 'AS unavailability returns a typed error' );
 assert_drain_job_contains( '( new ScopedDrainService() )->drain(', $ability_source, 'ability delegates to the shared scoped drain service' );
 assert_drain_job_contains( "'job_ids'                  => array( $" . 'job_id )', $ability_source, 'drain is scoped to one job_id' );
 assert_drain_job_contains( 'ScopedDrainService::HOOK_EXECUTE_STEP', $ability_source, 'drain includes execute-step actions' );

--- a/tests/successful-child-routing-smoke.php
+++ b/tests/successful-child-routing-smoke.php
@@ -17,6 +17,19 @@ if ( ! defined( 'WPINC' ) ) {
 $datamachine_successful_child_logs = array();
 $datamachine_execute_step_result   = array();
 
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public function __construct( private string $code, private string $message, private $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data() { return $this->data; }
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool { return $value instanceof WP_Error; }
+}
+
 if ( ! function_exists( 'do_action' ) ) {
 	function do_action( string $hook, ...$args ): void {
 		$GLOBALS['datamachine_successful_child_logs'][] = array(
@@ -43,7 +56,7 @@ if ( ! function_exists( 'wp_get_ability' ) ) {
 	function wp_get_ability( string $name ): object {
 		unset( $name );
 		return new class() {
-			public function execute( array $input ): array {
+			public function execute( array $input ) {
 				unset( $input );
 				return $GLOBALS['datamachine_execute_step_result'];
 			}
@@ -55,9 +68,11 @@ require_once __DIR__ . '/../inc/Core/JobStatus.php';
 require_once __DIR__ . '/../inc/Core/StepExecutionResult.php';
 require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
 require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
+require_once __DIR__ . '/../inc/Core/Database/ProcessedItems/ProcessedItems.php';
 require_once __DIR__ . '/../inc/Engine/ExecutionPlan.php';
 require_once __DIR__ . '/../inc/Engine/StepNavigator.php';
 require_once __DIR__ . '/../inc/Engine/Actions/Engine.php';
+require_once __DIR__ . '/../inc/Engine/Actions/Handlers/StepLifecycleHandler.php';
 require_once __DIR__ . '/../inc/Abilities/Engine/EngineHelpers.php';
 require_once __DIR__ . '/../inc/Abilities/Engine/ExecuteStepAbility.php';
 
@@ -69,6 +84,13 @@ class DataMachine_Successful_Child_Jobs extends Jobs {
 	public array $transitions = array();
 
 	public function __construct() {}
+
+	public function get_job( int $job_id ): ?array {
+		return array(
+			'job_id' => $job_id,
+			'status' => JobStatus::PROCESSING,
+		);
+	}
 
 	public function transition_job_status_result( int $job_id, string $status, bool $require_final = false ): array {
 		$this->transitions[] = array( $job_id, $status, $require_final );
@@ -158,6 +180,24 @@ try {
 	$stale_generation_noop = false;
 }
 $assert( 'stale generation remains a non-failing scheduler no-op', $stale_generation_noop );
+
+$GLOBALS['datamachine_execute_step_result'] = new WP_Error( 'job_not_found', 'Job not found.', array( 'retryable' => false ) );
+$non_retryable_noop                          = true;
+try {
+	datamachine_execute_step_action( 2930, 'handler_step' );
+} catch ( RuntimeException ) {
+	$non_retryable_noop = false;
+}
+$assert( 'native non-retryable failure remains a completed scheduler action', $non_retryable_noop );
+
+$GLOBALS['datamachine_execute_step_result'] = new WP_Error( 'scheduler_unavailable', 'Scheduler unavailable.', array( 'retryable' => true ) );
+$retryable_failure_surfaced                  = false;
+try {
+	datamachine_execute_step_action( 2930, 'handler_step' );
+} catch ( RuntimeException $exception ) {
+	$retryable_failure_surfaced = 'Scheduler unavailable.' === $exception->getMessage();
+}
+$assert( 'native retryable failure keeps the scheduler action failed', $retryable_failure_surfaced );
 
 echo "\nSuccessful child routing smoke complete: {$failures} failures.\n";
 exit( $failures > 0 ? 1 : 0 );


### PR DESCRIPTION
## Summary
- migrate engine and job registered callback failures to native `WP_Error` with retry, generation, ownership, recovery, and diagnostic metadata
- preserve durable runtime envelopes across scheduler, CLI, webhook, worker, and agent-bundle presentation boundaries
- add executable regression coverage for workflow, scheduler, drain, webhook, and bundle failure paths

## Verification
- changed-scope PHPCS and PHPStan: pass
- changed-scope audit: 0 introduced findings
- focused engine/job/CLI/bundle smokes: pass
- `git diff --check`: pass

WP Codebox PHPUnit runs for two focused groups encountered an unparseable recipe payload; executable smoke coverage and static gates pass.

Closes #3238