### PR TITLE
Fix retention storage reporting and reclamation

### DIFF
--- a/inc/Abilities/SystemAbilities.php
+++ b/inc/Abilities/SystemAbilities.php
@@ -25,6 +25,7 @@ use DataMachine\Engine\Tasks\RecurringRejectionTracker;
 use DataMachine\Engine\Tasks\RecurringScheduler;
 use DataMachine\Engine\Tasks\TaskScheduler;
 use DataMachine\Engine\Tasks\TaskRegistry;
+use DataMachine\Engine\AI\System\Tasks\Retention\RetentionCleanup;
 
 defined('ABSPATH') || exit;
 
@@ -165,6 +166,11 @@ class SystemAbilities {
 			'ownership' => array(
 				'label'    => __( 'Agent Ownership', 'data-machine' ),
 				'callback' => array( $this, 'runOwnershipDiagnostics' ),
+				'default'  => true,
+			),
+			'retention' => array(
+				'label'    => __( 'Retention Storage', 'data-machine' ),
+				'callback' => array( RetentionCleanup::class, 'tableBloatHealth' ),
 				'default'  => true,
 			),
 		);

--- a/inc/Cli/Commands/RetentionCommand.php
+++ b/inc/Cli/Commands/RetentionCommand.php
@@ -13,7 +13,6 @@ namespace DataMachine\Cli\Commands;
 
 use WP_CLI;
 use DataMachine\Cli\BaseCommand;
-use DataMachine\Core\Database\BaseRepository;
 use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 use DataMachine\Engine\AI\System\Tasks\Retention\RetentionCleanup;
 use DataMachine\Engine\Tasks\TaskScheduler;
@@ -80,23 +79,61 @@ class RetentionCommand extends BaseCommand {
 				'filter'    => $policy['filter'],
 				'rows'      => $size_info['rows'] ?? 'N/A',
 				'size_mb'   => $size_info['size_mb'] ?? 'N/A',
+				'free_mb'   => $size_info['free_mb'] ?? 'N/A',
+				'reclaim'   => $size_info['reclaim_ratio'] ?? 'N/A',
 			);
 		}
 
 		$this->format_items(
 			$policy_items,
-			array( 'domain', 'retention', 'rows', 'size_mb', 'filter' ),
+			array( 'domain', 'retention', 'rows', 'size_mb', 'free_mb', 'reclaim', 'filter' ),
 			$assoc_args
 		);
 
 		// Show total.
 		$total_mb = 0;
