### PR TITLE
fix: unify handler config previews and updates

### DIFF
--- a/inc/Abilities/FlowStep/FlowStepHelpers.php
+++ b/inc/Abilities/FlowStep/FlowStepHelpers.php
@@ -297,45 +297,34 @@ trait FlowStepHelpers {
 	protected function updateHandler( string $flow_step_id, string $handler_slug = '', array $handler_settings = array(), bool $validate_only = false ): bool|array {
 		$parts = apply_filters( 'datamachine_split_flow_step_id', null, $flow_step_id );
 		if ( ! $parts ) {
-			if ( ! $validate_only ) {
-				do_action( 'datamachine_log', 'error', 'Invalid flow_step_id format for handler update', array( 'flow_step_id' => $flow_step_id ) );
-			}
-			return false;
+			return $this->handlerUpdateError( $validate_only, 'Invalid flow_step_id format for handler update', array( 'flow_step_id' => $flow_step_id ) );
 		}
 		$flow_id = $parts['flow_id'];
 
 		$flow = $this->db_flows->get_flow( $flow_id );
 		if ( ! $flow ) {
-			if ( ! $validate_only ) {
-				do_action(
-					'datamachine_log',
-					'error',
-					'Flow handler update failed - flow not found',
-					array(
-						'flow_id'      => $flow_id,
-						'flow_step_id' => $flow_step_id,
-					)
-				);
-			}
-			return false;
+			return $this->handlerUpdateError(
+				$validate_only,
+				'Flow handler update failed - flow not found',
+				array(
+					'flow_id'      => $flow_id,
+					'flow_step_id' => $flow_step_id,
+				)
+			);
 		}
 
 		$flow_config = $flow['flow_config'] ?? array();
 
 		if ( ! isset( $flow_config[ $flow_step_id ] ) ) {
 			if ( ! isset( $parts['pipeline_step_id'] ) || empty( $parts['pipeline_step_id'] ) ) {
-				if ( ! $validate_only ) {
-					do_action(
-						'datamachine_log',
-						'error',
-						'Pipeline step ID is required for flow handler update',
-						array(
-							'flow_step_id' => $flow_step_id,
-							'parts'        => $parts,
-						)
-					);
-				}
-				return false;
+				return $this->handlerUpdateError(
+					$validate_only,
+					'Pipeline step ID is required for flow handler update',
+					array(
+						'flow_step_id' => $flow_step_id,
+						'parts'        => $parts,
+					)
+				);
 			}
 			$pipeline_step_id             = $parts['pipeline_step_id'];
 			$flow_config[ $flow_step_id ] = array(
@@ -354,11 +343,8 @@ trait FlowStepHelpers {
 			: ( $step['step_type'] ?? '' );
 
 		if ( empty( $effective_slug ) ) {
-			if ( ! $validate_only ) {
-				do_action( 'datamachine_log', 'error', 'No handler slug or step_type available for flow step update', array( 'flow_step_id' => $flow_step_id ) );
-			}
 			unset( $step );
-			return false;
+			return $this->handlerUpdateError( $validate_only, 'No handler slug or step_type available for flow step update', array( 'flow_step_id' => $flow_step_id ) );
 		}
 
 		// Get existing config for this handler/settings slug.
@@ -432,6 +418,22 @@ trait FlowStepHelpers {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Return an update failure without writing preview-mode logs.
+	 *
+	 * @param bool   $validate_only Whether the update is a non-persisting preview.
+	 * @param string $message Log message.
+	 * @param array  $context Log context.
+	 * @return false
+	 */
+	private function handlerUpdateError( bool $validate_only, string $message, array $context ): false {
+		if ( ! $validate_only ) {
+			do_action( 'datamachine_log', 'error', $message, $context );
+		}
+
+		return false;
 	}
 
 	/**

--- a/inc/Abilities/FlowStep/FlowStepHelpers.php
+++ b/inc/Abilities/FlowStep/FlowStepHelpers.php
@@ -139,9 +139,10 @@ trait FlowStepHelpers {
 	 * @since 0.38.0
 	 * @param string $handler_slug Handler slug.
 	 * @param array  $handler_config Raw configuration values to sanitize.
+	 * @param bool   $log_errors Whether sanitizer failures may be logged.
 	 * @return array Sanitized configuration values.
 	 */
-	protected function sanitizeHandlerConfig( string $handler_slug, array $handler_config ): array {
+	protected function sanitizeHandlerConfig( string $handler_slug, array $handler_config, bool $log_errors = true ): array {
 		$settings_class = $this->handler_abilities->getSettingsClass( $handler_slug );
 
 		if ( ! $settings_class || ! method_exists( $settings_class, 'sanitize' ) ) {
@@ -151,17 +152,51 @@ trait FlowStepHelpers {
 		try {
 			return $settings_class->sanitize( $handler_config );
 		} catch ( \Exception $e ) {
-			do_action(
-				'datamachine_log',
-				'warning',
-				'Handler config sanitization failed, using raw values',
-				array(
-					'handler_slug' => $handler_slug,
-					'error'        => $e->getMessage(),
-				)
-			);
+			if ( $log_errors ) {
+				do_action(
+					'datamachine_log',
+					'warning',
+					'Handler config sanitization failed, using raw values',
+					array(
+						'handler_slug' => $handler_slug,
+						'error'        => $e->getMessage(),
+					)
+				);
+			}
 			return $handler_config;
 		}
+	}
+
+	/**
+	 * Validate and merge a sparse handler configuration patch.
+	 *
+	 * Sanitizers commonly return complete objects containing defaults. Only
+	 * explicitly patched top-level fields are merged so omitted stored values
+	 * retain their value and type.
+	 *
+	 * @param string $handler_slug Handler slug.
+	 * @param array  $existing_config Stored configuration.
+	 * @param array  $handler_patch Sparse configuration patch.
+	 * @param bool   $log_errors Whether sanitizer failures may be logged.
+	 * @return array{valid: bool, config?: array, error?: array}
+	 */
+	protected function prepareHandlerConfigPatch( string $handler_slug, array $existing_config, array $handler_patch, bool $log_errors = true ): array {
+		$validation = $this->validateHandlerConfig( $handler_slug, $handler_patch );
+		if ( true !== $validation ) {
+			return array(
+				'valid' => false,
+				'error' => $validation,
+			);
+		}
+
+		$sanitized = $this->sanitizeHandlerConfig( $handler_slug, $handler_patch, $log_errors );
+		$sanitized = array_intersect_key( $sanitized, $handler_patch );
+		$merged    = self::deepMergeConfig( $existing_config, $sanitized );
+
+		return array(
+			'valid'  => true,
+			'config' => $this->handler_abilities->applyDefaults( $handler_slug, $merged ),
+		);
 	}
 
 	/**
@@ -256,27 +291,32 @@ trait FlowStepHelpers {
 	 * @param string $flow_step_id Flow step ID (format: pipeline_step_id_flow_id).
 	 * @param string $handler_slug Handler slug to set (uses existing if empty).
 	 * @param array  $handler_settings Handler configuration settings.
-	 * @return bool Success status.
+	 * @param bool   $validate_only Build and return the effective config without persisting.
+	 * @return bool|array Success status, or the effective update during validation.
 	 */
-	protected function updateHandler( string $flow_step_id, string $handler_slug = '', array $handler_settings = array() ): bool {
+	protected function updateHandler( string $flow_step_id, string $handler_slug = '', array $handler_settings = array(), bool $validate_only = false ): bool|array {
 		$parts = apply_filters( 'datamachine_split_flow_step_id', null, $flow_step_id );
 		if ( ! $parts ) {
-			do_action( 'datamachine_log', 'error', 'Invalid flow_step_id format for handler update', array( 'flow_step_id' => $flow_step_id ) );
+			if ( ! $validate_only ) {
+				do_action( 'datamachine_log', 'error', 'Invalid flow_step_id format for handler update', array( 'flow_step_id' => $flow_step_id ) );
+			}
 			return false;
 		}
 		$flow_id = $parts['flow_id'];
 
 		$flow = $this->db_flows->get_flow( $flow_id );
 		if ( ! $flow ) {
-			do_action(
-				'datamachine_log',
-				'error',
-				'Flow handler update failed - flow not found',
-				array(
-					'flow_id'      => $flow_id,
-					'flow_step_id' => $flow_step_id,
-				)
-			);
+			if ( ! $validate_only ) {
+				do_action(
+					'datamachine_log',
+					'error',
+					'Flow handler update failed - flow not found',
+					array(
+						'flow_id'      => $flow_id,
+						'flow_step_id' => $flow_step_id,
+					)
+				);
+			}
 			return false;
 		}
 
@@ -284,15 +324,17 @@ trait FlowStepHelpers {
 
 		if ( ! isset( $flow_config[ $flow_step_id ] ) ) {
 			if ( ! isset( $parts['pipeline_step_id'] ) || empty( $parts['pipeline_step_id'] ) ) {
-				do_action(
-					'datamachine_log',
-					'error',
-					'Pipeline step ID is required for flow handler update',
-					array(
-						'flow_step_id' => $flow_step_id,
-						'parts'        => $parts,
-					)
-				);
+				if ( ! $validate_only ) {
+					do_action(
+						'datamachine_log',
+						'error',
+						'Pipeline step ID is required for flow handler update',
+						array(
+							'flow_step_id' => $flow_step_id,
+							'parts'        => $parts,
+						)
+					);
+				}
 				return false;
 			}
 			$pipeline_step_id             = $parts['pipeline_step_id'];
@@ -312,7 +354,9 @@ trait FlowStepHelpers {
 			: ( $step['step_type'] ?? '' );
 
 		if ( empty( $effective_slug ) ) {
-			do_action( 'datamachine_log', 'error', 'No handler slug or step_type available for flow step update', array( 'flow_step_id' => $flow_step_id ) );
+			if ( ! $validate_only ) {
+				do_action( 'datamachine_log', 'error', 'No handler slug or step_type available for flow step update', array( 'flow_step_id' => $flow_step_id ) );
+			}
 			unset( $step );
 			return false;
 		}
@@ -331,19 +375,11 @@ trait FlowStepHelpers {
 			}
 		}
 
-		// Sanitize incoming values via handler's settings class before merge.
-		$handler_settings = $this->sanitizeHandlerConfig( $effective_slug, $handler_settings );
-
-		// Deep-merge so a partial update of a nested config object (e.g. a
-		// system_task step's `params` map) cannot silently drop the sibling
-		// keys it didn't mention. A shallow array_merge() replaces the whole
-		// `params` array, which is exactly how a `{"params":{"message":"..."}}`
-		// edit truncated a flow's stored message: channel/recipient vanished
-		// because they weren't restated. Recursive merge keeps unmentioned
-		// nested keys intact (#2673). Numeric-keyed lists are still replaced
-		// wholesale — partial list patching has no well-defined semantics.
-		$merged_config = self::deepMergeConfig( $existing_handler_config, $handler_settings );
-		$stored_config = $this->handler_abilities->applyDefaults( $effective_slug, $merged_config );
+		$prepared = $this->prepareHandlerConfigPatch( $effective_slug, $existing_handler_config, $handler_settings, ! $validate_only );
+		if ( ! $prepared['valid'] ) {
+			return false;
+		}
+		$stored_config = $prepared['config'];
 
 		if ( ! $uses_handler ) {
 			$step['flow_step_settings'] = $stored_config;
@@ -366,6 +402,13 @@ trait FlowStepHelpers {
 
 		$step['enabled'] = true;
 		unset( $step );
+
+		if ( $validate_only ) {
+			return array(
+				'handler_slug'   => $effective_slug,
+				'handler_config' => $stored_config,
+			);
+		}
 
 		$success = $this->db_flows->update_flow(
 			$flow_id,

--- a/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
+++ b/inc/Abilities/FlowStep/UpdateFlowStepAbility.php
@@ -72,15 +72,22 @@ class UpdateFlowStepAbility {
 								'type'        => 'string',
 								'description' => __( 'Remove a handler from this step (multi-handler mode). Provide handler slug to remove.', 'data-machine' ),
 							),
+							'validate_only'      => array(
+								'type'        => 'boolean',
+								'description' => __( 'Validate and return the effective update without persisting.', 'data-machine' ),
+								'default'     => false,
+							),
 						),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',
 						'properties' => array(
-							'success'      => array( 'type' => 'boolean' ),
-							'flow_step_id' => array( 'type' => 'string' ),
-							'message'      => array( 'type' => 'string' ),
-							'error'        => array( 'type' => 'string' ),
+							'success'                  => array( 'type' => 'boolean' ),
+							'flow_step_id'             => array( 'type' => 'string' ),
+							'message'                  => array( 'type' => 'string' ),
+							'error'                    => array( 'type' => 'string' ),
+							'validate_only'            => array( 'type' => 'boolean' ),
+							'effective_handler_config' => array( 'type' => 'object' ),
 						),
 					),
 					'execute_callback'    => array( $this, 'execute' ),
@@ -106,6 +113,7 @@ class UpdateFlowStepAbility {
 		$flow_step_settings = is_array( $input['flow_step_settings'] ?? null ) ? $input['flow_step_settings'] : array();
 		$handler_config     = $input['handler_config'] ?? array();
 		$user_message       = $input['user_message'] ?? null;
+		$validate_only      = ! empty( $input['validate_only'] );
 
 		if ( empty( $flow_step_id ) || ! is_string( $flow_step_id ) ) {
 			return new \WP_Error( 'invalid_flow_step_id', 'flow_step_id is required and must be a string', array( 'status' => 400 ) );
@@ -123,6 +131,10 @@ class UpdateFlowStepAbility {
 		$has_message_update = null !== $user_message;
 		$has_add_handler    = ! empty( $input['add_handler'] );
 		$has_remove_handler = ! empty( $input['remove_handler'] );
+
+		if ( $validate_only && ( $has_message_update || $has_add_handler || $has_remove_handler ) ) {
+			return new \WP_Error( 'invalid_validate_only_update', 'validate_only currently supports handler configuration updates only', array( 'status' => 400 ) );
+		}
 
 		if ( ! $has_handler_update && ! $has_message_update && ! $has_add_handler && ! $has_remove_handler ) {
 			return new \WP_Error( 'invalid_flow_step_update', 'At least one of handler_slug, handler_config, user_message, add_handler, or remove_handler is required', array( 'status' => 400 ) );
@@ -148,7 +160,8 @@ class UpdateFlowStepAbility {
 
 		$existing_step = is_array( $validation['step_config'] ?? null ) ? $validation['step_config'] : array();
 
-		$updated_fields = array();
+		$updated_fields           = array();
+		$effective_handler_config = null;
 
 		if ( $has_handler_update ) {
 			$effective_slug = FlowStepConfig::getEffectiveSlug( $existing_step, $handler_slug ?? '' );
@@ -172,10 +185,14 @@ class UpdateFlowStepAbility {
 				}
 			}
 
-			$success = $this->updateHandler( $flow_step_id, $effective_slug, $handler_config );
+			$handler_update = $this->updateHandler( $flow_step_id, $effective_slug, $handler_config, $validate_only );
 
-			if ( ! $success ) {
+			if ( ! $handler_update ) {
 				return new \WP_Error( 'flow_step_update_failed', 'Failed to update handler configuration', array( 'status' => 500 ) );
+			}
+
+			if ( $validate_only && is_array( $handler_update ) ) {
+				$effective_handler_config = $handler_update['handler_config'] ?? array();
 			}
 
 			if ( ! empty( $handler_slug ) ) {
@@ -236,20 +253,31 @@ class UpdateFlowStepAbility {
 			$updated_fields[] = 'user_message';
 		}
 
-		do_action(
-			'datamachine_log',
-			'info',
-			'Flow step updated via ability',
-			array(
-				'flow_step_id'   => $flow_step_id,
-				'updated_fields' => $updated_fields,
-			)
-		);
+		if ( ! $validate_only ) {
+			do_action(
+				'datamachine_log',
+				'info',
+				'Flow step updated via ability',
+				array(
+					'flow_step_id'   => $flow_step_id,
+					'updated_fields' => $updated_fields,
+				)
+			);
+		}
 
-		return array(
+		$result = array(
 			'success'      => true,
 			'flow_step_id' => $flow_step_id,
-			'message'      => 'Flow step updated successfully. Fields updated: ' . implode( ', ', $updated_fields ),
+			'message'      => ( $validate_only ? 'Flow step update validated. Fields: ' : 'Flow step updated successfully. Fields updated: ' ) . implode( ', ', $updated_fields ),
 		);
+
+		if ( $validate_only ) {
+			$result['validate_only'] = true;
+			if ( null !== $effective_handler_config ) {
+				$result['effective_handler_config'] = $effective_handler_config;
+			}
+		}
+
+		return $result;
 	}
 }

--- a/inc/Abilities/Pipeline/PipelineConfigurationAbilities.php
+++ b/inc/Abilities/Pipeline/PipelineConfigurationAbilities.php
@@ -8,6 +8,7 @@
 namespace DataMachine\Abilities\Pipeline;
 
 use DataMachine\Abilities\HandlerAbilities;
+use DataMachine\Abilities\FlowStep\FlowStepHelpers;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Abilities\PipelineStepAbilities;
 use DataMachine\Core\Database\Flows\Flows;
@@ -17,6 +18,7 @@ use DataMachine\Core\Steps\FlowStepConfig;
 defined( 'ABSPATH' ) || exit;
 
 class PipelineConfigurationAbilities {
+	use FlowStepHelpers;
 
 	private const SCHEMA_VERSION    = 'datamachine.pipeline_configuration.v1';
 	private static bool $registered = false;
@@ -26,9 +28,10 @@ class PipelineConfigurationAbilities {
 	private HandlerAbilities $handlers;
 
 	public function __construct() {
-		$this->pipelines = new Pipelines();
-		$this->flows     = new Flows();
-		$this->handlers  = new HandlerAbilities();
+		$this->initDatabases();
+		$this->pipelines = $this->db_pipelines;
+		$this->flows     = $this->db_flows;
+		$this->handlers  = $this->handler_abilities;
 		if ( self::$registered ) {
 			return;
 		}
@@ -347,13 +350,13 @@ class PipelineConfigurationAbilities {
 			if ( ! is_array( $patch['flow_step_settings'] ?? null ) ) {
 				return $this->error( 'invalid_configuration', 'flow_step_settings must be an object', 400 );
 			}
-			$slug       = (string) ( $step['step_type'] ?? '' );
-			$validation = $this->validateHandlerConfig( $slug, $patch['flow_step_settings'] );
-			if ( is_wp_error( $validation ) ) {
-				return $validation;
+			$slug     = (string) ( $step['step_type'] ?? '' );
+			$existing = is_array( $step['flow_step_settings'] ?? null ) ? $step['flow_step_settings'] : array();
+			$prepared = $this->prepareHandlerConfigPatch( $slug, $existing, $patch['flow_step_settings'] );
+			if ( ! $prepared['valid'] ) {
+				return $this->handlerConfigError( $prepared['error'] );
 			}
-			$existing                   = is_array( $step['flow_step_settings'] ?? null ) ? $step['flow_step_settings'] : array();
-			$step['flow_step_settings'] = $this->handlers->applyDefaults( $slug, $this->deepMerge( $existing, $this->sanitizeHandlerConfig( $slug, $patch['flow_step_settings'] ) ) );
+			$step['flow_step_settings'] = $prepared['config'];
 			return array( 'step' => $step );
 		}
 
@@ -382,12 +385,12 @@ class PipelineConfigurationAbilities {
 			if ( ! is_string( $handler_slug ) || ! is_array( $handler_config ) || ! $this->handlers->handlerExists( $handler_slug ) ) {
 				return $this->error( 'invalid_configuration', "Handler '{$handler_slug}' is unavailable or has invalid configuration", 400 );
 			}
-			$validation = $this->validateHandlerConfig( $handler_slug, $handler_config );
-			if ( is_wp_error( $validation ) ) {
-				return $validation;
+			$existing = is_array( $stored_configs[ $handler_slug ] ?? null ) ? $stored_configs[ $handler_slug ] : array();
+			$prepared = $this->prepareHandlerConfigPatch( $handler_slug, $existing, $handler_config );
+			if ( ! $prepared['valid'] ) {
+				return $this->handlerConfigError( $prepared['error'] );
 			}
-			$existing                        = is_array( $stored_configs[ $handler_slug ] ?? null ) ? $stored_configs[ $handler_slug ] : array();
-			$stored_configs[ $handler_slug ] = $this->handlers->applyDefaults( $handler_slug, $this->deepMerge( $existing, $this->sanitizeHandlerConfig( $handler_slug, $handler_config ) ) );
+			$stored_configs[ $handler_slug ] = $prepared['config'];
 			if ( ! in_array( $handler_slug, $stored_slugs, true ) ) {
 				$stored_slugs[] = $handler_slug;
 			}
@@ -401,18 +404,8 @@ class PipelineConfigurationAbilities {
 		return array( 'step' => $step );
 	}
 
-	private function validateHandlerConfig( string $slug, array $config ): array|\WP_Error {
-		$fields  = $this->handlers->getConfigFields( $slug );
-		$unknown = array_diff( array_keys( $config ), array_keys( $fields ) );
-		if ( ! empty( $fields ) && ! empty( $unknown ) ) {
-			return $this->error( 'unknown_field', "Unknown configuration fields for {$slug}: " . implode( ', ', $unknown ), 400 );
-		}
-		return array();
-	}
-
-	private function sanitizeHandlerConfig( string $slug, array $config ): array {
-		$class = $this->handlers->getSettingsClass( $slug );
-		return $class && method_exists( $class, 'sanitize' ) ? $class->sanitize( $config ) : $config;
+	private function handlerConfigError( array $error ): \WP_Error {
+		return $this->error( 'unknown_field', $error['error'] ?? 'Invalid handler configuration', 400 );
 	}
 
 	private function resolvePipeline( array $input ): array|\WP_Error {
@@ -522,16 +515,5 @@ class PipelineConfigurationAbilities {
 
 	private function error( string $code, string $message, int $status ): \WP_Error {
 		return new \WP_Error( $code, $message, array( 'status' => $status ) );
-	}
-
-	private function deepMerge( array $existing, array $patch ): array {
-		foreach ( $patch as $key => $value ) {
-			if ( is_string( $key ) && isset( $existing[ $key ] ) && is_array( $existing[ $key ] ) && is_array( $value ) && ! array_is_list( $existing[ $key ] ) && ! array_is_list( $value ) ) {
-				$existing[ $key ] = $this->deepMerge( $existing[ $key ], $value );
-				continue;
-			}
-			$existing[ $key ] = $value;
-		}
-		return $existing;
 	}
 }

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -25,6 +25,7 @@ use DataMachine\Cli\UserResolver;
 use DataMachine\Cli\Commands\DrainCommand;
 use DataMachine\Core\AbilityResult;
 use DataMachine\Core\Database\Flows\FlowConfigEscaping;
+use DataMachine\Core\PluginSettings;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Engine\Debug\SyncRunner;
 
@@ -1493,18 +1494,31 @@ class FlowsCommand extends BaseCommand {
 			}
 
 			$updated_keys = implode( ', ', array_keys( $unwrapped_config ) );
+			$step_ability = new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility();
 
 			if ( $dry_run ) {
-				WP_CLI::log( sprintf( '[dry-run] would update handler_config for step %s: %s; no changes written', $handler_step, $updated_keys ) );
+				$step_input['validate_only'] = true;
+			}
+
+			$step_result = AbilityResult::normalize( $step_ability->execute( $step_input ) );
+
+			if ( ! $step_result['success'] ) {
+				WP_CLI::error( $step_result['error'] ?? 'Failed to update handler config' );
+				return;
+			}
+
+			if ( $dry_run ) {
+				$effective_config = PluginSettings::redactForDisplay( '', $step_result['effective_handler_config'] ?? array() );
+				$effective_config = \DataMachine\Engine\AI\datamachine_bound_tool_trace_value( $effective_config );
+				WP_CLI::log(
+					sprintf(
+						'[dry-run] would update handler_config for step %s: %s; effective config: %s; no changes written',
+						$handler_step,
+						$updated_keys,
+						(string) wp_json_encode( $effective_config, JSON_UNESCAPED_SLASHES )
+					)
+				);
 			} else {
-				$step_ability = new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility();
-				$step_result  = AbilityResult::normalize( $step_ability->execute( $step_input ) );
-
-				if ( ! $step_result['success'] ) {
-					WP_CLI::error( $step_result['error'] ?? 'Failed to update handler config' );
-					return;
-				}
-
 				WP_CLI::success( sprintf( 'Handler config updated for step %s: %s', $handler_step, $updated_keys ) );
 			}
 		}

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -2968,10 +2968,40 @@ function datamachine_build_tool_trace( string $tool_name, array $tool_call, arra
 /**
  * Keep non-secret scalar tool arguments visible when full arguments are large.
  *
- * @param mixed $value Redacted trace value.
+ * @param mixed                   $value Redacted trace value.
+ * @param \SplObjectStorage|null $seen  Objects visited in the current branch.
+ * @param int                     $depth Current recursion depth.
  * @return mixed Bounded trace value.
  */
-function datamachine_bound_tool_trace_value( mixed $value ): mixed {
+function datamachine_bound_tool_trace_value( mixed $value, ?\SplObjectStorage $seen = null, int $depth = 0 ): mixed {
+	if ( $depth >= 32 ) {
+		return '[truncated]';
+	}
+
+	$seen ??= new \SplObjectStorage();
+
+	if ( is_object( $value ) ) {
+		if ( $seen->contains( $value ) ) {
+			return '[truncated]';
+		}
+
+		$seen->attach( $value );
+		$bounded = new \stdClass();
+		$count   = 0;
+		foreach ( get_object_vars( $value ) as $key => $child ) {
+			if ( $count >= 20 ) {
+				$bounded->__truncated__ = true;
+				break;
+			}
+
+			$bounded->{$key} = datamachine_bound_tool_trace_value( $child, $seen, $depth + 1 );
+			++$count;
+		}
+		$seen->detach( $value );
+
+		return $bounded;
+	}
+
 	if ( is_array( $value ) ) {
 		$bounded = array();
 		$count   = 0;
@@ -2981,7 +3011,7 @@ function datamachine_bound_tool_trace_value( mixed $value ): mixed {
 				break;
 			}
 
-			$bounded[ $key ] = datamachine_bound_tool_trace_value( $child );
+			$bounded[ $key ] = datamachine_bound_tool_trace_value( $child, $seen, $depth + 1 );
 			++$count;
 		}
 

--- a/tests/Unit/Abilities/PipelineConfigurationAbilitiesTest.php
+++ b/tests/Unit/Abilities/PipelineConfigurationAbilitiesTest.php
@@ -7,10 +7,38 @@
 
 namespace DataMachine\Tests\Unit\Abilities;
 
+use DataMachine\Abilities\FlowStep\UpdateFlowStepAbility;
+use DataMachine\Abilities\HandlerAbilities;
 use DataMachine\Abilities\Pipeline\PipelineConfigurationAbilities;
 use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Logs\LogRepository;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use WP_UnitTestCase;
+
+class TicketmasterLikeConfigurationSettings {
+
+	public static function get_fields(): array {
+		return array_fill_keys(
+			array( 'classification_type', 'location', 'radius', 'genre', 'venue_id', 'search', 'exclude_keywords', 'max_items', 'include_parking', 'params' ),
+			array()
+		);
+	}
+
+	public static function sanitize( array $raw ): array {
+		return array(
+			'classification_type' => (string) ( $raw['classification_type'] ?? '' ),
+			'location'            => (string) ( $raw['location'] ?? '' ),
+			'radius'              => (string) ( $raw['radius'] ?? '50' ),
+			'genre'               => (string) ( $raw['genre'] ?? '' ),
+			'venue_id'            => (string) ( $raw['venue_id'] ?? '' ),
+			'search'              => (string) ( $raw['search'] ?? '' ),
+			'exclude_keywords'    => (string) ( $raw['exclude_keywords'] ?? '' ),
+			'max_items'           => (int) ( $raw['max_items'] ?? 100 ),
+			'include_parking'     => (bool) ( $raw['include_parking'] ?? false ),
+			'params'              => is_array( $raw['params'] ?? null ) ? $raw['params'] : array(),
+		);
+	}
+}
 
 class PipelineConfigurationAbilitiesTest extends WP_UnitTestCase {
 
@@ -172,5 +200,241 @@ class PipelineConfigurationAbilitiesTest extends WP_UnitTestCase {
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
+	}
+
+	public function test_handler_patch_parity_uses_real_abilities_without_dry_run_persistence(): void {
+		$handler_filter = static function ( array $handlers, ?string $step_type ): array {
+			if ( null === $step_type || 'fetch' === $step_type ) {
+				$handlers['ticketmaster_like'] = array(
+					'type'  => 'fetch',
+					'label' => 'Ticketmaster Like',
+				);
+			}
+			return $handlers;
+		};
+		$settings_filter = static function ( array $settings, ?string $handler_slug ): array {
+			if ( null === $handler_slug || 'ticketmaster_like' === $handler_slug ) {
+				$settings['ticketmaster_like'] = new TicketmasterLikeConfigurationSettings();
+			}
+			return $settings;
+		};
+
+		add_filter( 'datamachine_handlers', $handler_filter, 10, 2 );
+		add_filter( 'datamachine_handler_settings', $settings_filter, 10, 2 );
+		HandlerAbilities::clearCache();
+
+		try {
+			$flows        = new Flows();
+			$flow_id      = (int) $flows->create_flow(
+				array(
+					'pipeline_id'      => $this->pipeline_id,
+					'flow_name'        => 'Handler Configuration Parity',
+					'flow_config'      => array(),
+					'scheduling_config' => array(),
+				)
+			);
+			$flow_step_id = $this->pipeline_id . '_ticketmaster_' . $flow_id;
+			$stored       = array(
+				'classification_type' => 'music',
+				'location'            => '51.5074,-0.1278',
+				'radius'              => 15,
+				'genre'               => 'rock',
+				'venue_id'            => 'KovZpZA6tFlA',
+				'search'              => 'live',
+				'exclude_keywords'    => 'tribute',
+				'max_items'           => 100,
+				'include_parking'     => true,
+				'params'              => array(
+					'filters' => array(
+						'city'    => 'London',
+						'keyword' => 'original',
+					),
+					'mode'    => 'strict',
+				),
+			);
+			$flow_config = array(
+				$flow_step_id => array(
+					'flow_step_id'     => $flow_step_id,
+					'pipeline_step_id' => $this->pipeline_id . '_ticketmaster',
+					'pipeline_id'      => $this->pipeline_id,
+					'flow_id'          => $flow_id,
+					'step_type'        => 'fetch',
+					'handler_slugs'    => array( 'ticketmaster_like' ),
+					'handler_configs'  => array( 'ticketmaster_like' => $stored ),
+				),
+			);
+			$flows->update_flow( $flow_id, array( 'flow_config' => $flow_config ) );
+
+			$patch = array(
+				'max_items' => 1,
+				'params'    => array( 'filters' => array( 'keyword' => 'updated' ) ),
+			);
+			$expected = $stored;
+			$expected['max_items'] = 1;
+			$expected['params']['filters']['keyword'] = 'updated';
+
+			$update     = new UpdateFlowStepAbility();
+			$logs       = new LogRepository();
+			$logs_before = $logs->get_logs()['total'];
+			$raw_before  = $flows->get_flow_config_json( $flow_id );
+			$preview     = $update->execute(
+				array(
+					'flow_step_id'   => $flow_step_id,
+					'handler_config' => $patch,
+					'validate_only'  => true,
+				)
+			);
+
+			$this->assertTrue( $preview['success'] );
+			$this->assertSame( $expected, $preview['effective_handler_config'] );
+			$this->assertSame( $raw_before, $flows->get_flow_config_json( $flow_id ) );
+			$this->assertSame( $logs_before, $logs->get_logs()['total'], 'Dry-run must not persist database logs.' );
+
+			$applied = $update->execute(
+				array(
+					'flow_step_id'   => $flow_step_id,
+					'handler_config' => $patch,
+				)
+			);
+			$this->assertTrue( $applied['success'] );
+			$stored_after_apply = $this->storedHandlerConfig( $flows, $flow_id, $flow_step_id );
+			$this->assertSame( $expected, $stored_after_apply );
+			$this->assertSame( 15, $stored_after_apply['radius'], 'Omitted scalar type must remain unchanged.' );
+			$this->assertTrue( $stored_after_apply['include_parking'], 'Omitted boolean sibling must remain unchanged.' );
+
+			$flows->update_flow( $flow_id, array( 'flow_config' => $flow_config ) );
+			$current       = $this->abilities->executeGet( array( 'pipeline_id' => $this->pipeline_id ) );
+			$flow_snapshot = $this->configurationFlowSnapshot( $current['flows'], $flow_id );
+			$owner_result  = $this->abilities->executeUpdate(
+				array(
+					'target'            => 'flow',
+					'flow_id'           => $flow_id,
+					'step_id'           => $flow_step_id,
+					'expected_revision' => $flow_snapshot['revision'],
+					'configuration'     => array( 'handler_config' => $patch ),
+				)
+			);
+			$this->assertTrue( $owner_result['success'] );
+			$this->assertSame( $expected, $this->storedHandlerConfig( $flows, $flow_id, $flow_step_id ) );
+
+			$full = array(
+				'classification_type' => 'sports',
+				'location'            => '40.7128,-74.0060',
+				'radius'              => 25,
+				'genre'               => '',
+				'venue_id'            => '',
+				'search'              => 'finals',
+				'exclude_keywords'    => '',
+				'max_items'           => 50,
+				'include_parking'     => false,
+				'params'              => array(
+					'filters' => array( 'city' => 'New York', 'keyword' => 'finals' ),
+					'mode'    => 'broad',
+				),
+			);
+			$sanitized_full = TicketmasterLikeConfigurationSettings::sanitize( $full );
+			$flows->update_flow( $flow_id, array( 'flow_config' => $flow_config ) );
+			$this->assertTrue(
+				$update->execute( array( 'flow_step_id' => $flow_step_id, 'handler_config' => $full ) )['success']
+			);
+			$this->assertSame( $sanitized_full, $this->storedHandlerConfig( $flows, $flow_id, $flow_step_id ) );
+
+			$flows->update_flow( $flow_id, array( 'flow_config' => $flow_config ) );
+			$current       = $this->abilities->executeGet( array( 'pipeline_id' => $this->pipeline_id ) );
+			$flow_snapshot = $this->configurationFlowSnapshot( $current['flows'], $flow_id );
+			$this->assertTrue(
+				$this->abilities->executeUpdate(
+					array(
+						'target'            => 'flow',
+						'flow_id'           => $flow_id,
+						'step_id'           => $flow_step_id,
+						'expected_revision' => $flow_snapshot['revision'],
+						'configuration'     => array( 'handler_config' => $full ),
+					)
+				)['success']
+			);
+			$this->assertSame( $sanitized_full, $this->storedHandlerConfig( $flows, $flow_id, $flow_step_id ) );
+		} finally {
+			remove_filter( 'datamachine_handlers', $handler_filter, 10 );
+			remove_filter( 'datamachine_handler_settings', $settings_filter, 10 );
+			HandlerAbilities::clearCache();
+		}
+	}
+
+	public function test_system_task_params_patch_preserves_task_and_nested_siblings(): void {
+		$flows        = new Flows();
+		$flow_id      = (int) $flows->create_flow(
+			array(
+				'pipeline_id'      => $this->pipeline_id,
+				'flow_name'        => 'System Task Configuration Parity',
+				'flow_config'      => array(),
+				'scheduling_config' => array(),
+			)
+		);
+		$flow_step_id = $this->pipeline_id . '_system_task_' . $flow_id;
+		$stored       = array(
+			'task_type' => 'dispatch_message',
+			'params'    => array(
+				'channel'   => 'extra-chill',
+				'recipient' => 'chubes',
+				'message'   => 'original',
+			),
+		);
+		$flow_config  = array(
+			$flow_step_id => array(
+				'flow_step_id'      => $flow_step_id,
+				'pipeline_step_id'  => $this->pipeline_id . '_system_task',
+				'pipeline_id'       => $this->pipeline_id,
+				'flow_id'           => $flow_id,
+				'step_type'         => 'system_task',
+				'flow_step_settings' => $stored,
+			),
+		);
+		$flows->update_flow( $flow_id, array( 'flow_config' => $flow_config ) );
+
+		$patch    = array( 'params' => array( 'message' => 'updated' ) );
+		$expected = $stored;
+		$expected['params']['message'] = 'updated';
+		$update   = new UpdateFlowStepAbility();
+		$preview  = $update->execute(
+			array(
+				'flow_step_id'       => $flow_step_id,
+				'flow_step_settings' => $patch,
+				'validate_only'      => true,
+			)
+		);
+
+		$this->assertTrue( $preview['success'] );
+		$this->assertSame( $expected, $preview['effective_handler_config'] );
+		$this->assertSame( $stored, $flows->get_flow( $flow_id )['flow_config'][ $flow_step_id ]['flow_step_settings'] );
+
+		$current       = $this->abilities->executeGet( array( 'pipeline_id' => $this->pipeline_id ) );
+		$flow_snapshot = $this->configurationFlowSnapshot( $current['flows'], $flow_id );
+		$result        = $this->abilities->executeUpdate(
+			array(
+				'target'            => 'flow',
+				'flow_id'           => $flow_id,
+				'step_id'           => $flow_step_id,
+				'expected_revision' => $flow_snapshot['revision'],
+				'configuration'     => array( 'flow_step_settings' => $patch ),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $expected, $flows->get_flow( $flow_id )['flow_config'][ $flow_step_id ]['flow_step_settings'] );
+	}
+
+	private function storedHandlerConfig( Flows $flows, int $flow_id, string $flow_step_id ): array {
+		$flow = $flows->get_flow( $flow_id );
+		return $flow['flow_config'][ $flow_step_id ]['handler_configs']['ticketmaster_like'];
+	}
+
+	private function configurationFlowSnapshot( array $flows, int $flow_id ): array {
+		foreach ( $flows as $flow ) {
+			if ( $flow_id === $flow['flow_id'] ) {
+				return $flow;
+			}
+		}
+		$this->fail( "Flow {$flow_id} is missing from the configuration snapshot." );
 	}
 }

--- a/tests/Unit/Abilities/PipelineConfigurationAbilitiesTest.php
+++ b/tests/Unit/Abilities/PipelineConfigurationAbilitiesTest.php
@@ -302,20 +302,7 @@ class PipelineConfigurationAbilitiesTest extends WP_UnitTestCase {
 			$this->assertSame( 15, $stored_after_apply['radius'], 'Omitted scalar type must remain unchanged.' );
 			$this->assertTrue( $stored_after_apply['include_parking'], 'Omitted boolean sibling must remain unchanged.' );
 
-			$flows->update_flow( $flow_id, array( 'flow_config' => $flow_config ) );
-			$current       = $this->abilities->executeGet( array( 'pipeline_id' => $this->pipeline_id ) );
-			$flow_snapshot = $this->configurationFlowSnapshot( $current['flows'], $flow_id );
-			$owner_result  = $this->abilities->executeUpdate(
-				array(
-					'target'            => 'flow',
-					'flow_id'           => $flow_id,
-					'step_id'           => $flow_step_id,
-					'expected_revision' => $flow_snapshot['revision'],
-					'configuration'     => array( 'handler_config' => $patch ),
-				)
-			);
-			$this->assertTrue( $owner_result['success'] );
-			$this->assertSame( $expected, $this->storedHandlerConfig( $flows, $flow_id, $flow_step_id ) );
+			$this->assertOwnerHandlerUpdatePersistsExpectedConfig( $flows, $flow_id, $flow_step_id, $flow_config, $patch, $expected );
 
 			$full = array(
 				'classification_type' => 'sports',
@@ -339,21 +326,7 @@ class PipelineConfigurationAbilitiesTest extends WP_UnitTestCase {
 			);
 			$this->assertSame( $sanitized_full, $this->storedHandlerConfig( $flows, $flow_id, $flow_step_id ) );
 
-			$flows->update_flow( $flow_id, array( 'flow_config' => $flow_config ) );
-			$current       = $this->abilities->executeGet( array( 'pipeline_id' => $this->pipeline_id ) );
-			$flow_snapshot = $this->configurationFlowSnapshot( $current['flows'], $flow_id );
-			$this->assertTrue(
-				$this->abilities->executeUpdate(
-					array(
-						'target'            => 'flow',
-						'flow_id'           => $flow_id,
-						'step_id'           => $flow_step_id,
-						'expected_revision' => $flow_snapshot['revision'],
-						'configuration'     => array( 'handler_config' => $full ),
-					)
-				)['success']
-			);
-			$this->assertSame( $sanitized_full, $this->storedHandlerConfig( $flows, $flow_id, $flow_step_id ) );
+			$this->assertOwnerHandlerUpdatePersistsExpectedConfig( $flows, $flow_id, $flow_step_id, $flow_config, $full, $sanitized_full );
 		} finally {
 			remove_filter( 'datamachine_handlers', $handler_filter, 10 );
 			remove_filter( 'datamachine_handler_settings', $settings_filter, 10 );
@@ -427,6 +400,24 @@ class PipelineConfigurationAbilitiesTest extends WP_UnitTestCase {
 	private function storedHandlerConfig( Flows $flows, int $flow_id, string $flow_step_id ): array {
 		$flow = $flows->get_flow( $flow_id );
 		return $flow['flow_config'][ $flow_step_id ]['handler_configs']['ticketmaster_like'];
+	}
+
+	private function assertOwnerHandlerUpdatePersistsExpectedConfig( Flows $flows, int $flow_id, string $flow_step_id, array $flow_config, array $patch, array $expected ): void {
+		$flows->update_flow( $flow_id, array( 'flow_config' => $flow_config ) );
+		$current       = $this->abilities->executeGet( array( 'pipeline_id' => $this->pipeline_id ) );
+		$flow_snapshot = $this->configurationFlowSnapshot( $current['flows'], $flow_id );
+		$result        = $this->abilities->executeUpdate(
+			array(
+				'target'            => 'flow',
+				'flow_id'           => $flow_id,
+				'step_id'           => $flow_step_id,
+				'expected_revision' => $flow_snapshot['revision'],
+				'configuration'     => array( 'handler_config' => $patch ),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $expected, $this->storedHandlerConfig( $flows, $flow_id, $flow_step_id ) );
 	}
 
 	private function configurationFlowSnapshot( array $flows, int $flow_id ): array {

--- a/tests/Unit/Cli/Commands/Flows/BulkConfigCommandTest.php
+++ b/tests/Unit/Cli/Commands/Flows/BulkConfigCommandTest.php
@@ -32,7 +32,7 @@ class BulkConfigCommandTest extends WP_UnitTestCase {
 			public array $handler_updates = array();
 			public array $message_updates = array();
 
-			protected function updateHandler( string $flow_step_id, string $handler_slug = '', array $handler_settings = array() ): bool {
+			protected function updateHandler( string $flow_step_id, string $handler_slug = '', array $handler_settings = array(), bool $validate_only = false ): bool|array {
 				$this->handler_updates[] = array(
 					'flow_step_id'    => $flow_step_id,
 					'handler_slug'    => $handler_slug,

--- a/tests/flow-update-handler-config-deep-merge-smoke.php
+++ b/tests/flow-update-handler-config-deep-merge-smoke.php
@@ -1,151 +1,234 @@
 <?php
 /**
- * Pure-PHP smoke test for atomic deep-merge of handler/settings config
- * (#2673).
+ * Behavioral smoke for handler-config partial update parity (#3024).
  *
  * Run with: php tests/flow-update-handler-config-deep-merge-smoke.php
- *
- * Pins the data-integrity fix for the CLI write path that nearly corrupted
- * a live flow: a partial `--handler-config '{"params":{"message":"..."}}'`
- * update used to be applied with a shallow array_merge(), which replaced the
- * entire `params` array and silently dropped the sibling keys (channel,
- * recipient) that weren't restated. The stored message was truncated rather
- * than left untouched.
- *
- * FlowStepHelpers::deepMergeConfig() recursively merges nested associative
- * arrays so a partial nested patch keeps the existing sibling keys. This
- * smoke pins:
- *
- *   1. A partial `params` patch preserves unmentioned sibling keys.
- *   2. A mentioned nested key is overwritten with the new value.
- *   3. Top-level scalar keys still behave like array_merge() (overwrite).
- *   4. Numeric-keyed (list) arrays are replaced wholesale, not index-merged.
- *   5. An empty incoming patch object does not clobber an existing nested map.
  *
  * @package DataMachine\Tests
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	define( 'ABSPATH', __DIR__ . '/' );
-}
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
 
-require_once dirname( __DIR__ ) . '/inc/Abilities/FlowStep/FlowStepHelpers.php';
+	$GLOBALS['handler_config_smoke_flow']   = array();
+	$GLOBALS['handler_config_smoke_logs']   = array();
+	$GLOBALS['handler_config_smoke_writes'] = array();
 
-/**
- * Minimal host that exposes the trait's protected static deepMergeConfig()
- * for direct assertion without a full WordPress bootstrap.
- */
-class DeepMergeConfigSmokeHost {
-	use \DataMachine\Abilities\FlowStep\FlowStepHelpers;
+	class WP_Error {}
 
-	public static function merge( array $existing, array $patch ): array {
-		return self::deepMergeConfig( $existing, $patch );
+	function apply_filters( $hook, $value, ...$args ) {
+		if ( 'datamachine_split_flow_step_id' === $hook ) {
+			return array(
+				'pipeline_step_id' => 'fetch_1',
+				'flow_id'          => 806,
+			);
+		}
+		return $value;
+	}
+
+	function do_action( $hook, ...$args ): void {
+		if ( 'datamachine_log' === $hook ) {
+			$GLOBALS['handler_config_smoke_logs'][] = $args;
+		}
 	}
 }
 
-// ─── Test harness ─────────────────────────────────────────────────────
+namespace DataMachine\Core\Database\Flows {
+	class Flows {
+		public function get_flow( $flow_id ) {
+			return $GLOBALS['handler_config_smoke_flow'];
+		}
 
-$failures = array();
-$passes   = 0;
-
-function smoke_assert_equals( $expected, $actual, string $name ): void {
-	global $failures, $passes;
-	if ( $expected === $actual ) {
-		++$passes;
-		echo "  ✓ {$name}\n";
-		return;
+		public function update_flow( $flow_id, $data ) {
+			$GLOBALS['handler_config_smoke_writes'][] = $data;
+			$GLOBALS['handler_config_smoke_flow']['flow_config'] = $data['flow_config'];
+			return true;
+		}
 	}
-
-	$failures[] = $name;
-	echo "  ✗ {$name}\n";
-	echo '    expected: ' . var_export( $expected, true ) . "\n";
-	echo '    actual:   ' . var_export( $actual, true ) . "\n";
 }
 
-echo "flow update --handler-config deep-merge atomicity smoke (#2673)\n";
-echo "----------------------------------------------------------------\n";
+namespace DataMachine\Core\Database\Pipelines {
+	class Pipelines {}
+}
 
-echo "\n[1] partial params patch preserves unmentioned sibling keys:\n";
+namespace DataMachine\Abilities {
+	class AbilityRegistration {
+		public static function on_abilities_api_init( callable $callback ): void {}
+	}
 
-$existing = array(
-	'task_type' => 'dispatch_message',
-	'params'    => array(
-		'channel'   => 'example-channel',
-		'recipient' => 'example-recipient',
-		'message'   => 'original long message body',
-	),
-);
+	class TicketmasterLikeSettings {
+		public static function sanitize( array $raw ): array {
+			return array(
+				'classification_type' => (string) ( $raw['classification_type'] ?? '' ),
+				'location'            => (string) ( $raw['location'] ?? '' ),
+				'radius'              => (string) ( $raw['radius'] ?? '50' ),
+				'genre'               => (string) ( $raw['genre'] ?? '' ),
+				'venue_id'            => (string) ( $raw['venue_id'] ?? '' ),
+				'search'              => (string) ( $raw['search'] ?? '' ),
+				'exclude_keywords'    => (string) ( $raw['exclude_keywords'] ?? '' ),
+				'max_items'           => (int) ( $raw['max_items'] ?? 100 ),
+				'params'              => is_array( $raw['params'] ?? null ) ? $raw['params'] : array(),
+			);
+		}
+	}
 
-$patch  = array( 'params' => array( 'message' => 'NEW message body' ) );
-$merged = DeepMergeConfigSmokeHost::merge( $existing, $patch );
+	class HandlerAbilities {
+		public function getSettingsClass( $slug ) {
+			return new TicketmasterLikeSettings();
+		}
 
-smoke_assert_equals(
-	array(
-		'task_type' => 'dispatch_message',
-		'params'    => array(
-			'channel'   => 'example-channel',
-			'recipient' => 'example-recipient',
-			'message'   => 'NEW message body',
+		public function getConfigFields( $slug ): array {
+			return array_fill_keys(
+				array( 'classification_type', 'location', 'radius', 'genre', 'venue_id', 'search', 'exclude_keywords', 'max_items', 'params' ),
+				array()
+			);
+		}
+
+		public function applyDefaults( $slug, array $config ): array {
+			return $config;
+		}
+	}
+
+	class PermissionHelper {}
+}
+
+namespace DataMachine\Core\Steps {
+	class FlowStepConfig {
+		public static function usesHandler( array $step ): bool {
+			return true;
+		}
+
+		public static function getEffectiveSlug( array $step, string $fallback = '' ): string {
+			return '' !== $fallback ? $fallback : ( $step['handler_slugs'][0] ?? '' );
+		}
+
+		public static function getHandlerConfigForSlug( array $step, string $slug ): array {
+			return $step['handler_configs'][ $slug ] ?? array();
+		}
+
+		public static function getPrimaryHandlerSlug( array $step ): ?string {
+			return $step['handler_slugs'][0] ?? null;
+		}
+
+		public static function getHandlerSlugs( array $step ): array {
+			return $step['handler_slugs'] ?? array();
+		}
+
+		public static function getHandlerConfigs( array $step ): array {
+			return $step['handler_configs'] ?? array();
+		}
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Abilities/FlowStep/FlowStepHelpers.php';
+	require_once dirname( __DIR__ ) . '/inc/Abilities/FlowStep/UpdateFlowStepAbility.php';
+
+	$failures = array();
+	$passes   = 0;
+
+	function parity_assert_same( $expected, $actual, string $name ): void {
+		global $failures, $passes;
+		if ( $expected === $actual ) {
+			++$passes;
+			return;
+		}
+		$failures[] = $name;
+		fwrite( STDERR, "FAIL: {$name}\nExpected: " . var_export( $expected, true ) . "\nActual: " . var_export( $actual, true ) . "\n" );
+	}
+
+	$stored = array(
+		'classification_type' => 'music',
+		'location'            => '51.5074,-0.1278',
+		'radius'              => '15',
+		'genre'               => 'rock',
+		'venue_id'            => 'KovZpZA6tFlA',
+		'search'              => 'live',
+		'exclude_keywords'    => 'tribute',
+		'max_items'           => 100,
+		'params'              => array(
+			'filters' => array(
+				'city'    => 'London',
+				'keyword' => 'original',
+			),
+			'mode'    => 'strict',
 		),
-	),
-	$merged,
-	'partial params message update keeps channel/recipient and task_type'
-);
+	);
 
-echo "\n[2] a mentioned nested key is overwritten:\n";
+	$GLOBALS['handler_config_smoke_flow'] = array(
+		'flow_id'     => 806,
+		'pipeline_id' => 208,
+		'flow_config' => array(
+			'fetch_1_806' => array(
+				'step_type'       => 'fetch',
+				'handler_slugs'    => array( 'ticketmaster' ),
+				'handler_configs'  => array( 'ticketmaster' => $stored ),
+			),
+		),
+	);
 
-smoke_assert_equals(
-	'NEW message body',
-	$merged['params']['message'],
-	'message reflects the patch value, not the original'
-);
+	$patch = array(
+		'max_items' => 1,
+		'params'    => array( 'filters' => array( 'keyword' => 'updated' ) ),
+	);
+	$expected = $stored;
+	$expected['max_items'] = 1;
+	$expected['params']['filters']['keyword'] = 'updated';
 
-echo "\n[3] top-level scalar keys overwrite (array_merge parity):\n";
+	$ability = new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility();
+	$before  = serialize( $GLOBALS['handler_config_smoke_flow'] );
+	$preview = $ability->execute(
+		array(
+			'flow_step_id'   => 'fetch_1_806',
+			'handler_config' => $patch,
+			'validate_only'  => true,
+		)
+	);
 
-$merged_scalar = DeepMergeConfigSmokeHost::merge(
-	array( 'task_type' => 'dispatch_message', 'params' => array( 'message' => 'x' ) ),
-	array( 'task_type' => 'send_email' )
-);
+	parity_assert_same( array(), $GLOBALS['handler_config_smoke_writes'], 'dry-run performs no persistence' );
+	parity_assert_same( array(), $GLOBALS['handler_config_smoke_logs'], 'dry-run writes no database-backed logs' );
+	parity_assert_same( $before, serialize( $GLOBALS['handler_config_smoke_flow'] ), 'dry-run leaves storage byte-identical' );
+	parity_assert_same( $expected, $preview['effective_handler_config'] ?? null, 'dry-run returns effective deep-merged config' );
 
-smoke_assert_equals( 'send_email', $merged_scalar['task_type'], 'top-level task_type overwrites' );
-smoke_assert_equals( array( 'message' => 'x' ), $merged_scalar['params'], 'untouched params survives a top-level overwrite' );
+	$applied_result = $ability->execute(
+		array(
+			'flow_step_id'   => 'fetch_1_806',
+			'handler_config' => $patch,
+		)
+	);
+	parity_assert_same( true, $applied_result['success'] ?? false, 'apply succeeds' );
+	$applied = $GLOBALS['handler_config_smoke_flow']['flow_config']['fetch_1_806']['handler_configs']['ticketmaster'];
+	parity_assert_same( $preview['effective_handler_config'], $applied, 'apply exactly matches dry-run preview' );
+	parity_assert_same( '51.5074,-0.1278', $applied['location'], 'omitted non-default location is preserved exactly' );
+	parity_assert_same( '15', $applied['radius'], 'omitted non-default radius type and value are preserved exactly' );
+	parity_assert_same( 'London', $applied['params']['filters']['city'], 'omitted nested params sibling is preserved' );
+	parity_assert_same( 'strict', $applied['params']['mode'], 'omitted params sibling is preserved' );
 
-echo "\n[4] numeric-keyed list arrays are replaced wholesale:\n";
+	$full = array(
+		'classification_type' => 'sports',
+		'location'            => '40.7128,-74.0060',
+		'radius'              => '25',
+		'genre'               => '',
+		'venue_id'            => '',
+		'search'              => 'finals',
+		'exclude_keywords'    => '',
+		'max_items'           => 50,
+		'params'              => array( 'filters' => array( 'city' => 'New York', 'keyword' => 'finals' ), 'mode' => 'broad' ),
+	);
+	$full_result = $ability->execute(
+		array(
+			'flow_step_id'   => 'fetch_1_806',
+			'handler_config' => $full,
+		)
+	);
+	parity_assert_same( true, $full_result['success'] ?? false, 'full-object update succeeds' );
+	parity_assert_same( $full, $GLOBALS['handler_config_smoke_flow']['flow_config']['fetch_1_806']['handler_configs']['ticketmaster'], 'full-object update remains exact' );
 
-$merged_list = DeepMergeConfigSmokeHost::merge(
-	array( 'params' => array( 'attachments' => array( 'a', 'b', 'c' ) ) ),
-	array( 'params' => array( 'attachments' => array( 'z' ) ) )
-);
-
-smoke_assert_equals(
-	array( 'z' ),
-	$merged_list['params']['attachments'],
-	'list value is replaced, not index-merged into [z,b,c]'
-);
-
-echo "\n[5] empty incoming patch object does not clobber an existing nested map:\n";
-
-$merged_empty = DeepMergeConfigSmokeHost::merge(
-	array( 'params' => array( 'message' => 'keep me', 'channel' => 'c1' ) ),
-	array( 'params' => array() )
-);
-
-smoke_assert_equals(
-	array( 'message' => 'keep me', 'channel' => 'c1' ),
-	$merged_empty['params'],
-	'empty params patch leaves the existing params map intact'
-);
-
-echo "\n----------------------------------------------------------------\n";
-$total = $passes + count( $failures );
-echo "{$passes} / {$total} passed\n";
-
-if ( ! empty( $failures ) ) {
-	echo "\nFailures:\n";
-	foreach ( $failures as $failure ) {
-		echo " - {$failure}\n";
+	if ( ! empty( $failures ) ) {
+		exit( 1 );
 	}
-	exit( 1 );
-}
 
-echo "\nAll assertions passed.\n";
+	echo "{$passes} handler-config parity assertions passed.\n";
+}

--- a/tests/flows-update-dry-run-no-persist-smoke.php
+++ b/tests/flows-update-dry-run-no-persist-smoke.php
@@ -10,10 +10,10 @@
  * 16k-char production flow message down to ~11 chars TWICE during verification.
  *
  * This test drives the REAL FlowsCommand::updateFlow() private method via
- * reflection against a SPY persistence layer (UpdateFlowStepAbility), pinning:
+ * reflection against a SPY UpdateFlowStepAbility, pinning:
  *
- *   1. With --dry-run, the persist ability is NEVER executed (zero DB writes),
- *      so the stored flow config is byte-identical before and after.
+ *   1. With --dry-run, the ability executes in validate_only mode but makes
+ *      zero DB writes, so stored flow config is byte-identical before/after.
  *   2. With --dry-run, the output reads like a preview ("[dry-run] would
  *      update ... no changes written"), NOT a "Handler config updated" success.
  *   3. WITHOUT --dry-run, the SAME command DOES execute the persist ability
@@ -67,7 +67,8 @@ function smoke_assert_equals( $expected, $actual, string $name ): void {
 
 // ─── Spy state (module-level so stubs can record into it) ─────────────
 
-$GLOBALS['__smoke_persist_calls']  = array(); // Records every UpdateFlowStepAbility::execute() input.
+$GLOBALS['__smoke_ability_calls']  = array(); // Records every UpdateFlowStepAbility::execute() input.
+$GLOBALS['__smoke_persist_calls']  = array(); // Records simulated writes only.
 $GLOBALS['__smoke_cli_lines']      = array(); // WP_CLI::log / line output.
 $GLOBALS['__smoke_cli_success']    = array(); // WP_CLI::success output.
 $GLOBALS['__smoke_cli_error']      = null;    // First WP_CLI::error message (throws to abort).
@@ -112,6 +113,12 @@ if ( ! function_exists( 'wp_unslash' ) ) {
 if ( ! function_exists( 'wp_kses_post' ) ) {
 	function wp_kses_post( $value ) {
 		return (string) $value;
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $value, $flags = 0 ) {
+		return json_encode( $value, $flags );
 	}
 }
 
@@ -208,6 +215,14 @@ namespace DataMachine\Engine\Debug {
 	}
 }
 
+namespace DataMachine\Core {
+	if ( ! class_exists( __NAMESPACE__ . '\\AbilityResult' ) ) {
+		class AbilityResult {
+			public static function normalize( $result ) { return $result; }
+		}
+	}
+}
+
 namespace DataMachine\Core\Steps {
 	if ( ! class_exists( __NAMESPACE__ . '\\FlowStepConfig' ) ) {
 		class FlowStepConfig {
@@ -240,13 +255,39 @@ namespace DataMachine\Abilities {
 }
 
 namespace DataMachine\Abilities\FlowStep {
-	// SPY: records every execute() call so the test can assert it is NEVER
-	// invoked during a dry-run and invoked exactly once otherwise.
+	// SPY: validate_only calls return the same effective preview shape as the
+	// real ability without recording a persistence call.
 	if ( ! class_exists( __NAMESPACE__ . '\\UpdateFlowStepAbility' ) ) {
 		class UpdateFlowStepAbility {
 			public function execute( $input ) {
+				$GLOBALS['__smoke_ability_calls'][] = $input;
+				$params = $input['handler_config']['params'] ?? array();
+				$result = array(
+					'success'                  => true,
+					'flow_step_id'             => $input['flow_step_id'] ?? '',
+					'message'                  => 'ok',
+					'effective_handler_config' => array(
+						'task'   => 'dispatch_message',
+						'params' => array(
+							'channel'      => 'extra-chill',
+							'recipient'    => 'chubes',
+							'message'      => $params['message'] ?? '',
+							'connection'   => $params['connection'] ?? array(),
+							'notes'        => str_repeat( 'N', 500 ),
+							'presentation' => (object) array(
+								'description' => str_repeat( 'O', 500 ),
+								'layout'      => 'compact',
+							),
+							'mode'         => 'chronological',
+						),
+					),
+				);
+				if ( ! empty( $input['validate_only'] ) ) {
+					$result['validate_only'] = true;
+					return $result;
+				}
 				$GLOBALS['__smoke_persist_calls'][] = $input;
-				return array( 'success' => true, 'flow_step_id' => $input['flow_step_id'] ?? '', 'message' => 'ok' );
+				return $result;
 			}
 		}
 	}
@@ -270,6 +311,8 @@ namespace DataMachine\Core\Database\Flows {
 
 namespace {
 
+	require_once dirname( __DIR__ ) . '/inc/Core/PluginSettings.php';
+	require_once dirname( __DIR__ ) . '/inc/Engine/AI/conversation-loop.php';
 	require_once dirname( __DIR__ ) . '/inc/Cli/JsonInput.php';
 	require_once dirname( __DIR__ ) . '/inc/Cli/Commands/Flows/FlowsCommand.php';
 
@@ -280,6 +323,7 @@ namespace {
 	 * a snapshot of recorded spy state.
 	 */
 	function smoke_run_update( array $assoc_args ): array {
+		$GLOBALS['__smoke_ability_calls'] = array();
 		$GLOBALS['__smoke_persist_calls'] = array();
 		$GLOBALS['__smoke_cli_lines']     = array();
 		$GLOBALS['__smoke_cli_success']   = array();
@@ -296,6 +340,7 @@ namespace {
 		}
 
 		return array(
+			'ability_calls' => $GLOBALS['__smoke_ability_calls'],
 			'persist_calls' => $GLOBALS['__smoke_persist_calls'],
 			'lines'         => $GLOBALS['__smoke_cli_lines'],
 			'success'       => $GLOBALS['__smoke_cli_success'],
@@ -314,16 +359,17 @@ namespace {
 	$dry = smoke_run_update(
 		array(
 			'step'           => 'step_abc',
-			'handler-config' => '{"params":{"message":"DRYRUN_SENTINEL_SHOULD_NOT_PERSIST"}}',
+			'handler-config' => '{"params":{"message":"DRYRUN_SENTINEL_SHOULD_NOT_PERSIST","connection":{"token":"NESTED_TOKEN_SENTINEL","password":"NESTED_PASSWORD_SENTINEL","cookie":"NESTED_COOKIE_SENTINEL"}}}',
 			'dry-run'        => true,
 		)
 	);
 
 	smoke_assert(
 		array() === $dry['persist_calls'],
-		'dry-run handler-config: persist ability NEVER executed',
+		'dry-run handler-config: no persistence occurs',
 		count( $dry['persist_calls'] ) . ' persist call(s) recorded'
 	);
+	smoke_assert_equals( true, $dry['ability_calls'][0]['validate_only'] ?? null, 'dry-run handler-config: ability executes in validate_only mode' );
 
 	$after = serialize( $GLOBALS['__smoke_stored_flow'] );
 	smoke_assert(
@@ -338,6 +384,31 @@ namespace {
 		$dry_text
 	);
 	smoke_assert(
+		false !== strpos( $dry_text, '"channel":"extra-chill"' ) && false !== strpos( $dry_text, '"recipient":"chubes"' ),
+		'dry-run handler-config: previews effective merged sibling values',
+		$dry_text
+	);
+	smoke_assert(
+		false === strpos( $dry_text, 'NESTED_TOKEN_SENTINEL' ) && false === strpos( $dry_text, 'NESTED_PASSWORD_SENTINEL' ) && false === strpos( $dry_text, 'NESTED_COOKIE_SENTINEL' ),
+		'dry-run handler-config: nested credentials never reach CLI output',
+		$dry_text
+	);
+	smoke_assert(
+		3 === substr_count( $dry_text, '"[redacted]"' ),
+		'dry-run handler-config: nested token, password, and cookie are redacted',
+		$dry_text
+	);
+	smoke_assert(
+		false === strpos( $dry_text, str_repeat( 'N', 500 ) ) && false !== strpos( $dry_text, '"mode":"chronological"' ),
+		'dry-run handler-config: oversized values are bounded without hiding useful siblings',
+		$dry_text
+	);
+	smoke_assert(
+		false === strpos( $dry_text, str_repeat( 'O', 500 ) ) && false !== strpos( $dry_text, '"layout":"compact"' ),
+		'dry-run handler-config: oversized nested object values are bounded without hiding object siblings',
+		$dry_text
+	);
+	smoke_assert(
 		array() === $dry['success'],
 		'dry-run handler-config: does NOT print a WP_CLI::success "updated" line',
 		implode( ' | ', $dry['success'] )
@@ -348,7 +419,7 @@ namespace {
 	$wet = smoke_run_update(
 		array(
 			'step'           => 'step_abc',
-			'handler-config' => '{"params":{"message":"REAL_WRITE"}}',
+			'handler-config' => '{"params":{"message":"DRYRUN_SENTINEL_SHOULD_NOT_PERSIST","connection":{"token":"NESTED_TOKEN_SENTINEL","password":"NESTED_PASSWORD_SENTINEL","cookie":"NESTED_COOKIE_SENTINEL"}}}',
 		)
 	);
 
@@ -361,6 +432,12 @@ namespace {
 		! empty( $wet['success'] ),
 		'non-dry-run handler-config: prints a success line'
 	);
+	$dry_ability_input = $dry['ability_calls'][0];
+	unset( $dry_ability_input['validate_only'] );
+	smoke_assert_equals( $dry_ability_input, $wet['ability_calls'][0], 'dry-run and apply send the same normalized handler update' );
+	smoke_assert_equals( 'NESTED_TOKEN_SENTINEL', $wet['ability_calls'][0]['handler_config']['params']['connection']['token'] ?? null, 'apply receives the unchanged nested token' );
+	smoke_assert_equals( 'NESTED_PASSWORD_SENTINEL', $wet['ability_calls'][0]['handler_config']['params']['connection']['password'] ?? null, 'apply receives the unchanged nested password' );
+	smoke_assert_equals( 'NESTED_COOKIE_SENTINEL', $wet['ability_calls'][0]['handler_config']['params']['connection']['cookie'] ?? null, 'apply receives the unchanged nested cookie' );
 
 	echo "\n[3] --set-user-message --dry-run makes ZERO writes:\n";
 


### PR DESCRIPTION
## Summary
- route dry-run and apply through one canonical sparse-sanitize/deep-merge path
- preserve omitted handler siblings, nested params, scalar types, and full-object updates
- prevent dry-run flow/log persistence and expose a bounded credential-redacted effective preview
- align CLI and pipeline configuration behavior with production regression coverage

## Verification
- handler parity and dry-run smokes pass
- changed-scope lint and audit report 0 findings
- PHP syntax, prefix policy, and `git diff --check` pass

Closes #3024