### PR TITLE
refactor: migrate content and fetch ability failures

### DIFF
--- a/inc/Abilities/Content/EditPostBlocksAbility.php
+++ b/inc/Abilities/Content/EditPostBlocksAbility.php
@@ -171,6 +171,15 @@ class EditPostBlocksAbility {
 	public static function handleChatToolCall( array $parameters, array $tool_def = array() ): array {
 		$tool_def;
 		$result = self::execute( $parameters );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'    => false,
+				'error'      => $result->get_error_message(),
+				'error_code' => $result->get_error_code(),
+				'error_data' => $result->get_error_data(),
+				'tool_name'  => 'edit_post_blocks',
+			);
+		}
 
 		return array(
 			'success'   => $result['success'],
@@ -185,7 +194,7 @@ class EditPostBlocksAbility {
 	 * @param array $input Ability input.
 	 * @return array
 	 */
-	public static function execute( array $input ): array {
+	public static function execute( array $input ): array|\WP_Error {
 		// Resolve the target blog. On multisite the post may live on another
 		// site than the one this request landed on; switch to it so the post
 		// read and the eventual apply target the right post. blog_id rides
@@ -198,10 +207,7 @@ class EditPostBlocksAbility {
 		// BlogContext::run_on_origin() in the preview branch.
 		$ctx = BlogContext::enter( $input );
 		if ( is_wp_error( $ctx ) ) {
-			return array(
-				'success' => false,
-				'error'   => $ctx->get_error_message(),
-			);
+			return $ctx;
 		}
 
 		try {
@@ -218,41 +224,28 @@ class EditPostBlocksAbility {
 	 * @param array|\WP_Error $ctx   Blog context token from BlogContext::enter().
 	 * @return array
 	 */
-	private static function execute_in_context( array $input, $ctx ): array {
+	private static function execute_in_context( array $input, $ctx ): array|\WP_Error {
 		$post_id = absint( $input['post_id'] ?? 0 );
 		$blog_id = absint( $input['blog_id'] ?? 0 );
 		$edits   = $input['edits'] ?? array();
 		$preview = ! empty( $input['preview'] );
 
 		if ( $post_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'Valid post_id is required',
-			);
+			return new \WP_Error( 'invalid_edit_post_id', 'Valid post_id is required', array( 'status' => 400 ) );
 		}
 
 		if ( empty( $edits ) || ! is_array( $edits ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'At least one edit operation is required',
-			);
+			return new \WP_Error( 'invalid_edit_operations', 'At least one edit operation is required', array( 'status' => 400 ) );
 		}
 
 		$post = get_post( $post_id );
 		if ( ! $post ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Post #%d does not exist', $post_id ),
-			);
+			return new \WP_Error( 'edit_post_not_found', sprintf( 'Post #%d does not exist', $post_id ), array( 'status' => 404 ) );
 		}
 
 		$block_content = ContentFormat::storedToBlocks( (string) $post->post_content, (string) $post->post_type );
 		if ( is_wp_error( $block_content ) ) {
-			return array(
-				'success' => false,
-				'post_id' => $post_id,
-				'error'   => $block_content->get_error_message(),
-			);
+			return self::content_format_error( $block_content, $post_id );
 		}
 
 		$blocks       = parse_blocks( $block_content );
@@ -325,22 +318,13 @@ class EditPostBlocksAbility {
 		$successful = array_filter( $changes, fn( $c ) => ! empty( $c['success'] ) );
 
 		if ( empty( $successful ) ) {
-			return array(
-				'success'         => false,
-				'post_id'         => $post_id,
-				'changes_applied' => $changes,
-				'error'           => 'No edits were applied — all operations failed',
-			);
+			return self::operations_failed_error( $post_id, $changes );
 		}
 
 		$new_content    = BlockSanitizer::sanitizeAndSerialize( $blocks );
 		$stored_content = ContentFormat::blocksToStored( $new_content, (string) $post->post_type );
 		if ( is_wp_error( $stored_content ) ) {
-			return array(
-				'success' => false,
-				'post_id' => $post_id,
-				'error'   => $stored_content->get_error_message(),
-			);
+			return self::content_format_error( $stored_content, $post_id );
 		}
 
 		// --- Preview mode: stage pending action, return preview envelope ---
@@ -399,10 +383,13 @@ class EditPostBlocksAbility {
 			);
 
 			if ( empty( $envelope['staged'] ) ) {
-				return array(
-					'success' => false,
-					'post_id' => $post_id,
-					'error'   => $envelope['error'] ?? 'Failed to stage preview.',
+				return new \WP_Error(
+					'edit_preview_stage_failed',
+					$envelope['error'] ?? 'Failed to stage preview.',
+					array(
+						'status'  => 500,
+						'post_id' => $post_id,
+					)
 				);
 			}
 
@@ -429,10 +416,14 @@ class EditPostBlocksAbility {
 		);
 
 		if ( is_wp_error( $result ) ) {
-			return array(
-				'success' => false,
-				'post_id' => $post_id,
-				'error'   => 'Failed to save: ' . $result->get_error_message(),
+			return new \WP_Error(
+				'edit_post_update_failed',
+				'Failed to save: ' . $result->get_error_message(),
+				array(
+					'status'        => 500,
+					'post_id'       => $post_id,
+					'wp_error_code' => $result->get_error_code(),
+				)
 			);
 		}
 
@@ -452,6 +443,32 @@ class EditPostBlocksAbility {
 			'post_id'         => $post_id,
 			'post_url'        => get_permalink( $post_id ),
 			'changes_applied' => $changes,
+		);
+	}
+
+	private static function content_format_error( \WP_Error $error, int $post_id ): \WP_Error {
+		return new \WP_Error(
+			$error->get_error_code(),
+			$error->get_error_message(),
+			array_merge(
+				array(
+					'status'  => 500,
+					'post_id' => $post_id,
+				),
+				is_array( $error->get_error_data() ) ? $error->get_error_data() : array()
+			)
+		);
+	}
+
+	private static function operations_failed_error( int $post_id, array $changes ): \WP_Error {
+		return new \WP_Error(
+			'edit_operations_failed',
+			'No edits were applied — all operations failed',
+			array(
+				'status'          => 422,
+				'post_id'         => $post_id,
+				'changes_applied' => $changes,
+			)
 		);
 	}
 

--- a/inc/Abilities/Content/GetPostBlocksAbility.php
+++ b/inc/Abilities/Content/GetPostBlocksAbility.php
@@ -161,6 +161,15 @@ class GetPostBlocksAbility {
 	public static function handleChatToolCall( array $parameters, array $tool_def = array() ): array {
 		$tool_def;
 		$result = self::execute( $parameters );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'    => false,
+				'error'      => $result->get_error_message(),
+				'error_code' => $result->get_error_code(),
+				'error_data' => $result->get_error_data(),
+				'tool_name'  => 'get_post_blocks',
+			);
+		}
 
 		return array(
 			'success'   => $result['success'],
@@ -175,7 +184,7 @@ class GetPostBlocksAbility {
 	 * @param array $input Ability input.
 	 * @return array
 	 */
-	public static function execute( array $input ): array {
+	public static function execute( array $input ): array|\WP_Error {
 		// prefer_autosave defaults true: proofread the freshest authored content (in-flight autosave).
 		$post_id         = absint( $input['post_id'] ?? 0 );
 		$block_types     = $input['block_types'] ?? array();
@@ -183,29 +192,20 @@ class GetPostBlocksAbility {
 		$prefer_autosave = ! array_key_exists( 'prefer_autosave', $input ) || ! empty( $input['prefer_autosave'] );
 
 		if ( $post_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'Valid post_id is required',
-			);
+			return new \WP_Error( 'invalid_get_post_id', 'Valid post_id is required', array( 'status' => 400 ) );
 		}
 
 		// Resolve the target blog. On multisite the post may live on another
 		// site than the one this request landed on; switch to it for the read.
 		$ctx = BlogContext::enter( $input );
 		if ( is_wp_error( $ctx ) ) {
-			return array(
-				'success' => false,
-				'error'   => $ctx->get_error_message(),
-			);
+			return $ctx;
 		}
 
 		try {
 			$post = get_post( $post_id );
 			if ( ! $post ) {
-				return array(
-					'success' => false,
-					'error'   => sprintf( 'Post #%d does not exist', $post_id ),
-				);
+				return new \WP_Error( 'get_post_not_found', sprintf( 'Post #%d does not exist', $post_id ), array( 'status' => 404 ) );
 			}
 
 			// Prefer the calling user's in-flight autosave when it is newer than
@@ -215,9 +215,16 @@ class GetPostBlocksAbility {
 
 			$block_content = ContentFormat::storedToBlocks( $source_content, (string) $post->post_type );
 			if ( is_wp_error( $block_content ) ) {
-				return array(
-					'success' => false,
-					'error'   => $block_content->get_error_message(),
+				return new \WP_Error(
+					$block_content->get_error_code(),
+					$block_content->get_error_message(),
+					array_merge(
+						array(
+							'status'  => 500,
+							'post_id' => $post_id,
+						),
+						is_array( $block_content->get_error_data() ) ? $block_content->get_error_data() : array()
+					)
 				);
 			}
 

--- a/inc/Abilities/Content/InsertContentAbility.php
+++ b/inc/Abilities/Content/InsertContentAbility.php
@@ -157,7 +157,17 @@ class InsertContentAbility {
 	public static function handleChatToolCall( array $params, array $tool_def = array() ): array {
 		unset( $tool_def );
 
-		return self::execute( $params );
+		$result = self::execute( $params );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'    => false,
+				'error'      => $result->get_error_message(),
+				'error_code' => $result->get_error_code(),
+				'error_data' => $result->get_error_data(),
+				'tool_name'  => 'insert_content',
+			);
+		}
+		return $result;
 	}
 
 	/**
@@ -166,7 +176,7 @@ class InsertContentAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with canonical diff preview data.
 	 */
-	public static function execute( array $input ): array {
+	public static function execute( array $input ): array|\WP_Error {
 		// Resolve the target blog. On multisite the post may live on another
 		// site than the one this request landed on; switch to it so the read,
 		// the edit_post capability check, and the eventual apply target the
@@ -179,10 +189,7 @@ class InsertContentAbility {
 		// BlogContext::run_on_origin() in the preview branch.
 		$ctx = BlogContext::enter( $input );
 		if ( is_wp_error( $ctx ) ) {
-			return array(
-				'success' => false,
-				'error'   => $ctx->get_error_message(),
-			);
+			return $ctx;
 		}
 
 		try {
@@ -199,7 +206,7 @@ class InsertContentAbility {
 	 * @param array|\WP_Error $ctx   Blog context token from BlogContext::enter().
 	 * @return array Result with canonical diff preview data.
 	 */
-	private static function execute_in_context( array $input, $ctx ): array {
+	private static function execute_in_context( array $input, $ctx ): array|\WP_Error {
 		$post_id               = absint( $input['post_id'] ?? 0 );
 		$blog_id               = absint( $input['blog_id'] ?? 0 );
 		$content               = $input['content'] ?? '';
@@ -208,32 +215,20 @@ class InsertContentAbility {
 		$preview               = ! array_key_exists( 'preview', $input ) || ! empty( $input['preview'] );
 
 		if ( $post_id <= 0 || '' === $content ) {
-			return array(
-				'success' => false,
-				'error'   => 'post_id and content are required.',
-			);
+			return new \WP_Error( 'invalid_insert_content', 'post_id and content are required.', array( 'status' => 400 ) );
 		}
 
 		if ( 'after_paragraph' === $position && '' === $target_paragraph_text ) {
-			return array(
-				'success' => false,
-				'error'   => 'target_paragraph_text is required when position is "after_paragraph".',
-			);
+			return new \WP_Error( 'invalid_insert_target', 'target_paragraph_text is required when position is "after_paragraph".', array( 'status' => 400 ) );
 		}
 
 		$post = get_post( $post_id );
 		if ( ! $post ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Post #%d not found.', $post_id ),
-			);
+			return new \WP_Error( 'insert_post_not_found', sprintf( 'Post #%d not found.', $post_id ), array( 'status' => 404 ) );
 		}
 
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'You do not have permission to edit this post.',
-			);
+			return new \WP_Error( 'insert_post_forbidden', 'You do not have permission to edit this post.', array( 'status' => 403 ) );
 		}
 
 		$current_content = $post->post_content;
@@ -261,17 +256,26 @@ class InsertContentAbility {
 			case 'after_paragraph':
 				$result = self::insert_after_paragraph( $current_content, $block_content, $target_paragraph_text );
 				if ( ! $result['success'] ) {
-					return $result;
+					return new \WP_Error(
+						'insert_target_not_found',
+						$result['error'] ?? 'Target paragraph not found.',
+						array(
+							'status'               => 404,
+							'available_paragraphs' => $result['available_paragraphs'] ?? array(),
+							'suggestion'           => $result['suggestion'] ?? '',
+						)
+					);
 				}
-					$new_content     = $result['content'];
-					$insertion_point = $result['insertion_point'];
-					$block_index     = (int) ( $result['block_index'] ?? count( $current_blocks ) );
+				$new_content     = $result['content'];
+				$insertion_point = $result['insertion_point'];
+				$block_index     = (int) ( $result['block_index'] ?? count( $current_blocks ) );
 				break;
 
 			default:
-				return array(
-					'success' => false,
-					'error'   => "Invalid position: {$position}. Must be beginning, end, or after_paragraph.",
+				return new \WP_Error(
+					'invalid_insert_position',
+					"Invalid position: {$position}. Must be beginning, end, or after_paragraph.",
+					array( 'status' => 400 )
 				);
 		}
 
@@ -285,10 +289,14 @@ class InsertContentAbility {
 			);
 
 			if ( is_wp_error( $update ) ) {
-				return array(
-					'success' => false,
-					'post_id' => $post_id,
-					'error'   => 'Failed to save: ' . $update->get_error_message(),
+				return new \WP_Error(
+					'insert_post_update_failed',
+					'Failed to save: ' . $update->get_error_message(),
+					array(
+						'status'        => 500,
+						'post_id'       => $post_id,
+						'wp_error_code' => $update->get_error_code(),
+					)
 				);
 			}
 
@@ -361,10 +369,13 @@ class InsertContentAbility {
 		);
 
 		if ( empty( $envelope['staged'] ) ) {
-			return array(
-				'success' => false,
-				'post_id' => $post_id,
-				'error'   => $envelope['error'] ?? 'Failed to stage preview.',
+			return new \WP_Error(
+				'insert_preview_stage_failed',
+				$envelope['error'] ?? 'Failed to stage preview.',
+				array(
+					'status'  => 500,
+					'post_id' => $post_id,
+				)
 			);
 		}
 

--- a/inc/Abilities/Content/ReplacePostBlocksAbility.php
+++ b/inc/Abilities/Content/ReplacePostBlocksAbility.php
@@ -165,6 +165,15 @@ class ReplacePostBlocksAbility {
 	public static function handleChatToolCall( array $parameters, array $tool_def = array() ): array {
 		$tool_def;
 		$result = self::execute( $parameters );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'    => false,
+				'error'      => $result->get_error_message(),
+				'error_code' => $result->get_error_code(),
+				'error_data' => $result->get_error_data(),
+				'tool_name'  => 'replace_post_blocks',
+			);
+		}
 
 		return array(
 			'success'   => $result['success'],
@@ -179,7 +188,7 @@ class ReplacePostBlocksAbility {
 	 * @param array $input Ability input.
 	 * @return array
 	 */
-	public static function execute( array $input ): array {
+	public static function execute( array $input ): array|\WP_Error {
 		// Resolve the target blog. On multisite the post may live on another
 		// site than the one this request landed on; switch to it so the post
 		// read and the eventual apply target the right post. blog_id rides
@@ -192,10 +201,7 @@ class ReplacePostBlocksAbility {
 		// BlogContext::run_on_origin() in the preview branch.
 		$ctx = BlogContext::enter( $input );
 		if ( is_wp_error( $ctx ) ) {
-			return array(
-				'success' => false,
-				'error'   => $ctx->get_error_message(),
-			);
+			return $ctx;
 		}
 
 		try {
@@ -212,40 +218,37 @@ class ReplacePostBlocksAbility {
 	 * @param array|\WP_Error $ctx   Blog context token from BlogContext::enter().
 	 * @return array
 	 */
-	private static function execute_in_context( array $input, $ctx ): array {
+	private static function execute_in_context( array $input, $ctx ): array|\WP_Error {
 		$post_id      = absint( $input['post_id'] ?? 0 );
 		$blog_id      = absint( $input['blog_id'] ?? 0 );
 		$replacements = $input['replacements'] ?? array();
 		$preview      = ! empty( $input['preview'] );
 
 		if ( $post_id <= 0 ) {
-			return array(
-				'success' => false,
-				'error'   => 'Valid post_id is required',
-			);
+			return new \WP_Error( 'invalid_replace_post_id', 'Valid post_id is required', array( 'status' => 400 ) );
 		}
 
 		if ( empty( $replacements ) || ! is_array( $replacements ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'At least one replacement is required',
-			);
+			return new \WP_Error( 'invalid_replacements', 'At least one replacement is required', array( 'status' => 400 ) );
 		}
 
 		$post = get_post( $post_id );
 		if ( ! $post ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Post #%d does not exist', $post_id ),
-			);
+			return new \WP_Error( 'replace_post_not_found', sprintf( 'Post #%d does not exist', $post_id ), array( 'status' => 404 ) );
 		}
 
 		$block_content = ContentFormat::storedToBlocks( (string) $post->post_content, (string) $post->post_type );
 		if ( is_wp_error( $block_content ) ) {
-			return array(
-				'success' => false,
-				'post_id' => $post_id,
-				'error'   => $block_content->get_error_message(),
+			return new \WP_Error(
+				$block_content->get_error_code(),
+				$block_content->get_error_message(),
+				array_merge(
+					array(
+						'status'  => 500,
+						'post_id' => $post_id,
+					),
+					is_array( $block_content->get_error_data() ) ? $block_content->get_error_data() : array()
+				)
 			);
 		}
 
@@ -308,21 +311,30 @@ class ReplacePostBlocksAbility {
 		$successful = array_filter( $changes, fn( $c ) => ! empty( $c['success'] ) );
 
 		if ( empty( $successful ) ) {
-			return array(
-				'success'         => false,
-				'post_id'         => $post_id,
-				'blocks_replaced' => $changes,
-				'error'           => 'No replacements were applied — all operations failed',
+			return new \WP_Error(
+				'replace_operations_failed',
+				'No replacements were applied — all operations failed',
+				array(
+					'status'          => 422,
+					'post_id'         => $post_id,
+					'blocks_replaced' => $changes,
+				)
 			);
 		}
 
 		$new_content    = BlockSanitizer::sanitizeAndSerialize( $blocks );
 		$stored_content = ContentFormat::blocksToStored( $new_content, (string) $post->post_type );
 		if ( is_wp_error( $stored_content ) ) {
-			return array(
-				'success' => false,
-				'post_id' => $post_id,
-				'error'   => $stored_content->get_error_message(),
+			return new \WP_Error(
+				$stored_content->get_error_code(),
+				$stored_content->get_error_message(),
+				array_merge(
+					array(
+						'status'  => 500,
+						'post_id' => $post_id,
+					),
+					is_array( $stored_content->get_error_data() ) ? $stored_content->get_error_data() : array()
+				)
 			);
 		}
 
@@ -377,10 +389,13 @@ class ReplacePostBlocksAbility {
 			);
 
 			if ( empty( $envelope['staged'] ) ) {
-				return array(
-					'success' => false,
-					'post_id' => $post_id,
-					'error'   => $envelope['error'] ?? 'Failed to stage preview.',
+				return new \WP_Error(
+					'replace_preview_stage_failed',
+					$envelope['error'] ?? 'Failed to stage preview.',
+					array(
+						'status'  => 500,
+						'post_id' => $post_id,
+					)
 				);
 			}
 
@@ -416,10 +431,14 @@ class ReplacePostBlocksAbility {
 		);
 
 		if ( is_wp_error( $result ) ) {
-			return array(
-				'success' => false,
-				'post_id' => $post_id,
-				'error'   => 'Failed to save: ' . $result->get_error_message(),
+			return new \WP_Error(
+				'replace_post_update_failed',
+				'Failed to save: ' . $result->get_error_message(),
+				array(
+					'status'        => 500,
+					'post_id'       => $post_id,
+					'wp_error_code' => $result->get_error_code(),
+				)
 			);
 		}
 

--- a/inc/Abilities/Content/UpsertPostAbility.php
+++ b/inc/Abilities/Content/UpsertPostAbility.php
@@ -287,6 +287,15 @@ class UpsertPostAbility {
 		}
 
 		$result = self::execute( $params );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'    => false,
+				'error'      => $result->get_error_message(),
+				'error_code' => $result->get_error_code(),
+				'error_data' => $result->get_error_data(),
+				'tool_name'  => 'upsert_post',
+			);
+		}
 		return array(
 			'success'   => ! empty( $result['success'] ),
 			'data'      => $result,
@@ -300,7 +309,7 @@ class UpsertPostAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with action: created|updated|no_change.
 	 */
-	public static function execute( array $input ): array {
+	public static function execute( array $input ): array|\WP_Error {
 		$post_type         = sanitize_key( $input['post_type'] ?? '' );
 		$title             = trim( $input['title'] ?? '' );
 		$content           = $input['content'] ?? '';
@@ -325,10 +334,7 @@ class UpsertPostAbility {
 		$create_stubs = ! empty( $input['create_stubs'] );
 
 		if ( '' === $post_type || '' === $title ) {
-			return array(
-				'success' => false,
-				'error'   => 'post_type and title are required.',
-			);
+			return new \WP_Error( 'invalid_upsert_input', 'post_type and title are required.', array( 'status' => 400 ) );
 		}
 
 		if ( $add_source_attribution && '' !== $source_url ) {
@@ -359,12 +365,7 @@ class UpsertPostAbility {
 
 		$stored_content = ContentFormat::sourceToStored( (string) $content, $content_format, $post_type );
 		if ( is_wp_error( $stored_content ) ) {
-			return array(
-				'success'    => false,
-				'error'      => $stored_content->get_error_message(),
-				'error_code' => $stored_content->get_error_code(),
-				'error_data' => $stored_content->get_error_data(),
-			);
+			return new \WP_Error( $stored_content->get_error_code(), $stored_content->get_error_message(), array_merge( array( 'status' => 400 ), is_array( $stored_content->get_error_data() ) ? $stored_content->get_error_data() : array() ) );
 		}
 
 		// Resolve parent_path if provided.
@@ -380,10 +381,7 @@ class UpsertPostAbility {
 			}
 
 			if ( is_wp_error( $resolved ) ) {
-				return array(
-					'success' => false,
-					'error'   => $resolved->get_error_message(),
-				);
+				return new \WP_Error( $resolved->get_error_code(), $resolved->get_error_message(), array_merge( array( 'status' => 404 ), is_array( $resolved->get_error_data() ) ? $resolved->get_error_data() : array() ) );
 			}
 
 			$parent_id = (int) $resolved;
@@ -409,13 +407,14 @@ class UpsertPostAbility {
 		if ( $post_id > 0 ) {
 			$existing_id = self::resolve_existing_post( $post_id, $slug, $parent_id, is_array( $identity_meta ) ? $identity_meta : array(), $post_type );
 			if ( is_wp_error( $existing_id ) ) {
-				return array(
-					'success' => false,
-					'error'   => $existing_id->get_error_message(),
+				return new \WP_Error(
+					$existing_id->get_error_code(),
+					$existing_id->get_error_message(),
+					array_merge( array( 'status' => 404 ), is_array( $existing_id->get_error_data() ) ? $existing_id->get_error_data() : array() )
 				);
 			}
 
-			return self::execute_resolved_write( $write_context, (int) $existing_id );
+			return self::callback_result( self::execute_resolved_write( $write_context, (int) $existing_id ) );
 		}
 
 		if ( self::has_usable_identity_meta( $identity_meta ) ) {
@@ -438,13 +437,10 @@ class UpsertPostAbility {
 		);
 
 		if ( is_wp_error( $existing_id ) ) {
-			return array(
-				'success' => false,
-				'error'   => $existing_id->get_error_message(),
-			);
+			return new \WP_Error( $existing_id->get_error_code(), $existing_id->get_error_message(), array_merge( array( 'status' => 404 ), is_array( $existing_id->get_error_data() ) ? $existing_id->get_error_data() : array() ) );
 		}
 
-		return self::execute_resolved_write( $write_context, (int) $existing_id );
+		return self::callback_result( self::execute_resolved_write( $write_context, (int) $existing_id ) );
 	}
 
 	/**
@@ -454,36 +450,37 @@ class UpsertPostAbility {
 	 * @param array $identity_meta Identity meta input.
 	 * @param string $slug         Slug fallback.
 	 * @param int   $parent_id     Slug parent scope.
-	 * @return array
+	 * @return array|\WP_Error
 	 */
 	private static function execute_identity_backed(
 		array $context,
 		array $identity_meta,
 		string $slug,
 		int $parent_id
-	): array {
+	): array|\WP_Error {
 		$post_type = $context['post_type'];
 
 		$slug_fallback_id = 0;
 		if ( '' !== $slug ) {
 			$slug_fallback_id = self::resolve_existing_post( 0, $slug, $parent_id, array(), $post_type );
 			if ( is_wp_error( $slug_fallback_id ) ) {
-				return array(
+				return self::callback_result( array(
 					'success'    => false,
 					'error'      => $slug_fallback_id->get_error_message(),
 					'error_code' => $slug_fallback_id->get_error_code(),
-				);
+					'error_data' => $slug_fallback_id->get_error_data(),
+				) );
 			}
 		}
 
 		$identity = PostIdentityReservations::normalize_identity( $post_type, $identity_meta );
 		if ( is_wp_error( $identity ) ) {
-			return array(
+			return self::callback_result( array(
 				'success'    => false,
 				'error'      => $identity->get_error_message(),
 				'error_code' => $identity->get_error_code(),
 				'error_data' => $identity->get_error_data(),
-			);
+			) );
 		}
 
 		$shell = array(
@@ -498,12 +495,12 @@ class UpsertPostAbility {
 		$reservations = new PostIdentityReservations();
 		$locked       = $reservations->acquire_lock( $identity['identity_hash'] );
 		if ( is_wp_error( $locked ) ) {
-			return array(
+			return self::callback_result( array(
 				'success'    => false,
 				'error'      => $locked->get_error_message(),
 				'error_code' => $locked->get_error_code(),
 				'error_data' => $locked->get_error_data(),
-			);
+			) );
 		}
 
 		$result   = array();
@@ -550,15 +547,38 @@ class UpsertPostAbility {
 		}
 
 		if ( ! $released ) {
-			return array(
+			return self::callback_result( array(
 				'success'    => false,
 				'error'      => 'Post identity lock release is uncertain; retry is required.',
 				'error_code' => 'identity_lock_release_uncertain',
 				'error_data' => array( 'retryable' => true ),
-			);
+			) );
 		}
 
-		return $result;
+		return self::callback_result( $result );
+	}
+
+	/** Convert legacy private write failures at the registered callback boundary. */
+	private static function callback_result( $result ): array|\WP_Error {
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		if ( ! is_array( $result ) ) {
+			return new \WP_Error( 'upsert_post_invalid_result', 'Upsert post returned an invalid result.', array( 'status' => 500 ) );
+		}
+		if ( ! empty( $result['success'] ) ) {
+			return $result;
+		}
+
+		$data           = is_array( $result['error_data'] ?? null ) ? $result['error_data'] : array();
+		$data['status'] = $data['status'] ?? 500;
+		foreach ( $result as $key => $value ) {
+			if ( ! in_array( $key, array( 'success', 'error', 'message', 'error_code', 'error_data' ), true ) ) {
+				$data[ $key ] = $value;
+			}
+		}
+
+		return new \WP_Error( (string) ( $result['error_code'] ?? 'upsert_post_failed' ), (string) ( $result['error'] ?? 'Upsert post failed.' ), $data );
 	}
 
 	/**

--- a/inc/Abilities/Fetch/FetchFilesAbility.php
+++ b/inc/Abilities/Fetch/FetchFilesAbility.php
@@ -103,7 +103,15 @@ class FetchFilesAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with fetched file data or error.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
+		$result = $this->execute_legacy( $input );
+		if ( is_wp_error( $result ) || ! empty( $result['success'] ) ) {
+			return $result;
+		}
+		return new \WP_Error( $result['error_code'] ?? 'files_fetch_failed', $result['error'] ?? 'File fetch failed.', array_merge( array( 'status' => 500 ), is_array( $result ) ? $result : array() ) );
+	}
+
+	private function execute_legacy( array $input ): array {
 		$logs   = array();
 		$config = $this->normalizeConfig( $input );
 

--- a/inc/Abilities/Fetch/FetchHttpGetTrait.php
+++ b/inc/Abilities/Fetch/FetchHttpGetTrait.php
@@ -14,7 +14,7 @@ trait FetchHttpGetTrait {
 	/**
 	 * Make HTTP GET request.
 	 */
-	private function httpGet( string $url, array $options ): array {
+	private function httpGet( string $url, array $options ): array|\WP_Error {
 		$args = array(
 			'timeout' => $options['timeout'] ?? 30,
 		);
@@ -22,17 +22,35 @@ trait FetchHttpGetTrait {
 		$response = wp_remote_get( $url, $args );
 
 		if ( is_wp_error( $response ) ) {
-			return array(
-				'success' => false,
-				'error'   => $response->get_error_message(),
+			return new \WP_Error(
+				'fetch_http_request_failed',
+				$response->get_error_message(),
+				array(
+					'status'         => 502,
+					'url'            => $url,
+					'transport_code' => $response->get_error_code(),
+				)
 			);
 		}
 
 		$status_code = wp_remote_retrieve_response_code( $response );
 		$body        = wp_remote_retrieve_body( $response );
 
+		if ( $status_code < 200 || $status_code >= 300 ) {
+			return new \WP_Error(
+				'fetch_http_status',
+				sprintf( 'HTTP request returned status %d.', $status_code ),
+				array(
+					'status'      => $status_code ? $status_code : 502,
+					'url'         => $url,
+					'status_code' => $status_code,
+					'body'        => $body,
+				)
+			);
+		}
+
 		return array(
-			'success'     => $status_code >= 200 && $status_code < 300,
+			'success'     => true,
 			'status_code' => $status_code,
 			'data'        => $body,
 		);

--- a/inc/Abilities/Fetch/FetchRssAbility.php
+++ b/inc/Abilities/Fetch/FetchRssAbility.php
@@ -110,7 +110,17 @@ class FetchRssAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with fetched data or error.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
+		return $this->execute_legacy( $input );
+	}
+
+	/**
+	 * Execute the existing RSS fetch implementation.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array|\WP_Error Result with fetched data or error.
+	 */
+	private function execute_legacy( array $input ): array|\WP_Error {
 		$logs   = array();
 		$config = $this->normalizeConfig( $input );
 
@@ -122,20 +132,27 @@ class FetchRssAbility {
 		$download_images  = $config['download_images'];
 
 		$result = $this->httpGet( $feed_url, array( 'context' => 'RSS Feed' ) );
-
-		if ( ! $result['success'] ) {
+		if ( is_wp_error( $result ) ) {
 			$logs[] = array(
 				'level'   => 'error',
 				'message' => 'Rss: Failed to fetch RSS feed.',
 				'data'    => array(
-					'error'    => $result['error'],
 					'feed_url' => $feed_url,
+					'error'    => $result->get_error_message(),
 				),
 			);
-			return array(
-				'success' => false,
-				'error'   => $result['error'],
-				'logs'    => $logs,
+			return new \WP_Error(
+				'rss_fetch_failed',
+				$result->get_error_message(),
+				array_merge(
+					array(
+						'status'         => 502,
+						'feed_url'       => $feed_url,
+						'transport_code' => $result->get_error_code(),
+						'logs'           => $logs,
+					),
+					is_array( $result->get_error_data() ) ? $result->get_error_data() : array()
+				)
 			);
 		}
 
@@ -146,10 +163,14 @@ class FetchRssAbility {
 				'message' => 'Rss: RSS feed content is empty.',
 				'data'    => array( 'feed_url' => $feed_url ),
 			);
-			return array(
-				'success' => false,
-				'error'   => 'RSS feed content is empty',
-				'logs'    => $logs,
+			return new \WP_Error(
+				'rss_empty',
+				'RSS feed content is empty',
+				array(
+					'status'   => 422,
+					'feed_url' => $feed_url,
+					'logs'     => $logs,
+				)
 			);
 		}
 
@@ -172,10 +193,15 @@ class FetchRssAbility {
 					'xml_errors' => implode( ', ', $error_messages ),
 				),
 			);
-			return array(
-				'success' => false,
-				'error'   => 'Failed to parse RSS feed XML: ' . implode( ', ', $error_messages ),
-				'logs'    => $logs,
+			return new \WP_Error(
+				'rss_parse_failed',
+				'Failed to parse RSS feed XML: ' . implode( ', ', $error_messages ),
+				array(
+					'status'     => 422,
+					'feed_url'   => $feed_url,
+					'xml_errors' => $error_messages,
+					'logs'       => $logs,
+				)
 			);
 		}
 
@@ -193,10 +219,14 @@ class FetchRssAbility {
 				'message' => 'Rss: Unsupported feed format or no items found in feed.',
 				'data'    => array( 'feed_url' => $feed_url ),
 			);
-			return array(
-				'success' => false,
-				'error'   => 'Unsupported feed format or no items found',
-				'logs'    => $logs,
+			return new \WP_Error(
+				'rss_items_missing',
+				'Unsupported feed format or no items found',
+				array(
+					'status'   => 422,
+					'feed_url' => $feed_url,
+					'logs'     => $logs,
+				)
 			);
 		}
 
@@ -529,5 +559,4 @@ class FetchRssAbility {
 
 		return $item_timestamp >= $cutoff;
 	}
-
 }

--- a/inc/Abilities/Fetch/FetchWordPressApiAbility.php
+++ b/inc/Abilities/Fetch/FetchWordPressApiAbility.php
@@ -111,7 +111,16 @@ class FetchWordPressApiAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with fetched data or error.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
+		$result = $this->execute_legacy( $input );
+		if ( is_wp_error( $result ) || ! empty( $result['success'] ) ) {
+			return $result;
+		}
+		$error_data = is_array( $result['error_data'] ?? null ) ? $result['error_data'] : array();
+		return new \WP_Error( $result['error_code'] ?? 'wordpress_api_fetch_failed', $result['error'] ?? 'WordPress API fetch failed.', array_merge( array( 'status' => 500 ), $error_data, $result ) );
+	}
+
+	private function execute_legacy( array $input ): array|\WP_Error {
 		$logs   = array();
 		$config = $this->normalizeConfig( $input );
 
@@ -129,9 +138,11 @@ class FetchWordPressApiAbility {
 				'message' => 'WordPressAPI: Endpoint URL is required.',
 			);
 			return array(
-				'success' => false,
-				'error'   => 'Endpoint URL is required',
-				'logs'    => $logs,
+				'success'    => false,
+				'error_code' => 'wordpress_api_endpoint_required',
+				'error'      => 'Endpoint URL is required',
+				'status'     => 400,
+				'logs'       => $logs,
 			);
 		}
 
@@ -142,9 +153,12 @@ class FetchWordPressApiAbility {
 				'data'    => array( 'endpoint_url' => $endpoint_url ),
 			);
 			return array(
-				'success' => false,
-				'error'   => 'Invalid endpoint URL format',
-				'logs'    => $logs,
+				'success'      => false,
+				'error_code'   => 'wordpress_api_endpoint_invalid',
+				'error'        => 'Invalid endpoint URL format',
+				'status'       => 400,
+				'endpoint_url' => $endpoint_url,
+				'logs'         => $logs,
 			);
 		}
 
@@ -163,6 +177,16 @@ class FetchWordPressApiAbility {
 		}
 
 		$result = $this->httpGet( $modified_url, array( 'context' => 'REST API' ) );
+		if ( is_wp_error( $result ) ) {
+			return new \WP_Error(
+				$result->get_error_code(),
+				$result->get_error_message(),
+				array_merge(
+					is_array( $result->get_error_data() ) ? $result->get_error_data() : array(),
+					array( 'logs' => $logs )
+				)
+			);
+		}
 
 		if ( ! $result['success'] ) {
 			$logs[] = array(
@@ -174,9 +198,12 @@ class FetchWordPressApiAbility {
 				),
 			);
 			return array(
-				'success' => false,
-				'error'   => $result['error'],
-				'logs'    => $logs,
+				'success'    => false,
+				'error_code' => $result['error_code'] ?? 'wordpress_api_upstream_failed',
+				'error'      => $result['error'],
+				'status'     => $result['status'] ?? 502,
+				'error_data' => is_array( $result['error_data'] ?? null ) ? $result['error_data'] : array(),
+				'logs'       => $logs,
 			);
 		}
 
@@ -188,9 +215,12 @@ class FetchWordPressApiAbility {
 				'data'    => array( 'endpoint_url' => $modified_url ),
 			);
 			return array(
-				'success' => false,
-				'error'   => 'Empty response from endpoint',
-				'logs'    => $logs,
+				'success'      => false,
+				'error_code'   => 'wordpress_api_empty_response',
+				'error'        => 'Empty response from endpoint',
+				'status'       => 502,
+				'endpoint_url' => $modified_url,
+				'logs'         => $logs,
 			);
 		}
 
@@ -206,9 +236,13 @@ class FetchWordPressApiAbility {
 				),
 			);
 			return array(
-				'success' => false,
-				'error'   => 'Invalid JSON response: ' . json_last_error_msg(),
-				'logs'    => $logs,
+				'success'      => false,
+				'error_code'   => 'wordpress_api_invalid_response',
+				'error'        => 'Invalid JSON response: ' . json_last_error_msg(),
+				'status'       => 502,
+				'endpoint_url' => $modified_url,
+				'json_error'   => json_last_error_msg(),
+				'logs'         => $logs,
 			);
 		}
 
@@ -602,5 +636,4 @@ class FetchWordPressApiAbility {
 
 		return $item_timestamp >= $cutoff;
 	}
-
 }

--- a/inc/Abilities/Fetch/FetchWordPressMediaAbility.php
+++ b/inc/Abilities/Fetch/FetchWordPressMediaAbility.php
@@ -113,7 +113,15 @@ class FetchWordPressMediaAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with media data or error.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
+		$result = $this->execute_legacy( $input );
+		if ( is_wp_error( $result ) || ! empty( $result['success'] ) ) {
+			return $result;
+		}
+		return new \WP_Error( $result['error_code'] ?? 'wordpress_media_fetch_failed', $result['error'] ?? 'WordPress media fetch failed.', array_merge( array( 'status' => 500 ), is_array( $result ) ? $result : array() ) );
+	}
+
+	private function execute_legacy( array $input ): array {
 		$logs   = array();
 		$config = $this->normalizeConfig( $input );
 
@@ -373,5 +381,4 @@ class FetchWordPressMediaAbility {
 
 		return $mime_patterns;
 	}
-
 }

--- a/inc/Abilities/Fetch/GetWordPressPostAbility.php
+++ b/inc/Abilities/Fetch/GetWordPressPostAbility.php
@@ -92,7 +92,16 @@ class GetWordPressPostAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with post data or error.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
+		$result = $this->execute_legacy( $input );
+		if ( is_wp_error( $result ) || ! empty( $result['success'] ) ) {
+			return $result;
+		}
+		$error_data = is_array( $result['error_data'] ?? null ) ? $result['error_data'] : array();
+		return new \WP_Error( $result['error_code'] ?? 'wordpress_post_fetch_failed', $result['error'] ?? 'WordPress post fetch failed.', array_merge( array( 'status' => 500 ), $error_data, $result ) );
+	}
+
+	private function execute_legacy( array $input ): array {
 		$logs   = array();
 		$config = $this->normalizeConfig( $input );
 
@@ -111,9 +120,12 @@ class GetWordPressPostAbility {
 					'data'    => array( 'source_url' => $source_url ),
 				);
 				return array(
-					'success' => false,
-					'error'   => sprintf( 'Could not extract valid WordPress post ID from URL: %s', $source_url ),
-					'logs'    => $logs,
+					'success'    => false,
+					'error_code' => 'wordpress_post_source_url_invalid',
+					'error'      => sprintf( 'Could not extract valid WordPress post ID from URL: %s', $source_url ),
+					'status'     => 400,
+					'source_url' => $source_url,
+					'logs'       => $logs,
 				);
 			}
 		}
@@ -124,9 +136,11 @@ class GetWordPressPostAbility {
 				'message' => 'Either post_id or source_url is required',
 			);
 			return array(
-				'success' => false,
-				'error'   => 'Either post_id or source_url is required',
-				'logs'    => $logs,
+				'success'    => false,
+				'error_code' => 'wordpress_post_identifier_required',
+				'error'      => 'Either post_id or source_url is required',
+				'status'     => 400,
+				'logs'       => $logs,
 			);
 		}
 
@@ -139,9 +153,12 @@ class GetWordPressPostAbility {
 				'data'    => array( 'post_id' => $post_id ),
 			);
 			return array(
-				'success' => false,
-				'error'   => sprintf( 'Post (ID: %d) not found or is trashed', $post_id ),
-				'logs'    => $logs,
+				'success'    => false,
+				'error_code' => 'wordpress_post_not_found',
+				'error'      => sprintf( 'Post (ID: %d) not found or is trashed', $post_id ),
+				'status'     => 404,
+				'post_id'    => $post_id,
+				'logs'       => $logs,
 			);
 		}
 

--- a/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
+++ b/inc/Abilities/Fetch/QueryWordPressPostsAbility.php
@@ -130,7 +130,15 @@ class QueryWordPressPostsAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with post data or error.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
+		$result = $this->execute_legacy( $input );
+		if ( is_wp_error( $result ) || ! empty( $result['success'] ) ) {
+			return $result;
+		}
+		return new \WP_Error( $result['error_code'] ?? 'wordpress_posts_query_failed', $result['error'] ?? 'WordPress posts query failed.', array_merge( array( 'status' => 500 ), is_array( $result ) ? $result : array() ) );
+	}
+
+	private function execute_legacy( array $input ): array {
 		$logs   = array();
 		$config = $this->normalizeConfig( $input );
 

--- a/inc/Abilities/File/AgentFileAbilities.php
+++ b/inc/Abilities/File/AgentFileAbilities.php
@@ -291,7 +291,7 @@ class AgentFileAbilities {
 		// Convention-path files (e.g. AGENTS.md at site root) live outside
 		// the layer directories but should still appear in the file list.
 		foreach ( MemoryFileRegistry::get_all() as $filename => $registry_meta ) {
-			$layer  = $registry_meta['layer'] ?? MemoryFileRegistry::LAYER_AGENT;
+			$layer = $registry_meta['layer'] ?? MemoryFileRegistry::LAYER_AGENT;
 			if ( MemoryFileRegistry::LAYER_PRINCIPAL === $layer && ( $user_id <= 0 || $agent_id <= 0 ) ) {
 				continue;
 			}
@@ -385,7 +385,7 @@ class AgentFileAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result with file data.
 	 */
-	public function executeGetAgentFile( array $input ): array {
+	public function executeGetAgentFile( array $input ): array|\WP_Error {
 		DirectoryManager::ensure_agent_files();
 
 		$filename = sanitize_file_name( $input['filename'] ?? '' );
@@ -396,9 +396,13 @@ class AgentFileAbilities {
 		$located = $this->locateMemory( $filename, $user_id, $agent_id );
 
 		if ( null === $located ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'File %s not found in any layer', $filename ),
+			return new \WP_Error(
+				'agent_file_not_found',
+				sprintf( 'File %s not found in any layer', $filename ),
+				array(
+					'status'   => 404,
+					'filename' => $filename,
+				)
 			);
 		}
 
@@ -429,7 +433,7 @@ class AgentFileAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result with write status.
 	 */
-	public function executeWriteAgentFile( array $input ): array {
+	public function executeWriteAgentFile( array $input ): array|\WP_Error {
 		$filename = sanitize_file_name( $input['filename'] ?? '' );
 		$content  = $input['content'] ?? '';
 
@@ -442,21 +446,34 @@ class AgentFileAbilities {
 		if ( ! MemoryFileRegistry::is_editable( $filename, $user_id_for_edit ) ) {
 			$edit_cap = MemoryFileRegistry::get_edit_capability( $filename );
 			if ( false === $edit_cap ) {
-				return array(
-					'success' => false,
-					'error'   => sprintf( 'File %s is read-only and cannot be edited.', $filename ),
+				return new \WP_Error(
+					'agent_file_read_only',
+					sprintf( 'File %s is read-only and cannot be edited.', $filename ),
+					array(
+						'status'   => 403,
+						'filename' => $filename,
+					)
 				);
 			}
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'You do not have permission to edit %s. Required capability: %s', $filename, $edit_cap ),
+			return new \WP_Error(
+				'agent_file_forbidden',
+				sprintf( 'You do not have permission to edit %s. Required capability: %s', $filename, $edit_cap ),
+				array(
+					'status'     => 403,
+					'filename'   => $filename,
+					'capability' => $edit_cap,
+				)
 			);
 		}
 
 		if ( MemoryFileRegistry::is_protected( $filename ) && '' === trim( $content ) ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Cannot write empty content to protected file: %s', $filename ),
+			return new \WP_Error(
+				'agent_file_empty',
+				sprintf( 'Cannot write empty content to protected file: %s', $filename ),
+				array(
+					'status'   => 400,
+					'filename' => $filename,
+				)
 			);
 		}
 
@@ -473,9 +490,13 @@ class AgentFileAbilities {
 		$result = $memory->replace_all( $content );
 
 		if ( empty( $result['success'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => $result['message'] ?? 'Failed to write file',
+			return new \WP_Error(
+				'agent_file_write_failed',
+				$result['message'] ?? 'Failed to write file',
+				array(
+					'status'   => 500,
+					'filename' => $filename,
+				)
 			);
 		}
 
@@ -502,13 +523,17 @@ class AgentFileAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result with deletion status.
 	 */
-	public function executeDeleteAgentFile( array $input ): array {
+	public function executeDeleteAgentFile( array $input ): array|\WP_Error {
 		$filename = sanitize_file_name( $input['filename'] ?? '' );
 
 		if ( MemoryFileRegistry::is_protected( $filename ) ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Cannot delete protected file: %s', $filename ),
+			return new \WP_Error(
+				'agent_file_protected',
+				sprintf( 'Cannot delete protected file: %s', $filename ),
+				array(
+					'status'   => 403,
+					'filename' => $filename,
+				)
 			);
 		}
 
@@ -518,9 +543,13 @@ class AgentFileAbilities {
 		$located  = $this->locateMemory( $filename, $user_id, $agent_id );
 
 		if ( null === $located ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'File %s not found in any layer', $filename ),
+			return new \WP_Error(
+				'agent_file_not_found',
+				sprintf( 'File %s not found in any layer', $filename ),
+				array(
+					'status'   => 404,
+					'filename' => $filename,
+				)
 			);
 		}
 
@@ -530,9 +559,13 @@ class AgentFileAbilities {
 		$delete = $memory->delete();
 
 		if ( empty( $delete['success'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => $delete['message'] ?? 'Failed to delete file',
+			return new \WP_Error(
+				'agent_file_delete_failed',
+				$delete['message'] ?? 'Failed to delete file',
+				array(
+					'status'   => 500,
+					'filename' => $filename,
+				)
 			);
 		}
 
@@ -563,14 +596,11 @@ class AgentFileAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result with updated file list.
 	 */
-	public function executeUploadAgentFile( array $input ): array {
+	public function executeUploadAgentFile( array $input ): array|\WP_Error {
 		$file = $input['file_data'] ?? null;
 
 		if ( ! $file || empty( $file['tmp_name'] ) || empty( $file['name'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'No file data provided',
-			);
+			return new \WP_Error( 'agent_file_upload_missing', 'No file data provided', array( 'status' => 400 ) );
 		}
 
 		$dm           = new DirectoryManager();
@@ -584,26 +614,31 @@ class AgentFileAbilities {
 		// hand bytes off to the store, which decides where they land.
 		$fs = FilesystemHelper::get();
 		if ( ! $fs ) {
-			return array(
-				'success' => false,
-				'error'   => 'Filesystem not available',
-			);
+			return new \WP_Error( 'agent_file_filesystem_unavailable', 'Filesystem not available', array( 'status' => 500 ) );
 		}
 
 		$content = $fs->get_contents( $file['tmp_name'] );
 		if ( false === $content ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to read uploaded file',
+			return new \WP_Error(
+				'agent_file_upload_read_failed',
+				'Failed to read uploaded file',
+				array(
+					'status'   => 400,
+					'filename' => $filename,
+				)
 			);
 		}
 
 		$memory = new AgentMemory( $user_id, $agent_id, $filename, $target_layer );
 		$write  = $memory->replace_all( (string) $content );
 		if ( empty( $write['success'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => $write['message'] ?? 'Failed to store file',
+			return new \WP_Error(
+				'agent_file_upload_write_failed',
+				$write['message'] ?? 'Failed to store file',
+				array(
+					'status'   => 500,
+					'filename' => $filename,
+				)
 			);
 		}
 

--- a/inc/Abilities/File/FlowFileAbilities.php
+++ b/inc/Abilities/File/FlowFileAbilities.php
@@ -257,19 +257,16 @@ class FlowFileAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result with files list.
 	 */
-	public function executeListFlowFiles( array $input ): array {
+	public function executeListFlowFiles( array $input ): array|\WP_Error {
 		$flow_step_id = $input['flow_step_id'] ?? null;
 
 		if ( ! $flow_step_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_step_id is required',
-			);
+			return new \WP_Error( 'flow_file_step_required', 'flow_step_id is required', array( 'status' => 400 ) );
 		}
 
 		$context = $this->resolveFlowContext( $flow_step_id );
 		if ( isset( $context['error'] ) ) {
-			return $context;
+			return new \WP_Error( $context['error_code'] ?? 'flow_file_context_failed', $context['error'], array( 'status' => 404 ) );
 		}
 
 		$files = $this->file_storage->get_all_files( $context );
@@ -284,20 +281,17 @@ class FlowFileAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result with file metadata.
 	 */
-	public function executeGetFlowFile( array $input ): array {
+	public function executeGetFlowFile( array $input ): array|\WP_Error {
 		$filename     = sanitize_file_name( $input['filename'] ?? '' );
 		$flow_step_id = $input['flow_step_id'] ?? null;
 
 		if ( ! $flow_step_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_step_id is required',
-			);
+			return new \WP_Error( 'flow_file_step_required', 'flow_step_id is required', array( 'status' => 400 ) );
 		}
 
 		$context = $this->resolveFlowContext( $flow_step_id );
 		if ( isset( $context['error'] ) ) {
-			return $context;
+			return new \WP_Error( $context['error_code'] ?? 'flow_file_context_failed', $context['error'], array( 'status' => 404 ) );
 		}
 
 		$files = $this->file_storage->get_all_files( $context );
@@ -311,9 +305,13 @@ class FlowFileAbilities {
 			}
 		}
 
-		return array(
-			'success' => false,
-			'error'   => sprintf( 'File %s not found in flow step %s', $filename, $flow_step_id ),
+		return new \WP_Error(
+			'flow_file_not_found',
+			sprintf( 'File %s not found in flow step %s', $filename, $flow_step_id ),
+			array(
+				'status'   => 404,
+				'filename' => $filename,
+			)
 		);
 	}
 
@@ -321,28 +319,29 @@ class FlowFileAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result with deletion status.
 	 */
-	public function executeDeleteFlowFile( array $input ): array {
+	public function executeDeleteFlowFile( array $input ): array|\WP_Error {
 		$filename     = sanitize_file_name( $input['filename'] ?? '' );
 		$flow_step_id = $input['flow_step_id'] ?? null;
 
 		if ( ! $flow_step_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_step_id is required',
-			);
+			return new \WP_Error( 'flow_file_step_required', 'flow_step_id is required', array( 'status' => 400 ) );
 		}
 
 		$context = $this->resolveFlowContext( $flow_step_id );
 		if ( isset( $context['error'] ) ) {
-			return $context;
+			return new \WP_Error( $context['error_code'] ?? 'flow_file_context_failed', $context['error'], array( 'status' => 404 ) );
 		}
 
 		$deleted = $this->file_storage->delete_file( $filename, $context );
 
 		if ( ! $deleted ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'File %s not found or could not be deleted', $filename ),
+			return new \WP_Error(
+				'flow_file_delete_failed',
+				sprintf( 'File %s not found or could not be deleted', $filename ),
+				array(
+					'status'   => 404,
+					'filename' => $filename,
+				)
 			);
 		}
 
@@ -366,58 +365,40 @@ class FlowFileAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result with files list.
 	 */
-	public function executeUploadFlowFile( array $input ): array {
+	public function executeUploadFlowFile( array $input ): array|\WP_Error {
 		$file         = $input['file_data'] ?? null;
 		$flow_step_id = $input['flow_step_id'] ?? null;
 
 		if ( ! $file || empty( $file['tmp_name'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'No file data provided',
-			);
+			return new \WP_Error( 'flow_file_upload_missing', 'No file data provided', array( 'status' => 400 ) );
 		}
 
 		if ( ! $flow_step_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_step_id is required',
-			);
+			return new \WP_Error( 'flow_file_step_required', 'flow_step_id is required', array( 'status' => 400 ) );
 		}
 
 		// Validate uploaded file.
 		$validation_error = $this->validateFileWithWordPress( $file );
 		if ( $validation_error ) {
-			return array(
-				'success' => false,
-				'error'   => $validation_error,
-			);
+			return new \WP_Error( 'flow_file_upload_invalid', $validation_error, array( 'status' => 400 ) );
 		}
 
 		$parts = apply_filters( 'datamachine_split_flow_step_id', null, $flow_step_id );
 
 		if ( ! $parts || empty( $parts['flow_id'] ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Invalid flow step ID format',
-			);
+			return new \WP_Error( 'flow_file_step_invalid', 'Invalid flow step ID format', array( 'status' => 400 ) );
 		}
 
 		$flow_id = (int) $parts['flow_id'];
 		$flow    = $this->db_flows->get_flow( $flow_id );
 
 		if ( ! $flow ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Flow %d not found', $flow_id ),
-			);
+			return new \WP_Error( 'flow_not_found', sprintf( 'Flow %d not found', $flow_id ), array( 'status' => 404 ) );
 		}
 
 		$pipeline_id = $flow['pipeline_id'] ?? null;
 		if ( ! $pipeline_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'Flow does not have a valid pipeline_id',
-			);
+			return new \WP_Error( 'flow_pipeline_missing', 'Flow does not have a valid pipeline_id', array( 'status' => 500 ) );
 		}
 
 		$context = array(
@@ -428,10 +409,7 @@ class FlowFileAbilities {
 		$stored = $this->file_storage->store_file( $file['tmp_name'], $file['name'], $context );
 
 		if ( ! $stored ) {
-			return array(
-				'success' => false,
-				'error'   => 'Failed to store file',
-			);
+			return new \WP_Error( 'flow_file_store_failed', 'Failed to store file', array( 'status' => 500 ) );
 		}
 
 		$files = $this->file_storage->get_all_files( $context );
@@ -446,39 +424,27 @@ class FlowFileAbilities {
 	 * @param array $input Input parameters.
 	 * @return array Result with cleanup status.
 	 */
-	public function executeCleanupFlowFiles( array $input ): array {
+	public function executeCleanupFlowFiles( array $input ): array|\WP_Error {
 		$job_id  = isset( $input['job_id'] ) ? (int) $input['job_id'] : null;
 		$flow_id = isset( $input['flow_id'] ) ? (int) $input['flow_id'] : null;
 
 		if ( ! $job_id && ! $flow_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'Must provide either job_id or flow_id for cleanup',
-			);
+			return new \WP_Error( 'flow_cleanup_target_required', 'Must provide either job_id or flow_id for cleanup', array( 'status' => 400 ) );
 		}
 
 		if ( $job_id && ! $flow_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'flow_id is required when cleaning up by job_id',
-			);
+			return new \WP_Error( 'flow_cleanup_flow_required', 'flow_id is required when cleaning up by job_id', array( 'status' => 400 ) );
 		}
 
 		// At this point $flow_id is always set (guards above handle the null cases).
 		$flow = $this->db_flows->get_flow( $flow_id );
 		if ( ! $flow ) {
-			return array(
-				'success' => false,
-				'error'   => sprintf( 'Flow %d not found', $flow_id ),
-			);
+			return new \WP_Error( 'flow_not_found', sprintf( 'Flow %d not found', $flow_id ), array( 'status' => 404 ) );
 		}
 
 		$pipeline_id = $flow['pipeline_id'] ?? null;
 		if ( ! $pipeline_id ) {
-			return array(
-				'success' => false,
-				'error'   => 'Flow does not have a valid pipeline_id',
-			);
+			return new \WP_Error( 'flow_pipeline_missing', 'Flow does not have a valid pipeline_id', array( 'status' => 500 ) );
 		}
 
 		$deleted_count = 0;

--- a/inc/Abilities/File/ScaffoldAbilities.php
+++ b/inc/Abilities/File/ScaffoldAbilities.php
@@ -470,15 +470,19 @@ class ScaffoldAbilities {
 			return false;
 		}
 
-		$fs->put_contents( $filepath, $content . "\n", FS_CHMOD_FILE );
-		FilesystemHelper::make_group_writable( $filepath );
-
 		// Protect directory from listing.
 		$index_path = trailingslashit( $directory ) . 'index.php';
 		if ( ! file_exists( $index_path ) ) {
-			$fs->put_contents( $index_path, "<?php\n// Silence is golden.\n", FS_CHMOD_FILE );
+			if ( ! $fs->put_contents( $index_path, "<?php\n// Silence is golden.\n", FS_CHMOD_FILE ) ) {
+				return false;
+			}
 			FilesystemHelper::make_group_writable( $index_path );
 		}
+
+		if ( ! $fs->put_contents( $filepath, $content . "\n", FS_CHMOD_FILE ) ) {
+			return false;
+		}
+		FilesystemHelper::make_group_writable( $filepath );
 
 		// Log only meaningful context keys.
 		$log_context = array_filter(

--- a/inc/Abilities/File/ScaffoldAbilities.php
+++ b/inc/Abilities/File/ScaffoldAbilities.php
@@ -131,30 +131,34 @@ class ScaffoldAbilities {
 	 * @param array $input Ability input.
 	 * @return array Result with success, message, filename(s), created count.
 	 */
-	public static function execute( array $input ): array {
+	public static function execute( array $input ): array|\WP_Error {
 		$layer = $input['layer'] ?? '';
 
 		// Mode 3: scaffold all registered files in a layer.
 		if ( ! empty( $layer ) ) {
-			return self::scaffold_layer( $layer, $input );
+			return self::callback_result( self::scaffold_layer( $layer, $input ) );
 		}
 
 		$filename = $input['filename'] ?? '';
 		if ( empty( $filename ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Either filename or layer is required.',
-			);
+			return new \WP_Error( 'scaffold_target_required', 'Either filename or layer is required.', array( 'status' => 400 ) );
 		}
 
 		// Mode 2: explicit filepath for dynamic files.
 		$explicit_path = $input['filepath'] ?? '';
 		if ( ! empty( $explicit_path ) ) {
-			return self::scaffold_at_path( $explicit_path, $filename, $input );
+			return self::callback_result( self::scaffold_at_path( $explicit_path, $filename, $input ) );
 		}
 
 		// Mode 1: registered file.
-		return self::scaffold_registered( $filename, $input );
+		return self::callback_result( self::scaffold_registered( $filename, $input ) );
+	}
+
+	private static function callback_result( array $result ): array|\WP_Error {
+		if ( ! empty( $result['success'] ) ) {
+			return $result;
+		}
+		return new \WP_Error( $result['error_code'] ?? 'scaffold_failed', $result['error'] ?? 'Scaffold failed.', array_merge( array( 'status' => 500 ), $result ) );
 	}
 
 	// =========================================================================
@@ -314,18 +318,37 @@ class ScaffoldAbilities {
 			);
 		}
 
-		$files   = MemoryFileRegistry::get_by_layer( $layer );
-		$results = array();
-		$created = 0;
+		$files    = MemoryFileRegistry::get_by_layer( $layer );
+		$results  = array();
+		$created  = 0;
+		$failures = array();
 
 		foreach ( $files as $filename => $meta ) {
 			$input['filename'] = $filename;
 			$result            = self::scaffold_registered( $filename, $input );
-			$results[]         = $result;
+			if ( empty( $result['success'] ) ) {
+				$result['filename'] = $filename;
+				$failures[]         = $result;
+			}
+			$results[] = $result;
 
 			if ( ! empty( $result['created'] ) ) {
 				++$created;
 			}
+		}
+
+		if ( ! empty( $failures ) ) {
+			return array(
+				'success'    => false,
+				'error_code' => 'scaffold_layer_failed',
+				'error'      => sprintf( 'Failed to scaffold %d of %d %s-layer file(s).', count( $failures ), count( $files ), $layer ),
+				'layer'      => $layer,
+				'created'    => $created,
+				'failed'     => count( $failures ),
+				'total'      => count( $files ),
+				'files'      => $results,
+				'failures'   => $failures,
+			);
 		}
 
 		return array(

--- a/inc/Abilities/File/ScaffoldAbilities.php
+++ b/inc/Abilities/File/ScaffoldAbilities.php
@@ -325,7 +325,17 @@ class ScaffoldAbilities {
 
 		foreach ( $files as $filename => $meta ) {
 			$input['filename'] = $filename;
-			$result            = self::scaffold_registered( $filename, $input );
+			if ( false === $meta['editable'] && empty( $meta['composable'] ) ) {
+				$result = array(
+					'success'  => true,
+					'message'  => sprintf( '%s is managed by its owning process.', $filename ),
+					'filename' => $filename,
+					'created'  => false,
+					'skipped'  => true,
+				);
+			} else {
+				$result = self::scaffold_registered( $filename, $input );
+			}
 			if ( empty( $result['success'] ) ) {
 				$result['filename'] = $filename;
 				$failures[]         = $result;

--- a/inc/Abilities/Publish/PublishWordPressAbility.php
+++ b/inc/Abilities/Publish/PublishWordPressAbility.php
@@ -147,7 +147,7 @@ class PublishWordPressAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with post data or error.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$logs   = array();
 		$config = $this->normalizeConfig( $input );
 
@@ -174,10 +174,14 @@ class PublishWordPressAbility {
 					'required_parameters' => array( 'title', 'content' ),
 				),
 			);
-			return array(
-				'success' => false,
-				'error'   => 'Missing required parameters: title and content',
-				'logs'    => $logs,
+			return new \WP_Error(
+				'publish_parameters_required',
+				'Missing required parameters: title and content',
+				array(
+					'status'              => 400,
+					'logs'                => $logs,
+					'provided_parameters' => array_keys( $input ),
+				)
 			);
 		}
 
@@ -186,10 +190,13 @@ class PublishWordPressAbility {
 				'level'   => 'error',
 				'message' => 'WordPress: Post type is required',
 			);
-			return array(
-				'success' => false,
-				'error'   => 'Post type is required',
-				'logs'    => $logs,
+			return new \WP_Error(
+				'publish_post_type_required',
+				'Post type is required',
+				array(
+					'status' => 400,
+					'logs'   => $logs,
+				)
 			);
 		}
 
@@ -204,10 +211,13 @@ class PublishWordPressAbility {
 					'sanitized_content_length' => strlen( $content ),
 				),
 			);
-			return array(
-				'success' => false,
-				'error'   => 'Content was empty after sanitization',
-				'logs'    => $logs,
+			return new \WP_Error(
+				'publish_content_empty',
+				'Content was empty after sanitization',
+				array(
+					'status' => 422,
+					'logs'   => $logs,
+				)
 			);
 		}
 
@@ -233,12 +243,16 @@ class PublishWordPressAbility {
 					'error'          => $stored_content->get_error_message(),
 				),
 			);
-			return array(
-				'success'    => false,
-				'error'      => $stored_content->get_error_message(),
-				'error_code' => $stored_content->get_error_code(),
-				'error_data' => $stored_content->get_error_data(),
-				'logs'       => $logs,
+			return new \WP_Error(
+				$stored_content->get_error_code(),
+				$stored_content->get_error_message(),
+				array_merge(
+					array(
+						'status' => 422,
+						'logs'   => $logs,
+					),
+					is_array( $stored_content->get_error_data() ) ? $stored_content->get_error_data() : array()
+				)
 			);
 		}
 
@@ -293,10 +307,15 @@ class PublishWordPressAbility {
 					'post_data' => $post_data,
 				),
 			);
-			return array(
-				'success' => false,
-				'error'   => 'Post creation failed: ' . $post_id->get_error_message(),
-				'logs'    => $logs,
+			return new \WP_Error(
+				'publish_post_creation_failed',
+				'Post creation failed: ' . $post_id->get_error_message(),
+				array(
+					'status'        => 500,
+					'logs'          => $logs,
+					'wp_error_code' => $post_id->get_error_code(),
+					'post_data'     => $post_data,
+				)
 			);
 		}
 
@@ -314,6 +333,7 @@ class PublishWordPressAbility {
 				}
 
 				$term_ids = array();
+				$errors   = array();
 				foreach ( $terms as $term ) {
 					if ( is_numeric( $term ) ) {
 						$term_ids[] = intval( $term );
@@ -326,18 +346,44 @@ class PublishWordPressAbility {
 							$term_ids[] = $term_obj->term_id;
 						} else {
 							$result = wp_insert_term( $term, $taxonomy );
-							if ( ! is_wp_error( $result ) ) {
-								$term_ids[] = $result['term_id'];
+							if ( is_wp_error( $result ) ) {
+								$errors[] = array(
+									'code'    => $result->get_error_code(),
+									'message' => $result->get_error_message(),
+									'term'    => $term,
+								);
+								continue;
 							}
+							$term_ids[] = $result['term_id'];
 						}
 					}
 				}
 
 				if ( ! empty( $term_ids ) ) {
-					$set_result                    = wp_set_object_terms( $post_id, $term_ids, $taxonomy );
-					$taxonomy_results[ $taxonomy ] = array(
-						'success'  => ! is_wp_error( $set_result ),
-						'term_ids' => $term_ids,
+					$set_result = wp_set_object_terms( $post_id, $term_ids, $taxonomy );
+					if ( is_wp_error( $set_result ) ) {
+						$errors[] = array(
+							'code'     => $set_result->get_error_code(),
+							'message'  => $set_result->get_error_message(),
+							'term_ids' => $term_ids,
+						);
+					}
+				}
+
+				$taxonomy_results[ $taxonomy ] = array(
+					'success'  => empty( $errors ),
+					'term_ids' => $term_ids,
+				);
+				if ( ! empty( $errors ) ) {
+					$taxonomy_results[ $taxonomy ]['errors'] = $errors;
+
+					$logs[] = array(
+						'level'   => 'warning',
+						'message' => 'WordPress: Taxonomy assignment completed with errors',
+						'data'    => array(
+							'taxonomy' => $taxonomy,
+							'errors'   => $errors,
+						),
 					);
 				}
 			}
@@ -346,7 +392,7 @@ class PublishWordPressAbility {
 		if ( ! empty( $taxonomy_results ) ) {
 			$logs[] = array(
 				'level'   => 'debug',
-				'message' => 'WordPress: Taxonomies assigned',
+				'message' => 'WordPress: Taxonomies processed',
 				'data'    => $taxonomy_results,
 			);
 		}

--- a/inc/Abilities/Update/UpdateWordPressAbility.php
+++ b/inc/Abilities/Update/UpdateWordPressAbility.php
@@ -129,7 +129,7 @@ class UpdateWordPressAbility {
 	 * @param array $input Input parameters.
 	 * @return array Result with update data or error.
 	 */
-	public function execute( array $input ): array {
+	public function execute( array $input ): array|\WP_Error {
 		$logs   = array();
 		$config = $this->normalizeConfig( $input );
 
@@ -146,10 +146,13 @@ class UpdateWordPressAbility {
 				'level'   => 'error',
 				'message' => 'WordPress Update: source_url is required',
 			);
-			return array(
-				'success' => false,
-				'error'   => 'source_url parameter is required for WordPress Update',
-				'logs'    => $logs,
+			return new \WP_Error(
+				'wordpress_update_source_url_required',
+				'source_url parameter is required for WordPress Update',
+				array(
+					'status' => 400,
+					'logs'   => $logs,
+				)
 			);
 		}
 
@@ -160,10 +163,14 @@ class UpdateWordPressAbility {
 				'message' => 'WordPress Update: Could not extract post ID from URL',
 				'data'    => array( 'source_url' => $source_url ),
 			);
-			return array(
-				'success' => false,
-				'error'   => "Could not extract valid WordPress post ID from URL: {$source_url}",
-				'logs'    => $logs,
+			return new \WP_Error(
+				'wordpress_update_source_url_invalid',
+				"Could not extract valid WordPress post ID from URL: {$source_url}",
+				array(
+					'status'     => 400,
+					'source_url' => $source_url,
+					'logs'       => $logs,
+				)
 			);
 		}
 
@@ -174,10 +181,34 @@ class UpdateWordPressAbility {
 				'message' => 'WordPress Update: Post does not exist',
 				'data'    => array( 'post_id' => $post_id ),
 			);
-			return array(
-				'success' => false,
-				'error'   => "WordPress post with ID {$post_id} does not exist",
-				'logs'    => $logs,
+			return new \WP_Error(
+				'wordpress_update_post_not_found',
+				"WordPress post with ID {$post_id} does not exist",
+				array(
+					'status'  => 404,
+					'post_id' => $post_id,
+					'logs'    => $logs,
+				)
+			);
+		}
+
+		$block_companion_modes = array_filter(
+			array(
+				'title'      => ! empty( $title ),
+				'content'    => ! empty( $content ),
+				'updates'    => ! empty( $updates ),
+				'taxonomies' => ! empty( $taxonomies ),
+			)
+		);
+		if ( ! empty( $block_updates ) && ! empty( $block_companion_modes ) ) {
+			return new \WP_Error(
+				'wordpress_update_mixed_mutation_modes',
+				'block_updates cannot be combined with other post mutations in one request.',
+				array(
+					'status'         => 400,
+					'post_id'        => $post_id,
+					'conflicts_with' => array_keys( $block_companion_modes ),
+				)
 			);
 		}
 
@@ -214,6 +245,9 @@ class UpdateWordPressAbility {
 				)
 			);
 
+			if ( is_wp_error( $block_result ) ) {
+				return $block_result;
+			}
 			$all_changes['block_updates'] = $block_result['changes_applied'] ?? array();
 
 			if ( ! $block_result['success'] ) {
@@ -221,6 +255,18 @@ class UpdateWordPressAbility {
 					'level'   => 'warning',
 					'message' => 'WordPress Update: Block updates failed',
 					'data'    => array( 'error' => $block_result['error'] ?? 'Unknown' ),
+				);
+				return new \WP_Error(
+					$block_result['error_code'] ?? 'wordpress_update_block_updates_failed',
+					$block_result['error'] ?? 'WordPress block updates failed.',
+					array_merge(
+						array(
+							'status'  => 422,
+							'post_id' => $post_id,
+							'logs'    => $logs,
+						),
+						is_array( $block_result['error_data'] ?? null ) ? $block_result['error_data'] : array()
+					)
 				);
 			} else {
 				$logs[] = array(
@@ -272,10 +318,16 @@ class UpdateWordPressAbility {
 					'message' => 'WordPress Update: wp_update_post failed',
 					'data'    => array( 'error' => $result->get_error_message() ),
 				);
-				return array(
-					'success' => false,
-					'error'   => 'WordPress post update failed: ' . $result->get_error_message(),
-					'logs'    => $logs,
+				return new \WP_Error(
+					'wordpress_post_update_failed',
+					'WordPress post update failed: ' . $result->get_error_message(),
+					array(
+						'status'        => 500,
+						'post_id'       => $post_id,
+						'wp_error_code' => $result->get_error_code(),
+						'wp_error_data' => $result->get_error_data(),
+						'logs'          => $logs,
+					)
 				);
 			}
 
@@ -284,10 +336,14 @@ class UpdateWordPressAbility {
 					'level'   => 'error',
 					'message' => 'WordPress Update: wp_update_post returned 0',
 				);
-				return array(
-					'success' => false,
-					'error'   => 'WordPress post update failed: wp_update_post returned 0',
-					'logs'    => $logs,
+				return new \WP_Error(
+					'wordpress_post_update_invalid_result',
+					'WordPress post update failed: wp_update_post returned 0',
+					array(
+						'status'  => 500,
+						'post_id' => $post_id,
+						'logs'    => $logs,
+					)
 				);
 			}
 		}

--- a/inc/Api/AgentFiles.php
+++ b/inc/Api/AgentFiles.php
@@ -260,6 +260,10 @@ class AgentFiles {
 			);
 		}
 
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'list_agent_files_error' );
+		}
+
 		if ( ! $result['success'] ) {
 			return new \WP_Error( 'list_agent_files_error', $result['error'], array( 'status' => 500 ) );
 		}
@@ -289,6 +293,10 @@ class AgentFiles {
 				$e->getMessage(),
 				array( 'status' => 500 )
 			);
+		}
+
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'get_agent_file_error' );
 		}
 
 		if ( ! $result['success'] ) {
@@ -333,6 +341,10 @@ class AgentFiles {
 
 		$result = self::getAbilities()->executeWriteAgentFile( $input );
 
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'put_agent_file_error' );
+		}
+
 		if ( ! $result['success'] ) {
 			$status = 400;
 			if ( false !== strpos( $result['error'] ?? '', 'Filesystem' ) || false !== strpos( $result['error'] ?? '', 'Failed' ) ) {
@@ -370,6 +382,9 @@ class AgentFiles {
 		}
 
 		$result = self::getAbilities()->executeDeleteAgentFile( $input );
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'delete_agent_file_error' );
+		}
 
 		if ( ! $result['success'] ) {
 			$status = false !== strpos( $result['error'] ?? '', 'not found' ) ? 404 : 400;

--- a/inc/Api/FlowFiles.php
+++ b/inc/Api/FlowFiles.php
@@ -134,6 +134,10 @@ class FlowFiles {
 			'flow_step_id' => sanitize_text_field( $flow_step_id ),
 		) );
 
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'list_files_error' );
+		}
+
 		if ( ! $result['success'] ) {
 			$status = false !== strpos( $result['error'] ?? '', 'not found' ) ? 404 : 400;
 			return new WP_Error( 'list_files_error', $result['error'], array( 'status' => $status ) );
@@ -174,6 +178,10 @@ class FlowFiles {
 
 		$result = self::getAbilities()->executeUploadFlowFile( $input );
 
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'upload_file_error' );
+		}
+
 		if ( ! $result['success'] ) {
 			$status = 400;
 			if ( false !== strpos( $result['error'] ?? '', 'not found' ) ) {
@@ -205,6 +213,10 @@ class FlowFiles {
 			'filename'     => $filename,
 			'flow_step_id' => sanitize_text_field( $flow_step_id ),
 		) );
+
+		if ( is_wp_error( $result ) ) {
+			return RestResultSpec::legacy_error( $result, 'delete_file_error' );
+		}
 
 		if ( ! $result['success'] ) {
 			$status = false !== strpos( $result['error'] ?? '', 'not found' ) ? 404 : 400;

--- a/inc/Cli/Commands/BlocksCommand.php
+++ b/inc/Cli/Commands/BlocksCommand.php
@@ -16,6 +16,7 @@ use DataMachine\Cli\BaseCommand;
 use DataMachine\Abilities\Content\GetPostBlocksAbility;
 use DataMachine\Abilities\Content\EditPostBlocksAbility;
 use DataMachine\Abilities\Content\ReplacePostBlocksAbility;
+use DataMachine\Core\AbilityResult;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -63,11 +64,11 @@ class BlocksCommand extends BaseCommand {
 			$block_types = array( $assoc_args['type'] );
 		}
 
-		$result = GetPostBlocksAbility::execute( array(
+		$result = AbilityResult::normalize( GetPostBlocksAbility::execute( array(
 			'post_id'     => $post_id,
 			'block_types' => $block_types,
 			'search'      => $search,
-		) );
+		) ) );
 
 		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( $result['error'] ?? 'Failed to parse blocks' );
@@ -146,7 +147,7 @@ class BlocksCommand extends BaseCommand {
 
 		if ( $dry_run ) {
 			// Preview: use get-post-blocks to show what would change.
-			$blocks_result = GetPostBlocksAbility::execute( array( 'post_id' => $post_id ) );
+			$blocks_result = AbilityResult::normalize( GetPostBlocksAbility::execute( array( 'post_id' => $post_id ) ) );
 			if ( empty( $blocks_result['success'] ) ) {
 				WP_CLI::error( $blocks_result['error'] ?? 'Failed to parse blocks' );
 			}
@@ -175,7 +176,7 @@ class BlocksCommand extends BaseCommand {
 			return;
 		}
 
-		$result = EditPostBlocksAbility::execute( array(
+		$result = AbilityResult::normalize( EditPostBlocksAbility::execute( array(
 			'post_id' => $post_id,
 			'edits'   => array(
 				array(
@@ -184,7 +185,7 @@ class BlocksCommand extends BaseCommand {
 					'replace'     => $replace,
 				),
 			),
-		) );
+		) ) );
 
 		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( $result['error'] ?? 'Edit failed' );
@@ -235,7 +236,7 @@ class BlocksCommand extends BaseCommand {
 			WP_CLI::error( '--content is required' );
 		}
 
-		$result = ReplacePostBlocksAbility::execute( array(
+		$result = AbilityResult::normalize( ReplacePostBlocksAbility::execute( array(
 			'post_id'      => $post_id,
 			'replacements' => array(
 				array(
@@ -243,7 +244,7 @@ class BlocksCommand extends BaseCommand {
 					'new_content' => $content,
 				),
 			),
-		) );
+		) ) );
 
 		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( $result['error'] ?? 'Replace failed' );

--- a/inc/Core/Identity/AgentIdentityStoreAdapter.php
+++ b/inc/Core/Identity/AgentIdentityStoreAdapter.php
@@ -171,6 +171,9 @@ class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
 					'instance_key'  => $scope->instance_key,
 				)
 			);
+			if ( function_exists( 'is_wp_error' ) && is_wp_error( $result ) ) {
+				throw new \RuntimeException( 'Failed to provision materialized agent scaffold: ' . esc_html( $result->get_error_message() ) );
+			}
 			if ( is_array( $result ) && empty( $result['success'] ) ) {
 				throw new \RuntimeException( 'Failed to provision materialized agent scaffold.' );
 			}

--- a/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
+++ b/inc/Engine/AI/System/Tasks/InternalLinkingTask.php
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
 
 use DataMachine\Abilities\Content\GetPostBlocksAbility;
 use DataMachine\Abilities\Content\ReplacePostBlocksAbility;
+use DataMachine\Core\AbilityResult;
 use DataMachine\Core\PluginSettings;
 use DataMachine\Engine\AI\RequestBuilder;
 
@@ -75,10 +76,10 @@ class InternalLinkingTask extends SystemTask {
 			return;
 		}
 
-		$blocks_result = GetPostBlocksAbility::execute( array(
+		$blocks_result = AbilityResult::normalize( GetPostBlocksAbility::execute( array(
 			'post_id'     => $post_id,
 			'block_types' => array( 'core/paragraph' ),
-		) );
+		) ) );
 
 		if ( empty( $blocks_result['success'] ) || empty( $blocks_result['blocks'] ) ) {
 			$this->completeJob( $jobId, array(
@@ -193,10 +194,10 @@ class InternalLinkingTask extends SystemTask {
 
 		$revision_id = wp_save_post_revision( $post_id );
 
-		$replace_result = ReplacePostBlocksAbility::execute( array(
+		$replace_result = AbilityResult::normalize( ReplacePostBlocksAbility::execute( array(
 			'post_id'      => $post_id,
 			'replacements' => $replacements,
-		) );
+		) ) );
 
 		if ( empty( $replace_result['success'] ) ) {
 			$this->failJob( $jobId, 'Failed to save block replacements: ' . ( $replace_result['error'] ?? 'Unknown error' ) );

--- a/tests/Unit/Abilities/Content/ContentActionHandlersTest.php
+++ b/tests/Unit/Abilities/Content/ContentActionHandlersTest.php
@@ -53,6 +53,26 @@ class ContentActionHandlersTest extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_direct_callbacks_return_stable_native_errors(): void {
+		$edit = EditPostBlocksAbility::execute( array() );
+		$this->assertWPError( $edit );
+		$this->assertSame( 'invalid_edit_post_id', $edit->get_error_code() );
+
+		$replace = ReplacePostBlocksAbility::execute( array() );
+		$this->assertWPError( $replace );
+		$this->assertSame( 'invalid_replace_post_id', $replace->get_error_code() );
+
+		$insert = InsertContentAbility::execute(
+			array(
+				'post_id'  => $this->post_id,
+				'content'  => 'Content',
+				'position' => 'sideways',
+			)
+		);
+		$this->assertWPError( $insert );
+		$this->assertSame( 'invalid_insert_position', $insert->get_error_code() );
+	}
+
 	public function test_edit_post_blocks_preview_stages_and_resolves(): void {
 		$result = EditPostBlocksAbility::execute(
 			array(

--- a/tests/Unit/Abilities/Content/UpsertPostAbilityTest.php
+++ b/tests/Unit/Abilities/Content/UpsertPostAbilityTest.php
@@ -83,7 +83,7 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 		$failed = UpsertPostAbility::execute( $this->input( 'write-failure', 'Will retry' ) );
 		remove_filter( 'wp_insert_post_empty_content', $fail );
 
-		$this->assertFalse( $failed['success'] );
+		$this->assertWPError( $failed );
 		$identity = PostIdentityReservations::normalize_identity( 'post', array( 'key' => '_source', 'value' => 'write-failure' ) );
 		$row      = $this->repository->get_reservation( $identity['identity_hash'] );
 		$this->assertSame( 'linked', $row['state'] );
@@ -267,7 +267,8 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 
 		$result = UpsertPostAbility::execute( $input );
 
-		$this->assertFalse( $result['success'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'not_found', $result->get_error_code() );
 		$identity = PostIdentityReservations::normalize_identity( 'post', $input['identity_meta'] );
 		$this->assertNull( $this->repository->get_reservation( $identity['identity_hash'] ) );
 	}
@@ -355,8 +356,8 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 
 		$result = UpsertPostAbility::execute( $input );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertSame( 'identity_meta_sanitizer_unstable', $result['error_code'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'identity_meta_sanitizer_unstable', $result->get_error_code() );
 	}
 
 	public function test_advisory_fence_spans_population_and_releases_on_success(): void {
@@ -386,10 +387,10 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 		$result = UpsertPostAbility::execute( $this->input( 'fenced-exception', 'Exception' ) );
 		remove_action( 'datamachine_upsert_post_identity_before_population', $throw );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertSame( 'identity_population_exception', $result['error_code'] );
-		$this->assertTrue( $result['error_data']['retryable'] );
-		$this->assertStringNotContainsString( 'Injected population exception', $result['error'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'identity_population_exception', $result->get_error_code() );
+		$this->assertTrue( $result->get_error_data()['retryable'] );
+		$this->assertStringNotContainsString( 'Injected population exception', $result->get_error_message() );
 		$this->assertIdentityLockIsFree( 'fenced-exception' );
 	}
 
@@ -413,9 +414,9 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 			remove_action( 'datamachine_upsert_post_identity_before_population', $throw_population );
 		}
 
-		$this->assertFalse( $result['success'] );
-		$this->assertSame( 'identity_population_exception', $result['error_code'] );
-		$this->assertTrue( $result['error_data']['retryable'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'identity_population_exception', $result->get_error_code() );
+		$this->assertTrue( $result->get_error_data()['retryable'] );
 		$this->assertIdentityLockIsFree( 'diagnostic-exception' );
 	}
 
@@ -429,9 +430,9 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 		remove_action( 'datamachine_upsert_post_identity_before_population', $callback );
 
 		$this->assertTrue( $outer['success'] );
-		$this->assertFalse( $recursive_result['success'] );
-		$this->assertSame( 'identity_lock_reentrant', $recursive_result['error_code'] );
-		$this->assertTrue( $recursive_result['error_data']['retryable'] );
+		$this->assertWPError( $recursive_result );
+		$this->assertSame( 'identity_lock_reentrant', $recursive_result->get_error_code() );
+		$this->assertTrue( $recursive_result->get_error_data()['retryable'] );
 		$this->assertIdentityLockIsFree( 'recursive-identity' );
 	}
 
@@ -446,9 +447,9 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 		$result = UpsertPostAbility::execute( $this->input( 'release-lost', 'Release lost' ) );
 		remove_action( 'datamachine_upsert_post_identity_before_population', $release );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertSame( 'identity_lock_release_uncertain', $result['error_code'] );
-		$this->assertTrue( $result['error_data']['retryable'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'identity_lock_release_uncertain', $result->get_error_code() );
+		$this->assertTrue( $result->get_error_data()['retryable'] );
 		$this->assertIdentityLockIsFree( 'release-lost' );
 	}
 
@@ -463,9 +464,9 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 		$connection->query( "SELECT GET_LOCK('{$lock_name}', 0)" );
 		try {
 			$result = UpsertPostAbility::execute( $this->input( 'fenced-busy', 'Busy' ) );
-			$this->assertFalse( $result['success'] );
-			$this->assertSame( 'identity_lock_unavailable', $result['error_code'] );
-			$this->assertTrue( $result['error_data']['retryable'] );
+			$this->assertWPError( $result );
+			$this->assertSame( 'identity_lock_unavailable', $result->get_error_code() );
+			$this->assertTrue( $result->get_error_data()['retryable'] );
 		} finally {
 			$connection->query( "SELECT RELEASE_LOCK('{$lock_name}')" );
 			$connection->close();

--- a/tests/Unit/Abilities/FetchWordPressApiAbilityTest.php
+++ b/tests/Unit/Abilities/FetchWordPressApiAbilityTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * FetchWordPressApiAbility tests.
+ *
+ * @package DataMachine\Tests\Unit\Abilities
+ */
+
+namespace DataMachine\Tests\Unit\Abilities;
+
+use DataMachine\Abilities\Fetch\FetchWordPressApiAbility;
+use WP_UnitTestCase;
+
+class FetchWordPressApiAbilityTest extends WP_UnitTestCase {
+
+	public function test_missing_endpoint_returns_specific_bad_request_error(): void {
+		$result = ( new FetchWordPressApiAbility() )->execute( array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wordpress_api_endpoint_required', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+		$this->assertArrayHasKey( 'logs', $result->get_error_data() );
+	}
+
+	public function test_invalid_endpoint_returns_specific_bad_request_error(): void {
+		$result = ( new FetchWordPressApiAbility() )->execute(
+			array( 'endpoint_url' => 'not-a-url' )
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wordpress_api_endpoint_invalid', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+		$this->assertSame( 'not-a-url', $result->get_error_data()['endpoint_url'] );
+	}
+
+	public function test_invalid_upstream_json_returns_specific_bad_gateway_error(): void {
+		$intercept = static function () {
+			return array(
+				'headers'  => array(),
+				'body'     => '{invalid',
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+			);
+		};
+		add_filter( 'pre_http_request', $intercept );
+		try {
+			$result = ( new FetchWordPressApiAbility() )->execute(
+				array( 'endpoint_url' => 'https://example.test/wp-json/wp/v2/posts' )
+			);
+		} finally {
+			remove_filter( 'pre_http_request', $intercept );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wordpress_api_invalid_response', $result->get_error_code() );
+		$this->assertSame( 502, $result->get_error_data()['status'] );
+		$this->assertSame( 'https://example.test/wp-json/wp/v2/posts', $result->get_error_data()['endpoint_url'] );
+		$this->assertArrayHasKey( 'json_error', $result->get_error_data() );
+	}
+
+	public function test_upstream_http_error_preserves_code_status_and_data(): void {
+		$intercept = static function () {
+			return array(
+				'headers'  => array(),
+				'body'     => 'Missing upstream resource.',
+				'response' => array(
+					'code'    => 404,
+					'message' => 'Not Found',
+				),
+				'cookies'  => array(),
+			);
+		};
+		add_filter( 'pre_http_request', $intercept );
+		try {
+			$result = ( new FetchWordPressApiAbility() )->execute(
+				array( 'endpoint_url' => 'https://example.test/wp-json/wp/v2/posts/404' )
+			);
+		} finally {
+			remove_filter( 'pre_http_request', $intercept );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'fetch_http_status', $result->get_error_code() );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
+		$this->assertSame( 404, $result->get_error_data()['status_code'] );
+		$this->assertSame( 'Missing upstream resource.', $result->get_error_data()['body'] );
+		$this->assertArrayHasKey( 'logs', $result->get_error_data() );
+	}
+}

--- a/tests/Unit/Abilities/FetchWordPressApiAbilityTest.php
+++ b/tests/Unit/Abilities/FetchWordPressApiAbilityTest.php
@@ -33,25 +33,12 @@ class FetchWordPressApiAbilityTest extends WP_UnitTestCase {
 	}
 
 	public function test_invalid_upstream_json_returns_specific_bad_gateway_error(): void {
-		$intercept = static function () {
-			return array(
-				'headers'  => array(),
-				'body'     => '{invalid',
-				'response' => array(
-					'code'    => 200,
-					'message' => 'OK',
-				),
-				'cookies'  => array(),
-			);
-		};
-		add_filter( 'pre_http_request', $intercept );
-		try {
-			$result = ( new FetchWordPressApiAbility() )->execute(
-				array( 'endpoint_url' => 'https://example.test/wp-json/wp/v2/posts' )
-			);
-		} finally {
-			remove_filter( 'pre_http_request', $intercept );
-		}
+		$result = $this->execute_with_response(
+			'{invalid',
+			200,
+			'OK',
+			'https://example.test/wp-json/wp/v2/posts'
+		);
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'wordpress_api_invalid_response', $result->get_error_code() );
@@ -61,25 +48,12 @@ class FetchWordPressApiAbilityTest extends WP_UnitTestCase {
 	}
 
 	public function test_upstream_http_error_preserves_code_status_and_data(): void {
-		$intercept = static function () {
-			return array(
-				'headers'  => array(),
-				'body'     => 'Missing upstream resource.',
-				'response' => array(
-					'code'    => 404,
-					'message' => 'Not Found',
-				),
-				'cookies'  => array(),
-			);
-		};
-		add_filter( 'pre_http_request', $intercept );
-		try {
-			$result = ( new FetchWordPressApiAbility() )->execute(
-				array( 'endpoint_url' => 'https://example.test/wp-json/wp/v2/posts/404' )
-			);
-		} finally {
-			remove_filter( 'pre_http_request', $intercept );
-		}
+		$result = $this->execute_with_response(
+			'Missing upstream resource.',
+			404,
+			'Not Found',
+			'https://example.test/wp-json/wp/v2/posts/404'
+		);
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'fetch_http_status', $result->get_error_code() );
@@ -87,5 +61,31 @@ class FetchWordPressApiAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( 404, $result->get_error_data()['status_code'] );
 		$this->assertSame( 'Missing upstream resource.', $result->get_error_data()['body'] );
 		$this->assertArrayHasKey( 'logs', $result->get_error_data() );
+	}
+
+	private function execute_with_response( string $body, int $code, string $message, string $endpoint_url ) {
+		$intercept = static function () use ( $body, $code, $message ) {
+			return self::http_response( $body, $code, $message );
+		};
+		add_filter( 'pre_http_request', $intercept );
+		try {
+			return ( new FetchWordPressApiAbility() )->execute(
+				array( 'endpoint_url' => $endpoint_url )
+			);
+		} finally {
+			remove_filter( 'pre_http_request', $intercept );
+		}
+	}
+
+	private static function http_response( string $body, int $code, string $message ): array {
+		return array(
+			'headers'  => array(),
+			'body'     => $body,
+			'response' => array(
+				'code'    => $code,
+				'message' => $message,
+			),
+			'cookies'  => array(),
+		);
 	}
 }

--- a/tests/Unit/Abilities/FileAbilitiesTest.php
+++ b/tests/Unit/Abilities/FileAbilitiesTest.php
@@ -91,9 +91,9 @@ class FileAbilitiesTest extends WP_UnitTestCase {
 	public function test_list_flow_files_requires_flow_step_id(): void {
 		$result = $this->flow_file_abilities->executeListFlowFiles( array() );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'flow_step_id is required', $result['error'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'flow_file_step_required', $result->get_error_code() );
+		$this->assertStringContainsString( 'flow_step_id is required', $result->get_error_message() );
 	}
 
 	// =========================================================================
@@ -108,8 +108,7 @@ class FileAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
+		$this->assertWPError( $result );
 	}
 
 	public function test_get_flow_file_requires_flow_step_id(): void {
@@ -119,9 +118,8 @@ class FileAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'flow_step_id is required', $result['error'] );
+		$this->assertWPError( $result );
+		$this->assertStringContainsString( 'flow_step_id is required', $result->get_error_message() );
 	}
 
 	// =========================================================================
@@ -135,8 +133,7 @@ class FileAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
+		$this->assertWPError( $result );
 	}
 
 	public function test_delete_flow_file_requires_flow_step_id(): void {
@@ -146,9 +143,8 @@ class FileAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'flow_step_id is required', $result['error'] );
+		$this->assertWPError( $result );
+		$this->assertStringContainsString( 'flow_step_id is required', $result->get_error_message() );
 	}
 
 	// =========================================================================
@@ -158,9 +154,8 @@ class FileAbilitiesTest extends WP_UnitTestCase {
 	public function test_cleanup_flow_files_requires_scope(): void {
 		$result = $this->flow_file_abilities->executeCleanupFlowFiles( array() );
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'Must provide either', $result['error'] );
+		$this->assertWPError( $result );
+		$this->assertStringContainsString( 'Must provide either', $result->get_error_message() );
 	}
 
 	public function test_cleanup_flow_files_job_requires_flow(): void {
@@ -170,9 +165,8 @@ class FileAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'flow_id is required', $result['error'] );
+		$this->assertWPError( $result );
+		$this->assertStringContainsString( 'flow_id is required', $result->get_error_message() );
 	}
 
 	public function test_cleanup_flow_files_with_invalid_flow_id(): void {
@@ -182,9 +176,9 @@ class FileAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertFalse( $result['success'] );
-		$this->assertArrayHasKey( 'error', $result );
-		$this->assertStringContainsString( 'not found', $result['error'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'flow_not_found', $result->get_error_code() );
+		$this->assertStringContainsString( 'not found', $result->get_error_message() );
 	}
 
 	public function test_cleanup_flow_files_with_valid_flow(): void {

--- a/tests/Unit/Abilities/GetWordPressPostAbilityTest.php
+++ b/tests/Unit/Abilities/GetWordPressPostAbilityTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * GetWordPressPostAbility tests.
+ *
+ * @package DataMachine\Tests\Unit\Abilities
+ */
+
+namespace DataMachine\Tests\Unit\Abilities;
+
+use DataMachine\Abilities\Fetch\GetWordPressPostAbility;
+use WP_UnitTestCase;
+
+class GetWordPressPostAbilityTest extends WP_UnitTestCase {
+
+	public function test_missing_identifier_returns_specific_bad_request_error(): void {
+		$result = ( new GetWordPressPostAbility() )->execute( array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wordpress_post_identifier_required', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+		$this->assertArrayHasKey( 'logs', $result->get_error_data() );
+	}
+
+	public function test_invalid_source_url_returns_specific_bad_request_error(): void {
+		$result = ( new GetWordPressPostAbility() )->execute(
+			array( 'source_url' => 'not-a-wordpress-url' )
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wordpress_post_source_url_invalid', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+		$this->assertSame( 'not-a-wordpress-url', $result->get_error_data()['source_url'] );
+	}
+
+	public function test_missing_post_returns_specific_not_found_error(): void {
+		$result = ( new GetWordPressPostAbility() )->execute(
+			array( 'post_id' => 999999999 )
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wordpress_post_not_found', $result->get_error_code() );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
+		$this->assertSame( 999999999, $result->get_error_data()['post_id'] );
+	}
+}

--- a/tests/Unit/Abilities/MultiAgentScopingTest.php
+++ b/tests/Unit/Abilities/MultiAgentScopingTest.php
@@ -316,7 +316,8 @@ class MultiAgentScopingTest extends WP_UnitTestCase {
 				'user_id'  => $this->agent_b_id,
 			)
 		);
-		$this->assertFalse( $result_b['success'] );
+		$this->assertWPError( $result_b );
+		$this->assertSame( 'agent_file_not_found', $result_b->get_error_code() );
 
 		// Delete from agent A — should succeed.
 		$result_a = $fa->executeDeleteAgentFile(

--- a/tests/Unit/Abilities/PermissionHelperTest.php
+++ b/tests/Unit/Abilities/PermissionHelperTest.php
@@ -340,6 +340,7 @@ class PermissionHelperTest extends WP_UnitTestCase {
 			456
 		);
 
+		$this->setExpectedIncorrectUsage( 'WP_Ability::execute' );
 		$result = $ability->execute( array() );
 
 		$this->assertWPError( $result );

--- a/tests/Unit/Abilities/PermissionHelperTest.php
+++ b/tests/Unit/Abilities/PermissionHelperTest.php
@@ -343,7 +343,7 @@ class PermissionHelperTest extends WP_UnitTestCase {
 		$result = $ability->execute( array() );
 
 		$this->assertWPError( $result );
-		$this->assertSame( 'datamachine_ability_scope_denied', $result->get_error_code() );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
 	}
 
 	public function test_view_analytics_granted_to_manage_flows_holder(): void {

--- a/tests/Unit/Abilities/ScaffoldAbilitiesTest.php
+++ b/tests/Unit/Abilities/ScaffoldAbilitiesTest.php
@@ -19,12 +19,7 @@ class ScaffoldAbilitiesTest extends WP_UnitTestCase {
 		$target = $directory . '/TEST.md';
 		$this->assertNotFalse( file_put_contents( $target, "existing\n" ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture setup.
 
-		$existing = ScaffoldAbilities::execute(
-			array(
-				'filename' => 'TEST.md',
-				'filepath' => $target,
-			)
-		);
+		$existing = self::scaffold_test_file( $target );
 		$this->assertIsArray( $existing );
 		$this->assertTrue( $existing['success'] );
 		$this->assertFalse( $existing['created'] );
@@ -68,12 +63,7 @@ class ScaffoldAbilitiesTest extends WP_UnitTestCase {
 		add_action( 'datamachine_log', $logger, 999, 2 );
 
 		try {
-			$failed = ScaffoldAbilities::execute(
-				array(
-					'filename' => 'TEST.md',
-					'filepath' => $target,
-				)
-			);
+			$failed = self::scaffold_test_file( $target );
 			$this->assertWPError( $failed );
 			$this->assertSame( 'scaffold_failed', $failed->get_error_code() );
 			$this->assertStringContainsString( 'Failed to write TEST.md', $failed->get_error_message() );
@@ -165,5 +155,14 @@ class ScaffoldAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( $data['failed'], count( $data['failures'] ) );
 		$this->assertSame( 'USER_MEMORY.md', $data['failures'][0]['filename'] );
 		$this->assertStringContainsString( 'Could not resolve directory', $data['failures'][0]['error'] );
+	}
+
+	private static function scaffold_test_file( string $target ): array|\WP_Error {
+		return ScaffoldAbilities::execute(
+			array(
+				'filename' => 'TEST.md',
+				'filepath' => $target,
+			)
+		);
 	}
 }

--- a/tests/Unit/Abilities/ScaffoldAbilitiesTest.php
+++ b/tests/Unit/Abilities/ScaffoldAbilitiesTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * ScaffoldAbilities tests.
+ *
+ * @package DataMachine\Tests\Unit\Abilities
+ */
+
+namespace DataMachine\Tests\Unit\Abilities;
+
+use DataMachine\Abilities\File\ScaffoldAbilities;
+use WP_UnitTestCase;
+
+class ScaffoldAbilitiesTest extends WP_UnitTestCase {
+
+	public function test_layer_scaffolding_aggregates_per_file_failures(): void {
+		$result = ScaffoldAbilities::execute( array( 'layer' => 'principal' ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'scaffold_layer_failed', $result->get_error_code() );
+		$data = $result->get_error_data();
+		$this->assertSame( 500, $data['status'] );
+		$this->assertGreaterThanOrEqual( 1, $data['failed'] );
+		$this->assertSame( $data['failed'], count( $data['failures'] ) );
+		$this->assertSame( 'USER_MEMORY.md', $data['failures'][0]['filename'] );
+		$this->assertStringContainsString( 'Could not resolve directory', $data['failures'][0]['error'] );
+	}
+}

--- a/tests/Unit/Abilities/ScaffoldAbilitiesTest.php
+++ b/tests/Unit/Abilities/ScaffoldAbilitiesTest.php
@@ -8,42 +8,133 @@
 namespace DataMachine\Tests\Unit\Abilities;
 
 use DataMachine\Abilities\File\ScaffoldAbilities;
+use DataMachine\Core\FilesRepository\FilesystemHelper;
 use WP_UnitTestCase;
 
 class ScaffoldAbilitiesTest extends WP_UnitTestCase {
 
 	public function test_existing_file_is_idempotent_but_write_failure_is_error(): void {
-		$parent = wp_tempnam( 'datamachine-scaffold' );
-		$this->assertNotFalse( $parent );
+		$directory = get_temp_dir() . 'datamachine-scaffold-' . wp_generate_uuid4();
+		$this->assertTrue( wp_mkdir_p( $directory ) );
+		$target = $directory . '/TEST.md';
+		$this->assertNotFalse( file_put_contents( $target, "existing\n" ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture setup.
 
 		$existing = ScaffoldAbilities::execute(
 			array(
 				'filename' => 'TEST.md',
-				'filepath' => $parent,
+				'filepath' => $target,
 			)
 		);
 		$this->assertIsArray( $existing );
 		$this->assertTrue( $existing['success'] );
 		$this->assertFalse( $existing['created'] );
+		$this->assertSame( "existing\n", file_get_contents( $target ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Test fixture assertion.
+		unlink( $target ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Test fixture transition.
 
 		$generator = static function ( string $content, string $filename ): string {
 			return 'TEST.md' === $filename ? '# Test' : $content;
 		};
 		add_filter( 'datamachine_scaffold_content', $generator, 999, 2 );
 
+		global $wp_filesystem;
+		$original_filesystem = FilesystemHelper::get();
+		$this->assertNotNull( $original_filesystem );
+		$wp_filesystem = new class($target) extends \WP_Filesystem_Direct {
+			private string $failed_path;
+
+			public array $writes = array();
+
+			public function __construct( string $failed_path ) {
+				parent::__construct( null );
+				$this->failed_path = $failed_path;
+			}
+
+			public function put_contents( $file, $contents, $mode = false ) {
+				$this->writes[] = $file;
+				if ( $this->failed_path === $file ) {
+					return false;
+				}
+
+				return parent::put_contents( $file, $contents, $mode );
+			}
+		};
+
+		$success_logs = 0;
+		$logger       = static function ( string $level, string $message ) use ( &$success_logs ): void {
+			if ( 'info' === $level && str_starts_with( $message, 'Scaffolded ' ) ) {
+				++$success_logs;
+			}
+		};
+		add_action( 'datamachine_log', $logger, 999, 2 );
+
 		try {
 			$failed = ScaffoldAbilities::execute(
 				array(
 					'filename' => 'TEST.md',
-					'filepath' => $parent . '/TEST.md',
+					'filepath' => $target,
 				)
 			);
 			$this->assertWPError( $failed );
 			$this->assertSame( 'scaffold_failed', $failed->get_error_code() );
 			$this->assertStringContainsString( 'Failed to write TEST.md', $failed->get_error_message() );
+			$this->assertFileDoesNotExist( $target );
+			$this->assertSame( array( $directory . '/index.php', $target ), $wp_filesystem->writes );
+			$this->assertSame( 0, $success_logs );
 		} finally {
 			remove_filter( 'datamachine_scaffold_content', $generator, 999 );
-			unlink( $parent ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Test fixture cleanup.
+			remove_action( 'datamachine_log', $logger, 999 );
+			$wp_filesystem = $original_filesystem;
+			if ( file_exists( $directory . '/index.php' ) ) {
+				unlink( $directory . '/index.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Test fixture cleanup.
+			}
+			rmdir( $directory ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Test fixture cleanup.
+		}
+	}
+
+	public function test_index_protection_write_failure_does_not_create_target(): void {
+		$directory = get_temp_dir() . 'datamachine-scaffold-' . wp_generate_uuid4();
+		$this->assertTrue( wp_mkdir_p( $directory ) );
+		$target     = $directory . '/TEST.md';
+		$index_path = $directory . '/index.php';
+		$generator  = static function ( string $content, string $filename ): string {
+			return 'TEST.md' === $filename ? '# Test' : $content;
+		};
+		add_filter( 'datamachine_scaffold_content', $generator, 999, 2 );
+
+		global $wp_filesystem;
+		$original_filesystem = FilesystemHelper::get();
+		$this->assertNotNull( $original_filesystem );
+		$wp_filesystem = new class($index_path) extends \WP_Filesystem_Direct {
+			private string $failed_path;
+
+			public array $writes = array();
+
+			public function __construct( string $failed_path ) {
+				parent::__construct( null );
+				$this->failed_path = $failed_path;
+			}
+
+			public function put_contents( $file, $contents, $mode = false ) {
+				$this->writes[] = $file;
+				return $this->failed_path === $file ? false : parent::put_contents( $file, $contents, $mode );
+			}
+		};
+
+		try {
+			$failed = ScaffoldAbilities::execute(
+				array(
+					'filename' => 'TEST.md',
+					'filepath' => $target,
+				)
+			);
+			$this->assertWPError( $failed );
+			$this->assertSame( 'scaffold_failed', $failed->get_error_code() );
+			$this->assertFileDoesNotExist( $target );
+			$this->assertSame( array( $index_path ), $wp_filesystem->writes );
+		} finally {
+			remove_filter( 'datamachine_scaffold_content', $generator, 999 );
+			$wp_filesystem = $original_filesystem;
+			rmdir( $directory ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Test fixture cleanup.
 		}
 	}
 

--- a/tests/Unit/Abilities/ScaffoldAbilitiesTest.php
+++ b/tests/Unit/Abilities/ScaffoldAbilitiesTest.php
@@ -12,6 +12,57 @@ use WP_UnitTestCase;
 
 class ScaffoldAbilitiesTest extends WP_UnitTestCase {
 
+	public function test_existing_file_is_idempotent_but_write_failure_is_error(): void {
+		$parent = wp_tempnam( 'datamachine-scaffold' );
+		$this->assertNotFalse( $parent );
+
+		$existing = ScaffoldAbilities::execute(
+			array(
+				'filename' => 'TEST.md',
+				'filepath' => $parent,
+			)
+		);
+		$this->assertIsArray( $existing );
+		$this->assertTrue( $existing['success'] );
+		$this->assertFalse( $existing['created'] );
+
+		$generator = static function ( string $content, string $filename ): string {
+			return 'TEST.md' === $filename ? '# Test' : $content;
+		};
+		add_filter( 'datamachine_scaffold_content', $generator, 999, 2 );
+
+		try {
+			$failed = ScaffoldAbilities::execute(
+				array(
+					'filename' => 'TEST.md',
+					'filepath' => $parent . '/TEST.md',
+				)
+			);
+			$this->assertWPError( $failed );
+			$this->assertSame( 'scaffold_failed', $failed->get_error_code() );
+			$this->assertStringContainsString( 'Failed to write TEST.md', $failed->get_error_message() );
+		} finally {
+			remove_filter( 'datamachine_scaffold_content', $generator, 999 );
+			unlink( $parent ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Test fixture cleanup.
+		}
+	}
+
+	public function test_layer_scaffolding_skips_machine_managed_files(): void {
+		$result = ScaffoldAbilities::execute(
+			array(
+				'layer'      => 'agent',
+				'agent_slug' => 'scaffold-machine-managed-' . wp_generate_uuid4(),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+		$wake = array_values( array_filter( $result['files'], static fn( array $file ): bool => 'WAKE.md' === $file['filename'] ) );
+		$this->assertCount( 1, $wake );
+		$this->assertTrue( $wake[0]['skipped'] );
+		$this->assertFalse( $wake[0]['created'] );
+	}
+
 	public function test_layer_scaffolding_aggregates_per_file_failures(): void {
 		$result = ScaffoldAbilities::execute( array( 'layer' => 'principal' ) );
 

--- a/tests/Unit/Abilities/UpdateWordPressAbilityTest.php
+++ b/tests/Unit/Abilities/UpdateWordPressAbilityTest.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * UpdateWordPressAbility tests.
+ *
+ * @package DataMachine\Tests\Unit\Abilities
+ */
+
+namespace DataMachine\Tests\Unit\Abilities;
+
+use DataMachine\Abilities\Update\UpdateWordPressAbility;
+use WP_UnitTestCase;
+
+class UpdateWordPressAbilityTest extends WP_UnitTestCase {
+
+	public function test_missing_source_url_returns_bad_request_error(): void {
+		$result = ( new UpdateWordPressAbility() )->execute( array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wordpress_update_source_url_required', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+		$this->assertArrayHasKey( 'logs', $result->get_error_data() );
+	}
+
+	public function test_invalid_source_url_returns_bad_request_error(): void {
+		$result = ( new UpdateWordPressAbility() )->execute(
+			array( 'source_url' => 'not-a-wordpress-url' )
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wordpress_update_source_url_invalid', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+		$this->assertSame( 'not-a-wordpress-url', $result->get_error_data()['source_url'] );
+	}
+
+	public function test_missing_post_returns_not_found_error(): void {
+		$result = ( new UpdateWordPressAbility() )->execute(
+			array( 'source_url' => home_url( '/?p=999999999' ) )
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wordpress_update_post_not_found', $result->get_error_code() );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
+		$this->assertSame( 999999999, $result->get_error_data()['post_id'] );
+	}
+
+	public function test_wp_update_post_failure_returns_stable_error_with_core_error_data(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_title'   => 'Original title',
+				'post_content' => 'Body',
+			)
+		);
+		$fail    = static fn() => true;
+
+		add_filter( 'wp_insert_post_empty_content', $fail );
+		try {
+			$result = ( new UpdateWordPressAbility() )->execute(
+				array(
+					'source_url' => get_permalink( $post_id ),
+					'title'      => 'Changed title',
+				)
+			);
+		} finally {
+			remove_filter( 'wp_insert_post_empty_content', $fail );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wordpress_post_update_failed', $result->get_error_code() );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+		$this->assertSame( $post_id, $result->get_error_data()['post_id'] );
+		$this->assertSame( 'empty_content', $result->get_error_data()['wp_error_code'] );
+	}
+
+	public function test_nested_block_error_is_returned_unchanged(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		$result = ( new UpdateWordPressAbility() )->execute(
+			array(
+				'source_url'    => get_permalink( $post_id ),
+				'block_updates' => array(
+					array(
+						'block_index' => 99,
+						'find'        => 'Body',
+						'replace'     => 'Changed',
+					),
+				),
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'edit_operations_failed', $result->get_error_code() );
+		$this->assertSame( 422, $result->get_error_data()['status'] );
+		$this->assertSame( $post_id, $result->get_error_data()['post_id'] );
+	}
+
+	public function test_mixed_block_and_surgical_updates_fail_before_writing(): void {
+		$original = '<!-- wp:paragraph --><p>Original body</p><!-- /wp:paragraph -->';
+		$post_id  = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => $original,
+			)
+		);
+
+		$result = ( new UpdateWordPressAbility() )->execute(
+			array(
+				'source_url'    => get_permalink( $post_id ),
+				'updates'       => array(
+					array(
+						'find'    => 'Original',
+						'replace' => 'Surgical',
+					),
+				),
+				'block_updates' => array(
+					array(
+						'block_index' => 0,
+						'find'        => 'Original',
+						'replace'     => 'Block',
+					),
+				),
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wordpress_update_mixed_mutation_modes', $result->get_error_code() );
+		$this->assertSame( array( 'updates' ), $result->get_error_data()['conflicts_with'] );
+		$this->assertSame( $original, get_post( $post_id )->post_content );
+	}
+
+	public function test_single_block_mutation_mode_remains_supported(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:paragraph --><p>Original body</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		$result = ( new UpdateWordPressAbility() )->execute(
+			array(
+				'source_url'    => get_permalink( $post_id ),
+				'block_updates' => array(
+					array(
+						'block_index' => 0,
+						'find'        => 'Original',
+						'replace'     => 'Updated',
+					),
+				),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertStringContainsString( 'Updated body', get_post( $post_id )->post_content );
+	}
+}

--- a/tests/Unit/Api/FileRestCompatibilityTest.php
+++ b/tests/Unit/Api/FileRestCompatibilityTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Legacy file REST compatibility tests.
+ *
+ * @package DataMachine\Tests\Unit\Api
+ */
+
+namespace DataMachine\Tests\Unit\Api;
+
+use DataMachine\Api\AgentFiles;
+use DataMachine\Api\FlowFiles;
+use WP_REST_Request;
+use WP_UnitTestCase;
+
+class FileRestCompatibilityTest extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+	}
+
+	public function test_agent_file_adapter_preserves_public_error_code(): void {
+		$request = new WP_REST_Request( 'GET', '/datamachine/v1/files/agent/missing-review-file.txt' );
+		$request->set_param( 'filename', 'missing-review-file.txt' );
+
+		$result = AgentFiles::get_agent_file( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'get_agent_file_error', $result->get_error_code() );
+		$this->assertSame( 'agent_file_not_found', $result->get_error_data()['ability_error_code'] );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
+	}
+
+	public function test_flow_file_adapter_preserves_public_error_code(): void {
+		$request = new WP_REST_Request( 'GET', '/datamachine/v1/files/flow' );
+		$request->set_param( 'flow_step_id', 'missing-review-step' );
+
+		$result = FlowFiles::list_files( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'list_files_error', $result->get_error_code() );
+		$this->assertSame( 'flow_file_context_failed', $result->get_error_data()['ability_error_code'] );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
+	}
+}

--- a/tests/Unit/Core/Identity/AgentIdentityStoreAdapterTest.php
+++ b/tests/Unit/Core/Identity/AgentIdentityStoreAdapterTest.php
@@ -13,6 +13,7 @@ use DataMachine\Core\Database\Agents\AgentAccess;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Core\Identity\AgentIdentityStoreAdapter;
+use DataMachine\Engine\AI\MemoryFileRegistry;
 use DataMachine\Tests\Fixtures\CountingProvisionAdapter;
 use DataMachine\Tests\Fixtures\DuplicateLoserAgents;
 use DataMachine\Tests\Fixtures\FailingProvisionAdapter;
@@ -143,6 +144,27 @@ class AgentIdentityStoreAdapterTest extends WP_UnitTestCase {
 		$identity = $this->store->materialize( $scope );
 		$this->assertSame( $identity->id, $this->store->resolve( $scope )->id );
 		$this->assertNotEmpty( $this->repository->get_agent( $identity->id )['provisioned_at'] );
+	}
+
+	public function test_native_scaffold_error_does_not_complete_provisioning(): void {
+		$this->register_agent( 'scaffold-error-agent' );
+		$scope    = new WP_Agent_Identity_Scope( 'scaffold-error-agent', $this->owner_a, 'scaffold-error' );
+		$filename = 'SCAFFOLD-FAILURE.md';
+		MemoryFileRegistry::register( $filename, 999, array( 'layer' => MemoryFileRegistry::LAYER_AGENT ) );
+
+		try {
+			$this->store->materialize( $scope );
+			$this->fail( 'A native scaffold WP_Error must abort provisioning.' );
+		} catch ( \RuntimeException $exception ) {
+			$this->assertStringContainsString( 'Failed to scaffold', $exception->getMessage() );
+		} finally {
+			MemoryFileRegistry::deregister( $filename );
+		}
+
+		$row = $this->repository->get_by_identity_scope( 'scaffold-error-agent', $this->owner_a, 'scaffold-error' );
+		$this->assertSame( '', (string) $row['provisioning_token'] );
+		$this->assertEmpty( $row['provisioned_at'] );
+		$this->assertNull( $this->store->resolve( $scope ) );
 	}
 
 	public function test_duplicate_key_loser_reconciles_pending_winner(): void {

--- a/tests/ability-result-wp-error-smoke.php
+++ b/tests/ability-result-wp-error-smoke.php
@@ -111,6 +111,15 @@ $assert( 'WP_Error message is preserved', 'Permission denied.' === $wp_error_res
 $assert( 'WP_Error code is preserved', 'rest_forbidden' === $wp_error_result['wp_error_code'] );
 $assert( 'WP_Error data is preserved', 403 === ( $wp_error_result['wp_error_data']['status'] ?? null ) );
 
+$caller_error = AbilityResult::normalize( new WP_Error( 'edit_operations_failed', 'No edits were applied.', array( 'status' => 422 ) ) );
+$assert( 'legacy callers receive the native error message', 'No edits were applied.' === $caller_error['error'] );
+$assert( 'legacy callers receive the native error code', 'edit_operations_failed' === $caller_error['wp_error_code'] );
+
+$blocks_command_source = file_get_contents( __DIR__ . '/../inc/Cli/Commands/BlocksCommand.php' );
+$internal_task_source  = file_get_contents( __DIR__ . '/../inc/Engine/AI/System/Tasks/InternalLinkingTask.php' );
+$assert( 'blocks CLI normalizes every direct content ability result', 4 === substr_count( $blocks_command_source, 'AbilityResult::normalize(' ) );
+$assert( 'internal linking normalizes both direct content ability results', 2 === substr_count( $internal_task_source, 'AbilityResult::normalize(' ) );
+
 $array_result = array(
 	'success' => false,
 	'error'   => 'Legacy failure.',
@@ -307,6 +316,14 @@ $assert( 'REST result spec applies failure status callback', 404 === ( $rest_spe
 
 $native_spec_error = new WP_Error( 'native_queue_denied', 'Queue access denied.', array( 'status' => 403 ) );
 $assert( 'REST result spec preserves native WP_Error unchanged', $native_spec_error === RestResultSpec::item()->response( $native_spec_error ) );
+
+$legacy_file_error = RestResultSpec::legacy_error(
+	new WP_Error( 'agent_file_not_found', 'File not found.', array( 'status' => 404, 'filename' => 'missing.txt' ) ),
+	'get_agent_file_error'
+);
+$assert( 'legacy file adapter preserves public REST error code', 'get_agent_file_error' === $legacy_file_error->get_error_code() );
+$assert( 'legacy file adapter preserves native ability error code', 'agent_file_not_found' === ( $legacy_file_error->get_error_data()['ability_error_code'] ?? '' ) );
+$assert( 'legacy file adapter preserves native status and diagnostics', 404 === ( $legacy_file_error->get_error_data()['status'] ?? 0 ) && 'missing.txt' === ( $legacy_file_error->get_error_data()['filename'] ?? '' ) );
 
 $GLOBALS['datamachine_test_abilities']['datamachine/test-rest'] = new class() {
 	public function execute( array $input ): array {

--- a/tests/content-format-abilities-smoke.php
+++ b/tests/content-format-abilities-smoke.php
@@ -686,8 +686,8 @@ namespace {
 			'content'   => "# Missing Declaration\n\nThis is markdown, not serialized blocks.",
 		)
 	);
-	assert_content_ability( 'raw-upsert-omitted-format-treats-markdown-as-blocks', false === $raw_markdown_without_format['success'] );
-	assert_content_ability( 'raw-upsert-omitted-markdown-fails-loudly', 'datamachine_content_format_blocks_missing_comments' === ( $raw_markdown_without_format['error_code'] ?? '' ) );
+	assert_content_ability( 'raw-upsert-omitted-format-treats-markdown-as-blocks', is_wp_error( $raw_markdown_without_format ) );
+	assert_content_ability( 'raw-upsert-omitted-markdown-fails-loudly', 'datamachine_content_format_blocks_missing_comments' === $raw_markdown_without_format->get_error_code() );
 	assert_content_ability( 'raw-upsert-omitted-markdown-does-not-write-post', $posts_before_raw_markdown_default === content_ability_post_count() );
 	assert_content_ability( 'internal-upsert-execute-callers-are-explicitly-audited', array() === content_ability_raw_upsert_execute_callers() );
 
@@ -724,8 +724,8 @@ namespace {
 			'content_format' => 'blocks',
 		)
 	);
-	assert_content_ability( 'malformed-blocks-source-fails', false === $malformed_blocks['success'] );
-	assert_content_ability( 'malformed-blocks-source-preserves-transformer-error-code', 'datamachine_content_format_blocks_unclosed_comment' === ( $malformed_blocks['error_code'] ?? '' ) );
+	assert_content_ability( 'malformed-blocks-source-fails', is_wp_error( $malformed_blocks ) );
+	assert_content_ability( 'malformed-blocks-source-preserves-transformer-error-code', 'datamachine_content_format_blocks_unclosed_comment' === $malformed_blocks->get_error_code() );
 	assert_content_ability( 'malformed-blocks-source-does-not-write-post', $posts_before_malformed === content_ability_post_count() );
 
 	$conversion_error = DataMachine\Abilities\Content\UpsertPostAbility::execute(
@@ -736,8 +736,8 @@ namespace {
 			'content_format' => 'markdown',
 		)
 	);
-	assert_content_ability( 'blocks-engine-conversion-error-fails', false === $conversion_error['success'] );
-	assert_content_ability( 'blocks-engine-conversion-error-code-is-distinct-from-missing-transformer', 'datamachine_content_format_blocks_engine_conversion_failed' === ( $conversion_error['error_code'] ?? '' ) );
+	assert_content_ability( 'blocks-engine-conversion-error-fails', is_wp_error( $conversion_error ) );
+	assert_content_ability( 'blocks-engine-conversion-error-code-is-distinct-from-missing-transformer', 'datamachine_content_format_blocks_engine_conversion_failed' === $conversion_error->get_error_code() );
 
 	$tool = DataMachine\Abilities\Content\UpsertPostAbility::getChatTool();
 	assert_content_ability( 'chat-tool-content-format-is-optional', ! in_array( 'content_format', $tool['required'] ?? array(), true ) );

--- a/tests/wordpress-publish-content-format-smoke.php
+++ b/tests/wordpress-publish-content-format-smoke.php
@@ -18,6 +18,12 @@ namespace DataMachine\Core {
 }
 
 namespace {
+    if ( ! function_exists( 'wp_register_ability' ) ) {
+        function wp_register_ability( string $name, array $args ): void {
+            $GLOBALS['__publish_format_abilities'][ $name ] = $args;
+        }
+    }
+
     if ( ! defined( 'ABSPATH' ) ) {
         define( 'ABSPATH', __DIR__ . '/' );
     }
@@ -41,11 +47,12 @@ namespace {
 
             private string $code;
             private string $message;
+            private $data;
 
             public function __construct( string $code = '', string $message = '', $data = null ) {
-                unset( $data );
                 $this->code    = $code;
                 $this->message = $message;
+                $this->data    = $data;
             }
 
             public function get_error_code(): string {
@@ -57,7 +64,7 @@ namespace {
             }
 
             public function get_error_data() {
-                return null;
+                return $this->data;
             }
         }
     }
@@ -67,6 +74,7 @@ namespace {
     $GLOBALS['__publish_format_meta']        = array();
     $GLOBALS['__publish_format_next_id']     = 100;
     $GLOBALS['__publish_format_conversions'] = array();
+    $GLOBALS['__publish_format_taxonomy_failure'] = '';
 
     if ( ! function_exists( 'doing_action' ) ) {
         function doing_action( string $hook ): bool {
@@ -198,6 +206,33 @@ namespace {
         }
     }
 
+    if ( ! function_exists( 'get_term_by' ) ) {
+        function get_term_by( string $field, $value, string $taxonomy ) {
+            unset( $field, $value, $taxonomy );
+            return false;
+        }
+    }
+
+    if ( ! function_exists( 'wp_insert_term' ) ) {
+        function wp_insert_term( $term, string $taxonomy ) {
+            unset( $taxonomy );
+            if ( 'insert' === $GLOBALS['__publish_format_taxonomy_failure'] ) {
+                return new WP_Error( 'term_insert_failed', 'Term creation failed.' );
+            }
+            return array( 'term_id' => crc32( (string) $term ) );
+        }
+    }
+
+    if ( ! function_exists( 'wp_set_object_terms' ) ) {
+        function wp_set_object_terms( int $post_id, array $term_ids, string $taxonomy ) {
+            unset( $post_id, $taxonomy );
+            if ( 'assign' === $GLOBALS['__publish_format_taxonomy_failure'] ) {
+                return new WP_Error( 'term_assignment_failed', 'Term assignment failed.' );
+            }
+            return $term_ids;
+        }
+    }
+
     if ( ! function_exists( 'update_post_meta' ) ) {
         function update_post_meta( int $post_id, string $key, $value ): void {
             $GLOBALS['__publish_format_meta'][ $post_id ][ $key ] = $value;
@@ -292,6 +327,11 @@ namespace {
 
     $ability = new \DataMachine\Abilities\Publish\PublishWordPressAbility();
 
+    $invalid_result = $ability->execute( array( 'title' => '', 'content' => '', 'post_type' => 'post' ) );
+    assert_publish_format( 'invalid-publish-returns-native-error', is_wp_error( $invalid_result ) );
+    assert_publish_format( 'invalid-publish-error-has-stable-code', 'publish_parameters_required' === $invalid_result->get_error_code() );
+    assert_publish_format( 'invalid-publish-error-has-http-status', 400 === ( $invalid_result->get_error_data()['status'] ?? 0 ) );
+
     $html_result = $ability->execute(
         array(
             'title'      => 'HTML post',
@@ -358,6 +398,22 @@ namespace {
     assert_publish_format( 'markdown-backed-post-type-publish-succeeds', true === ( $wiki_result['success'] ?? false ) );
     assert_publish_format( 'markdown-backed-post-type-stores-markdown', false === strpos( $wiki_content, '<!-- wp:' ) );
     assert_publish_format( 'markdown-backed-attribution-stays-markdown', false !== strpos( $wiki_content, '**Source:** [https://example.test/wiki](https://example.test/wiki)' ) );
+
+    $posts_before_taxonomy_failure = count( $GLOBALS['__publish_format_posts'] );
+    $GLOBALS['__publish_format_taxonomy_failure'] = 'insert';
+    $partial_taxonomy_result = $ability->execute(
+        array(
+            'title'      => 'Partial taxonomy post',
+            'content'    => '<p>Persist this post.</p>',
+            'post_type'  => 'post',
+            'taxonomies' => array( 'category' => array( 'Broken term' ) ),
+        )
+    );
+    $GLOBALS['__publish_format_taxonomy_failure'] = '';
+    assert_publish_format( 'taxonomy-failure-does-not-report-total-publish-failure', true === ( $partial_taxonomy_result['success'] ?? false ) );
+    assert_publish_format( 'taxonomy-failure-leaves-created-post-observable', $posts_before_taxonomy_failure + 1 === count( $GLOBALS['__publish_format_posts'] ) );
+    assert_publish_format( 'taxonomy-failure-is-returned-in-structured-diagnostics', 'term_insert_failed' === ( $partial_taxonomy_result['taxonomy_results']['category']['errors'][0]['code'] ?? '' ) );
+    assert_publish_format( 'taxonomy-failure-is-logged-as-warning', in_array( 'warning', array_column( $partial_taxonomy_result['logs'], 'level' ), true ) );
 
     $ability_source = file_get_contents( dirname( __DIR__ ) . '/inc/Abilities/Publish/PublishWordPressAbility.php' );
     $handler_source = file_get_contents( dirname( __DIR__ ) . '/inc/Core/Steps/Publish/Handlers/WordPress/WordPress.php' );


### PR DESCRIPTION
## Summary
- migrate content, file, fetch, publish, update, and scaffold callback failures to native `WP_Error`
- preserve nested HTTP status/data and legacy REST/CLI presentation contracts while removing object-as-array paths
- prevent mixed update partial writes, surface scaffold provisioning failures, and retain tolerant taxonomy partial-success diagnostics
- add direct regression coverage for identity, fetch, update, file REST, publish, and scaffold failure behavior

## Verification
- changed-scope PHPCS, PHPStan, and syntax: pass
- changed-scope audit: 0 introduced findings
- focused content/fetch/file/publish/scaffold smokes: 264 assertions pass
- `git diff --check`: pass

Filtered WP Codebox PHPUnit was unavailable because the MySQL runtime could not provision Docker; focused executable smokes and static gates pass.

Closes #3239