### PR TITLE
fix: preserve migrated email flow authorization

### DIFF
--- a/inc/Core/Steps/Fetch/Handlers/Email/Email.php
+++ b/inc/Core/Steps/Fetch/Handlers/Email/Email.php
@@ -75,6 +75,7 @@ class Email extends FetchHandler {
 			'flow_step_id'          => $context->getFlowStepId(),
 			'job_id'                => $context->getJobId(),
 			'principal_less_system' => null === $context->getAgentId() && 0 === get_current_user_id(),
+			'legacy_default_auth'   => (string) ( $config['_legacy_default_auth'] ?? '' ),
 		);
 		$result          = $ability->executeWithContext( $ability_input, $trusted_context );
 

--- a/inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php
+++ b/inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php
@@ -13,6 +13,7 @@ namespace DataMachine\Core\Steps\Fetch\Handlers\Email;
 
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\OAuth\BaseAuthProvider;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -213,7 +214,7 @@ class EmailAuth extends BaseAuthProvider {
 
 	private function can_use_default( array $context, int $agent_id, int $user_id ): bool {
 		if ( $agent_id > 0 ) {
-			return false;
+			return $this->can_use_migrated_legacy_default( $context, $agent_id );
 		}
 		if ( ! empty( $context['principal_less_system'] ) && ! empty( $context['_trusted_execution'] ) ) {
 			return true;
@@ -222,6 +223,39 @@ class EmailAuth extends BaseAuthProvider {
 			return class_exists( PermissionHelper::class ) && PermissionHelper::can_manage();
 		}
 		return $this->user_has_management_capability( $user_id );
+	}
+
+	/**
+	 * Preserve the signed default-mailbox grant written by the final pre-1.0 migration.
+	 */
+	private function can_use_migrated_legacy_default( array $context, int $agent_id ): bool {
+		$flow_id      = absint( $context['flow_id'] ?? 0 );
+		$flow_step_id = (string) ( $context['flow_step_id'] ?? '' );
+		$provided     = (string) ( $context['legacy_default_auth'] ?? '' );
+		if ( empty( $context['_trusted_execution'] ) || $flow_id <= 0 || '' === $flow_step_id || 64 !== strlen( $provided ) || ! ctype_xdigit( $provided ) ) {
+			return false;
+		}
+
+		$expected = self::legacy_default_marker( $flow_id, $flow_step_id, $agent_id );
+		if ( ! hash_equals( $expected, strtolower( $provided ) ) ) {
+			return false;
+		}
+
+		$flow = ( new Flows() )->get_flow( $flow_id );
+		if ( ! is_array( $flow ) || $agent_id !== absint( $flow['agent_id'] ?? 0 ) ) {
+			return false;
+		}
+
+		$persisted = $flow['flow_config'][ $flow_step_id ]['handler_configs']['email']['_legacy_default_auth'] ?? null;
+		return is_string( $persisted ) && hash_equals( $expected, strtolower( $persisted ) );
+	}
+
+	/**
+	 * Reproduce the marker format shipped by the final pre-1.0 migration.
+	 */
+	public static function legacy_default_marker( int $flow_id, string $flow_step_id, int $agent_id ): string {
+		$payload = implode( '|', array( 'email-default-v1', (string) $flow_id, $flow_step_id, (string) $agent_id ) );
+		return hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) );
 	}
 
 	public function grant_agent( string $account, string $owner_type, int $owner_id, int $agent_id, array $operations ): bool {

--- a/inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php
+++ b/inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php
@@ -242,7 +242,7 @@ class EmailAuth extends BaseAuthProvider {
 		}
 
 		$flow = ( new Flows() )->get_flow( $flow_id );
-		if ( ! is_array( $flow ) || $agent_id !== absint( $flow['agent_id'] ?? 0 ) ) {
+		if ( ! is_array( $flow ) || absint( $flow['agent_id'] ?? 0 ) !== $agent_id ) {
 			return false;
 		}
 

--- a/tests/legacy-email-upgrade-auth-smoke.php
+++ b/tests/legacy-email-upgrade-auth-smoke.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * End-to-end compatibility coverage for the final pre-1.0 email auth transform.
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Abilities {
+	class PermissionHelper {
+		public static function acting_user_id(): int {
+			return 0;
+		}
+
+		public static function get_acting_agent_id(): ?int {
+			return null;
+		}
+
+		public static function can_manage(): bool {
+			return false;
+		}
+
+		public static function can( string $action ): bool {
+			return false;
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\Flows {
+	class Flows {
+		public function get_flow( int $flow_id ): ?array {
+			return $GLOBALS['legacy_email_flows'][ get_current_blog_id() ][ $flow_id ] ?? null;
+		}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+	$GLOBALS['legacy_email_options'] = array();
+	$GLOBALS['legacy_email_flows']   = array();
+	$GLOBALS['legacy_email_blog_id'] = 1;
+
+	class WP_Error {
+		public function __construct( private string $code, private string $message = '', private array $data = array() ) {}
+		public function get_error_code(): string {
+			return $this->code;
+		}
+	}
+
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+
+	function __( string $text, string $domain = '' ): string {
+		return $text;
+	}
+
+	function absint( $value ): int {
+		return abs( (int) $value );
+	}
+
+	function sanitize_key( $value ): string {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $value ) );
+	}
+
+	function user_can( int $user_id, string $capability ): bool {
+		return false;
+	}
+
+	function get_current_blog_id(): int {
+		return $GLOBALS['legacy_email_blog_id'];
+	}
+
+	function get_site_option( string $name, $default = false ) {
+		return $GLOBALS['legacy_email_options'][ get_current_blog_id() ][ $name ] ?? $default;
+	}
+
+	function update_site_option( string $name, $value ): bool {
+		$GLOBALS['legacy_email_options'][ get_current_blog_id() ][ $name ] = $value;
+		return true;
+	}
+
+	function wp_salt( string $scheme = 'auth' ): string {
+		return 'legacy-upgrade-network-salt-' . $scheme;
+	}
+
+	function apply_filters( string $hook, $value ) {
+		return $value;
+	}
+
+	function do_action( string $hook, ...$args ): void {}
+
+	require_once __DIR__ . '/../inc/Core/OAuth/BaseAuthProvider.php';
+	require_once __DIR__ . '/../inc/Core/Steps/Fetch/Handlers/Email/EmailAuth.php';
+
+	use DataMachine\Core\Steps\Fetch\Handlers\Email\EmailAuth;
+
+	$failures = array();
+	$assert   = static function ( bool $condition, string $message ) use ( &$failures ): void {
+		if ( $condition ) {
+			echo "PASS: {$message}\n";
+			return;
+		}
+		$failures[] = $message;
+		echo "FAIL: {$message}\n";
+	};
+
+	$auth = new EmailAuth();
+	$auth->save_config(
+		array(
+			'imap_host'     => 'imap.example.test',
+			'imap_user'     => 'legacy@example.test',
+			'imap_password' => 'secret',
+		)
+	);
+
+	$flow_id      = 91;
+	$flow_step_id = 'step-email';
+	$agent_id     = 303;
+	$legacy_flow  = array(
+		'agent_id'   => $agent_id,
+		'flow_config' => array(
+			$flow_step_id => array(
+				'handler_slugs'   => array( 'email' ),
+				'handler_configs' => array( 'email' => array( 'folder' => 'INBOX' ) ),
+			),
+		),
+	);
+
+	// Represent the final pre-1.0 transform against the legacy persisted row.
+	$marker = EmailAuth::legacy_default_marker( $flow_id, $flow_step_id, $agent_id );
+	$assert( hash_hmac( 'sha256', 'email-default-v1|91|step-email|303', wp_salt( 'auth' ) ) === $marker, '1.0 reproduces the shipped pre-1.0 signature format' );
+	$legacy_flow['flow_config'][ $flow_step_id ]['handler_configs']['email']['_legacy_default_auth'] = $marker;
+	$GLOBALS['legacy_email_flows'][1][ $flow_id ] = $legacy_flow;
+
+	$context = array(
+		'agent_id'           => $agent_id,
+		'flow_id'            => $flow_id,
+		'flow_step_id'       => $flow_step_id,
+		'legacy_default_auth' => $marker,
+	);
+	$assert( ! is_wp_error( $auth->resolve_mailbox_for_principal( 'default', 'read', $context ) ), 'valid migrated row retains site default mailbox access after 1.0' );
+	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'default', 'read', array_diff_key( $context, array( 'legacy_default_auth' => true ) ) ) ), 'unsigned legacy flow fails closed' );
+
+	$forged_context                        = $context;
+	$forged_context['legacy_default_auth'] = str_repeat( 'a', 64 );
+	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'default', 'read', $forged_context ) ), 'forged marker fails closed' );
+
+	$new_flow_context            = $context;
+	$new_flow_context['flow_id'] = 92;
+	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'default', 'read', $new_flow_context ) ), 'new flow cannot replay a migrated marker' );
+
+	$wrong_agent_context             = $context;
+	$wrong_agent_context['agent_id'] = 404;
+	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'default', 'read', $wrong_agent_context ) ), 'marker cannot widen agent ownership' );
+
+	$wrong_step_context                 = $context;
+	$wrong_step_context['flow_step_id'] = 'other-step';
+	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'default', 'read', $wrong_step_context ) ), 'marker cannot widen step scope' );
+
+	$GLOBALS['legacy_email_blog_id'] = 2;
+	$auth->save_config(
+		array(
+			'imap_host'     => 'imap.other.test',
+			'imap_user'     => 'other@example.test',
+			'imap_password' => 'other-secret',
+		)
+	);
+	$assert( is_wp_error( $auth->resolve_mailbox_for_principal( 'default', 'read', $context ) ), 'marker cannot cross site scope without its persisted row' );
+
+	if ( $failures ) {
+		exit( 1 );
+	}
+
+	echo 'legacy-email-upgrade-auth-smoke: ok' . PHP_EOL;
+}