-		foreach ( $sizes as $size_info ) {
+		foreach ( $sizes['_unique'] ?? array() as $size_info ) {
 			$total_mb += (float) $size_info['size_mb'];
 		}
 
 		WP_CLI::log( '' );
 		WP_CLI::log( sprintf( 'Total tracked table size: %.1f MB', $total_mb ) );
+	}
+
+	/**
+	 * Rebuild selected owned InnoDB tables after explicit confirmation.
+	 *
+	 * [--tables=<tables>]
+	 * : Comma-separated physical or unprefixed owned table names.
+	 *
+	 * [--yes]
+	 * : Confirm the table rebuild. Without this flag the command is a dry run.
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function optimize( array $args, array $assoc_args ): void {
+		$raw = (string) ( $assoc_args['tables'] ?? '' );
+		$selected = array_values( array_filter( array_map( 'trim', explode( ',', $raw ) ) ) );
+		if ( empty( $selected ) ) {
+			WP_CLI::error( 'Provide --tables with one or more owned table names.' );
+			return;
+		}
+
+		if ( ! isset( $assoc_args['yes'] ) ) {
+			WP_CLI::log( 'Dry run. Pass --yes to rebuild selected tables: ' . implode( ', ', $selected ) );
+			return;
+		}
+
+		$result = RetentionCleanup::optimizeOwnedTables( $selected );
+		foreach ( $result['rejected'] as $table => $reason ) {
+			WP_CLI::warning( sprintf( '%s: %s', $table, $reason ) );
+		}
+		if ( empty( $result['optimized'] ) ) {
+			WP_CLI::error( 'No selected table was optimized.' );
+			return;
+		}
+		WP_CLI::success( 'Optimized: ' . implode( ', ', $result['optimized'] ) );
 	}
 
 	/**
@@ -434,7 +471,6 @@ class RetentionCommand extends BaseCommand {
 	private function get_table_sizes(): array {
 		global $wpdb;
 
-		$sizes  = array();
 		$tables = array(
 			'Completed jobs'  => $wpdb->prefix . 'datamachine_jobs',
 			'Failed jobs'     => $wpdb->prefix . 'datamachine_jobs',
@@ -443,49 +479,15 @@ class RetentionCommand extends BaseCommand {
 			'AS actions'      => $wpdb->prefix . 'actionscheduler_actions',
 			'Stale claims'    => $wpdb->prefix . 'actionscheduler_claims',
 		);
-
-		// Deduplicate tables for the query (jobs appears twice).
-		$unique_tables = array_unique( array_values( $tables ) );
-
-		$table_data = array();
-
-		if ( BaseRepository::is_sqlite() ) {
-			// SQLite: no information_schema. Count rows per table; size is unavailable.
-			foreach ( $unique_tables as $tbl ) {
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-				$count              = (int) $wpdb->get_var(
-					$wpdb->prepare( 'SELECT COUNT(*) FROM %i', $tbl )
-				);
-				$table_data[ $tbl ] = array(
-					'rows'    => $count,
-					'size_mb' => '0.0',
-				);
-			}
-		} else {
-			$placeholders = implode( ',', array_fill( 0, count( $unique_tables ), '%s' ) );
-
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$results = $wpdb->get_results(
-				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholder list is generated from table count and values are still prepared.
-				$wpdb->prepare(
-					"SELECT table_name, table_rows,
-						ROUND((data_length + index_length) / 1024 / 1024, 1) AS size_mb
-					FROM information_schema.tables
-					WHERE table_schema = DATABASE()
-					AND table_name IN ({$placeholders})",
-					...$unique_tables
-				)
-				// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$allocations = RetentionCleanup::ownedTableAllocations();
+		$table_data  = array();
+		foreach ( $allocations as $table => $data ) {
+			$table_data[ $table ] = array(
+				'rows'    => $data['rows'],
+				'size_mb' => null === $data['live_bytes'] ? 'N/A' : number_format( $data['live_bytes'] / 1024 / 1024, 1 ),
+				'free_mb' => null === $data['allocated_free_bytes'] ? 'N/A' : number_format( $data['allocated_free_bytes'] / 1024 / 1024, 1 ),
+				'reclaim_ratio' => null === $data['reclaim_ratio'] ? 'N/A' : number_format( 100 * $data['reclaim_ratio'], 1 ) . '%',
 			);
-
-			if ( $results ) {
-				foreach ( $results as $row ) {
-					$table_data[ $row->table_name ] = array(
-						'rows'    => (int) $row->table_rows,
-						'size_mb' => $row->size_mb,
-					);
-				}
-			}
 		}
 
 		foreach ( $tables as $domain => $table_name ) {
@@ -494,6 +496,7 @@ class RetentionCommand extends BaseCommand {
 				'size_mb' => '0.0',
 			);
 		}
+		$sizes['_unique'] = $table_data;
 
 		// Chat sessions routes through the conversation store so swapped
 		// backends (e.g. AI Framework adapters) can opt into the metrics

--- a/inc/Cli/Commands/RetentionCommand.php
+++ b/inc/Cli/Commands/RetentionCommand.php
@@ -503,7 +503,8 @@ class RetentionCommand extends BaseCommand {
 		// table or bow out by returning null.
 		$chat_metrics = ConversationStoreFactory::get()->get_storage_metrics();
 		if ( null !== $chat_metrics ) {
-			$sizes['Chat sessions'] = $chat_metrics;
+			$sizes['Chat sessions']            = $chat_metrics;
+			$sizes['_unique']['Chat sessions'] = $chat_metrics;
 		}
 
 		return $sizes;

--- a/inc/Cli/Commands/SystemCommand.php
+++ b/inc/Cli/Commands/SystemCommand.php
@@ -167,6 +167,20 @@ class SystemCommand extends BaseCommand {
 			if ( isset( $check_result['message'] ) ) {
 				WP_CLI::log( sprintf( '  Message:        %s', $check_result['message'] ) );
 			}
+			if ( ! empty( $check_result['warnings'] ) ) {
+				foreach ( $check_result['warnings'] as $warning ) {
+					WP_CLI::warning(
+						sprintf(
+							'%s: live %s bytes, reclaimable %s bytes (%s%%). Run %s',
+							$warning['table'],
+							number_format_i18n( (int) $warning['live_bytes'] ),
+							number_format_i18n( (int) $warning['reclaimable_bytes'] ),
+							number_format_i18n( 100 * (float) $warning['reclaim_ratio'], 1 ),
+							$warning['command']
+						)
+					);
+				}
+			}
 			if ( isset( $check_result[ DependencyChecker::CHECK_ACTION_SCHEDULER ] ) && is_array( $check_result[ DependencyChecker::CHECK_ACTION_SCHEDULER ] ) ) {
 				$action_scheduler = $check_result[ DependencyChecker::CHECK_ACTION_SCHEDULER ];
 				WP_CLI::log( sprintf( '  Pending:        %d', (int) ( $action_scheduler['pending_count'] ?? 0 ) ) );

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -274,6 +274,174 @@ class RetentionCleanup {
 	}
 
 	/**
+	 * Owned physical tables that may be inspected or rebuilt by retention.
+	 *
+	 * @return array<string, string> Logical suffix to prefixed table name.
+	 */
+	public static function ownedTableNames(): array {
+		global $wpdb;
+
+		return array(
+			'datamachine_jobs'              => $wpdb->prefix . 'datamachine_jobs',
+			'datamachine_logs'              => $wpdb->prefix . 'datamachine_logs',
+			'datamachine_processed_items'   => $wpdb->prefix . 'datamachine_processed_items',
+			'actionscheduler_actions'       => $wpdb->prefix . 'actionscheduler_actions',
+			'actionscheduler_logs'          => $wpdb->prefix . 'actionscheduler_logs',
+			'actionscheduler_claims'        => $wpdb->prefix . 'actionscheduler_claims',
+		);
+	}
+
+	public static function tableFreeBytesThreshold(): int {
+		return max( 0, (int) apply_filters( 'datamachine_table_free_bytes_threshold', 1024 * 1024 * 1024 ) );
+	}
+
+	public static function tableFreeRatioThreshold(): float {
+		return max( 0.0, (float) apply_filters( 'datamachine_table_free_ratio_threshold', 0.5 ) );
+	}
+
+	/**
+	 * Report physical allocation for tables owned by Data Machine.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public static function ownedTableAllocations(): array {
+		global $wpdb;
+		$tables = self::ownedTableNames();
+		$report = array();
+
+		foreach ( $tables as $suffix => $table ) {
+			$report[ $table ] = array(
+				'table'                 => $table,
+				'logical_name'          => $suffix,
+				'rows'                  => 0,
+				'live_bytes'            => null,
+				'allocated_free_bytes'  => null,
+				'allocation_bytes'      => null,
+				'reclaim_ratio'        => null,
+				'engine'               => null,
+				'available'             => false,
+			);
+		}
+
+		if ( class_exists( BaseRepository::class ) && BaseRepository::is_sqlite() ) {
+			foreach ( $report as $table => &$row ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$row['rows'] = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $table ) );
+			}
+			unset( $row );
+			return $report;
+		}
+
+		$names        = array_keys( $report );
+		$placeholders = implode( ',', array_fill( 0, count( $names ), '%s' ) );
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT TABLE_NAME, ENGINE, TABLE_ROWS, DATA_LENGTH, INDEX_LENGTH, DATA_FREE FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ({$placeholders})",
+				...$names
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		if ( ! is_array( $results ) ) {
+			return $report;
+		}
+
+		foreach ( $results as $result ) {
+			$table = (string) ( $result->TABLE_NAME ?? '' );
+			if ( ! isset( $report[ $table ] ) ) {
+				continue;
+			}
+			$live = (int) ( $result->DATA_LENGTH ?? 0 ) + (int) ( $result->INDEX_LENGTH ?? 0 );
+			$free = max( 0, (int) ( $result->DATA_FREE ?? 0 ) );
+			$report[ $table ]['rows']                 = (int) ( $result->TABLE_ROWS ?? 0 );
+			$report[ $table ]['live_bytes']           = $live;
+			$report[ $table ]['allocated_free_bytes'] = $free;
+			$report[ $table ]['allocation_bytes']     = $live + $free;
+			$report[ $table ]['reclaim_ratio']        = $live + $free > 0 ? $free / ( $live + $free ) : 0.0;
+			$report[ $table ]['engine']                = (string) ( $result->ENGINE ?? '' );
+			$report[ $table ]['available']             = true;
+		}
+
+		return $report;
+	}
+
+	/**
+	 * Rebuild explicitly selected owned InnoDB tables after validating metadata.
+	 *
+	 * @param array<int, string> $selected Physical or unprefixed table names.
+	 * @return array{optimized: array<int, string>, rejected: array<string, string>}
+	 */
+	public static function optimizeOwnedTables( array $selected ): array {
+		$owned    = self::ownedTableNames();
+		$allowed  = array_combine( array_values( $owned ), array_values( $owned ) );
+		foreach ( $owned as $suffix => $table ) {
+			$allowed[ $suffix ] = $table;
+		}
+		$report    = self::ownedTableAllocations();
+		$optimized = array();
+		$rejected  = array();
+
+		if ( class_exists( BaseRepository::class ) && BaseRepository::is_sqlite() ) {
+			foreach ( $selected as $table ) {
+				$rejected[ (string) $table ] = 'SQLite does not support InnoDB table allocation';
+			}
+			return array( 'optimized' => $optimized, 'rejected' => $rejected );
+		}
+
+		global $wpdb;
+		foreach ( $selected as $requested ) {
+			$key = (string) $requested;
+			if ( ! isset( $allowed[ $key ] ) ) {
+				$rejected[ $key ] = 'table is not owned by Data Machine';
+				continue;
+			}
+			$table = $allowed[ $key ];
+			if ( empty( $report[ $table ]['available'] ) || 'innodb' !== strtolower( (string) $report[ $table ]['engine'] ) ) {
+				$rejected[ $table ] = 'InnoDB metadata is unavailable or table is not InnoDB';
+				continue;
+			}
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange
+			if ( false !== $wpdb->query( $wpdb->prepare( 'OPTIMIZE TABLE %i', $table ) ) ) {
+				$optimized[] = $table;
+			}
+		}
+
+		return array( 'optimized' => $optimized, 'rejected' => $rejected );
+	}
+
+	/**
+	 * Return actionable DATA_FREE warnings for the health surface.
+	 *
+	 * @return array{status: string, warnings: array<int, array<string, mixed>>, thresholds: array<string, mixed>}
+	 */
+	public static function tableBloatHealth(): array {
+		$absolute = self::tableFreeBytesThreshold();
+		$ratio    = self::tableFreeRatioThreshold();
+		$warnings = array();
+		foreach ( self::ownedTableAllocations() as $table => $data ) {
+			$free = $data['allocated_free_bytes'];
+			$share = $data['reclaim_ratio'];
+			if ( null === $free || null === $share || ( $free < $absolute && $share < $ratio ) ) {
+				continue;
+			}
+			$warnings[] = array(
+				'table'              => $table,
+				'live_bytes'         => $data['live_bytes'],
+				'reclaimable_bytes'  => $free,
+				'reclaim_ratio'      => $share,
+				'command'            => 'wp datamachine retention optimize --tables=' . $table . ' --yes',
+			);
+		}
+
+		return array(
+			'status'     => empty( $warnings ) ? 'ok' : 'warning',
+			'warnings'   => $warnings,
+			'thresholds' => array( 'free_bytes' => $absolute, 'free_ratio' => $ratio ),
+		);
+	}
+
+	/**
 	 * Read-only row estimates for the Action Scheduler tables.
 	 *
 	 * Pure read with no side effects — safe for health/diagnostic surfaces.
@@ -1210,9 +1378,10 @@ class RetentionCleanup {
 
 		$threshold = self::actionSchedulerOptimizeThreshold();
 		$optimized = array();
+		$owned    = array_values( self::ownedTableNames() );
 
 		foreach ( $tables_affected as $table => $affected ) {
-			if ( (int) $affected < $threshold ) {
+			if ( ! in_array( $table, $owned, true ) || (int) $affected < $threshold ) {
 				continue;
 			}
 

--- a/tests/retention-reporting-smoke.php
+++ b/tests/retention-reporting-smoke.php
@@ -48,6 +48,7 @@ namespace {
 	$results = '$results';
 	assert_retention_reporting( 'restricted information_schema returns unavailable allocation', str_contains( $cleanup_source, "if ( ! is_array( $results ) )" ) );
 	assert_retention_reporting( 'show total uses unique physical allocation', str_contains( $command_source, "\$sizes['_unique']" ) );
+	assert_retention_reporting( 'show total preserves separately measured chat storage', str_contains( $command_source, "\$sizes['_unique']['Chat sessions']" ) );
 	assert_retention_reporting( 'operator optimizer accepts selected tables only', str_contains( $command_source, 'RetentionCleanup::optimizeOwnedTables' ) );
 
 	require_once $root . '/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php';

--- a/tests/retention-reporting-smoke.php
+++ b/tests/retention-reporting-smoke.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Focused regression coverage for retention table allocation reporting (#3282, #3283).
+ *
+ * Run with: php tests/retention-reporting-smoke.php
+ */
+
+declare( strict_types=1 );
+
+namespace DataMachine\Core\Database {
+	abstract class BaseRepository {
+		public static bool $sqlite = false;
+
+		public static function is_sqlite(): bool {
+			return self::$sqlite;
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/../' );
+	}
+
+	$GLOBALS['retention_reporting_filters'] = array();
+	function apply_filters( string $hook, $value ) {
+		return $GLOBALS['retention_reporting_filters'][ $hook ] ?? $value;
+	}
+	function do_action( ...$args ): void {}
+
+	$failed = 0;
+	$total  = 0;
+	function assert_retention_reporting( string $name, bool $condition ): void {
+		global $failed, $total;
+		++$total;
+		if ( $condition ) {
+			echo "  [PASS] {$name}\n";
+			return;
+		}
+		++$failed;
+		echo "  [FAIL] {$name}\n";
+	}
+
+	$root = dirname( __DIR__ );
+	$cleanup_source = file_get_contents( $root . '/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php' ) ?: '';
+	$command_source = file_get_contents( $root . '/inc/Cli/Commands/RetentionCommand.php' ) ?: '';
+	assert_retention_reporting( 'SQLite path avoids information_schema', str_contains( $cleanup_source, 'BaseRepository::is_sqlite()' ) );
+	$results = '$results';
+	assert_retention_reporting( 'restricted information_schema returns unavailable allocation', str_contains( $cleanup_source, "if ( ! is_array( $results ) )" ) );
+	assert_retention_reporting( 'show total uses unique physical allocation', str_contains( $command_source, "\$sizes['_unique']" ) );
+	assert_retention_reporting( 'operator optimizer accepts selected tables only', str_contains( $command_source, 'RetentionCleanup::optimizeOwnedTables' ) );
+
+	require_once $root . '/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php';
+	use DataMachine\Engine\AI\System\Tasks\Retention\RetentionCleanup;
+
+	final class RetentionReportingWpdb {
+		public string $prefix = 'wp_';
+		public bool $restricted = false;
+		public int $optimize_calls = 0;
+
+		public function prepare( string $sql, ...$args ): array {
+			return array( 'sql' => $sql, 'args' => $args );
+		}
+
+		public function get_results( $prepared ): ?array {
+			if ( $this->restricted ) {
+				return null;
+			}
+			return array(
+				(object) array(
+					'TABLE_NAME'    => 'wp_datamachine_jobs',
+					'ENGINE'        => 'InnoDB',
+					'TABLE_ROWS'    => 2,
+					'DATA_LENGTH'   => 100,
+					'INDEX_LENGTH'  => 100,
+					'DATA_FREE'     => 900,
+				),
+			);
+		}
+
+		public function get_var( $prepared ): int {
+			return 7;
+		}
+
+		public function query( $prepared ): int {
+			++$this->optimize_calls;
+			return 0;
+		}
+	}
+
+	$wpdb = new RetentionReportingWpdb();
+	$GLOBALS['wpdb'] = $wpdb;
+	\DataMachine\Core\Database\BaseRepository::$sqlite = true;
+	$sqlite = RetentionCleanup::ownedTableAllocations();
+	assert_retention_reporting( 'SQLite reports rows without claiming byte allocation', 7 === $sqlite['wp_datamachine_jobs']['rows'] && null === $sqlite['wp_datamachine_jobs']['live_bytes'] );
+	\DataMachine\Core\Database\BaseRepository::$sqlite = false;
+	$allocations = RetentionCleanup::ownedTableAllocations();
+	$jobs = $allocations['wp_datamachine_jobs'];
+	assert_retention_reporting( 'low-row high-DATA_FREE table is reported', 2 === $jobs['rows'] && 900 === $jobs['allocated_free_bytes'] );
+	assert_retention_reporting( 'live bytes and reclaim ratio are reported', 200 === $jobs['live_bytes'] && 0.8181818181818182 === $jobs['reclaim_ratio'] );
+
+	$GLOBALS['retention_reporting_filters']['datamachine_table_free_bytes_threshold'] = 800;
+	$GLOBALS['retention_reporting_filters']['datamachine_table_free_ratio_threshold'] = 0.8;
+	$health = RetentionCleanup::tableBloatHealth();
+	assert_retention_reporting( 'threshold warning names exact table and command', 'warning' === $health['status'] && 'wp_datamachine_jobs' === $health['warnings'][0]['table'] && str_contains( $health['warnings'][0]['command'], '--tables=wp_datamachine_jobs --yes' ) );
+
+	$optimized = RetentionCleanup::optimizeOwnedTables( array( 'datamachine_jobs', 'wp_not_owned' ) );
+	assert_retention_reporting( 'selected owned table is optimized', in_array( 'wp_datamachine_jobs', $optimized['optimized'], true ) && 1 === $wpdb->optimize_calls );
+	assert_retention_reporting( 'selected table allowlist rejects foreign table', isset( $optimized['rejected']['wp_not_owned'] ) );
+
+	$wpdb->restricted = true;
+	$unavailable = RetentionCleanup::ownedTableAllocations();
+	assert_retention_reporting( 'information_schema failure degrades without byte claims', false === $unavailable['wp_datamachine_jobs']['available'] && null === $unavailable['wp_datamachine_jobs']['allocated_free_bytes'] );
+
+	if ( $failed > 0 ) {
+		echo "retention-reporting-smoke failed: {$failed}/{$total} assertions failed.\n";
+		exit( 1 );
+	}
+	echo "retention-reporting-smoke passed: {$total} assertions.\n";
+}


### PR DESCRIPTION
## Summary
Surface physical InnoDB allocation and make retention totals accurate so operators can detect and safely reclaim table bloat.

## What changed
- Deduplicate physical tables when calculating retention storage totals.
- Report owned-table live bytes, reclaimable bytes, and reclaim ratios with safe SQLite and restricted-metadata fallback.
- Add health warnings and an allowlisted operator-confirmed table optimization command.

## How to test
1. Run `composer install --no-interaction --prefer-dist && composer lint`; expect passes.
2. Run `php tests/retention-reporting-smoke.php`; expect passes.
3. Run `php tests/retention-action-scheduler-batching-smoke.php`; expect passes.

## Compatibility
Additive CLI and health output changes; automatic optimization remains disabled and existing retention policy behavior is preserved.

## Evidence
- Action Scheduler retention smoke: passed (Passed)
- Base advanced after verification: verified main at 354fdb371320afd483f406d4fb90828a61c9938a; publication observed 48997d2dfb745f53585d93a1281ac812e5e13530. Candidate ancestry was validated against the verified snapshot.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/data-machine/issues/3282
- Reviewer-resolvable evidence from source\_refs\[1\]: https://github.com/Extra-Chill/data-machine/issues/3283
- Verified finalization base: main at 354fdb371320afd483f406d4fb90828a61c9938a
- composer lint: passed (Passed)
- retention reporting smoke: passed (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode via Homeboy)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Investigated the production storage failure, implemented the smallest changes in the existing retention substrate, and added focused regression coverage.

## Source relationships
- Closes #3282
- Closes #3283
