### PR TITLE
fix: restore one-time flow cleanup

### DIFF
--- a/inc/Engine/Actions/Handlers/JobCompleteHandler.php
+++ b/inc/Engine/Actions/Handlers/JobCompleteHandler.php
@@ -38,13 +38,14 @@ class JobCompleteHandler {
 	private static function cleanup_one_time_flow( $job_id ) {
 		$db_jobs = new \DataMachine\Core\Database\Jobs\Jobs();
 		$job     = $db_jobs->get_job( $job_id );
+		$flow_id = (int) ( $job['flow_id'] ?? 0 );
 
-		if ( ! $job || empty( $job->flow_id ) ) {
+		if ( ! $job || 0 === $flow_id ) {
 			return;
 		}
 
 		$db_flows = new \DataMachine\Core\Database\Flows\Flows();
-		$flow     = $db_flows->get_flow( $job->flow_id );
+		$flow     = $db_flows->get_flow( $flow_id );
 
 		if ( ! $flow ) {
 			return;
@@ -57,7 +58,7 @@ class JobCompleteHandler {
 
 		if ( ( $scheduling['interval'] ?? '' ) === 'one_time' ) {
 			$result = \DataMachine\Api\Flows\FlowScheduling::handle_scheduling_update(
-				(int) $job->flow_id,
+				$flow_id,
 				array( 'interval' => 'manual' ),
 				true
 			);
@@ -67,7 +68,7 @@ class JobCompleteHandler {
 					'error',
 					'One-time flow completion left schedule reconciliation drift',
 					array_merge(
-						array( 'flow_id' => (int) $job->flow_id ),
+						array( 'flow_id' => $flow_id ),
 						\DataMachine\Engine\Tasks\RecurringScheduler::errorMetadata( $result )
 					)
 				);

--- a/tests/Unit/Api/Flows/FlowScheduleReconcilerTest.php
+++ b/tests/Unit/Api/Flows/FlowScheduleReconcilerTest.php
@@ -388,8 +388,12 @@ class FlowScheduleReconcilerTest extends WP_UnitTestCase {
 		$transition_updates = 0;
 		$flows_table        = $wpdb->prefix . Flows::TABLE_NAME;
 		$capture_transition = static function ( string $query ) use ( &$transition_updates, $flow_id, $flows_table ): string {
-			$pattern = '/^UPDATE `?' . preg_quote( $flows_table, '/' ) . '`? SET `?scheduling_config`? = .* WHERE `?flow_id`? = ' . $flow_id . '$/';
-			if ( str_contains( $query, '"interval":"manual"' ) && preg_match( $pattern, trim( $query ) ) ) {
+			$update_pattern = '/^\s*UPDATE\s+`?'
+				. preg_quote( $flows_table, '/' )
+				. '`?\s+SET\s+`?scheduling_config`?\s*=.+?\s+WHERE\s*\(?\s*`?flow_id`?\s*=\s*'
+				. '(?:[\'\"]' . $flow_id . '[\'\"]|' . $flow_id . ')\s*\)?\s*;?\s*$/is';
+			$manual_pattern = '/(?:\\\\)?"interval(?:\\\\)?"\s*:\s*(?:\\\\)?"manual(?:\\\\)?"/';
+			if ( preg_match( $manual_pattern, $query ) && preg_match( $update_pattern, $query ) ) {
 				++$transition_updates;
 			}
 			return $query;

--- a/tests/Unit/Api/Flows/FlowScheduleReconcilerTest.php
+++ b/tests/Unit/Api/Flows/FlowScheduleReconcilerTest.php
@@ -11,6 +11,8 @@ use DataMachine\Api\Flows\FlowScheduleReconciler;
 use DataMachine\Api\Flows\FlowScheduleReconciliationLock;
 use DataMachine\Api\Flows\FlowScheduling;
 use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Engine\Actions\Handlers\JobCompleteHandler;
 use DataMachine\Engine\Tasks\RecurringScheduler;
 use WP_UnitTestCase;
 
@@ -362,6 +364,69 @@ class FlowScheduleReconcilerTest extends WP_UnitTestCase {
 		$this->assertSame( 'flow_schedule_reconciliation_locked', $result['code'] );
 
 		$this->assertTrue( FlowScheduleReconciliationLock::release( $token ) );
+	}
+
+	public function test_completed_one_time_job_reverts_flow_to_manual_idempotently(): void {
+		global $wpdb;
+
+		$flow_id = $this->create_flow(
+			'One-time completion cleanup',
+			array(
+				'interval'  => 'one_time',
+				'timestamp' => time() + HOUR_IN_SECONDS,
+			)
+		);
+		$job_id = (int) ( new Jobs() )->create_job(
+			array(
+				'pipeline_id' => $this->pipeline_id,
+				'flow_id'     => $flow_id,
+				'source'      => 'pipeline',
+			)
+		);
+		$this->assertIsInt( $job_id );
+
+		$transition_updates = 0;
+		$flows_table        = $wpdb->prefix . Flows::TABLE_NAME;
+		$capture_transition = static function ( string $query ) use ( &$transition_updates, $flow_id, $flows_table ): string {
+			$pattern = '/^UPDATE `?' . preg_quote( $flows_table, '/' ) . '`? SET `?scheduling_config`? = .* WHERE `?flow_id`? = ' . $flow_id . '$/';
+			if ( str_contains( $query, '"interval":"manual"' ) && preg_match( $pattern, trim( $query ) ) ) {
+				++$transition_updates;
+			}
+			return $query;
+		};
+		add_filter( 'query', $capture_transition );
+
+		try {
+			JobCompleteHandler::handle( $job_id, 'completed' );
+
+			$flow = ( new Flows() )->get_flow( $flow_id );
+			$this->assertNotNull( $flow );
+			$this->assertIsArray( $flow['scheduling_config'] );
+			$this->assertSame( 'manual', $flow['scheduling_config']['interval'] ?? null );
+			$this->assertSame( 1, $transition_updates );
+
+			// Terminal accounting may replay completion after a crash; the second pass is a no-op.
+			JobCompleteHandler::handle( $job_id, 'completed' );
+			$this->assertSame( 1, $transition_updates );
+
+			JobCompleteHandler::handle( PHP_INT_MAX, 'completed' );
+			$this->assertSame( 1, $transition_updates );
+
+			$deleted_flow_id = $this->create_flow( 'Deleted one-time flow', array( 'interval' => 'one_time' ) );
+			$deleted_job_id  = (int) ( new Jobs() )->create_job(
+				array(
+					'pipeline_id' => $this->pipeline_id,
+					'flow_id'     => $deleted_flow_id,
+					'source'      => 'pipeline',
+				)
+			);
+			$this->assertTrue( $this->flows->delete_flow( $deleted_flow_id ) );
+
+			JobCompleteHandler::handle( $deleted_job_id, 'completed' );
+			$this->assertSame( 1, $transition_updates );
+		} finally {
+			remove_filter( 'query', $capture_transition );
+		}
 	}
 
 	private function create_flow( string $name, array $scheduling ): int {


### PR DESCRIPTION
## Summary
- read completed job metadata through the canonical array contract
- reset one-time flow schedules to manual after completion
- keep replay, missing-job, and deleted-flow cleanup idempotent and safe

## Verification
- focused handler-path regression and smoke pass
- changed-scope lint and audit pass with zero findings
- PHP syntax and `git diff --check` pass

Closes #2959