### PR TITLE
fix: preserve scheduled batch state

### DIFF
--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -379,12 +379,15 @@ class BatchScheduler {
 	 *   has been lost; consumer must fail the parent in that case.
 	 */
 	public static function processChunk( int $parent_job_id, callable $createItem, ?int $expected_offset = null ): array {
-		$parent_engine = datamachine_get_engine_data( $parent_job_id );
+		// A scheduled chunk starts in a separate request. Read through the jobs
+		// table so stale persistent-cache state cannot hide a committed worklist.
+		$parent_job    = ( new Jobs() )->get_job( $parent_job_id );
+		$parent_engine = is_array( $parent_job['engine_data'] ?? null ) ? $parent_job['engine_data'] : array();
 		if ( self::STORAGE_VERSION === (int) ( $parent_engine['batch_storage_version'] ?? 0 ) ) {
 			return self::processV2Chunk( $parent_job_id, $createItem, $expected_offset, $parent_engine );
 		}
 
-		return self::processLegacyChunk( $parent_job_id, $createItem, $expected_offset );
+		return self::processLegacyChunk( $parent_job_id, $createItem, $expected_offset, $parent_engine );
 	}
 
 	/** Process a durable v2 worklist chunk. */
@@ -721,9 +724,8 @@ class BatchScheduler {
 	}
 
 	/** Existing engine_data worklist processor for persisted v1 batches. */
-	private static function processLegacyChunk( int $parent_job_id, callable $createItem, ?int $expected_offset = null ): array {
-		$parent_engine = datamachine_get_engine_data( $parent_job_id );
-		$batch_state   = $parent_engine['batch_state'] ?? null;
+	private static function processLegacyChunk( int $parent_job_id, callable $createItem, ?int $expected_offset, array $parent_engine ): array {
+		$batch_state = $parent_engine['batch_state'] ?? null;
 
 		if ( ! is_array( $batch_state ) ) {
 			if ( null !== $expected_offset && ! empty( $parent_engine['batch'] ) ) {

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -400,6 +400,26 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$this->assertEquals( 2, $parent_engine['batch_scheduled'] );
 	}
 
+	public function test_scheduled_chunk_reads_persisted_batch_state_when_cache_is_stale(): void {
+		$parent_id = $this->create_parent_job();
+		$engine    = $this->make_engine_snapshot( $parent_id );
+		$stale     = datamachine_get_engine_data( $parent_id );
+		$packets   = array(
+			$this->make_data_packet( 'Event A' ),
+			$this->make_data_packet( 'Event B' ),
+		);
+
+		$scheduler = new PipelineBatchScheduler();
+		$scheduler->fanOut( $parent_id, 'step_abc_123', $packets, $engine );
+
+		wp_cache_set( $parent_id, $stale, 'datamachine_engine_data' );
+		$scheduler->processChunk( $parent_id, 0 );
+
+		$parent_job = $this->jobs_db->get_job( $parent_id );
+		$this->assertStringNotContainsString( 'batch_state_missing', (string) $parent_job['status'] );
+		$this->assertCount( 2, $this->jobs_db->get_children( $parent_id ) );
+	}
+
 	public function test_process_chunk_propagates_claim_ownership_to_children(): void {
 		$parent_id = $this->create_parent_job();
 		$engine    = $this->make_engine_snapshot( $parent_id );
@@ -541,8 +561,11 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 			$this->assertTrue( ( new ProcessedItems() )->owns_active_claim( $claims[ $item_identifier ], $parent_id ), 'Worklist adoption must precede child ownership transfer at index ' . $index );
 		}
 
+		wp_cache_delete( $parent_id, 'datamachine_engine_data' );
+		$this->assertArrayHasKey( 'batch_state', datamachine_get_engine_data( $parent_id ) );
+
 		$scheduler = new PipelineBatchScheduler();
-		$scheduler->processChunk( $parent_id );
+		$scheduler->processChunk( $parent_id, 0 );
 
 		$children = $wpdb->get_results(
 			$wpdb->prepare( 'SELECT job_id, label FROM %i WHERE parent_job_id = %d', $wpdb->prefix . 'datamachine_jobs', $parent_id ),

--- a/tests/fanout-adoption-recovery-smoke.php
+++ b/tests/fanout-adoption-recovery-smoke.php
@@ -60,7 +60,13 @@ namespace DataMachine\Core\Database\BatchItems {
 }
 
 namespace DataMachine\Core\Database\Jobs {
-	class Jobs {}
+	class Jobs {
+		public static array $engines = array();
+		public function get_job( int $job_id ): ?array {
+			$engine = self::$engines[ $job_id ] ?? \DataMachine\Core\EngineData::$engines[ $job_id ] ?? array();
+			return array( 'engine_data' => $engine );
+		}
+	}
 }
 
 namespace DataMachine\Core {
@@ -91,6 +97,7 @@ namespace DataMachine\Core {
 namespace {
 	use DataMachine\Core\ActionScheduler\BatchScheduler;
 	use DataMachine\Core\Database\BatchItems\BatchItems;
+	use DataMachine\Core\Database\Jobs\Jobs;
 	use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 	use DataMachine\Core\EngineData;
 
@@ -175,6 +182,14 @@ namespace {
 	BatchScheduler::processChunk( 20, $create_child, 0 );
 	BatchScheduler::processChunk( 20, $create_child, 0 );
 	$assert( 1 === $children, 'duplicate recovered chunk delivery creates exactly one child' );
+
+	EngineData::$engines[30] = array();
+	BatchScheduler::start( 30, 'fanout_hook', array( $item ), array(), 'pipeline', BatchScheduler::COMPLETION_STRATEGY_CHILDREN_COMPLETE );
+	Jobs::$engines[30]       = EngineData::$engines[30];
+	EngineData::$engines[30] = array();
+	$scheduled_children      = 0;
+	BatchScheduler::processChunk( 30, static function () use ( &$scheduled_children ): int { return ++$scheduled_children; }, 0 );
+	$assert( 1 === $scheduled_children, 'scheduled chunk reads durable batch state when the persistent cache is stale' );
 
 	echo "fanout-adoption-recovery-smoke: {$passes} passed, {$failures} failed\n";
 	exit( $failures > 0 ? 1 : 0 );


### PR DESCRIPTION
## Summary
- read batch parent engine data directly from the jobs table when a scheduled chunk crosses into a new request
- keep v2 and legacy chunk dispatch on the same fresh parent snapshot so stale persistent object-cache entries cannot hide committed batch state
- add PHPUnit and executable smoke coverage for a durable v2 worklist with a stale pre-fan-out cache snapshot

## Root cause
`BatchScheduler::start()` committed the storage-v2 worklist and `batch_state` to the parent job before scheduling `datamachine_pipeline_batch_chunk`. When that hook ran in a later Action Scheduler request, `BatchScheduler::processChunk()` loaded the parent through `datamachine_get_engine_data()`, which prefers the persistent object cache. A stale pre-fan-out Redis entry therefore made the committed jobs-table `batch_state` appear missing. The v2 consumer failed the still-processing parent with `batch_state_missing`, finalized the worklist, and never scheduled a child.

The fix belongs in Data Machine's canonical `BatchScheduler` lifecycle because this is the shared scheduler/storage boundary for pipeline and task batches. Consumers should not compensate for stale cache snapshots or reconstruct canonical batch state.

## Production evidence
Events job 883429, Dice.fm flow 815 / pipeline 211:

```
Status: failed
Reason: batch_state_missing
Batch: true
Batch Storage Version: 2
Batch Total: 5
Batch Scheduled: 0
Batch Hook: datamachine_pipeline_batch_chunk
Batch Completion Strategy: children_complete
```

The persisted Action Scheduler action ran once with `{"parent_job_id":883429,"offset":0}` and completed without creating children. A Classic Center parent in the same scheduled run failed identically.

Closes #3262

## Tests
- `php tests/fanout-adoption-recovery-smoke.php` - 10 passed, 0 failed, including the stale-cache/durable-row scheduler regression
- `php tests/batch-completion-strategy-smoke.php` - all passed
- `php tests/task-scheduler-batch-parent-link-smoke.php` - all passed
- `php tests/pipeline-batch-terminal-parent-guard-smoke.php` - 4 passed, 0 failed
- `php tests/batch-child-agent-id-smoke.php` - all passed
- `php tests/parallel-map-fanout-adapter-smoke.php` - 35 passed
- `homeboy review lint data-machine --placement local --changed-since origin/main` - PHPCS and PHPStan passed with no findings
- `vendor/bin/phpcs inc/Core/ActionScheduler/BatchScheduler.php tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php` - passed

A focused canonical PHPUnit regression was added to `PipelineBatchSchedulerTest`. The local managed PHPUnit command could not execute because WP Codebox returned `PHPUNIT_ZERO_TESTS cause=recipe_run_payload_unparseable`; PR CI should rerun the canonical suite.

## Residual risk
The fresh jobs-table read adds one uncached parent-row query per batch chunk, intentionally at the cross-request correctness boundary. After deployment, verify fresh scheduled Dice.fm and Classic Center parents retain storage-v2 state, schedule every eligible child, and reconcile through `children_complete` without `batch_state_missing`.