### PR TITLE
Preserve system authorization for queued email

### DIFF
--- a/inc/Abilities/Publish/SendEmailAbility.php
+++ b/inc/Abilities/Publish/SendEmailAbility.php
@@ -256,7 +256,7 @@ class SendEmailAbility {
 			$config['from_name']  = (string) ( $resolved['credentials']['display_name'] ?? '' );
 		} else {
 			$legacy_sender_allowed = is_array( $queued_context )
-				? ! empty( $queued_context['legacy_sender'] ) && $this->userCanManageLegacySender( absint( $queued_context['user_id'] ?? 0 ) )
+				? ! empty( $queued_context['legacy_sender'] ) && ( 'system' === ( $queued_context['issuer_type'] ?? '' ) || $this->userCanManageLegacySender( absint( $queued_context['user_id'] ?? 0 ) ) )
 				: $this->canUseLegacySender();
 			if ( ! $legacy_sender_allowed ) {
 				return new \WP_Error( 'email_auth_ref_required', 'An authorized mailbox ref is required to send email.', array( 'status' => 403 ) );

--- a/inc/Abilities/Publish/SendEmailQueuedAbility.php
+++ b/inc/Abilities/Publish/SendEmailQueuedAbility.php
@@ -275,8 +275,9 @@ class SendEmailQueuedAbility {
 			'user_id'  => PermissionHelper::acting_user_id(),
 			'agent_id' => absint( PermissionHelper::get_acting_agent_id() ),
 			'token_id' => absint( PermissionHelper::get_acting_token_id() ),
+			'system'   => method_exists( PermissionHelper::class, 'is_authenticated_context' ) && PermissionHelper::is_authenticated_context(),
 		);
-		if ( $context['user_id'] <= 0 ) {
+		if ( $context['user_id'] <= 0 && ! $context['system'] ) {
 			return $this->queueError( 'email_queue_issuer_required', 'An identified issuer is required to queue email.', 403, $logs );
 		}
 		if ( ! empty( $input['auth_ref'] ) ) {
@@ -453,11 +454,12 @@ class SendEmailQueuedAbility {
 	private function createMailboxGrant( array $input, array $context ): array {
 		$issued_at = time();
 		$nonce     = wp_generate_uuid4();
+		$system    = ! empty( $context['system'] ) && (int) $context['user_id'] <= 0;
 		$grant     = array(
 			'user_id'       => (int) $context['user_id'],
 			'agent_id'      => (int) $context['agent_id'],
 			'token_id'      => (int) $context['token_id'],
-			'issuer_type'   => (int) $context['agent_id'] > 0 ? ( (int) $context['token_id'] > 0 ? 'agent_token' : 'agent' ) : 'user',
+			'issuer_type'   => $system ? 'system' : ( (int) $context['agent_id'] > 0 ? ( (int) $context['token_id'] > 0 ? 'agent_token' : 'agent' ) : 'user' ),
 			'issued_at'     => $issued_at,
 			'nonce'         => $nonce,
 			'legacy_sender' => empty( $input['auth_ref'] ),
@@ -512,6 +514,9 @@ class SendEmailQueuedAbility {
 		$agent_id    = absint( $grant['agent_id'] ?? 0 );
 		$token_id    = absint( $grant['token_id'] ?? 0 );
 		$issuer_type = (string) ( $grant['issuer_type'] ?? '' );
+		if ( 'system' === $issuer_type ) {
+			return 0 === $user_id && 0 === $agent_id && 0 === $token_id;
+		}
 		if ( $user_id <= 0 || ! get_user_by( 'id', $user_id ) ) {
 			return false;
 		}

--- a/tests/send-email-template-smoke.php
+++ b/tests/send-email-template-smoke.php
@@ -422,6 +422,23 @@ $queued = wp_get_ability( 'datamachine/send-email-queued' );
 $GLOBALS['ec_scheduled'] = array();
 $res = $queued->execute( array( 'to' => 'user@example.com', 'subject' => 'No issuer', 'body' => 'body' ) );
 ec_assert( 'queued email rejects principal-less ambient execution', is_wp_error( $res ) && 0 === count( $GLOBALS['ec_scheduled'] ) );
+
+$system_input = array( 'to' => 'user@example.com', 'subject' => 'System issuer', 'body' => 'body' );
+$grant_method = new ReflectionMethod( \DataMachine\Abilities\Publish\SendEmailQueuedAbility::class, 'createMailboxGrant' );
+$grant_method->setAccessible( true );
+$system_input['_mailbox_grant'] = $grant_method->invoke(
+	new \DataMachine\Abilities\Publish\SendEmailQueuedAbility(),
+	$system_input,
+	array( 'user_id' => 0, 'agent_id' => 0, 'token_id' => 0, 'system' => true )
+);
+$system_input['_attempt'] = 1;
+ec_assert( 'system grant records no user identity', 'system' === $system_input['_mailbox_grant']['issuer_type'] && 0 === $system_input['_mailbox_grant']['user_id'] );
+$GLOBALS['ec_wp_mail_calls'] = array();
+$system_worker = new \DataMachine\Abilities\Publish\SendEmailQueuedAbility();
+$system_worker->runWorker( $system_input );
+ec_assert( 'worker accepts signed system issuer grant', 1 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+$GLOBALS['ec_scheduled'] = array();
+
 \DataMachine\Abilities\PermissionHelper::$user_id = 1;
 
 $res = $queued->execute( array(


### PR DESCRIPTION
## Summary
- preserve pre-authenticated system authorization in signed queued-email grants
- keep anonymous ambient queue calls denied while allowing verified system grants through the worker
- allow the synchronous mail worker to use default SMTP only for the HMAC-verified system issuer

## Safety
- user, agent, token, mailbox, and capability grant behavior is unchanged
- the system issuer requires `PermissionHelper::run_as_authenticated()` and is signed with all identity IDs fixed to zero
- payload or issuer tampering still invalidates the grant

## Verification
- `composer lint`
- `php tests/send-email-template-smoke.php` (55 assertions)
- `php tests/named-mailbox-security-contract-smoke.php`

Closes #3304