### PR TITLE
fix: redact credentials from pipeline CSV exports

### DIFF
--- a/docs/core-system/import-export.md
+++ b/docs/core-system/import-export.md
@@ -10,7 +10,7 @@ The import/export system handles pipeline structures including steps, configurat
 
 ### Export Process
 
-Pipeline export generates a CSV file containing complete pipeline and flow configuration data:
+Pipeline export generates a CSV file containing portable pipeline and flow configuration data. Handler credentials are excluded by default: provider-backed credentials become `auth_ref` values when available, and credential-shaped fields are otherwise removed recursively.
 
 ```csv
 pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,settings
@@ -37,6 +37,8 @@ Pipeline import processes CSV data to recreate pipeline structures and flow conf
 3. Adds pipeline steps with proper execution ordering
 4. Maintains flow-specific handler configurations
 
+Imported `auth_ref` values resolve against authorization configured on the destination installation. Configure the corresponding destination provider/account before running the imported flow; exports do not carry API keys, access or refresh tokens, bearer credentials, passwords, or other inline secrets.
+
 Import through `POST /wp-json/wp-abilities/v1/abilities/datamachine/import-pipelines/run`. Successful ability payloads include the imported pipeline IDs. The curated `datamachine/v1/pipelines` controller does not provide CSV import.
 
 ### Import Behavior
@@ -48,12 +50,12 @@ Import through `POST /wp-json/wp-abilities/v1/abilities/datamachine/import-pipel
 
 ## Security & Permissions
 
-All import/export operations require `manage_options` capability, ensuring only administrators can perform these actions.
+All import/export operations require `manage_options` capability, ensuring only administrators can perform these actions. CSV exports are always credential-free even for administrators and do not provide a full-secret backup mode.
 
 ## Use Cases
 
 ### Backup & Restore
-Regularly export pipeline configurations for backup purposes, enabling quick restoration after updates or migrations.
+Regularly export portable pipeline configurations for backup purposes. Restore or configure destination authorization separately.
 
 ### Migration
 Export pipelines from development environments and import into production systems.

--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -35,6 +35,7 @@ use DataMachine\Engine\Bundle\AgentBundleArrayAdapter;
 use DataMachine\Engine\Bundle\AgentBundleManifest;
 use DataMachine\Engine\Bundle\AgentBundleRuntimeDrift;
 use DataMachine\Engine\Bundle\AgentBundlePipelineFile;
+use DataMachine\Engine\Bundle\AuthRefHandlerConfig;
 use DataMachine\Engine\Bundle\AgentConfigArtifactProjector;
 use DataMachine\Engine\Bundle\AgentTemplateMetadata;
 use DataMachine\Engine\Bundle\AgentPackageProjection;
@@ -493,20 +494,7 @@ class AgentBundler {
 			return $configs;
 		}
 
