### PR TITLE
fix: initialize scheduler schema across multisite

### DIFF
--- a/inc/Core/ActionScheduler/GroupRegistrar.php
+++ b/inc/Core/ActionScheduler/GroupRegistrar.php
@@ -25,6 +25,20 @@ class GroupRegistrar {
 	}
 
 	/**
+	 * Check whether the custom-table store can safely answer queue queries.
+	 */
+	public static function tablesExist(): bool {
+		if ( ! class_exists( '\ActionScheduler_StoreSchema' ) || ! class_exists( '\ActionScheduler_LoggerSchema' ) ) {
+			return false;
+		}
+
+		$store_schema  = new \ActionScheduler_StoreSchema();
+		$logger_schema = new \ActionScheduler_LoggerSchema();
+
+		return $store_schema->tables_exist() && $logger_schema->tables_exist();
+	}
+
+	/**
 	 * Ensure the custom-table data store has the group row.
 	 */
 	private static function ensureCustomTableGroup( string $group ): void {

--- a/inc/Core/ActionScheduler/QueueTuning.php
+++ b/inc/Core/ActionScheduler/QueueTuning.php
@@ -40,30 +40,102 @@ function datamachine_get_queue_tuning_defaults(): array {
  */
 add_action(
 	'action_scheduler_init',
-	function () {
-		$defaults = datamachine_get_queue_tuning_defaults();
-		$tuning   = \DataMachine\Core\PluginSettings::get( 'queue_tuning', array() );
-
-		$concurrent = isset( $tuning['concurrent_batches'] ) ? absint( $tuning['concurrent_batches'] ) : $defaults['concurrent_batches'];
-		$batch_size = isset( $tuning['batch_size'] ) ? absint( $tuning['batch_size'] ) : $defaults['batch_size'];
-		$time_limit = isset( $tuning['time_limit'] ) ? absint( $tuning['time_limit'] ) : $defaults['time_limit'];
-
-		add_filter( 'action_scheduler_queue_runner_concurrent_batches', function () use ( $concurrent ) {
-			return $concurrent;
-		} );
-
-		add_filter( 'action_scheduler_queue_runner_batch_size', function () use ( $batch_size ) {
-			return $batch_size;
-		} );
-
-		add_filter( 'action_scheduler_queue_runner_time_limit', function () use ( $time_limit ) {
-			return $time_limit;
-		} );
-
-		datamachine_enable_cron_async_dispatch();
-		datamachine_install_deadlock_resilient_runner();
-	}
+	__NAMESPACE__ . '\\datamachine_initialize_queue_tuning'
 );
+
+/**
+ * Reconcile queue tuning and dispatch callbacks for the current blog.
+ */
+function datamachine_initialize_queue_tuning(): void {
+	datamachine_remove_queue_tuning_filters();
+	datamachine_disable_async_dispatch();
+	datamachine_disable_queue_runner();
+
+	if ( ! GroupRegistrar::tablesExist() ) {
+		return;
+	}
+
+	$defaults = datamachine_get_queue_tuning_defaults();
+	$tuning   = PluginSettings::get( 'queue_tuning', array() );
+
+	datamachine_queue_tuning_for_blog(
+		array(
+			'concurrent_batches' => isset( $tuning['concurrent_batches'] ) ? absint( $tuning['concurrent_batches'] ) : $defaults['concurrent_batches'],
+			'batch_size'         => isset( $tuning['batch_size'] ) ? absint( $tuning['batch_size'] ) : $defaults['batch_size'],
+			'time_limit'         => isset( $tuning['time_limit'] ) ? absint( $tuning['time_limit'] ) : $defaults['time_limit'],
+		)
+	);
+
+	add_filter( 'action_scheduler_queue_runner_concurrent_batches', __NAMESPACE__ . '\\datamachine_filter_concurrent_batches' );
+	add_filter( 'action_scheduler_queue_runner_batch_size', __NAMESPACE__ . '\\datamachine_filter_batch_size' );
+	add_filter( 'action_scheduler_queue_runner_time_limit', __NAMESPACE__ . '\\datamachine_filter_time_limit' );
+
+	datamachine_enable_cron_async_dispatch();
+	datamachine_install_deadlock_resilient_runner();
+}
+
+/**
+ * Store or retrieve queue tuning for the current blog.
+ *
+ * @param array|null $tuning Tuning values to store, or null to retrieve them.
+ * @return array Current blog's tuning values.
+ */
+function datamachine_queue_tuning_for_blog( ?array $tuning = null ): array {
+	static $tuning_by_blog = array();
+
+	$blog_id = function_exists( 'get_current_blog_id' ) ? get_current_blog_id() : 0;
+
+	if ( null !== $tuning ) {
+		$tuning_by_blog[ $blog_id ] = $tuning;
+	}
+
+	return $tuning_by_blog[ $blog_id ] ?? datamachine_get_queue_tuning_defaults();
+}
+
+/**
+ * Remove Data Machine's queue tuning filters.
+ */
+function datamachine_remove_queue_tuning_filters(): void {
+	remove_filter( 'action_scheduler_queue_runner_concurrent_batches', __NAMESPACE__ . '\\datamachine_filter_concurrent_batches' );
+	remove_filter( 'action_scheduler_queue_runner_batch_size', __NAMESPACE__ . '\\datamachine_filter_batch_size' );
+	remove_filter( 'action_scheduler_queue_runner_time_limit', __NAMESPACE__ . '\\datamachine_filter_time_limit' );
+}
+
+function datamachine_filter_concurrent_batches(): int {
+	return datamachine_queue_tuning_for_blog()['concurrent_batches'];
+}
+
+function datamachine_filter_batch_size(): int {
+	return datamachine_queue_tuning_for_blog()['batch_size'];
+}
+
+function datamachine_filter_time_limit(): int {
+	return datamachine_queue_tuning_for_blog()['time_limit'];
+}
+
+/**
+ * Prevent Action Scheduler from querying an incomplete custom-table schema on shutdown.
+ */
+function datamachine_disable_async_dispatch(): void {
+	$runner = \ActionScheduler::runner();
+	remove_action( 'shutdown', __NAMESPACE__ . '\\datamachine_dispatch_async_request' );
+
+	if ( method_exists( $runner, 'unhook_dispatch_async_request' ) ) {
+		$runner->unhook_dispatch_async_request();
+	}
+
+	remove_action( 'shutdown', array( $runner, 'maybe_dispatch_async_request' ) );
+}
+
+/**
+ * Prevent Action Scheduler from running against an incomplete custom-table schema.
+ */
+function datamachine_disable_queue_runner(): void {
+	$runner = \ActionScheduler::runner();
+
+	remove_action( 'action_scheduler_run_queue', array( $runner, 'run' ) );
+	remove_action( 'action_scheduler_run_queue', __NAMESPACE__ . '\\datamachine_run_queue_with_deadlock_retries' );
+}
 
 /**
  * Make the Action Scheduler queue runner resilient to transient claim deadlocks.
@@ -92,11 +164,8 @@ add_action(
  *
  *  1. Idempotency. `action_scheduler_init` can fire more than once in a request
  *     (notably on multisite, where AS may initialize across switch_to_blog()
- *     contexts). Without a guard, each fire would stack another wrapper closure on
- *     `action_scheduler_run_queue` — the queue would then run two-plus times per
- *     dispatch, multiplying the concurrent claim_actions() pressure that causes the
- *     deadlock in the first place. A static guard makes the swap happen once per
- *     request.
+ *     contexts). A named callback makes each registration replace the same hook
+ *     entry instead of stacking wrapper closures that run the queue multiple times.
  *
  *  2. Sufficient retry budget. Under concurrent batches (default 3) the same hot
  *     rows can deadlock several times in quick succession, so a 3-attempt /
@@ -108,49 +177,36 @@ add_action(
  * @since 0.153.6
  */
 function datamachine_install_deadlock_resilient_runner(): void {
-	static $installed = false;
-
-	// `action_scheduler_init` can fire multiple times per request; only swap once.
-	if ( $installed ) {
-		return;
-	}
-	$installed = true;
-
-	$runner = \ActionScheduler::runner();
-
 	// Swap AS's default `run` callback for a deadlock-resilient wrapper.
-	remove_action( 'action_scheduler_run_queue', array( $runner, 'run' ) );
+	datamachine_disable_queue_runner();
+	add_action( 'action_scheduler_run_queue', __NAMESPACE__ . '\\datamachine_run_queue_with_deadlock_retries', 10, 1 );
+}
 
-	add_action(
-		'action_scheduler_run_queue',
-		function ( $context = '' ) use ( $runner ) {
-			$max_attempts = 5;
-			$attempt      = 0;
+/**
+ * Run the current blog's queue with retries for transient database deadlocks.
+ *
+ * @param string $context Queue runner context.
+ * @return mixed Queue runner result.
+ */
+function datamachine_run_queue_with_deadlock_retries( $context = '' ) {
+	$runner       = \ActionScheduler::runner();
+	$max_attempts = 5;
+	$attempt      = 0;
 
-			while ( true ) {
-				$attempt++;
+	while ( true ) {
+		++$attempt;
 
-				try {
-					return $runner->run( $context );
-				} catch ( \RuntimeException $e ) {
-					if ( ! datamachine_is_transient_deadlock( $e ) || $attempt >= $max_attempts ) {
-						// Not retryable, or we're out of attempts — let it surface.
-						throw $e;
-					}
-
-					// Transient deadlock: back off with exponential, jittered delay,
-					// then retry. 50/100/200/400ms (+ up to 50ms jitter) caps total
-					// backoff under ~1s — comfortably inside the batch time limit —
-					// while giving the competing transaction time to commit and
-					// release its locks.
-					$backoff_us = ( 50000 * ( 2 ** ( $attempt - 1 ) ) ) + random_int( 0, 50000 );
-					usleep( $backoff_us );
-				}
+		try {
+			return $runner->run( $context );
+		} catch ( \RuntimeException $e ) {
+			if ( ! datamachine_is_transient_deadlock( $e ) || $attempt >= $max_attempts ) {
+				throw $e;
 			}
-		},
-		10,
-		1
-	);
+
+			$backoff_us = ( 50000 * ( 2 ** ( $attempt - 1 ) ) ) + random_int( 0, 50000 );
+			usleep( $backoff_us );
+		}
+	}
 }
 
 /**
@@ -186,25 +242,21 @@ function datamachine_is_transient_deadlock( \Throwable $e ): bool {
  * @since 0.41.0
  */
 function datamachine_enable_cron_async_dispatch(): void {
-	$runner = \ActionScheduler::runner();
+	datamachine_disable_async_dispatch();
+	add_action( 'shutdown', __NAMESPACE__ . '\\datamachine_dispatch_async_request' );
+}
 
-	// Remove the original gated shutdown callback.
-	remove_action( 'shutdown', array( $runner, 'maybe_dispatch_async_request' ) );
-
-	// Add our own that skips the is_admin() check.
-	add_action(
-		'shutdown',
-		function () use ( $runner ) {
-			// The OptionLock already throttles to once per 60 seconds — this is the
-			// same guard AS uses, minus the is_admin() gate that blocks cron contexts.
-			if (
-				! \ActionScheduler::lock()->is_locked( 'async-request-runner' )
-				&& \ActionScheduler::lock()->set( 'async-request-runner' )
-			) {
-				$ref           = new \ReflectionProperty( get_class( $runner ), 'async_request' );
-				$async_request = $ref->getValue( $runner );
-				$async_request->maybe_dispatch();
-			}
-		}
-	);
+/**
+ * Dispatch an async queue request without Action Scheduler's admin-only gate.
+ */
+function datamachine_dispatch_async_request(): void {
+	if (
+		! \ActionScheduler::lock()->is_locked( 'async-request-runner' )
+		&& \ActionScheduler::lock()->set( 'async-request-runner' )
+	) {
+		$runner        = \ActionScheduler::runner();
+		$ref           = new \ReflectionProperty( get_class( $runner ), 'async_request' );
+		$async_request = $ref->getValue( $runner );
+		$async_request->maybe_dispatch();
+	}
 }

--- a/inc/Core/Bootstrap/ActivationServiceProvider.php
+++ b/inc/Core/Bootstrap/ActivationServiceProvider.php
@@ -119,6 +119,7 @@ final class ActivationServiceProvider {
 	 * Run setup for one site.
 	 */
 	public static function activate_for_site(): void {
+		self::ensure_action_scheduler_tables();
 		self::register_capabilities();
 		self::ensure_all_tables();
 		datamachine_migrate_legacy_email_flow_auth();
@@ -130,6 +131,44 @@ final class ActivationServiceProvider {
 		\DataMachine\Engine\AI\ComposableFileGenerator::regenerate_all();
 		datamachine_mark_flow_schedule_reconciliation();
 		update_option( 'datamachine_db_version', DATAMACHINE_VERSION, true );
+	}
+
+	/**
+	 * Initialize Action Scheduler's custom tables for the current site.
+	 *
+	 * Action Scheduler stores these tables using the current site's prefix, so
+	 * network activation must run its schema registration inside each site.
+	 */
+	public static function ensure_action_scheduler_tables(): void {
+		if ( ! class_exists( '\ActionScheduler_StoreSchema' ) || ! class_exists( '\ActionScheduler_LoggerSchema' ) ) {
+			return;
+		}
+
+		global $wpdb;
+
+		$store_schema  = new \ActionScheduler_StoreSchema();
+		$logger_schema = new \ActionScheduler_LoggerSchema();
+		$table_names   = array(
+			\ActionScheduler_StoreSchema::ACTIONS_TABLE,
+			\ActionScheduler_StoreSchema::CLAIMS_TABLE,
+			\ActionScheduler_StoreSchema::GROUPS_TABLE,
+			\ActionScheduler_LoggerSchema::LOG_TABLE,
+		);
+
+		// AS registers the same suffixes on every blog. Remove prior entries so a
+		// network activation leaves one registration per table, not one per site.
+		$wpdb->tables = array_values( array_diff( $wpdb->tables, $table_names ) );
+
+		$store_schema->init();
+		$logger_schema->init();
+
+		try {
+			$store_schema->register_tables( ! $store_schema->tables_exist() );
+			$logger_schema->register_tables( ! $logger_schema->tables_exist() );
+		} finally {
+			remove_action( 'action_scheduler_before_schema_update', array( $store_schema, 'update_schema_5_0' ), 10 );
+			remove_action( 'action_scheduler_before_schema_update', array( $logger_schema, 'update_schema_3_0' ), 10 );
+		}
 	}
 
 	/**

--- a/tests/action-scheduler-multisite-smoke.php
+++ b/tests/action-scheduler-multisite-smoke.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Behavioral multisite smoke for Action Scheduler lifecycle setup.
+ *
+ * Run with: php tests/action-scheduler-multisite-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( defined( 'WPINC' ) ) {
+	fwrite( STDOUT, "action-scheduler-multisite-smoke: standalone harness skipped under real WordPress.\n" );
+	return;
+}
+
+require __DIR__ . '/fixtures/action-scheduler-multisite-standalone.php';

--- a/tests/fixtures/action-scheduler-multisite-standalone.php
+++ b/tests/fixtures/action-scheduler-multisite-standalone.php
@@ -1,0 +1,494 @@
+<?php
+/**
+ * Behavioral multisite smoke for Action Scheduler lifecycle setup.
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+
+	define( 'ABSPATH', __DIR__ . '/wordpress/' );
+	define( 'HOUR_IN_SECONDS', 3600 );
+	define( 'DATAMACHINE_VERSION', 'test-version' );
+
+	$GLOBALS['datamachine_test_blog_id'] = 1;
+	$GLOBALS['datamachine_test_hooks']   = array();
+	$GLOBALS['datamachine_test_options'] = array();
+
+	class WP_Site {
+		public int $blog_id;
+
+		public function __construct( int $blog_id ) {
+			$this->blog_id = $blog_id;
+		}
+	}
+
+	class DataMachineTestRepository {
+		public static function __callStatic( string $name, array $arguments ) {
+			unset( $name, $arguments );
+		}
+
+		public function __call( string $name, array $arguments ) {
+			unset( $name, $arguments );
+		}
+	}
+
+	#[\AllowDynamicProperties]
+	class DataMachineActionSchedulerWpdb {
+		public string $base_prefix = 'wp_';
+		public string $prefix = 'wp_';
+		public array $tables = array();
+		public array $existing_tables = array();
+
+		public function set_blog_id( int $blog_id ): void {
+			$this->prefix = 1 === $blog_id ? 'wp_' : "wp_{$blog_id}_";
+		}
+
+		public function prepare( string $query, ...$args ): array {
+			return array(
+				'query' => $query,
+				'args'  => $args,
+			);
+		}
+
+		public function get_var( $query ) {
+			if ( is_array( $query ) && false !== strpos( $query['query'], 'SHOW TABLES LIKE' ) ) {
+				$table = str_replace( '\\_', '_', (string) $query['args'][0] );
+				return isset( $this->existing_tables[ $table ] ) ? $table : null;
+			}
+
+			return null;
+		}
+
+		public function get_col( string $query ): array {
+			if ( preg_match( "/SHOW TABLES LIKE '([^']+)'/", $query, $matches ) ) {
+				return isset( $this->existing_tables[ $matches[1] ] ) ? array( $matches[1] ) : array();
+			}
+
+			return array();
+		}
+
+		public function query( string $query ): int {
+			unset( $query );
+			return 0;
+		}
+
+		public function get_charset_collate(): string {
+			return '';
+		}
+	}
+
+	$GLOBALS['wpdb'] = new DataMachineActionSchedulerWpdb();
+
+	function datamachine_test_callback_id( $callback ): string {
+		if ( is_array( $callback ) ) {
+			$owner = is_object( $callback[0] ) ? spl_object_hash( $callback[0] ) : (string) $callback[0];
+			return $owner . '::' . $callback[1];
+		}
+
+		return $callback instanceof \Closure ? spl_object_hash( $callback ) : (string) $callback;
+	}
+
+	function add_action( string $hook, $callback, int $priority = 10, int $accepted_args = 1 ): bool {
+		$id = datamachine_test_callback_id( $callback );
+		$GLOBALS['datamachine_test_hooks'][ $hook ][ $priority ][ $id ] = array( $callback, $accepted_args );
+		return true;
+	}
+
+	function add_filter( string $hook, $callback, int $priority = 10, int $accepted_args = 1 ): bool {
+		return add_action( $hook, $callback, $priority, $accepted_args );
+	}
+
+	function remove_filter( string $hook, $callback, int $priority = 10 ): bool {
+		return remove_action( $hook, $callback, $priority );
+	}
+
+	function remove_action( string $hook, $callback, int $priority = 10 ): bool {
+		$id = datamachine_test_callback_id( $callback );
+		if ( ! isset( $GLOBALS['datamachine_test_hooks'][ $hook ][ $priority ][ $id ] ) ) {
+			return false;
+		}
+
+		unset( $GLOBALS['datamachine_test_hooks'][ $hook ][ $priority ][ $id ] );
+		return true;
+	}
+
+	function do_action( string $hook, ...$args ): void {
+		$priorities = $GLOBALS['datamachine_test_hooks'][ $hook ] ?? array();
+		ksort( $priorities );
+		foreach ( $priorities as $callbacks ) {
+			foreach ( $callbacks as list( $callback, $accepted_args ) ) {
+				$callback( ...array_slice( $args, 0, $accepted_args ) );
+			}
+		}
+	}
+
+	function apply_filters( string $hook, $value ) {
+		$priorities = $GLOBALS['datamachine_test_hooks'][ $hook ] ?? array();
+		ksort( $priorities );
+		foreach ( $priorities as $callbacks ) {
+			foreach ( $callbacks as list( $callback ) ) {
+				$value = $callback( $value );
+			}
+		}
+		return $value;
+	}
+
+	function datamachine_test_hook_count( string $hook ): int {
+		$count = 0;
+		foreach ( $GLOBALS['datamachine_test_hooks'][ $hook ] ?? array() as $callbacks ) {
+			$count += count( $callbacks );
+		}
+		return $count;
+	}
+
+	function datamachine_test_has_callback( string $hook, $callback, int $priority = 10 ): bool {
+		$id = datamachine_test_callback_id( $callback );
+		return isset( $GLOBALS['datamachine_test_hooks'][ $hook ][ $priority ][ $id ] );
+	}
+
+	function get_option( string $name, $default = false ) {
+		$blog_id = $GLOBALS['datamachine_test_blog_id'];
+		return $GLOBALS['datamachine_test_options'][ $blog_id ][ $name ] ?? $default;
+	}
+
+	function get_current_blog_id(): int {
+		return $GLOBALS['datamachine_test_blog_id'];
+	}
+
+	function absint( $value ): int {
+		return abs( (int) $value );
+	}
+
+	function add_option( string $name, $value ): bool {
+		$blog_id = $GLOBALS['datamachine_test_blog_id'];
+		if ( isset( $GLOBALS['datamachine_test_options'][ $blog_id ][ $name ] ) ) {
+			return false;
+		}
+
+		$GLOBALS['datamachine_test_options'][ $blog_id ][ $name ] = $value;
+		return true;
+	}
+
+	function update_option( string $name, $value, $autoload = null ): bool {
+		unset( $autoload );
+		$GLOBALS['datamachine_test_options'][ $GLOBALS['datamachine_test_blog_id'] ][ $name ] = $value;
+		return true;
+	}
+
+	function delete_option( string $name ): bool {
+		unset( $GLOBALS['datamachine_test_options'][ $GLOBALS['datamachine_test_blog_id'] ][ $name ] );
+		return true;
+	}
+
+	function switch_to_blog( int $blog_id ): bool {
+		$GLOBALS['datamachine_test_blog_stack'][] = $GLOBALS['datamachine_test_blog_id'];
+		$GLOBALS['datamachine_test_blog_id']       = $blog_id;
+		$GLOBALS['wpdb']->set_blog_id( $blog_id );
+		return true;
+	}
+
+	function restore_current_blog(): bool {
+		$blog_id = array_pop( $GLOBALS['datamachine_test_blog_stack'] );
+		$GLOBALS['datamachine_test_blog_id'] = $blog_id;
+		$GLOBALS['wpdb']->set_blog_id( $blog_id );
+		return true;
+	}
+
+	function is_plugin_active_for_network( string $plugin ): bool {
+		unset( $plugin );
+		return true;
+	}
+
+	function plugin_basename( string $file ): string {
+		return basename( dirname( $file ) ) . '/' . basename( $file );
+	}
+
+	function get_role( string $role_name ): object {
+		unset( $role_name );
+		return new class() {
+			public function add_cap( string $capability ): void {
+				unset( $capability );
+			}
+		};
+	}
+
+	function set_transient( string $name, $value, int $expiration ): bool {
+		unset( $name, $value, $expiration );
+		return true;
+	}
+
+	function datamachine_migrate_legacy_email_flow_auth(): void {}
+	function datamachine_ensure_default_memory_files(): bool {
+		return true;
+	}
+	function datamachine_mark_flow_schedule_reconciliation(): void {}
+
+	function dbDelta( string $definition ): array {
+		if ( ! preg_match( '/CREATE TABLE\s+([^\s(]+)/i', $definition, $matches ) ) {
+			return array();
+		}
+
+		$table = trim( $matches[1], '`' );
+		$GLOBALS['wpdb']->existing_tables[ $table ] = true;
+		return array( $table => "Created table {$table}" );
+	}
+}
+
+namespace DataMachine\Core {
+	class PluginSettings {
+		public static function getDefaultQueueTuning(): array {
+			return array( 'concurrent_batches' => 3, 'batch_size' => 25, 'time_limit' => 60 );
+		}
+
+		public static function get( string $key, array $default ): array {
+			unset( $key );
+			return $GLOBALS['datamachine_test_queue_tuning'][ $GLOBALS['datamachine_test_blog_id'] ] ?? $default;
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\Agents {
+	class Agents extends \DataMachineTestRepository {}
+	class AgentAccess extends \DataMachineTestRepository {}
+	class AgentTokens extends \DataMachineTestRepository {}
+}
+
+namespace DataMachine\Core\Database\Logs {
+	class LogRepository extends \DataMachineTestRepository {}
+}
+
+namespace DataMachine\Core\Database\Pipelines {
+	class Pipelines extends \DataMachineTestRepository {}
+}
+
+namespace DataMachine\Core\Database\Flows {
+	class Flows extends \DataMachineTestRepository {}
+}
+
+namespace DataMachine\Core\Database\Jobs {
+	class Jobs extends \DataMachineTestRepository {}
+}
+
+namespace DataMachine\Core\Database\ProcessedItems {
+	class ProcessedItems extends \DataMachineTestRepository {}
+}
+
+namespace DataMachine\Core\Database\BatchItems {
+	class BatchItems extends \DataMachineTestRepository {}
+}
+
+namespace DataMachine\Core\Database\TrackedItems {
+	class TrackedItems extends \DataMachineTestRepository {}
+}
+
+namespace DataMachine\Core\Database\PostIdentityIndex {
+	class PostIdentityIndex extends \DataMachineTestRepository {}
+}
+
+namespace DataMachine\Core\Database\PostIdentityReservations {
+	class PostIdentityReservations extends \DataMachineTestRepository {}
+}
+
+namespace DataMachine\Core\Database\BundleArtifacts {
+	class InstalledBundleArtifacts extends \DataMachineTestRepository {}
+}
+
+namespace DataMachine\Core\Database\RunMetadata {
+	class RunMetadata extends \DataMachineTestRepository {}
+}
+
+namespace DataMachine\Core\Database\Chat {
+	class Chat extends \DataMachineTestRepository {}
+}
+
+namespace DataMachine\Engine\AI\Actions {
+	class PendingActionStore extends \DataMachineTestRepository {}
+}
+
+namespace DataMachine\Engine\AI {
+	class ComposableFileGenerator extends \DataMachineTestRepository {}
+}
+
+namespace {
+	$root = dirname( __DIR__, 2 );
+	require_once $root . '/vendor/woocommerce/action-scheduler/classes/abstracts/ActionScheduler_Abstract_Schema.php';
+	require_once $root . '/vendor/woocommerce/action-scheduler/classes/schema/ActionScheduler_StoreSchema.php';
+	require_once $root . '/vendor/woocommerce/action-scheduler/classes/schema/ActionScheduler_LoggerSchema.php';
+	require_once $root . '/inc/Core/Bootstrap/ActivationServiceProvider.php';
+	require_once $root . '/inc/Core/ActionScheduler/GroupRegistrar.php';
+
+	class DataMachineTestQueueRunner {
+		public int $dispatches = 0;
+		public int $runs = 0;
+
+		public function hook_queue_runner(): void {
+			add_action( 'action_scheduler_run_queue', array( $this, 'run' ) );
+		}
+
+		public function run(): void {
+			++$this->runs;
+		}
+
+		public function hook_dispatch_async_request(): void {
+			add_action( 'shutdown', array( $this, 'maybe_dispatch_async_request' ) );
+		}
+
+		public function unhook_dispatch_async_request(): void {
+			remove_action( 'shutdown', array( $this, 'maybe_dispatch_async_request' ) );
+		}
+
+		public function maybe_dispatch_async_request(): void {
+			++$this->dispatches;
+		}
+	}
+
+	class DataMachineTestActionSchedulerLock {
+		public function is_locked( string $key ): bool {
+			unset( $key );
+			return false;
+		}
+
+		public function set( string $key ): bool {
+			unset( $key );
+			return true;
+		}
+	}
+
+	class ActionScheduler {
+		private static ?DataMachineTestQueueRunner $runner = null;
+
+		public static function runner(): DataMachineTestQueueRunner {
+			self::$runner ??= new DataMachineTestQueueRunner();
+			return self::$runner;
+		}
+
+		public static function lock(): DataMachineTestActionSchedulerLock {
+			return new DataMachineTestActionSchedulerLock();
+		}
+	}
+
+	$failures = 0;
+	$passes   = 0;
+
+	function datamachine_action_scheduler_assert( bool $condition, string $message ): void {
+		global $failures, $passes;
+
+		if ( $condition ) {
+			++$passes;
+			fwrite( STDOUT, "PASS: {$message}\n" );
+			return;
+		}
+
+		++$failures;
+		fwrite( STDERR, "FAIL: {$message}\n" );
+	}
+
+	function datamachine_action_scheduler_tables_for_blog( int $blog_id ): array {
+		$prefix = 1 === $blog_id ? 'wp_' : "wp_{$blog_id}_";
+		return array(
+			$prefix . ActionScheduler_StoreSchema::ACTIONS_TABLE,
+			$prefix . ActionScheduler_StoreSchema::CLAIMS_TABLE,
+			$prefix . ActionScheduler_StoreSchema::GROUPS_TABLE,
+			$prefix . ActionScheduler_LoggerSchema::LOG_TABLE,
+		);
+	}
+
+	function datamachine_assert_blog_setup( int $blog_id, string $context ): void {
+		global $wpdb;
+
+		foreach ( datamachine_action_scheduler_tables_for_blog( $blog_id ) as $table ) {
+			datamachine_action_scheduler_assert( isset( $wpdb->existing_tables[ $table ] ), "{$context}: creates {$table}" );
+		}
+
+		$options = $GLOBALS['datamachine_test_options'][ $blog_id ] ?? array();
+		datamachine_action_scheduler_assert( isset( $options['schema-ActionScheduler_StoreSchema'] ), "{$context}: records store schema version" );
+		datamachine_action_scheduler_assert( isset( $options['schema-ActionScheduler_LoggerSchema'] ), "{$context}: records logger schema version" );
+		datamachine_action_scheduler_assert( DATAMACHINE_VERSION === ( $options['datamachine_db_version'] ?? null ), "{$context}: records Data Machine version" );
+	}
+
+	use DataMachine\Core\Bootstrap\ActivationServiceProvider;
+
+	// Existing-site activation runs both registered activation callbacks.
+	ActivationServiceProvider::activate_defaults_for_site();
+	ActivationServiceProvider::activate_for_site();
+	datamachine_assert_blog_setup( 1, 'existing site' );
+	datamachine_action_scheduler_assert( isset( $GLOBALS['datamachine_test_options'][1]['datamachine_settings'] ), 'existing site: records defaults' );
+
+	// A newly created site must receive the same per-blog schema and options.
+	ActivationServiceProvider::on_new_site( new WP_Site( 2 ) );
+	datamachine_assert_blog_setup( 2, 'new site' );
+	datamachine_action_scheduler_assert( isset( $GLOBALS['datamachine_test_options'][2]['datamachine_settings'] ), 'new site: records defaults' );
+	datamachine_action_scheduler_assert( 1 === $GLOBALS['datamachine_test_blog_id'], 'new-site setup restores the original blog' );
+
+	// Repeating both lifecycle paths must not duplicate registrations or callbacks.
+	ActivationServiceProvider::activate_for_site();
+	ActivationServiceProvider::on_new_site( new WP_Site( 2 ) );
+	foreach ( array( ActionScheduler_StoreSchema::ACTIONS_TABLE, ActionScheduler_StoreSchema::CLAIMS_TABLE, ActionScheduler_StoreSchema::GROUPS_TABLE, ActionScheduler_LoggerSchema::LOG_TABLE ) as $table ) {
+		datamachine_action_scheduler_assert( 1 === count( array_keys( $GLOBALS['wpdb']->tables, $table, true ) ), "repeated setup registers {$table} once" );
+	}
+	datamachine_action_scheduler_assert( 0 === datamachine_test_hook_count( 'action_scheduler_before_schema_update' ), 'repeated setup removes schema migration callbacks' );
+	datamachine_assert_blog_setup( 1, 'repeated existing site' );
+	datamachine_assert_blog_setup( 2, 'repeated new site' );
+
+	// A first initialization with missing schema leaves no queue runner or dispatcher callbacks.
+	$runner = ActionScheduler::runner();
+	$missing_table = 'wp_' . ActionScheduler_StoreSchema::ACTIONS_TABLE;
+	unset( $GLOBALS['wpdb']->existing_tables[ $missing_table ] );
+	$runner->hook_queue_runner();
+	$runner->hook_dispatch_async_request();
+	require_once $root . '/inc/Core/ActionScheduler/QueueTuning.php';
+	do_action( 'action_scheduler_init' );
+	datamachine_action_scheduler_assert( 0 === datamachine_test_hook_count( 'action_scheduler_run_queue' ), 'first missing-schema initialization removes all queue runner callbacks' );
+	datamachine_action_scheduler_assert( 0 === datamachine_test_hook_count( 'shutdown' ), 'first missing-schema initialization removes all dispatchers' );
+
+	// A healthy re-initialization restores exactly one runner, dispatcher, and each filter.
+	$GLOBALS['wpdb']->existing_tables[ $missing_table ] = true;
+	$runner->hook_queue_runner();
+	$runner->hook_dispatch_async_request();
+	do_action( 'action_scheduler_init' );
+	datamachine_action_scheduler_assert( 1 === datamachine_test_hook_count( 'action_scheduler_run_queue' ), 'healthy initialization installs one Data Machine queue runner' );
+	datamachine_action_scheduler_assert( datamachine_test_has_callback( 'action_scheduler_run_queue', 'DataMachine\\Core\\ActionScheduler\\datamachine_run_queue_with_deadlock_retries' ), 'healthy initialization installs the retry queue runner' );
+	datamachine_action_scheduler_assert( 1 === datamachine_test_hook_count( 'shutdown' ), 'healthy initialization installs one Data Machine dispatcher' );
+	datamachine_action_scheduler_assert( datamachine_test_has_callback( 'shutdown', 'DataMachine\\Core\\ActionScheduler\\datamachine_dispatch_async_request' ), 'healthy initialization installs the Data Machine dispatcher' );
+	foreach ( array( 'action_scheduler_queue_runner_concurrent_batches', 'action_scheduler_queue_runner_batch_size', 'action_scheduler_queue_runner_time_limit' ) as $filter ) {
+		datamachine_action_scheduler_assert( 1 === datamachine_test_hook_count( $filter ), "healthy initialization installs one {$filter} callback" );
+	}
+
+	$runner->hook_queue_runner();
+	$runner->hook_dispatch_async_request();
+	do_action( 'action_scheduler_init' );
+	datamachine_action_scheduler_assert( 1 === datamachine_test_hook_count( 'action_scheduler_run_queue' ), 'healthy to healthy keeps one Data Machine queue runner' );
+	datamachine_action_scheduler_assert( datamachine_test_has_callback( 'action_scheduler_run_queue', 'DataMachine\\Core\\ActionScheduler\\datamachine_run_queue_with_deadlock_retries' ), 'healthy to healthy keeps the retry queue runner' );
+	datamachine_action_scheduler_assert( 1 === datamachine_test_hook_count( 'shutdown' ), 'healthy to healthy keeps one Data Machine dispatcher' );
+	datamachine_action_scheduler_assert( datamachine_test_has_callback( 'shutdown', 'DataMachine\\Core\\ActionScheduler\\datamachine_dispatch_async_request' ), 'healthy to healthy keeps the Data Machine dispatcher' );
+	foreach ( array( 'action_scheduler_queue_runner_concurrent_batches', 'action_scheduler_queue_runner_batch_size', 'action_scheduler_queue_runner_time_limit' ) as $filter ) {
+		datamachine_action_scheduler_assert( 1 === datamachine_test_hook_count( $filter ), "healthy to healthy keeps one {$filter} callback" );
+	}
+
+	// Tuning remains scoped to the active blog while callbacks remain process-global.
+	$GLOBALS['datamachine_test_queue_tuning'][1] = array( 'concurrent_batches' => 4, 'batch_size' => 30, 'time_limit' => 70 );
+	do_action( 'action_scheduler_init' );
+	switch_to_blog( 2 );
+	$GLOBALS['datamachine_test_queue_tuning'][2] = array( 'concurrent_batches' => 2, 'batch_size' => 15, 'time_limit' => 45 );
+	do_action( 'action_scheduler_init' );
+	datamachine_action_scheduler_assert( 2 === apply_filters( 'action_scheduler_queue_runner_concurrent_batches', 1 ), 'blog 2 uses its own queue tuning' );
+	restore_current_blog();
+	datamachine_action_scheduler_assert( 4 === apply_filters( 'action_scheduler_queue_runner_concurrent_batches', 1 ), 'restored blog uses its own queue tuning' );
+
+	// A later missing schema removes both AS and Data Machine dispatchers and all tuning filters.
+	unset( $GLOBALS['wpdb']->existing_tables[ $missing_table ] );
+	$runner->hook_queue_runner();
+	$runner->hook_dispatch_async_request();
+	do_action( 'action_scheduler_init' );
+	datamachine_action_scheduler_assert( 0 === datamachine_test_hook_count( 'action_scheduler_run_queue' ), 'healthy to missing removes all queue runner callbacks' );
+	datamachine_action_scheduler_assert( 0 === datamachine_test_hook_count( 'shutdown' ), 'missing schema unhooks the default shutdown dispatcher' );
+	foreach ( array( 'action_scheduler_queue_runner_concurrent_batches', 'action_scheduler_queue_runner_batch_size', 'action_scheduler_queue_runner_time_limit' ) as $filter ) {
+		datamachine_action_scheduler_assert( 0 === datamachine_test_hook_count( $filter ), "healthy to missing removes {$filter} callbacks" );
+	}
+	do_action( 'shutdown' );
+	datamachine_action_scheduler_assert( 0 === $runner->dispatches, 'missing schema does not dispatch an async request' );
+
+	fwrite( STDOUT, "\n{$passes} passed, {$failures} failed.\n" );
+	exit( $failures > 0 ? 1 : 0 );
+}

--- a/tests/fixtures/wordpress/wp-admin/includes/upgrade.php
+++ b/tests/fixtures/wordpress/wp-admin/includes/upgrade.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Empty upgrade include for standalone schema smokes.
+ *
+ * The smoke defines its dbDelta() double before Action Scheduler loads this file.
+ *
+ * @package DataMachine\Tests
+ */


### PR DESCRIPTION
## Summary
- initialize Action Scheduler schemas for every existing and newly created multisite blog
- use Action Scheduler-owned schema readiness checks and deduplicate table/callback registration
- fail closed by removing queue runners, shutdown dispatchers, and tuning filters when schema is unavailable
- add behavioral multisite and repeated-initialization coverage

## Verification
- multisite scheduler smoke: 60 assertions pass
- changed-scope lint and audit pass with zero findings
- PHP syntax and `git diff --check` pass

Closes #2970