### PR TITLE
Align direct ability permission test with WordPress

### DIFF
--- a/tests/Unit/Abilities/PermissionHelperTest.php
+++ b/tests/Unit/Abilities/PermissionHelperTest.php
@@ -340,6 +340,7 @@ class PermissionHelperTest extends WP_UnitTestCase {
 			456
 		);
 
+		$this->setExpectedIncorrectUsage( 'WP_Ability::execute' );
 		$result = $ability->execute( array() );
 
 		$this->assertWPError( $result );

--- a/tests/Unit/Abilities/PermissionHelperTest.php
+++ b/tests/Unit/Abilities/PermissionHelperTest.php
@@ -343,7 +343,7 @@ class PermissionHelperTest extends WP_UnitTestCase {
 		$result = $ability->execute( array() );
 
 		$this->assertWPError( $result );
-		$this->assertSame( 'datamachine_ability_scope_denied', $result->get_error_code() );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
 	}
 
 	public function test_view_analytics_granted_to_manage_flows_holder(): void {


### PR DESCRIPTION
## Summary

- assert the public `WP_Ability::execute()` permission error code
- retain the adjacent filter-level assertion for Data Machine’s specific scope-denial code
- align the test with the WordPress 7.1 ability lifecycle contract

Closes #3260.

## Verification

- `vendor/bin/phpcs tests/Unit/Abilities/PermissionHelperTest.php`
- inspected current `WP_Ability::execute()` implementation: non-true permission results are returned as `ability_invalid_permissions`
- focused WP Codebox execution was attempted but could not start because the local verifier could not resolve the `docker` executable while provisioning MySQL; CI provides the authoritative replay

## AI assistance

GPT-5.6-sol via OpenCode extracted the structured CI failure, verified the WordPress core contract, implemented the assertion change, and ran lint plus the attempted focused verification. Chris Huber reviewed the change and remains responsible for every line.