-		$rewritten = array();
-		foreach ( $configs as $handler_slug => $handler_config ) {
-			if ( ! is_array( $handler_config ) ) {
-				continue;
-			}
-			$config = apply_filters( 'datamachine_handler_config_to_auth_ref', $handler_config, (string) $handler_slug, $context );
-			if ( is_wp_error( $config ) || ! is_array( $config ) ) {
-				$config = array();
-			}
-			$rewritten[ (string) $handler_slug ] = self::strip_secret_like_values( $config );
-		}
-
-		ksort( $rewritten, SORT_STRING );
-		return $rewritten;
+		return AuthRefHandlerConfig::project_for_export( $configs, $context );
 	}
 
 	private static function resolve_export_manifest( int $agent_id, array $context ): array {
@@ -585,22 +573,6 @@ class AgentBundler {
 		}
 
 		return \DataMachine\Engine\Bundle\BundleSchema::normalize_agent_site_scope( $stored_scope );
-	}
-
-	private static function strip_secret_like_values( array $value ): array {
-		$secret_keys = array( 'access_token', 'refresh_token', 'token', 'secret', 'client_secret', 'password', 'api_key', 'apikey', 'key' );
-		foreach ( $value as $key => $child ) {
-			$key_string = strtolower( (string) $key );
-			if ( in_array( $key_string, $secret_keys, true ) || str_contains( $key_string, 'secret' ) || str_contains( $key_string, 'token' ) || str_contains( $key_string, 'password' ) ) {
-				unset( $value[ $key ] );
-				continue;
-			}
-			if ( is_array( $child ) ) {
-				$value[ $key ] = self::strip_secret_like_values( $child );
-			}
-		}
-		ksort( $value, SORT_STRING );
-		return $value;
 	}
 
 	/**

--- a/inc/Engine/Actions/ImportExport.php
+++ b/inc/Engine/Actions/ImportExport.php
@@ -13,6 +13,7 @@ namespace DataMachine\Engine\Actions;
 
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\FlowStepConfigFactory;
+use DataMachine\Engine\Bundle\AuthRefHandlerConfig;
 use DataMachine\Engine\PortableFlowStepFields;
 
 // Prevent direct access
@@ -32,9 +33,8 @@ class ImportExport {
 	 *            canonical handler fields into each flow_config entry keyed by the
 	 *            freshly-generated flow_step_id (#1133 step 2, #1293 shape cleanup).
 	 *
-	 * NOTE on secrets: handler_configs is restored verbatim. Any auth tokens / API keys in
-	 * the exported CSV will land in the imported flow's config. A scrub-or-reference policy
-	 * is orthogonal to the lossiness fix and is tracked separately.
+	 * Handler configs are restored as exported. Default exports contain portable auth refs
+	 * and ordinary settings, never inline credentials.
 	 */
 	public function handle_import( $type, $data ) {
 		if ( ! current_user_can( 'manage_options' ) ) {
@@ -439,7 +439,13 @@ class ImportExport {
 					$flow_step_id = apply_filters( 'datamachine_generate_flow_step_id', '', $step['pipeline_step_id'], $flow['flow_id'] );
 					$flow_step    = $flow_config[ $flow_step_id ] ?? array();
 
-					$settings = $this->export_flow_step_settings( $flow_step );
+					$settings = $this->export_flow_step_settings(
+						$flow_step,
+						array(
+							'pipeline_id' => (int) $pipeline_id,
+							'flow_id'     => (int) $flow['flow_id'],
+						)
+					);
 
 					if ( ! empty( $settings ) ) {
 						$csv_rows[] = array(
@@ -471,14 +477,14 @@ class ImportExport {
 	 * AI tool-policy state is stored beside those fields because it is flow-scoped
 	 * runtime state, not pipeline structure.
 	 */
-	private function export_flow_step_settings( array $flow_step ): array {
+	private function export_flow_step_settings( array $flow_step, array $context = array() ): array {
 		$settings        = array();
 		$primary_handler = FlowStepConfig::getPrimaryHandlerSlug( $flow_step ) ?? '';
 
 		if ( FlowStepConfig::usesHandler( $flow_step ) && ! empty( $primary_handler ) ) {
 			$settings = array(
 				'handler_slugs'   => FlowStepConfig::getHandlerSlugs( $flow_step ),
-				'handler_configs' => FlowStepConfig::getHandlerConfigs( $flow_step ),
+				'handler_configs' => AuthRefHandlerConfig::project_for_export( FlowStepConfig::getHandlerConfigs( $flow_step ), $context ),
 			);
 		} elseif ( ! FlowStepConfig::usesHandler( $flow_step ) && ! empty( FlowStepConfig::getPrimaryHandlerConfig( $flow_step ) ) ) {
 			$settings = array(

--- a/inc/Engine/Bundle/AuthRefHandlerConfig.php
+++ b/inc/Engine/Bundle/AuthRefHandlerConfig.php
@@ -73,6 +73,33 @@ final class AuthRefHandlerConfig {
 	}
 
 	/**
+	 * Project handler configs into a deterministic, credential-free export map.
+	 *
+	 * @param array<string,mixed> $handler_configs Handler configs keyed by handler slug.
+	 * @param array               $context Export context.
+	 * @return array<string,array<string,mixed>>
+	 */
+	public static function project_for_export( array $handler_configs, array $context = array() ): array {
+		$projected = array();
+
+		foreach ( $handler_configs as $handler_slug => $handler_config ) {
+			if ( ! is_array( $handler_config ) ) {
+				continue;
+			}
+
+			$config = apply_filters( 'datamachine_handler_config_to_auth_ref', $handler_config, (string) $handler_slug, $context );
+			if ( is_wp_error( $config ) || ! is_array( $config ) ) {
+				$config = array();
+			}
+
+			$projected[ (string) $handler_slug ] = self::strip_secret_like_values( $config );
+		}
+
+		ksort( $projected, SORT_STRING );
+		return $projected;
+	}
+
+	/**
 	 * Resolve auth_ref form to local handler config for import/runtime.
 	 *
 	 * @param array|\WP_Error $handler_config Handler config or previous error.
@@ -170,6 +197,22 @@ final class AuthRefHandlerConfig {
 		} catch ( BundleValidationException $e ) {
 			return new \WP_Error( 'auth_ref_invalid', $e->getMessage() );
 		}
+	}
+
+	private static function strip_secret_like_values( array $value ): array {
+		$secret_keys = array( 'access_token', 'refresh_token', 'token', 'secret', 'client_secret', 'password', 'api_key', 'apikey', 'key', 'authorization' );
+		foreach ( $value as $key => $child ) {
+			$key_string = strtolower( (string) $key );
+			if ( in_array( $key_string, $secret_keys, true ) || str_contains( $key_string, 'secret' ) || str_contains( $key_string, 'token' ) || str_contains( $key_string, 'password' ) || str_contains( $key_string, 'credential' ) || str_contains( $key_string, 'bearer' ) ) {
+				unset( $value[ $key ] );
+				continue;
+			}
+			if ( is_array( $child ) ) {
+				$value[ $key ] = self::strip_secret_like_values( $child );
+			}
+		}
+		ksort( $value, SORT_STRING );
+		return $value;
 	}
 
 	private static function redact_error( \WP_Error $error, AuthRef $ref ): \WP_Error {

--- a/tests/Unit/Api/Pipelines/PipelinesEndpointTest.php
+++ b/tests/Unit/Api/Pipelines/PipelinesEndpointTest.php
@@ -7,8 +7,13 @@
 
 namespace DataMachine\Tests\Unit\Api\Pipelines;
 
+use DataMachine\Abilities\Pipeline\CreatePipelineAbility;
+use DataMachine\Abilities\Pipeline\ImportExportAbility;
+use DataMachine\Abilities\PipelineStepAbilities;
 use DataMachine\Api\Pipelines\Pipelines;
+use DataMachine\Core\Database\Flows\Flows;
 use WP_REST_Request;
+use WP_REST_Response;
 use WP_UnitTestCase;
 
 class PipelinesEndpointTest extends WP_UnitTestCase {
@@ -36,5 +41,57 @@ class PipelinesEndpointTest extends WP_UnitTestCase {
 		$this->assertSame( 'export_failed', $response->get_error_code() );
 		$this->assertSame( 'Export failed', $response->get_error_message() );
 		$this->assertSame( 500, $response->get_error_data()['status'] );
+	}
+
+	public function test_csv_ability_and_rest_exports_exclude_handler_credentials(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$created = ( new CreatePipelineAbility() )->execute(
+			array(
+				'pipeline_name' => 'Secure Public Export',
+				'flow_config'   => array( 'flow_name' => 'Default Flow' ),
+			)
+		);
+		$this->assertIsArray( $created );
+
+		$pipeline_id = (int) $created['pipeline_id'];
+		$flow_id     = (int) $created['flow_id'];
+		$added       = ( new PipelineStepAbilities() )->executeAddPipelineStep(
+			array(
+				'pipeline_id' => $pipeline_id,
+				'step_type'   => 'fetch',
+			)
+		);
+		$this->assertIsArray( $added );
+
+		$flow_step_id = apply_filters( 'datamachine_generate_flow_step_id', '', $added['pipeline_step_id'], $flow_id );
+		$db_flows     = new Flows();
+		$flow         = $db_flows->get_flow( $flow_id );
+		$flow_config  = $flow['flow_config'];
+		$flow_config[ $flow_step_id ]['handler_slugs']   = array( 'custom_api' );
+		$flow_config[ $flow_step_id ]['handler_configs'] = array(
+			'custom_api' => array(
+				'endpoint' => 'https://api.example.test',
+				'api_key'  => 'public-boundary-api-key',
+				'nested'   => array( 'access_token' => 'public-boundary-token' ),
+			),
+		);
+		$db_flows->update_flow( $flow_id, array( 'flow_config' => $flow_config ) );
+
+		$ability_result = ( new ImportExportAbility() )->executeExport( array( 'pipeline_ids' => array( $pipeline_id ) ) );
+		$this->assertIsArray( $ability_result );
+		$this->assertStringContainsString( 'https://api.example.test', $ability_result['data'] );
+		$this->assertStringNotContainsString( 'public-boundary-api-key', $ability_result['data'] );
+		$this->assertStringNotContainsString( 'public-boundary-token', $ability_result['data'] );
+
+		$request = new WP_REST_Request( 'GET', '/datamachine/v1/pipelines' );
+		$request->set_param( 'format', 'csv' );
+		$request->set_param( 'ids', (string) $pipeline_id );
+		$response = Pipelines::handle_get_pipelines( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( $ability_result['data'], $response->get_data() );
+		$this->assertSame( 'text/csv; charset=utf-8', $response->get_headers()['Content-Type'] );
 	}
 }

--- a/tests/Unit/Api/Pipelines/PipelinesEndpointTest.php
+++ b/tests/Unit/Api/Pipelines/PipelinesEndpointTest.php
@@ -81,9 +81,12 @@ class PipelinesEndpointTest extends WP_UnitTestCase {
 
 		$ability_result = ( new ImportExportAbility() )->executeExport( array( 'pipeline_ids' => array( $pipeline_id ) ) );
 		$this->assertIsArray( $ability_result );
-		$this->assertStringContainsString( 'https://api.example.test', $ability_result['data'] );
 		$this->assertStringNotContainsString( 'public-boundary-api-key', $ability_result['data'] );
 		$this->assertStringNotContainsString( 'public-boundary-token', $ability_result['data'] );
+		$csv_rows          = str_getcsv( $ability_result['data'], "\n" );
+		$flow_row          = str_getcsv( $csv_rows[2] );
+		$exported_settings = json_decode( $flow_row[7], true );
+		$this->assertSame( 'https://api.example.test', $exported_settings['handler_configs']['custom_api']['endpoint'] );
 
 		$request = new WP_REST_Request( 'GET', '/datamachine/v1/pipelines' );
 		$request->set_param( 'format', 'csv' );

--- a/tests/auth-ref-handler-config-smoke.php
+++ b/tests/auth-ref-handler-config-smoke.php
@@ -186,6 +186,41 @@ $assert( 'export strips password', ! array_key_exists( 'imap_password', $rewritt
 $assert( 'export strips the complete IMAP connection identity', ! array_key_exists( 'imap_host', $rewritten ) && ! array_key_exists( 'imap_user', $rewritten ) );
 $assert( 'export output does not contain secret value', ! str_contains( wp_json_encode( $rewritten ), 'super-secret-app-password' ) );
 
+echo "\n[1b] Shared export projector applies refs and strict recursive fallback\n";
+$projected = AuthRefHandlerConfig::project_for_export(
+	array(
+		'email'   => array(
+			'imap_host'     => 'imap.example.test',
+			'imap_user'     => 'reader@example.test',
+			'imap_password' => 'provider-password',
+			'folder'        => 'Archive',
+		),
+		'unknown' => array(
+			'api_key'     => 'direct-api-key',
+			'auth_ref'    => 'custom:default',
+			'endpoint'    => 'https://api.example.test',
+			'credentials' => array(
+				'access_token' => 'nested-access-token',
+				'password'     => 'nested-password',
+			),
+			'headers'     => array(
+				'authorization' => 'Bearer nested-bearer-secret',
+				'accept'        => 'application/json',
+			),
+		),
+	),
+	array( 'flow_id' => 12 )
+);
+
+$projected_json = wp_json_encode( $projected );
+$assert( 'projector inserts provider-owned auth_ref', 'email_imap:default' === ( $projected['email']['auth_ref'] ?? null ) );
+$assert( 'projector preserves provider ordinary settings', 'Archive' === ( $projected['email']['folder'] ?? null ) );
+$assert( 'projector preserves existing auth_ref without provider resolution', 'custom:default' === ( $projected['unknown']['auth_ref'] ?? null ) );
+$assert( 'projector preserves unknown-handler ordinary settings', 'https://api.example.test' === ( $projected['unknown']['endpoint'] ?? null ) );
+$assert( 'projector preserves nested non-secret settings', 'application/json' === ( $projected['unknown']['headers']['accept'] ?? null ) );
+$assert( 'projector strips direct and nested credentials', ! str_contains( $projected_json, 'direct-api-key' ) && ! str_contains( $projected_json, 'nested-access-token' ) && ! str_contains( $projected_json, 'nested-password' ) );
+$assert( 'projector strips bearer authorization', ! str_contains( $projected_json, 'nested-bearer-secret' ) );
+
 echo "\n[2] Import/runtime resolution restores local config while preserving static fields\n";
 $resolved = apply_filters(
 	'datamachine_auth_ref_to_handler_config',

--- a/tests/export-agent-ability-smoke.php
+++ b/tests/export-agent-ability-smoke.php
@@ -87,6 +87,7 @@ require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleArtifactExtensions.php'
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleArtifactDefinitions.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/BundleRelativePath.php';
 require_once __DIR__ . '/../inc/Engine/Bundle/AgentBundleDirectory.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/AuthRefHandlerConfig.php';
 require_once __DIR__ . '/../inc/Core/Agents/AgentBundler.php';
 require_once __DIR__ . '/../inc/Abilities/AgentAbilities.php';
 

--- a/tests/import-export-portable-flow-settings-smoke.php
+++ b/tests/import-export-portable-flow-settings-smoke.php
@@ -48,9 +48,21 @@ if ( ! function_exists( 'esc_html' ) ) {
 	}
 }
 
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $value ): bool {
+		return $value instanceof WP_Error;
+	}
+}
+
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfig.php';
 require_once __DIR__ . '/../inc/Core/Steps/FlowStepConfigFactory.php';
 require_once __DIR__ . '/../inc/Engine/PortableFlowStepFields.php';
+require_once __DIR__ . '/../inc/Engine/Bundle/AuthRefHandlerConfig.php';
 require_once __DIR__ . '/../inc/Engine/Actions/ImportExport.php';
 
 use DataMachine\Engine\Actions\ImportExport;
@@ -147,6 +159,40 @@ assert_csv_equals( array( 'webhook_payload' ), $fetch_settings['handler_slugs'] 
 assert_csv_equals( array( 'payload_path' => 'pull_request' ), $fetch_settings['handler_configs']['webhook_payload'] ?? null, 'fetch handler_configs export', $failures, $passes );
 assert_csv_equals( array( 'after' => '2026-04-01' ), $fetch_settings['config_patch_queue'][0]['patch'] ?? null, 'fetch config_patch_queue exports canonical patch entry', $failures, $passes );
 assert_csv_equals( 'drain', $fetch_settings['queue_mode'] ?? null, 'fetch queue_mode exports as portable settings', $failures, $passes );
+
+$secure_settings = call_import_export_private(
+	$import_export,
+	'export_flow_step_settings',
+	array(
+		'step_type'       => 'fetch',
+		'handler_slugs'   => array( 'custom_api' ),
+		'handler_configs' => array(
+			'custom_api' => array(
+				'auth_ref'  => 'custom:destination',
+				'api_key'   => 'csv-direct-key',
+				'endpoint'  => 'https://api.example.test',
+				'auth'      => array(
+					'refresh_token' => 'csv-refresh-token',
+					'password'      => 'csv-password',
+				),
+				'headers'   => array(
+					'bearer_token' => 'csv-bearer-token',
+					'accept'       => 'application/json',
+				),
+			),
+		),
+	)
+);
+$secure_json = json_encode( $secure_settings );
+assert_csv_equals( 'custom:destination', $secure_settings['handler_configs']['custom_api']['auth_ref'] ?? null, 'CSV settings preserve auth_ref', $failures, $passes );
+assert_csv_equals( 'https://api.example.test', $secure_settings['handler_configs']['custom_api']['endpoint'] ?? null, 'CSV settings preserve ordinary handler config', $failures, $passes );
+assert_csv_equals( 'application/json', $secure_settings['handler_configs']['custom_api']['headers']['accept'] ?? null, 'CSV settings preserve nested ordinary config', $failures, $passes );
+assert_csv_equals( false, str_contains( $secure_json, 'csv-direct-key' ) || str_contains( $secure_json, 'csv-refresh-token' ) || str_contains( $secure_json, 'csv-password' ) || str_contains( $secure_json, 'csv-bearer-token' ), 'CSV settings exclude direct and nested credentials', $failures, $passes );
+
+$secure_csv = 'pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,settings' . "\n";
+$secure_csv .= '1,Secure,0,fetch,{},9,Destination,' . '"' . str_replace( '"', '""', (string) $secure_json ) . '"';
+$secure_rows = $parse_csv->invoke( $import_export, $secure_csv );
+assert_csv_equals( $secure_settings, $secure_rows[0]['settings'] ?? null, 'import preserves the credential-free exported settings', $failures, $passes );
 
 $normalized = call_import_export_private(
 	$import_export,


### PR DESCRIPTION
## Summary
- stop the default pipeline CSV exporter from serializing live handler credentials into migration, sharing, and version-control artifacts
- centralize bundle and CSV auth projection in `AuthRefHandlerConfig`, preserving provider-owned `auth_ref` values and ordinary handler settings
- apply strict recursive fallback redaction for direct and nested API keys, tokens, bearer/authorization values, passwords, secrets, and credential-shaped fields when no provider/reference resolves
- document that CSV exports exclude credentials and destination authorization must be configured separately

## Tests
- `php tests/auth-ref-handler-config-smoke.php`
- `php tests/import-export-portable-flow-settings-smoke.php`
- `php tests/export-agent-ability-smoke.php`
- changed-file PHP syntax checks
- `homeboy review lint --changed-only --summary`
- `homeboy review audit --changed-since origin/main --profile pr --json-summary`
- `homeboy review build`
- `composer audit --locked`
- `npm audit --omit=dev`
- `git diff --check`

The full `homeboy review test` gate was attempted twice, but WP Codebox returned an unparseable recipe payload and reported zero executed tests both times (tracked by Extra-Chill/homeboy#12784 and related open fixes). Focused executable import/export and bundle projection suites pass, and REST/ability boundary regression coverage is included for CI.

Closes #3300