### PR TITLE
refactor: remove vendor names from generic layer

### DIFF
--- a/docs/core-system/oauth-handlers.md
+++ b/docs/core-system/oauth-handlers.md
@@ -442,10 +442,7 @@ public function refresh_token(): bool; // Token refresh implementation
 
 **Providers Using BaseOAuth2Provider**:
 
-Core data-machine ships only `EmailAuth` (`inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php`). Concrete OAuth2 social/event providers live in extension plugins:
-
-- `data-machine-socials` — `RedditAuth`, `FacebookAuth`, `ThreadsAuth`, etc.
-- `data-machine-events` — `DiceFmAuth`, `TicketmasterAuth`, etc.
+Core data-machine ships only `EmailAuth` (`inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php`). Concrete OAuth2 providers live next to their handlers in extension plugins.
 
 **Example Implementation**:
 
@@ -675,8 +672,7 @@ Concrete OAuth providers self-register via the `datamachine_auth_providers` filt
 
 **In extension plugins:**
 
-- `data-machine-socials` — Bluesky, Twitter, Reddit, Facebook, Threads, etc.
-- `data-machine-events` — Dice.fm, Ticketmaster, etc.
+Concrete providers live next to their handlers and self-register through the provider filter.
 
 **Reusable provider pattern**:
 

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -689,12 +689,12 @@ Processed items (deduplication). **Alias**: `processed-item`. **Since**: 0.41.0
 ```bash
 # Audit processed-item rows by flow/handler
 wp datamachine processed-items audit
-wp datamachine processed-items audit --handler=ticketmaster --min-waste=0
+wp datamachine processed-items audit --handler=source_api --min-waste=0
 
 # Clear processed items for a pipeline or flow
 wp datamachine processed-items clear --pipeline=5 --yes
 wp datamachine processed-items clear --flow=10 --yes
-wp datamachine processed-items clear --handler=ticketmaster --after=2025-01-01 --dry-run
+wp datamachine processed-items clear --handler=source_api --after=2025-01-01 --dry-run
 wp datamachine processed-items clear --all --yes
 
 # Clean dedupe rows whose jobs have been purged

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -1428,7 +1428,7 @@ class ExecuteStepAbility {
 	 * The DataPacket structure stores the packet kind in the top-level 'type'
 	 * key (set by DataPacket::__construct's third argument).
 	 * 'metadata.source_type' carries the ORIGINAL input source_type (e.g.
-	 * 'ticketmaster', 'web_scraper') — never 'ai_handler_complete'. The
+	 * 'source_api', 'web_scraper') — never 'ai_handler_complete'. The
 	 * pre-#1096 implementation filtered on metadata.source_type, which was a
 	 * silent no-op that let every packet fan out into doomed child jobs.
 	 *

--- a/inc/Cli/Commands/Flows/BulkConfigCommand.php
+++ b/inc/Cli/Commands/Flows/BulkConfigCommand.php
@@ -69,11 +69,11 @@ class BulkConfigCommand extends BaseCommand {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # Preview: ramp max_items for all ticketmaster flows globally
-	 *     wp datamachine flows bulk-config --handler=ticketmaster --config='{"max_items":5}' --scope=global --dry-run
+	 *     # Preview: ramp max_items for all source_api flows globally
+	 *     wp datamachine flows bulk-config --handler=source_api --config='{"max_items":5}' --scope=global --dry-run
 	 *
-	 *     # Execute: update all dice_fm flows in pipeline 10
-	 *     wp datamachine flows bulk-config --handler=dice_fm --config='{"max_items":10}' --scope=pipeline --pipeline_id=10 --execute
+	 *     # Execute: update all catalog_import flows in pipeline 10
+	 *     wp datamachine flows bulk-config --handler=catalog_import --config='{"max_items":10}' --scope=pipeline --pipeline_id=10 --execute
 	 *
 	 *     # Execute: update a single flow
 	 *     wp datamachine flows bulk-config --handler=rss --config='{"max_items":3}' --scope=flow --flow_id=25 --execute

--- a/inc/Cli/Commands/ProcessedItemsCommand.php
+++ b/inc/Cli/Commands/ProcessedItemsCommand.php
@@ -39,7 +39,7 @@ class ProcessedItemsCommand extends BaseCommand {
 	 * ## OPTIONS
 	 *
 	 * [--handler=<handler_type>]
-	 * : Filter to a specific handler type (e.g., "ticketmaster", "dice_fm", "universal_web_scraper").
+	 * : Filter to a specific handler type (e.g., "source_api", "catalog_import", "web_scraper").
 	 *
 	 * [--pipeline=<pipeline_id>]
 	 * : Filter to a specific pipeline.
@@ -60,7 +60,7 @@ class ProcessedItemsCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     wp datamachine processed-items audit
-	 *     wp datamachine processed-items audit --handler=ticketmaster
+	 *     wp datamachine processed-items audit --handler=source_api
 	 *     wp datamachine processed-items audit --pipeline=3 --min-waste=0
 	 *
 	 * @subcommand audit
@@ -222,7 +222,7 @@ class ProcessedItemsCommand extends BaseCommand {
 	 * : Clear all processed items for this flow ID.
 	 *
 	 * [--handler=<handler_type>]
-	 * : Clear all processed items for this handler type (e.g., "ticketmaster", "dice_fm").
+	 * : Clear all processed items for this handler type (e.g., "source_api", "catalog_import").
 	 *
 	 * [--after=<date>]
 	 * : Only clear items processed after this date (YYYY-MM-DD or datetime).
@@ -243,10 +243,10 @@ class ProcessedItemsCommand extends BaseCommand {
 	 *
 	 *     wp datamachine processed-items clear --pipeline=12
 	 *     wp datamachine processed-items clear --flow=42
-	 *     wp datamachine processed-items clear --handler=ticketmaster --yes
-	 *     wp datamachine processed-items clear --handler=ticketmaster --after=2025-01-01
+	 *     wp datamachine processed-items clear --handler=source_api --yes
+	 *     wp datamachine processed-items clear --handler=source_api --after=2025-01-01
 	 *     wp datamachine processed-items clear --all --yes
-	 *     wp datamachine processed-items clear --handler=dice_fm --dry-run
+	 *     wp datamachine processed-items clear --handler=catalog_import --dry-run
 	 *
 	 * @subcommand clear
 	 */

--- a/inc/Cli/Commands/TestCommand.php
+++ b/inc/Cli/Commands/TestCommand.php
@@ -27,17 +27,17 @@ defined( 'ABSPATH' ) || exit;
  *     wp datamachine test --list
  *
  *     # Show config schema for a handler
- *     wp datamachine test ticketmaster --describe
+ *     wp datamachine test source_api --describe
  *
  *     # Test a handler with config
- *     wp datamachine test ticketmaster --config='{"lat":32.7,"lng":-79.9,"radius":50}'
- *     wp datamachine fetch test --handler=ticketmaster --config='{"lat":32.7,"lng":-79.9,"radius":50}'
+ *     wp datamachine test source_api --config='{"query":"example"}'
+ *     wp datamachine fetch test --handler=source_api --config='{"query":"example"}'
  *
  *     # Test using an existing flow's config
  *     wp datamachine test --flow=42
  *
  *     # Limit output and get JSON
- *     wp datamachine test ticketmaster --config='...' --limit=3 --format=json
+ *     wp datamachine test source_api --config='...' --limit=3 --format=json
  *
  * @since 0.55.3
  */
@@ -92,13 +92,13 @@ class TestCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     wp datamachine test --list
-	 *     wp datamachine test ticketmaster --describe
-	 *     wp datamachine test ticketmaster --config='{"lat":32.7,"lng":-79.9,"radius":50}'
-	 *     wp datamachine fetch test --handler=ticketmaster --config='{"lat":32.7,"lng":-79.9,"radius":50}'
+	 *     wp datamachine test source_api --describe
+	 *     wp datamachine test source_api --config='{"query":"example"}'
+	 *     wp datamachine fetch test --handler=source_api --config='{"query":"example"}'
 	 *     wp datamachine test rss --config='{"feed_url":"https://example.com/feed"}'
 	 *     wp datamachine test --flow=42
-	 *     wp datamachine test ticketmaster --config='...' --limit=3 --format=json
-	 *     wp datamachine test ticketmaster --config='...' --raw --byte-limit=1048576 --format=json
+	 *     wp datamachine test source_api --config='...' --limit=3 --format=json
+	 *     wp datamachine test source_api --config='...' --raw --byte-limit=1048576 --format=json
 	 *
 	 * @when after_wp_load
 	 */

--- a/inc/Engine/Bundle/AgentBundleAbilityService.php
+++ b/inc/Engine/Bundle/AgentBundleAbilityService.php
@@ -403,13 +403,13 @@ final class AgentBundleAbilityService {
 
 			// Pipeline-scoped handler fallback (primary): the unique-slug pass
 			// above misses for live-origin source flows because the bundle's slug
-			// was deduped at export ("dice-fm-101") and its `name` was renamed to
-			// "<Source> — <City>" (event-bundles#5), while the live row still
-			// carries the bare source label ("Dice.fm"). Neither editable label
+			// was deduped at export ("catalog-import-101") and its `name` was
+			// renamed to a contextual label, while the live row still carries the
+			// bare source label ("Catalog Import"). Neither editable label
 			// can meet the live row. The flow's import HANDLER, however, is
 			// rename-proof: within this already-matched parent pipeline a given
-			// source ("dice_fm", "ticketmaster") appears once — per-venue scrapers
-			// share `universal_web_scraper` but already resolved on the unique
+			// source ("catalog_import", "source_api") appears once; shared handlers
+			// already resolved on the unique
 			// slug pass before reaching here. So re-key BOTH sides on the
 			// normalized handler identity (bundle `steps[]` vs live `flow_config`).
 			// A unique match is unambiguous; a genuine in-pipeline handler

--- a/inc/Engine/Bundle/AgentBundleSlugMatcher.php
+++ b/inc/Engine/Bundle/AgentBundleSlugMatcher.php
@@ -33,7 +33,7 @@ final class AgentBundleSlugMatcher {
 	 * Index a set of existing rows by their effective normalized slug.
 	 *
 	 * When two or more rows resolve to the SAME normalized slug (e.g. four live
-	 * flows all named "Ticketmaster"), the slug is ambiguous: no single row can
+	 * flows all named "Catalog Import"), the slug is ambiguous: no single row can
 	 * be bound to the incoming bundle artifact without guessing. Ambiguous slugs
 	 * are omitted from the returned `matched` map and surfaced in `ambiguous`
 	 * so callers can refuse to guess.
@@ -87,8 +87,8 @@ final class AgentBundleSlugMatcher {
 	 * normalized display name and ignores `portable_slug` entirely. It exists
 	 * for the pipeline-scoped flow fallback in adopt: a live-origin flow row has
 	 * no slug column, so its only stable identity WITHIN an already-matched
-	 * parent pipeline is its source label (`flow_name` = "Ticketmaster",
-	 * "Dice.fm"). Within one city pipeline that label is unique, so keying on it
+	 * parent pipeline is its source label (`flow_name` = "Source API",
+	 * "Catalog Import"). Within one pipeline that label is unique, so keying on it
 	 * is unambiguous; across the whole agent it is not, which is why callers must
 	 * only ever hand this the live rows of a SINGLE matched pipeline.
 	 *
@@ -148,7 +148,7 @@ final class AgentBundleSlugMatcher {
 	 *
 	 * Unlike {@see self::bundle_slug()} (which prefers the artifact's UNIQUE
 	 * `slug`/`portable_slug`), this keys purely on the display name — the source
-	 * label ("Ticketmaster", "Dice.fm"). It is the bundle-side counterpart to
+	 * label ("Source API", "Catalog Import"). It is the bundle-side counterpart to
 	 * {@see self::index_existing_by_name()} and is used only for the
 	 * pipeline-scoped flow fallback: within a single matched pipeline the source
 	 * label uniquely identifies the flow, and the live row carries no slug to key
@@ -169,16 +169,15 @@ final class AgentBundleSlugMatcher {
 	/**
 	 * Compute the normalized HANDLER-identity key for a bundle flow.
 	 *
-	 * The display name is mutable: extrachill-event-bundles#5 renamed every
-	 * colliding bundle flow `name` from the bare source label ("Dice.fm") to
-	 * "<Source> — <City>" ("Dice.fm — Austin"), and the export-time global
-	 * dedupe appends a numeric suffix to the slug ("dice-fm-101"). Neither the
-	 * renamed name nor the deduped slug can meet the unchanged live `flow_name`
-	 * ("Dice.fm"). The flow's SOURCE handler, however, is rename-proof: the first
-	 * non-AI/non-output step's handler slug ("dice_fm", "ticketmaster",
-	 * "bandsintown") is the stable per-source identity that survives every UI
-	 * rename. Within a single city pipeline a given import source appears once
-	 * (per-venue scrapers all share `universal_web_scraper`, but those resolve on
+	 * The display name is mutable: a consumer may rename a bundle flow from the
+	 * bare source label ("Catalog Import") to a contextual label such as
+	 * "Catalog Import Primary", while export-time deduplication appends a numeric
+	 * suffix to the slug ("catalog-import-101"). Neither the renamed name nor the
+	 * deduped slug can meet the unchanged live `flow_name` ("Catalog Import"). The
+	 * flow's SOURCE handler, however, is rename-proof: the first non-AI/non-output
+	 * step's handler slug ("catalog_import", "source_api") is the stable
+	 * per-source identity that survives every UI rename. Within a single pipeline
+	 * a given import source appears once (shared handlers resolve on
 	 * the unique slug pass BEFORE this fallback is reached), so the handler key is
 	 * unambiguous there. This is the bundle-side counterpart to
 	 * {@see self::index_existing_by_handler()}.
@@ -407,9 +406,9 @@ final class AgentBundleSlugMatcher {
 	 *
 	 * Precedence: `portable_slug` -> `slug` -> display name. The bundle flow /
 	 * pipeline file carries a UNIQUE `slug` (the portable identity, e.g.
-	 * `ticketmaster`, `ticketmaster-4`) that the upgrade planner already keys
+	 * `catalog-import`, `catalog-import-4`) that the upgrade planner already keys
 	 * the ledger on. The display name is a NON-UNIQUE label — for flows it is
-	 * the source/handler ("Ticketmaster", "Dice.fm"), shared by hundreds of
+	 * the source/handler ("Source API", "Catalog Import"), shared by many
 	 * rows — so keying on it collapses distinct artifacts into one slug and
 	 * makes adopt refuse them as ambiguous. Preferring the artifact's own
 	 * `slug` before the display name keeps the bundle side keyed on the same

--- a/tests/Unit/Abilities/Engine/ExecuteStepFanOutFilterTest.php
+++ b/tests/Unit/Abilities/Engine/ExecuteStepFanOutFilterTest.php
@@ -39,15 +39,15 @@ class ExecuteStepFanOutFilterTest extends WP_UnitTestCase {
 		$packets = array(
 			$this->make_packet(
 				'ai_handler_complete',
-				array( 'handler_tool' => 'upsert_event', 'source_type' => 'ticketmaster' )
+				array( 'handler_tool' => 'upsert_event', 'source_type' => 'source_api' )
 			),
 			$this->make_packet(
 				'tool_result',
-				array( 'tool_name' => 'daily_memory', 'source_type' => 'ticketmaster' )
+				array( 'tool_name' => 'daily_memory', 'source_type' => 'source_api' )
 			),
 			$this->make_packet(
 				'ai_response',
-				array( 'source_type' => 'ticketmaster' )
+				array( 'source_type' => 'source_api' )
 			),
 		);
 
@@ -114,7 +114,7 @@ class ExecuteStepFanOutFilterTest extends WP_UnitTestCase {
 
 	/**
 	 * Regression guard: the pre-#1096 implementation filtered on
-	 * metadata.source_type. The original input source_type is 'ticketmaster',
+	 * metadata.source_type. The original input source_type is 'source_api',
 	 * 'web_scraper', etc. — NEVER 'ai_handler_complete'. If the filter
 	 * accidentally reverts to checking metadata.source_type, this test will
 	 * fail because tool_result and ai_response packets will leak through.
@@ -123,7 +123,7 @@ class ExecuteStepFanOutFilterTest extends WP_UnitTestCase {
 		$packets = array(
 			$this->make_packet(
 				'ai_handler_complete',
-				array( 'handler_tool' => 'upsert_event', 'source_type' => 'ticketmaster' )
+				array( 'handler_tool' => 'upsert_event', 'source_type' => 'source_api' )
 			),
 			// Craft a malicious-looking tool_result whose metadata.source_type
 			// is literally 'ai_handler_complete' — must still be filtered out.

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -97,7 +97,7 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 				'body'  => wp_json_encode( array( 'event' => array( 'title' => $title ) ) ),
 			),
 			'metadata'  => array(
-				'source_type'      => 'ticketmaster',
+				'source_type'      => 'source_api',
 				'event_identifier' => md5( $title ),
 				'success'          => true,
 			),
@@ -124,7 +124,7 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		return (int) $job_id;
 	}
 
-	private function claim_for_parent( int $parent_id, string $item_identifier, string $source_type = 'ticketmaster' ): array {
+	private function claim_for_parent( int $parent_id, string $item_identifier, string $source_type = 'source_api' ): array {
 		$identity_scope = 'event_import:' . $source_type;
 		$token          = ( new ProcessedItems() )->claim_item_owned( $identity_scope, $source_type, $item_identifier, $parent_id );
 		$this->assertIsString( $token );
@@ -314,7 +314,7 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 	 * Regression for #2762: a concurrent RunMetrics write must not clobber
 	 * batch_state written by fan-out.
 	 *
-	 * Reproduces the lost-update race where the Ticketmaster fan-out flow
+	 * Reproduces the lost-update race where a source API fan-out flow
 	 * fails children with batch_state_missing: fan-out writes batch_state, but
 	 * a RunMetrics persist that started from a pre-fan-out baseline overwrites
 	 * the whole engine_data column with a snapshot that has no batch key. The
@@ -523,7 +523,7 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 			$packet['metadata']['source_item_id'] = $item_identifier;
 			$packet['metadata']['_engine_data']   = array(
 				'item_identifier' => $item_identifier,
-				'source_type'     => 'ticketmaster',
+				'source_type'     => 'source_api',
 			);
 			$packets[] = $packet;
 		}
@@ -687,8 +687,8 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 	public function test_scheduled_fanout_does_not_bind_ambiguous_or_conflicting_identity(): void {
 		$parent_id = $this->create_parent_job();
 		$processed = new ProcessedItems();
-		$this->assertIsString( $processed->claim_item_owned( 'scope-a', 'ticketmaster', 'shared-id', $parent_id ) );
-		$this->assertIsString( $processed->claim_item_owned( 'scope-b', 'ticketmaster', 'shared-id', $parent_id ) );
+		$this->assertIsString( $processed->claim_item_owned( 'scope-a', 'source_api', 'shared-id', $parent_id ) );
+		$this->assertIsString( $processed->claim_item_owned( 'scope-b', 'source_api', 'shared-id', $parent_id ) );
 
 		$ambiguous = $this->make_data_packet( 'Ambiguous Event' );
 		$ambiguous['metadata']['source_item_id'] = 'shared-id';
@@ -731,7 +731,7 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 		$packet['metadata']['source_item_id'] = 'duplicate-id';
 		$packet['metadata']['_engine_data']   = array(
 			'item_identifier' => 'duplicate-id',
-			'source_type'     => 'ticketmaster',
+			'source_type'     => 'source_api',
 		);
 
 		$route = new \ReflectionMethod( ExecuteStepAbility::class, 'routeAfterExecution' );

--- a/tests/Unit/Abilities/FlowCreationAtomicityTest.php
+++ b/tests/Unit/Abilities/FlowCreationAtomicityTest.php
@@ -67,9 +67,9 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 
 		$this->handlers_filter = static function ( array $handlers, ?string $step_type ): array {
 			if ( null === $step_type || 'event_import' === $step_type ) {
-				$handlers['ticketmaster'] = array(
+				$handlers['source_api'] = array(
 					'type'  => 'event_import',
-					'label' => 'Ticketmaster',
+					'label' => 'Source API',
 				);
 			}
 			if ( null === $step_type || 'upsert' === $step_type ) {
@@ -94,8 +94,8 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 			2
 		);
 		$this->settings_filter = static function ( array $settings, ?string $handler_slug ): array {
-			if ( null === $handler_slug || 'ticketmaster' === $handler_slug ) {
-				$settings['ticketmaster'] = new AtomicEventImportSettings();
+			if ( null === $handler_slug || 'source_api' === $handler_slug ) {
+				$settings['source_api'] = new AtomicEventImportSettings();
 			}
 			if ( null === $handler_slug || 'upsert_event' === $handler_slug ) {
 				$settings['upsert_event'] = new AtomicUpsertSettings();
@@ -152,8 +152,8 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 
 		$flow       = ( new Flows() )->get_flow( (int) $result['flow_id'] );
 		$step_types = array_column( $flow['flow_config'], null, 'step_type' );
-		$this->assertSame( array( 'ticketmaster' ), $step_types['event_import']['handler_slugs'] );
-		$this->assertSame( 'ticketmaster', $step_types['event_import']['handler_configs']['ticketmaster']['source'] );
+		$this->assertSame( array( 'source_api' ), $step_types['event_import']['handler_slugs'] );
+		$this->assertSame( 'source_api', $step_types['event_import']['handler_configs']['source_api']['source'] );
 		$this->assertSame( 'Import upcoming events.', $step_types['ai'][ QueueAbility::SLOT_PROMPT_QUEUE ][0]['prompt'] );
 		$this->assertSame( array( 'upsert_event' ), $step_types['upsert']['handler_slugs'] );
 		$this->assertSame( 'event', $step_types['upsert']['handler_configs']['upsert_event']['post_type'] );
@@ -178,7 +178,7 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 		foreach ( array( false, true ) as $validate_only ) {
 			$input = $this->validInput( 'Malformed Alias Flow' );
 			$input['step_configs']['event_import'] = array(
-				$alias => array( 'ticketmaster' ),
+				$alias => array( 'source_api' ),
 			);
 			$input['validate_only'] = $validate_only;
 			$before = $this->flowCount();
@@ -403,8 +403,8 @@ class FlowCreationAtomicityTest extends WP_UnitTestCase {
 			'flow_name'    => $flow_name,
 			'step_configs' => array(
 				'event_import' => array(
-					'handler_slug'   => 'ticketmaster',
-					'handler_config' => array( 'source' => 'ticketmaster' ),
+					'handler_slug'   => 'source_api',
+					'handler_config' => array( 'source' => 'source_api' ),
 				),
 				'ai'           => array(
 					'user_message' => 'Import upcoming events.',

--- a/tests/Unit/Cli/Commands/Flows/BulkConfigCommandTest.php
+++ b/tests/Unit/Cli/Commands/Flows/BulkConfigCommandTest.php
@@ -233,7 +233,7 @@ class BulkConfigCommandTest extends WP_UnitTestCase {
 		$ability = new ConfigureFlowStepsAbility();
 		$result  = $ability->execute( array(
 			'pipeline_id'    => $this->pipeline_id,
-			'handler_slug'   => 'ticketmaster',
+			'handler_slug'   => 'source_api',
 			'handler_config' => array( 'max_items' => 10 ),
 		) );
 

--- a/tests/Unit/Core/Steps/AI/AIStepTest.php
+++ b/tests/Unit/Core/Steps/AI/AIStepTest.php
@@ -413,7 +413,7 @@ class AIStepTest extends TestCase {
 			array(
 				'type'     => 'fetch',
 				'data'     => array( 'title' => 'Test' ),
-				'metadata' => array( 'source_type' => 'ticketmaster' ),
+				'metadata' => array( 'source_type' => 'source_api' ),
 			),
 		);
 
@@ -438,7 +438,7 @@ class AIStepTest extends TestCase {
 			array( 'upsert_event' => array( 'handler' => 'upsert_event', 'handler_config' => array() ) )
 		);
 
-		$this->assertSame( 'ticketmaster', $result[0]['metadata']['source_type'] );
+		$this->assertSame( 'source_api', $result[0]['metadata']['source_type'] );
 	}
 
 	public function test_process_loop_results_correlates_non_contiguous_outputs_by_disposition_id(): void {

--- a/tests/Unit/Core/Steps/Fetch/FetchHandlerDataPacketTest.php
+++ b/tests/Unit/Core/Steps/Fetch/FetchHandlerDataPacketTest.php
@@ -66,7 +66,7 @@ class FetchHandlerDataPacketTest extends TestCase {
 	}
 
 	public function test_multiple_items_creates_multiple_packets(): void {
-		$handler = $this->createStubHandler( 'ticketmaster', array() );
+		$handler = $this->createStubHandler( 'source_api', array() );
 		$method  = $this->getToDataPackets();
 
 		$items = array(

--- a/tests/agent-bundle-slug-matcher-smoke.php
+++ b/tests/agent-bundle-slug-matcher-smoke.php
@@ -41,26 +41,26 @@ echo "agent-bundle-slug-matcher-smoke\n";
 
 // ---- 1. NULL portable_slug rows resolve via the display-name fallback. -----
 $live_pipelines = array(
-	array( 'pipeline_id' => 101, 'pipeline_name' => 'Ticketmaster Columbus', 'portable_slug' => null ),
-	array( 'pipeline_id' => 102, 'pipeline_name' => 'Dice FM Austin', 'portable_slug' => '' ),
+	array( 'pipeline_id' => 101, 'pipeline_name' => 'Source API Primary', 'portable_slug' => null ),
+	array( 'pipeline_id' => 102, 'pipeline_name' => 'Catalog Import Secondary', 'portable_slug' => '' ),
 );
 
 $index = AgentBundleSlugMatcher::index_existing( $live_pipelines, 'pipeline_name', 'pipeline' );
 
 agent_bundle_slug_matcher_assert(
-	isset( $index['matched']['ticketmaster-columbus'] ),
+	isset( $index['matched']['source-api-primary'] ),
 	'NULL portable_slug pipeline resolves by normalized name',
 	$failures,
 	$passes
 );
 agent_bundle_slug_matcher_assert(
-	101 === ( $index['matched']['ticketmaster-columbus']['pipeline_id'] ?? 0 ),
+	101 === ( $index['matched']['source-api-primary']['pipeline_id'] ?? 0 ),
 	'matched row is the correct live pipeline',
 	$failures,
 	$passes
 );
 agent_bundle_slug_matcher_assert(
-	isset( $index['matched']['dice-fm-austin'] ),
+	isset( $index['matched']['catalog-import-secondary'] ),
 	'empty-string portable_slug pipeline resolves by normalized name',
 	$failures,
 	$passes
@@ -73,11 +73,11 @@ agent_bundle_slug_matcher_assert(
 );
 
 // ---- 2. Bundle side computes the SAME key the existing side does. ----------
-$bundle_pipeline = array( 'original_id' => 9, 'pipeline_name' => 'Ticketmaster Columbus', 'portable_slug' => null );
+$bundle_pipeline = array( 'original_id' => 9, 'pipeline_name' => 'Source API Primary', 'portable_slug' => null );
 $bundle_key      = AgentBundleSlugMatcher::bundle_slug( $bundle_pipeline, 'pipeline_name', 'pipeline' );
 
 agent_bundle_slug_matcher_assert(
-	'ticketmaster-columbus' === $bundle_key,
+	'source-api-primary' === $bundle_key,
 	'bundle-side slug matches existing-side slug (symmetric)',
 	$failures,
 	$passes
@@ -103,28 +103,28 @@ agent_bundle_slug_matcher_assert(
 
 // ---- 4. Duplicate names surface as ambiguous, never silently mismatched. ---
 $dupes = array(
-	array( 'flow_id' => 1, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
-	array( 'flow_id' => 2, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
-	array( 'flow_id' => 3, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
-	array( 'flow_id' => 4, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
+	array( 'flow_id' => 1, 'flow_name' => 'Catalog Import', 'portable_slug' => null ),
+	array( 'flow_id' => 2, 'flow_name' => 'Catalog Import', 'portable_slug' => null ),
+	array( 'flow_id' => 3, 'flow_name' => 'Catalog Import', 'portable_slug' => null ),
+	array( 'flow_id' => 4, 'flow_name' => 'Catalog Import', 'portable_slug' => null ),
 	array( 'flow_id' => 5, 'flow_name' => 'Unique Flow', 'portable_slug' => null ),
 );
 $flow_index = AgentBundleSlugMatcher::index_existing( $dupes, 'flow_name', 'flow' );
 
 agent_bundle_slug_matcher_assert(
-	isset( $flow_index['ambiguous']['ticketmaster'] ),
-	'four flows named "Ticketmaster" surface as ambiguous',
+	isset( $flow_index['ambiguous']['catalog-import'] ),
+	'four flows named "Catalog Import" surface as ambiguous',
 	$failures,
 	$passes
 );
 agent_bundle_slug_matcher_assert(
-	4 === count( $flow_index['ambiguous']['ticketmaster'] ),
+	4 === count( $flow_index['ambiguous']['catalog-import'] ),
 	'all four colliding rows are recorded for the ambiguous slug',
 	$failures,
 	$passes
 );
 agent_bundle_slug_matcher_assert(
-	! isset( $flow_index['matched']['ticketmaster'] ),
+	! isset( $flow_index['matched']['catalog-import'] ),
 	'ambiguous slug is NOT placed in the matched map (no guessing)',
 	$failures,
 	$passes
@@ -150,19 +150,19 @@ agent_bundle_slug_matcher_assert(
 );
 
 // ---- 6. Acceptance: an all-NULL-portable_slug agent yields 0 would-create. --
-// Mirrors the adopt() matching loop on a fixture that reproduces the events-bot
+// Mirrors the adopt() matching loop on a fixture that reproduces a consumer
 // shape (every live row portable_slug NULL). Before the fix, the existing map
 // keyed by '' and EVERY bundle artifact was classified new_artifact (would
 // INSERT a duplicate). After the fix, all resolve to matched / 0 unmatched.
 $live_all_null = array(
-	array( 'pipeline_id' => 11, 'pipeline_name' => 'Ticketmaster Columbus', 'portable_slug' => null ),
-	array( 'pipeline_id' => 12, 'pipeline_name' => 'Dice FM Austin', 'portable_slug' => null ),
-	array( 'pipeline_id' => 13, 'pipeline_name' => 'Bandsintown Nashville', 'portable_slug' => null ),
+	array( 'pipeline_id' => 11, 'pipeline_name' => 'Source API Primary', 'portable_slug' => null ),
+	array( 'pipeline_id' => 12, 'pipeline_name' => 'Catalog Import Secondary', 'portable_slug' => null ),
+	array( 'pipeline_id' => 13, 'pipeline_name' => 'Partner Feed Tertiary', 'portable_slug' => null ),
 );
 $bundle_pipelines = array(
-	array( 'original_id' => 1, 'pipeline_name' => 'Ticketmaster Columbus', 'portable_slug' => null ),
-	array( 'original_id' => 2, 'pipeline_name' => 'Dice FM Austin', 'portable_slug' => null ),
-	array( 'original_id' => 3, 'pipeline_name' => 'Bandsintown Nashville', 'portable_slug' => null ),
+	array( 'original_id' => 1, 'pipeline_name' => 'Source API Primary', 'portable_slug' => null ),
+	array( 'original_id' => 2, 'pipeline_name' => 'Catalog Import Secondary', 'portable_slug' => null ),
+	array( 'original_id' => 3, 'pipeline_name' => 'Partner Feed Tertiary', 'portable_slug' => null ),
 );
 
 $accept_index = AgentBundleSlugMatcher::index_existing( $live_all_null, 'pipeline_name', 'pipeline' );
@@ -191,16 +191,16 @@ agent_bundle_slug_matcher_assert(
 );
 
 // ---- 7. bundle_slug() prefers the artifact's UNIQUE slug over display name. -
-// Mirrors events-bot: hundreds of flows share the display name "Ticketmaster"
+// Mirrors a consumer agent: many flows share the display name "Catalog Import"
 // but each bundle flow artifact carries a DISTINCT unique `slug`
-// (ticketmaster, ticketmaster-4, ...). Keying on the unique slug instead of the
+// (catalog-import, catalog-import-4, ...). Keying on the unique slug instead of the
 // non-unique name means they resolve to distinct keys → 0 ambiguous, all match.
 $same_name_flows = array(
-	array( 'original_id' => 1, 'flow_name' => 'Ticketmaster', 'slug' => 'ticketmaster' ),
-	array( 'original_id' => 2, 'flow_name' => 'Ticketmaster', 'slug' => 'ticketmaster-4' ),
-	array( 'original_id' => 3, 'flow_name' => 'Ticketmaster', 'slug' => 'ticketmaster-9' ),
-	array( 'original_id' => 4, 'flow_name' => 'Dice.fm', 'slug' => 'dice-fm' ),
-	array( 'original_id' => 5, 'flow_name' => 'Dice.fm', 'slug' => 'dice-fm-2' ),
+	array( 'original_id' => 1, 'flow_name' => 'Catalog Import', 'slug' => 'catalog-import' ),
+	array( 'original_id' => 2, 'flow_name' => 'Catalog Import', 'slug' => 'catalog-import-4' ),
+	array( 'original_id' => 3, 'flow_name' => 'Catalog Import', 'slug' => 'catalog-import-9' ),
+	array( 'original_id' => 4, 'flow_name' => 'Source API', 'slug' => 'source-api' ),
+	array( 'original_id' => 5, 'flow_name' => 'Source API', 'slug' => 'source-api-2' ),
 );
 
 $bundle_slugs = array();
@@ -209,7 +209,7 @@ foreach ( $same_name_flows as $bundle_flow ) {
 }
 
 agent_bundle_slug_matcher_assert(
-	array( 'ticketmaster', 'ticketmaster-4', 'ticketmaster-9', 'dice-fm', 'dice-fm-2' ) === $bundle_slugs,
+	array( 'catalog-import', 'catalog-import-4', 'catalog-import-9', 'source-api', 'source-api-2' ) === $bundle_slugs,
 	'same-named flows with distinct slugs resolve to distinct bundle slugs',
 	$failures,
 	$passes
@@ -243,35 +243,35 @@ foreach ( $bundle_slugs as $key ) {
 }
 agent_bundle_slug_matcher_assert(
 	5 === $matched_all && 0 === $ambiguous_ct,
-	'events-bot shape: all 5 same-named flows match their unique slug, 0 ambiguous',
+	'consumer shape: all 5 same-named flows match their unique slug, 0 ambiguous',
 	$failures,
 	$passes
 );
 
 // ---- 8. Degenerate fallback: NO slug + duplicate names still refuses. -------
-// Preserves #2668's four-"Ticketmaster" guarantee for the genuinely slug-less
+// Preserves #2668's four-same-name guarantee for the genuinely slug-less
 // case — when there is nothing unique to key on, adopt must still refuse.
 $slugless_dupes = array(
-	array( 'flow_id' => 1, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
-	array( 'flow_id' => 2, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
-	array( 'flow_id' => 3, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
-	array( 'flow_id' => 4, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
+	array( 'flow_id' => 1, 'flow_name' => 'Catalog Import', 'portable_slug' => null ),
+	array( 'flow_id' => 2, 'flow_name' => 'Catalog Import', 'portable_slug' => null ),
+	array( 'flow_id' => 3, 'flow_name' => 'Catalog Import', 'portable_slug' => null ),
+	array( 'flow_id' => 4, 'flow_name' => 'Catalog Import', 'portable_slug' => null ),
 );
 $slugless_index = AgentBundleSlugMatcher::index_existing( $slugless_dupes, 'flow_name', 'flow' );
 agent_bundle_slug_matcher_assert(
-	isset( $slugless_index['ambiguous']['ticketmaster'] ) && ! isset( $slugless_index['matched']['ticketmaster'] ),
+	isset( $slugless_index['ambiguous']['catalog-import'] ) && ! isset( $slugless_index['matched']['catalog-import'] ),
 	'degenerate (no slug + duplicate names) still refuses as ambiguous',
 	$failures,
 	$passes
 );
 // And the slug-less bundle artifact (no portable_slug, no slug) keys on name.
 $slugless_artifact = AgentBundleSlugMatcher::bundle_slug(
-	array( 'flow_name' => 'Ticketmaster' ),
+	array( 'flow_name' => 'Catalog Import' ),
 	'flow_name',
 	'flow'
 );
 agent_bundle_slug_matcher_assert(
-	'ticketmaster' === $slugless_artifact,
+	'catalog-import' === $slugless_artifact,
 	'slug-less bundle artifact falls back to the normalized display name',
 	$failures,
 	$passes
@@ -313,10 +313,10 @@ agent_bundle_slug_matcher_assert(
 );
 
 // ---- 10. Pipeline-scoped fallback: source label is unique within a pipeline.
-// Reproduces the events-bot live-origin shape end to end: N city pipelines,
-// each with a same-named "Ticketmaster" AND "Dice.fm" live flow (portable_slug
+// Reproduces a live-origin shape end to end: N pipelines, each with same-named
+// "Catalog Import" and "Source API" live flows (portable_slug
 // NULL, flow_name the bare source label). The bundle flow carries the UNIQUE
-// slug ("ticketmaster-63"), which the global slug pass can never match against a
+// slug ("catalog-import-63"), which the global slug pass cannot match against a
 // slugless live row. The pipeline-scoped fallback re-keys both sides on the
 // normalized source label WITHIN the bounded pipeline, where it is unique.
 //
@@ -325,16 +325,16 @@ agent_bundle_slug_matcher_assert(
 // the name-key fallback resolves it.
 $scoped_pipelines = array(
 	101 => array(
-		array( 'flow_id' => 1, 'pipeline_id' => 101, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
-		array( 'flow_id' => 2, 'pipeline_id' => 101, 'flow_name' => 'Dice.fm', 'portable_slug' => null ),
+		array( 'flow_id' => 1, 'pipeline_id' => 101, 'flow_name' => 'Catalog Import', 'portable_slug' => null ),
+		array( 'flow_id' => 2, 'pipeline_id' => 101, 'flow_name' => 'Source API', 'portable_slug' => null ),
 	),
 	102 => array(
-		array( 'flow_id' => 3, 'pipeline_id' => 102, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
-		array( 'flow_id' => 4, 'pipeline_id' => 102, 'flow_name' => 'Dice.fm', 'portable_slug' => null ),
+		array( 'flow_id' => 3, 'pipeline_id' => 102, 'flow_name' => 'Catalog Import', 'portable_slug' => null ),
+		array( 'flow_id' => 4, 'pipeline_id' => 102, 'flow_name' => 'Source API', 'portable_slug' => null ),
 	),
 	103 => array(
-		array( 'flow_id' => 5, 'pipeline_id' => 103, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
-		array( 'flow_id' => 6, 'pipeline_id' => 103, 'flow_name' => 'Dice.fm', 'portable_slug' => null ),
+		array( 'flow_id' => 5, 'pipeline_id' => 103, 'flow_name' => 'Catalog Import', 'portable_slug' => null ),
+		array( 'flow_id' => 6, 'pipeline_id' => 103, 'flow_name' => 'Source API', 'portable_slug' => null ),
 	),
 );
 
@@ -342,12 +342,12 @@ $scoped_pipelines = array(
 // what AgentBundleArrayAdapter writes) and the bare source label in flow_name.
 // original_pipeline_id maps to a matched live pipeline (id == live id here).
 $scoped_bundle_flows = array(
-	array( 'original_pipeline_id' => 101, 'flow_name' => 'Ticketmaster', 'portable_slug' => 'ticketmaster' ),
-	array( 'original_pipeline_id' => 101, 'flow_name' => 'Dice.fm', 'portable_slug' => 'dice-fm' ),
-	array( 'original_pipeline_id' => 102, 'flow_name' => 'Ticketmaster', 'portable_slug' => 'ticketmaster-2' ),
-	array( 'original_pipeline_id' => 102, 'flow_name' => 'Dice.fm', 'portable_slug' => 'dice-fm-2' ),
-	array( 'original_pipeline_id' => 103, 'flow_name' => 'Ticketmaster', 'portable_slug' => 'ticketmaster-3' ),
-	array( 'original_pipeline_id' => 103, 'flow_name' => 'Dice.fm', 'portable_slug' => 'dice-fm-3' ),
+	array( 'original_pipeline_id' => 101, 'flow_name' => 'Catalog Import', 'portable_slug' => 'catalog-import' ),
+	array( 'original_pipeline_id' => 101, 'flow_name' => 'Source API', 'portable_slug' => 'source-api' ),
+	array( 'original_pipeline_id' => 102, 'flow_name' => 'Catalog Import', 'portable_slug' => 'catalog-import-2' ),
+	array( 'original_pipeline_id' => 102, 'flow_name' => 'Source API', 'portable_slug' => 'source-api-2' ),
+	array( 'original_pipeline_id' => 103, 'flow_name' => 'Catalog Import', 'portable_slug' => 'catalog-import-3' ),
+	array( 'original_pipeline_id' => 103, 'flow_name' => 'Source API', 'portable_slug' => 'source-api-3' ),
 );
 
 $scoped_matched   = 0;
@@ -390,18 +390,18 @@ agent_bundle_slug_matcher_assert(
 	$passes
 );
 agent_bundle_slug_matcher_assert(
-	1 === ( $matched_flow_ids['ticketmaster'] ?? 0 )
-		&& 3 === ( $matched_flow_ids['ticketmaster-2'] ?? 0 )
-		&& 5 === ( $matched_flow_ids['ticketmaster-3'] ?? 0 ),
-	'pipeline-scoped: each Ticketmaster slug binds to the row in its OWN pipeline',
+	1 === ( $matched_flow_ids['catalog-import'] ?? 0 )
+		&& 3 === ( $matched_flow_ids['catalog-import-2'] ?? 0 )
+		&& 5 === ( $matched_flow_ids['catalog-import-3'] ?? 0 ),
+	'pipeline-scoped: each catalog import slug binds to the row in its OWN pipeline',
 	$failures,
 	$passes
 );
 agent_bundle_slug_matcher_assert(
-	2 === ( $matched_flow_ids['dice-fm'] ?? 0 )
-		&& 4 === ( $matched_flow_ids['dice-fm-2'] ?? 0 )
-		&& 6 === ( $matched_flow_ids['dice-fm-3'] ?? 0 ),
-	'pipeline-scoped: each Dice.fm slug binds to the row in its OWN pipeline',
+	2 === ( $matched_flow_ids['source-api'] ?? 0 )
+		&& 4 === ( $matched_flow_ids['source-api-2'] ?? 0 )
+		&& 6 === ( $matched_flow_ids['source-api-3'] ?? 0 ),
+	'pipeline-scoped: each source API slug binds to the row in its OWN pipeline',
 	$failures,
 	$passes
 );
@@ -411,10 +411,10 @@ agent_bundle_slug_matcher_assert(
 // there is no unique signal, so the name fallback must surface ambiguous and
 // NEVER guess — preserving the #2668 guarantee at the per-pipeline scope.
 $tie_rows = array(
-	array( 'flow_id' => 11, 'pipeline_id' => 200, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
-	array( 'flow_id' => 12, 'pipeline_id' => 200, 'flow_name' => 'Ticketmaster', 'portable_slug' => null ),
+	array( 'flow_id' => 11, 'pipeline_id' => 200, 'flow_name' => 'Catalog Import', 'portable_slug' => null ),
+	array( 'flow_id' => 12, 'pipeline_id' => 200, 'flow_name' => 'Catalog Import', 'portable_slug' => null ),
 );
-$tie_bundle = array( 'original_pipeline_id' => 200, 'flow_name' => 'Ticketmaster', 'portable_slug' => 'ticketmaster-77' );
+$tie_bundle = array( 'original_pipeline_id' => 200, 'flow_name' => 'Catalog Import', 'portable_slug' => 'catalog-import-77' );
 
 $tie_slug_key   = AgentBundleSlugMatcher::bundle_slug( $tie_bundle, 'flow_name', 'flow' );
 $tie_slug_index = AgentBundleSlugMatcher::index_existing( $tie_rows, 'flow_name', 'flow' );
@@ -439,16 +439,16 @@ agent_bundle_slug_matcher_assert(
 // stable cross-side signal is the source label.
 $name_only = AgentBundleSlugMatcher::index_existing_by_name(
 	array(
-		array( 'flow_id' => 1, 'flow_name' => 'Ticketmaster', 'portable_slug' => 'some-stored-slug' ),
-		array( 'flow_id' => 2, 'flow_name' => 'Dice.fm', 'portable_slug' => null ),
+		array( 'flow_id' => 1, 'flow_name' => 'Catalog Import', 'portable_slug' => 'some-stored-slug' ),
+		array( 'flow_id' => 2, 'flow_name' => 'Source API', 'portable_slug' => null ),
 	),
 	'flow_name',
 	'flow'
 );
 agent_bundle_slug_matcher_assert(
-	isset( $name_only['matched']['ticketmaster'] )
-		&& 1 === ( $name_only['matched']['ticketmaster']['flow_id'] ?? 0 )
-		&& isset( $name_only['matched']['dice-fm'] ),
+	isset( $name_only['matched']['catalog-import'] )
+		&& 1 === ( $name_only['matched']['catalog-import']['flow_id'] ?? 0 )
+		&& isset( $name_only['matched']['source-api'] ),
 	'index_existing_by_name keys on normalized name regardless of portable_slug',
 	$failures,
 	$passes
@@ -456,35 +456,35 @@ agent_bundle_slug_matcher_assert(
 
 // ---- 13. bundle_name_key keys on the source label, never the unique slug. ---
 $label_key = AgentBundleSlugMatcher::bundle_name_key(
-	array( 'flow_name' => 'Ticketmaster', 'portable_slug' => 'ticketmaster-63', 'slug' => 'ticketmaster-63' ),
+	array( 'flow_name' => 'Catalog Import', 'portable_slug' => 'catalog-import-63', 'slug' => 'catalog-import-63' ),
 	'flow_name',
 	'flow'
 );
 agent_bundle_slug_matcher_assert(
-	'ticketmaster' === $label_key,
+	'catalog-import' === $label_key,
 	'bundle_name_key resolves the source label, ignoring the unique slug',
 	$failures,
 	$passes
 );
 
 // ---- 14. Handler-identity fallback: rename-proof in-pipeline match. ---------
-// Reproduces the events-bot live-origin bundle shape that the slug AND name
+// Reproduces a consumer live-origin bundle shape that the slug AND name
 // fallbacks both miss (#2683). The in-memory bundle adopt loads carries each
 // flow's steps in `flow_config` (keyed by step id), its `flow_name` RENAMED to
-// "<Source> — <City>" (event-bundles#5) and its `portable_slug` deduped
-// ("dice-fm-101") — so neither the unique-slug pass nor the name fallback can
+// to a contextual label and its `portable_slug` deduped
+// ("catalog-import-101") — so neither the unique-slug pass nor the name fallback can
 // meet the live row, whose `flow_name` is still the bare source label
-// ("Dice.fm"). The import HANDLER is the only rename-proof identity, present on
+// ("Catalog Import"). The import HANDLER is the only rename-proof identity, present on
 // BOTH sides as `flow_config[<step>].handler_slugs[0]`.
 $handler_live_rows = array(
-	// Pipeline 9 (Austin): one Dice.fm source flow + one Ticketmaster source flow.
+	// Pipeline 9: one catalog import flow and one source API flow.
 	array(
 		'flow_id'       => 26,
 		'pipeline_id'   => 9,
-		'flow_name'     => 'Dice.fm',
+		'flow_name'     => 'Catalog Import',
 		'portable_slug' => null,
 		'flow_config'   => array(
-			'9_a_26' => array( 'step_type' => 'event_import', 'execution_order' => 0, 'handler_slugs' => array( 'dice_fm' ) ),
+			'9_a_26' => array( 'step_type' => 'fetch', 'execution_order' => 0, 'handler_slugs' => array( 'catalog_import' ) ),
 			'9_b_26' => array( 'step_type' => 'ai', 'execution_order' => 1 ),
 			'9_c_26' => array( 'step_type' => 'upsert', 'execution_order' => 2, 'handler_slugs' => array( 'upsert_event' ) ),
 		),
@@ -492,10 +492,10 @@ $handler_live_rows = array(
 	array(
 		'flow_id'       => 27,
 		'pipeline_id'   => 9,
-		'flow_name'     => 'Ticketmaster',
+		'flow_name'     => 'Source API',
 		'portable_slug' => null,
 		'flow_config'   => array(
-			'9_d_27' => array( 'step_type' => 'event_import', 'execution_order' => 0, 'handler_slugs' => array( 'ticketmaster' ) ),
+			'9_d_27' => array( 'step_type' => 'fetch', 'execution_order' => 0, 'handler_slugs' => array( 'source_api' ) ),
 			'9_e_27' => array( 'step_type' => 'ai', 'execution_order' => 1 ),
 		),
 	),
@@ -505,10 +505,10 @@ $handler_live_rows = array(
 // handler lives in `flow_config` exactly like the live row.
 $handler_bundle_flow = array(
 	'original_pipeline_id' => 9,
-	'flow_name'            => 'Dice.fm — Austin',
-	'portable_slug'        => 'dice-fm-101',
+	'flow_name'            => 'Catalog Import Primary',
+	'portable_slug'        => 'catalog-import-101',
 	'flow_config'          => array(
-		'1_bundle_step_0_70' => array( 'step_type' => 'event_import', 'execution_order' => 0, 'handler_slugs' => array( 'dice_fm' ) ),
+		'1_bundle_step_0_70' => array( 'step_type' => 'fetch', 'execution_order' => 0, 'handler_slugs' => array( 'catalog_import' ) ),
 		'1_bundle_step_1_70' => array( 'step_type' => 'ai', 'execution_order' => 1 ),
 		'1_bundle_step_2_70' => array( 'step_type' => 'upsert', 'execution_order' => 2, 'handler_slugs' => array( 'upsert_event' ) ),
 	),
@@ -519,41 +519,41 @@ $h_name_key = AgentBundleSlugMatcher::bundle_name_key( $handler_bundle_flow, 'fl
 $h_handler  = AgentBundleSlugMatcher::bundle_handler_key( $handler_bundle_flow, 'flow' );
 
 agent_bundle_slug_matcher_assert(
-	'dice-fm-101' === $h_slug_key && 'dice-fm-austin' === $h_name_key && 'dice-fm' === $h_handler,
-	'events-bot shape: slug=dice-fm-101, name=dice-fm-austin, handler=dice-fm (rename-proof)',
+	'catalog-import-101' === $h_slug_key && 'catalog-import-primary' === $h_name_key && 'catalog-import' === $h_handler,
+	'consumer shape: slug=catalog-import-101, name=catalog-import-primary, handler=catalog-import (rename-proof)',
 	$failures,
 	$passes
 );
 
-// Slug pass misses (live row has NULL slug -> keyed on "dice-fm").
+// Slug pass misses (live row has NULL slug -> keyed on "catalog-import").
 $h_slug_index = AgentBundleSlugMatcher::index_existing( $handler_live_rows, 'flow_name', 'flow' );
 agent_bundle_slug_matcher_assert(
 	! isset( $h_slug_index['matched'][ $h_slug_key ] ),
-	'events-bot shape: deduped slug "dice-fm-101" misses the slug pass (live keyed on "dice-fm")',
+	'consumer shape: deduped slug "catalog-import-101" misses the slug pass (live keyed on "catalog-import")',
 	$failures,
 	$passes
 );
-// Name pass misses (bundle name "dice-fm-austin" vs live "dice-fm").
+// Name pass misses (bundle name "catalog-import-primary" vs live "catalog-import").
 $h_name_index = AgentBundleSlugMatcher::index_existing_by_name( $handler_live_rows, 'flow_name', 'flow' );
 agent_bundle_slug_matcher_assert(
 	! isset( $h_name_index['matched'][ $h_name_key ] ),
-	'events-bot shape: renamed name "dice-fm-austin" misses the name pass (live "dice-fm")',
+	'consumer shape: renamed name "catalog-import-primary" misses the name pass (live "catalog-import")',
 	$failures,
 	$passes
 );
 // Handler pass matches the correct row, unambiguously.
 $h_index = AgentBundleSlugMatcher::index_existing_by_handler( $handler_live_rows, 'flow' );
 agent_bundle_slug_matcher_assert(
-	isset( $h_index['matched']['dice-fm'] )
-		&& 26 === ( $h_index['matched']['dice-fm']['flow_id'] ?? 0 )
+	isset( $h_index['matched']['catalog-import'] )
+		&& 26 === ( $h_index['matched']['catalog-import']['flow_id'] ?? 0 )
 		&& empty( $h_index['ambiguous'] ),
-	'events-bot shape: handler fallback binds "dice-fm" to its live row (flow_id 26), 0 ambiguous',
+	'consumer shape: handler fallback binds "catalog-import" to its live row (flow_id 26), 0 ambiguous',
 	$failures,
 	$passes
 );
 agent_bundle_slug_matcher_assert(
-	isset( $h_index['matched']['ticketmaster'] ) && 27 === ( $h_index['matched']['ticketmaster']['flow_id'] ?? 0 ),
-	'events-bot shape: the sibling Ticketmaster source flow binds to flow_id 27 by handler',
+	isset( $h_index['matched']['source-api'] ) && 27 === ( $h_index['matched']['source-api']['flow_id'] ?? 0 ),
+	'consumer shape: the sibling source API flow binds to flow_id 27 by handler',
 	$failures,
 	$passes
 );
@@ -579,26 +579,26 @@ agent_bundle_slug_matcher_assert(
 // shape (flow_config map) must derive the SAME key from the same flow.
 $doc_shape = array(
 	'steps' => array(
-		array( 'step_type' => 'event_import', 'step_position' => 0, 'handler_slugs' => array( 'dice_fm' ) ),
+		array( 'step_type' => 'fetch', 'step_position' => 0, 'handler_slugs' => array( 'catalog_import' ) ),
 		array( 'step_type' => 'ai', 'step_position' => 1 ),
 	),
 );
 $array_shape = array(
 	'flow_config' => array(
 		'x1' => array( 'step_type' => 'ai', 'execution_order' => 1 ),
-		'x0' => array( 'step_type' => 'event_import', 'execution_order' => 0, 'handler_slugs' => array( 'dice_fm' ) ),
+		'x0' => array( 'step_type' => 'fetch', 'execution_order' => 0, 'handler_slugs' => array( 'catalog_import' ) ),
 	),
 );
 agent_bundle_slug_matcher_assert(
-	'dice-fm' === AgentBundleSlugMatcher::bundle_handler_key( $doc_shape, 'flow' )
-		&& 'dice-fm' === AgentBundleSlugMatcher::bundle_handler_key( $array_shape, 'flow' ),
+	'catalog-import' === AgentBundleSlugMatcher::bundle_handler_key( $doc_shape, 'flow' )
+		&& 'catalog-import' === AgentBundleSlugMatcher::bundle_handler_key( $array_shape, 'flow' ),
 	'handler key is identical for steps[] (document) and flow_config (array-bundle) shapes',
 	$failures,
 	$passes
 );
 agent_bundle_slug_matcher_assert(
-	'dice-fm' === AgentBundleSlugMatcher::bundle_handler_key(
-		array( 'flow_config' => array( 'x' => array( 'step_type' => 'event_import', 'handler_configs' => array( 'dice_fm' => array() ) ) ) ),
+	'catalog-import' === AgentBundleSlugMatcher::bundle_handler_key(
+		array( 'flow_config' => array( 'x' => array( 'step_type' => 'fetch', 'handler_configs' => array( 'catalog_import' => array() ) ) ) ),
 		'flow'
 	),
 	'handler key falls back to the handler_configs map key when handler_slugs is absent',
@@ -607,7 +607,7 @@ agent_bundle_slug_matcher_assert(
 );
 
 // ---- 17. Handler fallback STILL refuses a genuine in-pipeline source tie. ---
-// Two flows with the SAME source handler in ONE pipeline (e.g. two Dice.fm
+// Two flows with the SAME source handler in ONE pipeline (e.g. two catalog
 // searches) and no slug/name signal to split them: the handler pass must
 // surface ambiguous and NEVER guess — preserving #2668 at the source-identity
 // scope.
@@ -615,21 +615,21 @@ $handler_tie_rows = array(
 	array(
 		'flow_id'       => 51,
 		'pipeline_id'   => 200,
-		'flow_name'     => 'Dice.fm Rock',
+		'flow_name'     => 'Catalog Import Alpha',
 		'portable_slug' => null,
-		'flow_config'   => array( 's' => array( 'step_type' => 'event_import', 'execution_order' => 0, 'handler_slugs' => array( 'dice_fm' ) ) ),
+		'flow_config'   => array( 's' => array( 'step_type' => 'fetch', 'execution_order' => 0, 'handler_slugs' => array( 'catalog_import' ) ) ),
 	),
 	array(
 		'flow_id'       => 52,
 		'pipeline_id'   => 200,
-		'flow_name'     => 'Dice.fm Jazz',
+		'flow_name'     => 'Catalog Import Beta',
 		'portable_slug' => null,
-		'flow_config'   => array( 's' => array( 'step_type' => 'event_import', 'execution_order' => 0, 'handler_slugs' => array( 'dice_fm' ) ) ),
+		'flow_config'   => array( 's' => array( 'step_type' => 'fetch', 'execution_order' => 0, 'handler_slugs' => array( 'catalog_import' ) ) ),
 	),
 );
 $tie_handler_index = AgentBundleSlugMatcher::index_existing_by_handler( $handler_tie_rows, 'flow' );
 agent_bundle_slug_matcher_assert(
-	isset( $tie_handler_index['ambiguous']['dice-fm'] ) && ! isset( $tie_handler_index['matched']['dice-fm'] ),
+	isset( $tie_handler_index['ambiguous']['catalog-import'] ) && ! isset( $tie_handler_index['matched']['catalog-import'] ),
 	'handler fallback: two same-source flows in ONE pipeline stay ambiguous (no guess)',
 	$failures,
 	$passes

--- a/tests/agent-conversation-runtime-policy-smoke.php
+++ b/tests/agent-conversation-runtime-policy-smoke.php
@@ -263,7 +263,7 @@ $terminal_signal_policy   = new DataMachineHandlerCompletionPolicy( array( 'upse
 $terminal_signal_decision = $terminal_signal_policy->recordToolResult(
 	'reject_source',
 	array(
-		'handler' => 'ticketmaster',
+		'handler' => 'source_api',
 		'runtime' => array( 'completion_signal' => 'terminal' ),
 	),
 	array( 'success' => true ),
@@ -285,7 +285,7 @@ $terminal_failed_policy   = new DataMachineHandlerCompletionPolicy( array( 'upse
 $terminal_failed_decision = $terminal_failed_policy->recordToolResult(
 	'reject_source',
 	array(
-		'handler' => 'ticketmaster',
+		'handler' => 'source_api',
 		'runtime' => array( 'completion_signal' => 'terminal' ),
 	),
 	array( 'success' => false ),
@@ -297,7 +297,7 @@ assert_runtime_policy( ! $terminal_failed_decision->isComplete(), 'failed termin
 $terminal_result_policy   = new DataMachineHandlerCompletionPolicy( array( 'upsert_event' ) );
 $terminal_result_decision = $terminal_result_policy->recordToolResult(
 	'defer_item',
-	array( 'handler' => 'ticketmaster' ),
+	array( 'handler' => 'source_api' ),
 	array(
 		'success' => true,
 		'runtime' => array( 'completion_signal' => 'terminal' ),

--- a/tests/tool-source-registry-smoke.php
+++ b/tests/tool-source-registry-smoke.php
@@ -217,7 +217,7 @@ class SourcePolicyToolManager extends ToolManager {
 			);
 		}
 
-		if ( 'ticketmaster_fetch' === $handler_slug ) {
+		if ( 'source_api_fetch' === $handler_slug ) {
 			return array(
 				'adjacent_fetch' => array( 'handler' => $handler_slug, 'origin' => 'adjacent' ),
 			);
@@ -293,8 +293,8 @@ $tools   = resolve_source_tools(
 		'previous_step_config' => array(
 			'flow_step_id'    => 'fetch_step',
 			'step_type'       => 'fetch',
-			'handler_slugs'   => array( 'ticketmaster_fetch' ),
-			'handler_configs' => array( 'ticketmaster_fetch' => array( 'marker' => 'previous' ) ),
+			'handler_slugs'   => array( 'source_api_fetch' ),
+			'handler_configs' => array( 'source_api_fetch' => array( 'marker' => 'previous' ) ),
 		),
 		'next_step_config'     => array(
 			'flow_step_id'     => 'publish_step',
@@ -308,7 +308,7 @@ $tools   = resolve_source_tools(
 assert_source_equals( array( 'adjacent_fetch', 'collision_tool', 'adjacent_publish', 'static_pipeline_tool' ), array_keys( $tools ), 'pipeline source order is deterministic', $failures, $passes );
 assert_source_equals( 'adjacent', $tools['collision_tool']['origin'] ?? '', 'adjacent handler tool wins static name collision', $failures, $passes );
 assert_source_equals( false, isset( $tools['handler_wrapper'] ), 'pipeline static source skips handler wrappers', $failures, $passes );
-assert_source_equals( array( 'ticketmaster_fetch:previous:fetch_step', 'publish_to_wordpress:next:publish_step' ), $manager->handler_calls, 'adjacent handler source receives configs and cache scopes', $failures, $passes );
+assert_source_equals( array( 'source_api_fetch:previous:fetch_step', 'publish_to_wordpress:next:publish_step' ), $manager->handler_calls, 'adjacent handler source receives configs and cache scopes', $failures, $passes );
 
 echo "\n[2] non-pipeline modes use static registry only:\n";
 $manager = new SourcePolicyToolManager();

--- a/tests/upsert-handler-result-handoff-smoke.php
+++ b/tests/upsert-handler-result-handoff-smoke.php
@@ -211,9 +211,9 @@ assert_handoff_equals( 'ai_handler_complete', $packets[0]['type'] ?? null, 'AI s
 assert_handoff_equals( 'wiki_upsert', $packets[0]['metadata']['handler_tool'] ?? null, 'packet carries required handler slug', $failures, $passes );
 
 $claim = array(
-	'identity_scope'  => 'ticketmaster-fetch',
-	'source_type'     => 'ticketmaster',
-	'item_identifier' => 'Z7r9jZ1A7-sr_',
+	'identity_scope'  => 'source-api-fetch',
+	'source_type'     => 'source_api',
+	'item_identifier' => 'catalog-item-42',
 	'ownership_token' => 'scheduled-child-token',
 );
 $claim['disposition_id'] = ProcessedItems::disposition_identity( $claim['identity_scope'], $claim['source_type'], $claim['item_identifier'] );
@@ -224,7 +224,7 @@ $claimed_packets         = $method->invoke(
 		'tool_execution_results' => array(
 			array(
 				'tool_name'       => 'wiki_upsert',
-				'parameters'      => array( 'title' => 'Scheduled Ticketmaster Event' ),
+				'parameters'      => array( 'title' => 'Scheduled Catalog Item' ),
 				'is_handler_tool' => true,
 				'result'          => array(
 					'success'  => true,
@@ -237,7 +237,7 @@ $claimed_packets         = $method->invoke(
 			),
 		),
 	),
-	array( array( 'metadata' => array( 'source_type' => 'ticketmaster' ) ) ),
+	array( array( 'metadata' => array( 'source_type' => 'source_api' ) ) ),
 	array(
 		'flow_step_id' => 'ai_step',
 		'engine_data'  => array( ProcessedItems::CLAIM_METADATA_KEY => $claim ),


### PR DESCRIPTION
## Summary
- replace source/vendor-shaped comments, CLI examples, docs, and regression fixtures with neutral generic identities
- preserve bundle slug matching, ambiguity handling, packet lifecycle, scheduled claim handoff, and CLI test coverage
- remove all tracked first-party matches for the issue's vendor/consumer acceptance set

## Audit

Scope: tracked first-party `inc/`, `tests/`, `docs/`, `README.md`, and `readme.txt`; third-party `vendor/`, generated build artifacts, and historical changelogs were excluded.

Before:

```bash
git grep -ioE 'ticketmaster|dice\.fm|\bdice\b|bandsintown|event-bundles' -- inc tests docs README.md readme.txt | wc -l
# 206
```

After:

```bash
grep -riE 'ticketmaster|dice\.fm|\bdice\b|bandsintown|event-bundles' inc/ tests/ docs/ README.md readme.txt
# no output
```

No executable production branch compared against a scoped vendor literal. Production matches were comments, docblocks, or CLI examples; executable comparisons existed only inside regression fixtures and were replaced with equivalent neutral handler/source identities.

## Files and semantics
- `AgentBundleSlugMatcher` and `AgentBundleAbilityService`: retain the same generic matching explanation using `source_api` and `catalog_import` examples.
- CLI commands and docs: use neutral, executable placeholder handler examples.
- Bundle matcher smoke: retains the same row counts, duplicate-name ambiguity, slug precedence, pipeline scoping, rename-proof handler fallback, and refusal-to-guess assertions.
- Claim handoff smoke: computes the same disposition identity from a neutral scope/source/item tuple and verifies the same active-claim reconciliation.
- Existing PHPUnit and smoke fixtures: replace only source/handler identity values; assertion strength and control flow are unchanged.

## Verification

```bash
php tests/agent-bundle-slug-matcher-smoke.php
# 37/37 assertions passed

php tests/upsert-handler-result-handoff-smoke.php
# 16/16 assertions passed

homeboy review lint --changed-only --summary
# passed; phpcs, eslint, and phpstan reported 0 findings

homeboy review audit --profile pr --changed-since origin/main --summary
# passed; 0 introduced findings, 2 pre-existing contextual findings

git diff --check
# passed
```

The local authoritative full test command was also attempted:

```bash
homeboy review test --summary
```

It did not reach plugin activation or PHPUnit: WP Codebox selected the Docker-backed `wordpress-database` service, but this host has no `docker` executable (`provider-unavailable`, `ENOENT`). The run reported 0 executed tests and `recipe_run_payload_unparseable`; this is harness availability drift rather than a candidate test failure. GitHub's differential Homeboy workflow is the strongest available full-suite candidate/baseline gate and will run on this PR.

Closes #3268