--- a/tests/named-mailbox-security-contract-smoke.php
+++ b/tests/named-mailbox-security-contract-smoke.php
@@ -33,7 +33,7 @@ $assert( str_contains( $email, "0 === stripos( \$header, 'From:' )" ), 'syntheti
 $assert( substr_count( $api, '...self::mailbox_args()' ) >= 12 && str_contains( $api, "'args'                => self::mailbox_args()" ), 'all email REST routes advertise mailbox selectors' );
 $assert( str_contains( $api, "'auth_ref' => array(" ) && str_contains( $api, "'mailbox'  => array(" ), 'REST schema declares auth_ref and mailbox' );
 $assert( substr_count( $cli, '[--auth-ref=<ref>]' ) >= 14 && substr_count( $cli, '[--mailbox=<name>]' ) >= 14, 'all email CLI commands document both mailbox selectors' );
-$assert( ! str_contains( $handler, '_legacy_default_auth' ), 'email handler accepts only explicit canonical mailbox authorization' );
+$assert( str_contains( $handler, "'legacy_default_auth'   => (string) ( \$config['_legacy_default_auth'] ?? '' )" ), 'email handler forwards only the persisted legacy marker into trusted execution context' );
 $assert( strpos( $queue, 'verifyMailboxGrant( $payload )' ) < strpos( $queue, "wp_get_ability( 'datamachine/send-email' )" ), 'queue worker verifies signed authorization before ability execution' );
 $assert( strpos( $queue, 'currentIssuerAuthorized( $grant )' ) < strpos( $queue, "wp_get_ability( 'datamachine/send-email' )" ), 'queue worker revalidates explicit issuer authority before ability execution' );
 $assert( str_contains( $queue, "'token_id'" ) && str_contains( $queue, "(int) \$context['token_id']" ) && str_contains( $queue, "'issuer_type'" ), 'signed queue envelope captures stable non-secret issuer identity' );


### PR DESCRIPTION
## Summary
- preserve the final pre-1.0 `_legacy_default_auth` signature contract for already-migrated agent-owned email fetch steps
- authorize the site default mailbox only when the HMAC, trusted flow/step/agent context, current-site persisted row, persisted marker, and persisted agent owner all match
- keep unsigned, malformed, forged, new-flow, agent-mismatched, step-mismatched, and cross-site attempts fail-closed; canonical named mailboxes and delegation remain required for new configuration

## Upgrade Coverage
- represents the final pre-1.0 transform from an unreferenced legacy agent-owned email step
- confirms 1.0 reproduces the shipped `email-default-v1|flow_id|flow_step_id|agent_id` signature and resolves the valid migrated row
- covers unsigned and forged markers, replay into a new flow, mismatched agent and step scope, and multisite replay without the originating persisted row

## Verification
- `php tests/legacy-email-upgrade-auth-smoke.php`
- `php tests/named-mailbox-delegation-smoke.php`
- `php tests/named-mailbox-security-contract-smoke.php`
- changed-file syntax checks
- changed-file and full `composer lint`
- `npm run build`
- `git diff --check`
- full pure-PHP smoke sweep reaches the known unrelated failure tracked by #3201
- full and focused Homeboy PHPUnit attempts executed zero tests because of the WP Codebox recipe-payload failure tracked by Extra-Chill/homeboy#12784 (runs `798cf3af-e454-4bc7-b7da-c29f2a1abbdf` and `15d2fae5-ccc6-42b9-a9d4-e2c9397ba6ff`)

Closes #3290