### PR TITLE
perf: add bounded job metadata reads

### DIFF
--- a/inc/Core/ActionScheduler/BatchScheduler.php
+++ b/inc/Core/ActionScheduler/BatchScheduler.php
@@ -677,7 +677,7 @@ class BatchScheduler {
 	 */
 	public static function finalize( int $parent_job_id ): bool {
 		$current = EngineData::retrieve( $parent_job_id );
-		$job     = ( new Jobs() )->get_job( $parent_job_id );
+		$job     = ( new Jobs() )->get_job_metadata( $parent_job_id );
 		if ( ! is_array( $job ) ) {
 			global $wpdb;
 			if ( '' !== (string) $wpdb->last_error ) {

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -400,7 +400,7 @@ class Jobs extends BaseRepository {
 			return false;
 		}
 
-		$job = $this->get_job( $job_id );
+		$job = $this->get_job_metadata( $job_id );
 		if ( ! is_array( $job ) || ! hash_equals( $claim_token, (string) ( $job['operation_claim_token'] ?? '' ) ) ) {
 			return false;
 		}
@@ -415,7 +415,7 @@ class Jobs extends BaseRepository {
 	 * Check whether an enqueue claim still owns the active generation.
 	 */
 	public function owns_operation_enqueue_claim( int $job_id, string $token, int $generation ): bool {
-		$job = $this->get_job( $job_id );
+		$job = $this->get_job_metadata( $job_id );
 
 		return is_array( $job )
 			&& 'enqueuing' === ( $job['operation_state'] ?? '' )
@@ -643,7 +643,7 @@ class Jobs extends BaseRepository {
 		if ( 1 === (int) $updated ) {
 			return true;
 		}
-		$job = false !== $updated ? $this->get_job( $job_id ) : null;
+		$job = false !== $updated ? $this->get_job_metadata( $job_id ) : null;
 		return is_array( $job )
 			&& 'enqueued' === (string) ( $job['operation_state'] ?? '' )
 			&& (int) ( $job['operation_generation'] ?? 0 ) === $generation
@@ -757,6 +757,20 @@ class Jobs extends BaseRepository {
 		$job = $this->decode_job_json( $job );
 
 		return $job;
+	}
+
+	/** Fetch job metadata without selecting or decoding JSON envelopes. */
+	public function get_job_metadata( int $job_id ): ?array {
+		if ( empty( $job_id ) ) {
+			return null;
+		}
+
+		$fields = 'job_id, user_id, agent_id, pipeline_id, flow_id, parent_job_id, source, label, status, created_at, completed_at, handler_slug, terminal_accounting_state, terminal_accounting_owner, terminal_accounting_claimed_at, terminal_accounting_processed_count, operation_state, operation_action_id, operation_claimed_at, operation_claim_token, operation_generation, operation_effects_begun_at, operation_step_id, operation_ref_hash, request_fingerprint';
+		// phpcs:disable WordPress.DB.PreparedSQL -- The nested prepare binds the plugin table identifier and job ID.
+		$job = $this->wpdb->get_row( $this->wpdb->prepare( "SELECT {$fields} FROM %i WHERE job_id = %d", $this->table_name, $job_id ), ARRAY_A );
+		// phpcs:enable WordPress.DB.PreparedSQL
+
+		return is_array( $job ) ? $job : null;
 	}
 
 	/** Decode JSON-backed columns returned by direct row reads. */

--- a/inc/Core/DirectJobEnqueuer.php
+++ b/inc/Core/DirectJobEnqueuer.php
@@ -47,7 +47,7 @@ class DirectJobEnqueuer {
 			return $this->failure( 'invalid_enqueue_target' );
 		}
 
-		$job                 = $this->jobs->get_job( $job_id );
+		$job                 = $this->jobs->get_job_metadata( $job_id );
 		$generation          = max( 0, (int) ( $job['operation_generation'] ?? 0 ) );
 		$token               = (string) ( $job['operation_claim_token'] ?? '' );
 		$args                = $this->actionArgs( $job_id, $flow_step_id, $generation, $token );
@@ -64,7 +64,7 @@ class DirectJobEnqueuer {
 
 		$claim = $this->jobs->claim_operation_enqueue( $job_id );
 		if ( false === $claim ) {
-			$job                 = $this->jobs->get_job( $job_id );
+			$job                 = $this->jobs->get_job_metadata( $job_id );
 			$current_generation  = max( 0, (int) ( $job['operation_generation'] ?? 0 ) );
 			$current_token       = (string) ( $job['operation_claim_token'] ?? '' );
 			$current_action_args = $this->actionArgs( $job_id, $flow_step_id, $current_generation, $current_token );
@@ -84,7 +84,7 @@ class DirectJobEnqueuer {
 		// recorded success. Reconcile that action before creating another one.
 		$scheduled_action_id = $this->scheduledActionId( $args );
 		if ( $scheduled_action_id > 0 ) {
-			return $this->reconcileScheduledAction( $job_id, $this->jobs->get_job( $job_id ), $scheduled_action_id, $generation, $token );
+			return $this->reconcileScheduledAction( $job_id, $this->jobs->get_job_metadata( $job_id ), $scheduled_action_id, $generation, $token );
 		}
 
 		if ( ! $this->jobs->owns_operation_enqueue_claim( $job_id, $token, $generation ) ) {
@@ -234,7 +234,7 @@ class DirectJobEnqueuer {
 			return $this->success( $action_id, $generation );
 		}
 
-		$reloaded = $this->jobs->get_job( $job_id );
+		$reloaded = $this->jobs->get_job_metadata( $job_id );
 		if ( is_array( $reloaded )
 			&& 'enqueued' === ( $reloaded['operation_state'] ?? '' )
 			&& (int) ( $reloaded['operation_generation'] ?? 0 ) === $generation

--- a/inc/Core/Steps/WebhookGate/WebhookGateStep.php
+++ b/inc/Core/Steps/WebhookGate/WebhookGateStep.php
@@ -96,7 +96,7 @@ class WebhookGateStep extends Step {
 
 				// Only fail the job if it's still waiting.
 				$db_jobs = new \DataMachine\Core\Database\Jobs\Jobs();
-				$job     = $db_jobs->get_job( $job_id );
+				$job     = $db_jobs->get_job_metadata( $job_id );
 
 				if ( ! $job || 'waiting' !== ( $job['status'] ?? '' ) ) {
 					return; // Job already resumed or failed.
@@ -298,7 +298,7 @@ class WebhookGateStep extends Step {
 
 		// Verify job is actually in waiting status.
 		$db_jobs = new \DataMachine\Core\Database\Jobs\Jobs();
-		$job     = $db_jobs->get_job( $job_id );
+		$job     = $db_jobs->get_job_metadata( $job_id );
 
 		if ( ! $job || 'waiting' !== ( $job['status'] ?? '' ) ) {
 			return new \WP_Error(

--- a/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
+++ b/tests/Unit/Core/Database/JobLifecycleTransitionTest.php
@@ -49,6 +49,41 @@ class JobLifecycleTransitionTest extends WP_UnitTestCase {
 		$this->assertSame( JobStatus::FAILED, $job['status'] );
 	}
 
+	public function test_metadata_read_does_not_materialize_large_json_envelopes(): void {
+		$large_value        = str_repeat( 'packet-', 128 );
+		$engine_data        = array( 'batch' => true, 'references' => array_fill( 0, 2000, $large_value ) );
+		$operation_envelope = array( 'steps' => array_fill( 0, 2000, $large_value ) );
+		$job_id             = $this->db_jobs->create_job(
+			array(
+				'label'              => 'Bounded metadata',
+				'engine_data'        => $engine_data,
+				'operation_envelope' => $operation_envelope,
+			)
+		);
+		$this->assertIsInt( $job_id );
+		unset( $large_value, $engine_data, $operation_envelope );
+		gc_collect_cycles();
+
+		$queries_before = get_num_queries();
+		$memory_before  = memory_get_usage();
+		$metadata       = $this->db_jobs->get_job_metadata( $job_id );
+		$memory_delta = memory_get_usage() - $memory_before;
+		$this->assertIsArray( $metadata );
+		$this->assertSame( JobStatus::PENDING, $metadata['status'] );
+		$this->assertArrayNotHasKey( 'engine_data', $metadata );
+		$this->assertArrayNotHasKey( 'operation_envelope', $metadata );
+		$this->assertSame( 1, get_num_queries() - $queries_before );
+		$this->assertStringNotContainsString( 'engine_data', strtolower( (string) $GLOBALS['wpdb']->last_query ) );
+		$this->assertStringNotContainsString( 'operation_envelope', strtolower( (string) $GLOBALS['wpdb']->last_query ) );
+		$this->assertLessThan( 1024 * 1024, $memory_delta, 'Metadata projection should not materialize either multi-megabyte JSON envelope.' );
+
+		$full = $this->db_jobs->get_job( $job_id );
+		$this->assertIsArray( $full['engine_data'] );
+		$this->assertCount( 2000, $full['engine_data']['references'] );
+		$this->assertIsArray( $full['operation_envelope'] );
+		$this->assertCount( 2000, $full['operation_envelope']['steps'] );
+	}
+
 	public function test_concurrent_pathless_child_recovery_has_one_owner(): void {
 		$parent_id = $this->db_jobs->create_job( array( 'label' => 'Recovery parent' ) );
 		$child_id  = $this->db_jobs->create_job( array( 'label' => 'Recovery child', 'parent_job_id' => $parent_id ) );

--- a/tests/direct-job-generation-smoke.php
+++ b/tests/direct-job-generation-smoke.php
@@ -27,6 +27,10 @@ final class DirectJobGenerationFakeJobs extends Jobs {
 		return 42 === $job_id ? $this->job : null;
 	}
 
+	public function get_job_metadata( int $job_id ): ?array {
+		return $this->get_job( $job_id );
+	}
+
 	public function claim_operation_enqueue( int $job_id, int $lease_seconds = 30 ): array|false {
 		$lease_seconds;
 		if ( 42 !== $job_id || $this->claim_blocked ) {


### PR DESCRIPTION
## Summary
- add an uncached metadata-only job projection that excludes large engine and operation envelopes
- migrate status, ownership, enqueue, webhook, and finalization callers that do not need payload data
- preserve full reads for lifecycle and batch consumers and add large-envelope/query-count regression coverage

## Verification
- changed-scope PHPCS and PHPStan pass
- changed-scope audit reports 0 introduced findings
- direct enqueue, batch terminal-parent, and prefix-policy smokes pass
- `git diff --check`

Closes #2928