### PR TITLE
fix: reconcile scheduled packet claims

### DIFF
--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -1256,8 +1256,11 @@ class AIStep extends Step {
 
 			$tool_def = $available_tools[ $tool_name ] ?? null;
 
-			$disposition_id = (string) ( $tool_result['disposition_id'] ?? $tool_parameters['disposition_id'] ?? '' );
-			$matched_claim  = '' !== $disposition_id && class_exists( ProcessedItems::class ) ? ProcessedItems::resolve_disposition_claim( $engine_data, $disposition_id, false ) : null;
+			$execution_parameters = is_array( $tool_result['metadata']['datamachine']['parameters'] ?? null )
+				? $tool_result['metadata']['datamachine']['parameters']
+				: array();
+			$disposition_id       = (string) ( $tool_result['disposition_id'] ?? $execution_parameters['disposition_id'] ?? $tool_parameters['disposition_id'] ?? '' );
+			$matched_claim        = '' !== $disposition_id && class_exists( ProcessedItems::class ) ? ProcessedItems::resolve_disposition_claim( $engine_data, $disposition_id, false ) : null;
 			if ( $is_handler_tool && ! empty( $active_claims ) && null === $matched_claim ) {
 				$tool_result = array(
 					'success'   => false,

--- a/inc/Core/Steps/AI/AIStep.php
+++ b/inc/Core/Steps/AI/AIStep.php
@@ -1256,9 +1256,7 @@ class AIStep extends Step {
 
 			$tool_def = $available_tools[ $tool_name ] ?? null;
 
-			$execution_parameters = is_array( $tool_result['metadata']['datamachine']['parameters'] ?? null )
-				? $tool_result['metadata']['datamachine']['parameters']
-				: array();
+			$execution_parameters = is_array( $tool_result['metadata']['datamachine']['parameters'] ?? null ) ? $tool_result['metadata']['datamachine']['parameters'] : array();
 			$disposition_id       = (string) ( $tool_result['disposition_id'] ?? $execution_parameters['disposition_id'] ?? $tool_parameters['disposition_id'] ?? '' );
 			$matched_claim        = '' !== $disposition_id && class_exists( ProcessedItems::class ) ? ProcessedItems::resolve_disposition_claim( $engine_data, $disposition_id, false ) : null;
 			if ( $is_handler_tool && ! empty( $active_claims ) && null === $matched_claim ) {

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -17,6 +17,7 @@ use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\EngineData;
 use DataMachine\Core\JobStatus;
+use DataMachine\Core\Steps\AI\AIStep;
 use DataMachine\Core\Steps\Fetch\Tools\FetchItemDispositionTool;
 use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
 use WP_UnitTestCase;
@@ -584,6 +585,76 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 			$replayed   = StepLifecycleHandler::reconcileStepOutput( $child_id, array( 'step_type' => 'ai' ), array( $result_packet ), true );
 			$this->assertTrue( $reconciled['success'] );
 			$this->assertTrue( $replayed['success'] );
+			$this->assertFalse( ( new ProcessedItems() )->has_active_claim( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] ) );
+		}
+	}
+
+	public function test_scheduled_fanout_reconciles_handler_identity_from_normalized_execution_parameters(): void {
+		$parent_id = $this->create_parent_job();
+		$packets   = array();
+		$claims    = array();
+		foreach ( array( 'event-a' => 'Event A', 'event-b' => 'Event B' ) as $item_identifier => $title ) {
+			$claim                    = $this->claim_for_parent( $parent_id, $item_identifier );
+			$claims[ $title ]         = $claim;
+			$packet                   = $this->make_data_packet( $title );
+			$packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] = $claim;
+			$packets[] = $packet;
+		}
+
+		$scheduler = new PipelineBatchScheduler();
+		$children  = array();
+		foreach ( $packets as $index => $packet ) {
+			$child_id = $scheduler->createChildJobFromBatch( $packet, array( 'next_flow_step_id' => 'ai-step' ), $parent_id, $index, 'packet-' . $index );
+			$this->assertIsInt( $child_id );
+			$children[] = array(
+				'job_id' => $child_id,
+				'label'  => $packet['data']['title'],
+			);
+		}
+		$this->assertCount( 2, $children );
+
+		$process_results = new \ReflectionMethod( AIStep::class, 'processLoopResults' );
+		foreach ( $children as $child ) {
+			$child_id = (int) $child['job_id'];
+			$claim    = $claims[ $child['label'] ];
+			$this->assertTrue( ( new ProcessedItems() )->owns_active_claim( $claim, $child_id ) );
+
+			$output = $process_results->invoke(
+				null,
+				array(
+					'messages'               => array(),
+					'tool_execution_results' => array(
+						array(
+							'tool_name'       => 'upsert_event',
+							'parameters'      => array( 'title' => $child['label'] ),
+							'is_handler_tool' => true,
+							'result'          => array(
+								'success'  => true,
+								'metadata' => array(
+									'datamachine' => array(
+										'parameters' => array(
+											'title'          => $child['label'],
+											'disposition_id' => $claim['disposition_id'],
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+				array( $this->make_data_packet( $child['label'] ) ),
+				array(
+					'flow_step_id' => 'ai-step',
+					'engine_data'  => datamachine_get_engine_data( $child_id ),
+				),
+				array( 'upsert_event' => array( 'handler' => 'upsert_event', 'handler_config' => array() ) )
+			);
+
+			$this->assertCount( 1, $output );
+			$this->assertSame( 'ai_handler_complete', $output[0]['type'] );
+			$this->assertSame( $claim['disposition_id'], $output[0]['metadata']['disposition_id'] );
+			$reconciled = StepLifecycleHandler::reconcileStepOutput( $child_id, array( 'step_type' => 'ai' ), $output, true );
+			$this->assertTrue( $reconciled['success'] );
 			$this->assertFalse( ( new ProcessedItems() )->has_active_claim( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] ) );
 		}
 	}

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -655,6 +655,8 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 			$this->assertSame( $claim['disposition_id'], $output[0]['metadata']['disposition_id'] );
 			$reconciled = StepLifecycleHandler::reconcileStepOutput( $child_id, array( 'step_type' => 'ai' ), $output, true );
 			$this->assertTrue( $reconciled['success'] );
+			$this->assertSame( 1, $reconciled['retained'] );
+			$this->assertTrue( StepLifecycleHandler::handleCompleted( $child_id ) );
 			$this->assertFalse( ( new ProcessedItems() )->has_active_claim( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] ) );
 		}
 	}

--- a/tests/upsert-handler-result-handoff-smoke.php
+++ b/tests/upsert-handler-result-handoff-smoke.php
@@ -71,6 +71,8 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 
 require_once __DIR__ . '/../inc/Core/DataPacket.php';
 require_once __DIR__ . '/../inc/Core/PluginSettings.php';
+require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
+require_once __DIR__ . '/../inc/Core/Database/ProcessedItems/ProcessedItems.php';
 require_once __DIR__ . '/../inc/Core/Steps/Step.php';
 require_once __DIR__ . '/../inc/Core/Steps/StepTypeRegistrationTrait.php';
 require_once __DIR__ . '/../inc/Core/Steps/QueueableTrait.php';
@@ -97,6 +99,7 @@ require_once __DIR__ . '/../inc/Engine/AI/conversation-loop.php';
 require_once __DIR__ . '/../inc/Core/Steps/AI/AIStep.php';
 
 use DataMachine\Core\Steps\AI\AIStep;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Engine\AI\Tools\ToolPolicyResolver;
 use DataMachine\Engine\AI\Tools\ToolResultFinder;
 
@@ -206,6 +209,43 @@ $packets = $method->invoke(
 assert_handoff_equals( 1, count( $packets ), 'AI step emitted one downstream packet', $failures, $passes );
 assert_handoff_equals( 'ai_handler_complete', $packets[0]['type'] ?? null, 'AI step emitted handler-complete packet', $failures, $passes );
 assert_handoff_equals( 'wiki_upsert', $packets[0]['metadata']['handler_tool'] ?? null, 'packet carries required handler slug', $failures, $passes );
+
+$claim = array(
+	'identity_scope'  => 'ticketmaster-fetch',
+	'source_type'     => 'ticketmaster',
+	'item_identifier' => 'Z7r9jZ1A7-sr_',
+	'ownership_token' => 'scheduled-child-token',
+);
+$claim['disposition_id'] = ProcessedItems::disposition_identity( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] );
+$claimed_packets         = $method->invoke(
+	null,
+	array(
+		'messages'               => array(),
+		'tool_execution_results' => array(
+			array(
+				'tool_name'       => 'wiki_upsert',
+				'parameters'      => array( 'title' => 'Scheduled Ticketmaster Event' ),
+				'is_handler_tool' => true,
+				'result'          => array(
+					'success'  => true,
+					'metadata' => array(
+						'datamachine' => array(
+							'parameters' => array( 'disposition_id' => $claim['disposition_id'] ),
+						),
+					),
+				),
+			),
+		),
+	),
+	array( array( 'metadata' => array( 'source_type' => 'ticketmaster' ) ) ),
+	array(
+		'flow_step_id' => 'ai_step',
+		'engine_data'  => array( ProcessedItems::CLAIM_METADATA_KEY => $claim ),
+	),
+	$available_tools
+);
+assert_handoff_equals( 'ai_handler_complete', $claimed_packets[0]['type'] ?? null, 'normalized execution parameters preserve successful handler output', $failures, $passes );
+assert_handoff_equals( $claim['disposition_id'], $claimed_packets[0]['metadata']['disposition_id'] ?? null, 'normalized execution parameters identify the exact active claim', $failures, $passes );
 
 $found = ToolResultFinder::findHandlerResult( $packets, 'wiki_upsert', 'upsert_step', false );
 assert_handoff_equals( $packets[0], $found, 'ToolResultFinder finds packet by required handler slug', $failures, $passes );


### PR DESCRIPTION
## Summary
- recover the exact packet disposition identity from Data Machine's normalized execution parameters when the original model call omitted the inferable single-claim ID
- preserve successful handler output through `AIStep::processLoopResults()` so terminal reconciliation completes the scheduled child's exact owned claim
- cover the executor-to-AI-output handoff with a pure-PHP smoke assertion and a two-packet scheduled-fanout child integration regression

## Root Cause
The #3236/#3242 lifecycle fixes correctly bind each fanout packet to an exact claim, persist that descriptor into the scheduled child, and atomically transfer ownership from parent to child. For a child with one active claim, the tool executor can infer `disposition_id` and records the normalized executed parameters under `result.metadata.datamachine.parameters`.

At the next boundary, `AIStep::processLoopResults()` only inspected the result's top-level `disposition_id` and the original model-supplied parameters. Agents API mediation can preserve the inferred ID only in Data Machine's normalized result metadata, leaving both inspected locations empty. The successful handler output was therefore rewritten as `invalid_packet_disposition` with `Successful handler output did not identify an active packet claim.` even though the child still owned the exact claim.

The fix belongs in Data Machine's canonical packet lifecycle because this is the generic executor-result-to-packet reconciliation handoff used by every claim-bound handler. Ticketmaster and Data Machine Events correctly supplied packet identity and require no compensation.

## Production Evidence
Events job `885625`, Ticketmaster flow `469`, pipeline `109`:

```
Status: failed
Reason: tool_result_failed
Error: Successful handler output did not identify an active packet claim.
Created: 2026-08-20 08:51 ET
Completed: 2026-08-20 10:27 ET
Item Identifier: Z7r9jZ1A7-sr_
Source Type: ticketmaster
```

The job contains packet-disposition evidence, and the prior `packet disposition identity is required` signature is absent after Data Machine `0.175.4` / Data Machine Events `0.55.5`.

Closes #3263

## Tests
Passed locally:

- `homeboy review lint --changed-only --placement local` (PHPCS and PHPStan passed; final advisory alignment warnings corrected and PHPCS rerun clean)
- `php tests/upsert-handler-result-handoff-smoke.php` (16/16)
- `php tests/pipeline-child-claim-smoke.php` (1/1)
- `php tests/packet-disposition-contract-smoke.php` (6/6)
- `php tests/packet-reconciliation-transaction-smoke.php` (19/19)
- `vendor/bin/phpcs inc/Core/Steps/AI/AIStep.php tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php tests/upsert-handler-result-handoff-smoke.php` (clean)
- `git diff --check origin/main...HEAD` (clean)

The new MySQL-backed PHPUnit regression creates two deterministic scheduled fanout children, verifies each child owns its exact claim, reconciles a successful normalized handler result, and verifies terminal claim completion. Local WP Codebox could not run that MySQL path because this host has no `docker` executable; the SQLite fallback reaches PHPUnit but intentionally cannot execute Data Machine's MySQL `FOR UPDATE` ownership transaction. PR CI is the authoritative integration run.

## Residual Risk
- The fix relies on the existing Data Machine-owned normalized parameter envelope produced by the loop tool executor; top-level result and original model-parameter fallbacks remain unchanged.
- After deployment, run a newly scheduled multi-item Ticketmaster flow and verify its child jobs complete without `tool_result_failed`, each exact claim terminalizes, and job `885625`'s successor signature does not recur.