### PR TITLE
fix: clear production npm audit advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12573,9 +12573,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
 			"devOptional": true,
 			"funding": [
 				{
@@ -15921,9 +15921,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"devOptional": true,
 			"funding": [
 				{
@@ -17840,9 +17840,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"devOptional": true,
 			"funding": [
 				{
@@ -18950,9 +18950,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.26",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+			"integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
 			"devOptional": true,
 			"funding": [
 				{
@@ -18970,7 +18970,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.17",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},


### PR DESCRIPTION
## Summary

- refresh the existing compatible `stylelint` dependency graph pulled through `@wordpress/components` without changing declared dependency ranges
- update `fast-uri` 3.1.2 to 3.1.5, `js-yaml` 4.2.0 to 4.3.1, `nanoid` 3.3.12 to 3.3.18, and `postcss` 8.5.15 to 8.5.26
- clear all four high-severity production advisory groups recorded in #3287

## Safety

These are patch-level lockfile resolutions within the ranges already accepted by their parents:

- `ajv@8.20.0` accepts `fast-uri@^3.0.1`
- `cosmiconfig@9.0.2` accepts `js-yaml@^4.1.0`
- `postcss@8.5.26` resolves its compatible Nano ID 3.x dependency to 3.3.18
- `stylelint@16.26.1` accepts `postcss@^8.4.31`

No manifest ranges, release versions, source files, built assets, or changelog entries changed.

## Verification

- `npm ci` passes
- `npm audit --omit=dev` passes with 0 vulnerabilities
- `npm run build` passes after the clean install
- `git diff --check` passes
- Homeboy full lint was invoked and reported the existing repository baseline: 192 PHPCS findings and 97 ESLint ignored-file warnings; this lockfile-only patch introduces no lintable source changes
- Homeboy full test was invoked, but the Codebox provider returned zero tests because its recipe payload was unparseable; this infrastructure failure is already tracked in Extra-Chill/homeboy#12784 and related fixes
- `--changed-only` lint unexpectedly scanned the full repository despite only `package-lock.json` being dirty; tracked separately as Extra-Chill/homeboy#12797

The PR workflow's differential full-suite gate remains authoritative for candidate-versus-main behavior.

Closes #3287