### PR TITLE
fix: allow trusted agent scaffold bootstrap

### DIFF
--- a/inc/Abilities/File/ScaffoldAbilities.php
+++ b/inc/Abilities/File/ScaffoldAbilities.php
@@ -6,8 +6,10 @@
  * creating missing memory files lives here — directory resolution,
  * content generation, file writing, permission checks.
  *
- * Every caller uses the ability directly:
+ * External callers use the ability directly:
  *   wp_get_ability( 'datamachine/scaffold-memory-file' )->execute( $input )
+ * Trusted domain bootstrap may invoke execute() without re-entering the public
+ * permission boundary.
  *
  * Content generators register on the `datamachine_scaffold_content`
  * filter, keyed by filename. The ability never overwrites existing files.

--- a/inc/Core/Identity/AgentIdentityStoreAdapter.php
+++ b/inc/Core/Identity/AgentIdentityStoreAdapter.php
@@ -160,9 +160,10 @@ class AgentIdentityStoreAdapter implements WP_Agent_Identity_Store {
 			}
 		}
 
-		$scaffold = ScaffoldAbilities::get_ability();
-		if ( $scaffold ) {
-			$result = $scaffold->execute(
+		if ( ScaffoldAbilities::get_ability() ) {
+			// Identity materialization is trusted domain work. Calling the public
+			// ability runner here would require a logged-in user during bootstrap.
+			$result = ScaffoldAbilities::execute(
 				array(
 					'layer'         => 'agent',
 					'agent_slug'    => $scope->agent_slug,

--- a/inc/Engine/Agents/AgentMaterializer.php
+++ b/inc/Engine/Agents/AgentMaterializer.php
@@ -24,7 +24,7 @@ class AgentMaterializer {
 	 * For each registered slug:
 	 *   - Row already exists -> leave it alone (mutable fields are DB-owned)
 	 *   - Row missing        -> resolve owner, create row, bootstrap access,
-	 *                          ensure agent directory, trigger scaffold ability
+	 *                          ensure agent directory, scaffold memory files
 	 *
 	 * Idempotent: safe to call multiple times per request. Returns a
 	 * summary of what happened for logging / testing.

--- a/tests/Unit/Core/Identity/AgentIdentityStoreAdapterTest.php
+++ b/tests/Unit/Core/Identity/AgentIdentityStoreAdapterTest.php
@@ -9,6 +9,7 @@ namespace DataMachine\Tests\Unit\Core\Identity;
 
 use AgentsAPI\Core\Identity\WP_Agent_Identity_Scope;
 use AgentsAPI\Core\Identity\WP_Agent_Materialized_Identity;
+use DataMachine\Abilities\File\ScaffoldAbilities;
 use DataMachine\Core\Database\Agents\AgentAccess;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\FilesRepository\DirectoryManager;
@@ -165,6 +166,34 @@ class AgentIdentityStoreAdapterTest extends WP_UnitTestCase {
 		$this->assertSame( '', (string) $row['provisioning_token'] );
 		$this->assertEmpty( $row['provisioned_at'] );
 		$this->assertNull( $this->store->resolve( $scope ) );
+	}
+
+	public function test_bootstrap_materializes_without_authenticated_user_while_public_ability_remains_denied(): void {
+		$slug = 'unauthenticated-bootstrap-agent';
+		$this->register_agent( $slug );
+		wp_set_current_user( 0 );
+
+		$identity  = $this->store->materialize( new WP_Agent_Identity_Scope( $slug, $this->owner_a ) );
+		$directory = ( new DirectoryManager() )->resolve_agent_directory( array( 'agent_id' => $identity->id ) );
+
+		$this->assertSame( $identity->id, $this->store->resolve( $identity->scope )->id );
+		$this->assertFileExists( trailingslashit( $directory ) . 'SOUL.md' );
+		$this->assertFileExists( trailingslashit( $directory ) . 'MEMORY.md' );
+
+		$ability = ScaffoldAbilities::get_ability();
+		$this->assertNotNull( $ability );
+		$result = $ability->execute(
+			array(
+				'layer'         => 'agent',
+				'agent_slug'    => $slug,
+				'agent_id'      => $identity->id,
+				'owner_user_id' => $this->owner_a,
+				'instance_key'  => 'default',
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
 	}
 
 	public function test_duplicate_key_loser_reconciles_pending_winner(): void {


### PR DESCRIPTION
## Summary
- provision materialized agent scaffolds through the existing domain callback instead of re-entering the public ability permission boundary
- preserve the registered-ability/pre-init guard and normal external `datamachine/scaffold-memory-file` authorization
- add regression coverage for unauthenticated bootstrap provisioning and denied public execution

## Root cause
Agent reconciliation runs on `init` during activation and managed PHPUnit bootstrap without an authenticated WordPress user. `AgentIdentityStoreAdapter::provision_identity()` performed trusted internal provisioning through `WP_Ability::execute()`, so the scaffold ability's correct `datamachine_chat` permission check rejected the activation call before its callback ran.

The adapter now confirms the scaffold ability is registered, preserving existing early-execution behavior, then invokes the existing `ScaffoldAbilities::execute()` domain callback directly. This bypass is confined to identity materialization inside Data Machine; the public ability registration and permission callback are unchanged. The regression test proves an unauthenticated call through the public ability still returns `ability_invalid_permissions`.

## Verification
- `php -l` passed for all four modified PHP files
- `php tests/scaffold-ability-activation-smoke.php` passed
- `git diff --check` passed
- changed-file Homeboy lint passed with zero PHPCS, PHPStan, or ESLint findings (run `7f54ff6e-5e64-44b9-8036-07fde79822c0`)
- PR architecture audit passed with no introduced findings
- focused managed PHPUnit was attempted in run `cffba2b8-8a66-4a18-9e75-1aab6b72969d`, but WP Codebox executed zero tests because its required `wordpress-database` Docker provider could not start: `provider-unavailable`, command `docker`, cause `ENOENT` (`Provider command executable was not found`)
- full repository lint was also run and reported 309 existing repository-wide findings; the bounded changed-file lint above is clean

No changelog or version files were edited.

Closes #3277