### PR TITLE
fix: make Webhook Gate resume single-winner

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -15,14 +15,15 @@
 namespace DataMachine\Abilities\Engine;
 
 use DataMachine\Abilities\StepTypeAbilities;
-use DataMachine\Core\EngineData;
 use DataMachine\Core\ChildJobRecoveryPolicy;
+use DataMachine\Core\DataPacketStore;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachine\Core\EngineData;
 use DataMachine\Core\FilesRepository\FileCleanup;
 use DataMachine\Core\FilesRepository\FileRetrieval;
 use DataMachine\Core\JobStatus;
-use DataMachine\Core\RunMetrics;
 use DataMachine\Core\RecoveryExecutionFence;
-use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachine\Core\RunMetrics;
 use DataMachine\Core\StepExecutionResult;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\Step;
@@ -227,7 +228,7 @@ class ExecuteStepAbility {
 			$context            = datamachine_get_file_context( $flow_id );
 			$retrieval          = new FileRetrieval();
 			$dataPackets        = $retrieval->retrieve_data_by_job_id( $job_id, $context );
-			$step_input_packets = is_array( $engine_snapshot['step_input_packets'][ $flow_step_id ] ?? null ) ? $engine_snapshot['step_input_packets'][ $flow_step_id ] : array();
+			$step_input_packets = is_array( $engine_snapshot['step_input_packets'][ $flow_step_id ] ?? null ) ? DataPacketStore::hydrate_many( $engine_snapshot['step_input_packets'][ $flow_step_id ] ) : array();
 			if ( ! empty( $step_input_packets ) ) {
 				$dataPackets = array_merge( $step_input_packets, $dataPackets );
 			}

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -224,9 +224,13 @@ class ExecuteStepAbility {
 			$flow_id = $flow_step_config['flow_id'];
 
 			/** @var array $context */
-			$context     = datamachine_get_file_context( $flow_id );
-			$retrieval   = new FileRetrieval();
-			$dataPackets = $retrieval->retrieve_data_by_job_id( $job_id, $context );
+			$context            = datamachine_get_file_context( $flow_id );
+			$retrieval          = new FileRetrieval();
+			$dataPackets        = $retrieval->retrieve_data_by_job_id( $job_id, $context );
+			$step_input_packets = is_array( $engine_snapshot['step_input_packets'][ $flow_step_id ] ?? null ) ? $engine_snapshot['step_input_packets'][ $flow_step_id ] : array();
+			if ( ! empty( $step_input_packets ) ) {
+				$dataPackets = array_merge( $step_input_packets, $dataPackets );
+			}
 			if ( empty( $dataPackets ) && 'direct' === $flow_id ) {
 				$direct_step_data_packets = is_array( $engine_snapshot['direct_step_data_packets'][ $flow_step_id ] ?? null ) ? $engine_snapshot['direct_step_data_packets'][ $flow_step_id ] : array();
 				if ( ! empty( $direct_step_data_packets ) ) {

--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -168,25 +168,9 @@ class ScheduleNextStepAbility {
 			}
 		}
 
-		// Action Scheduler only receives IDs.
-		$action_args = array(
-			'job_id'       => $job_id,
-			'flow_step_id' => $flow_step_id,
-		);
-		$job         = $this->db_jobs->get_job( $job_id );
-		if ( 'direct' === (string) ( $job['flow_id'] ?? '' ) && (int) ( $job['operation_generation'] ?? 0 ) > 0 ) {
-			$action_args['operation_generation']  = (int) $job['operation_generation'];
-			$action_args['operation_claim_token'] = (string) ( $job['operation_claim_token'] ?? '' );
-		}
-
 		$schedule_exception = null;
 		try {
-			$action_id = as_schedule_single_action(
-				time(),
-				'datamachine_execute_step',
-				$action_args,
-				'data-machine'
-			);
+			$action_id = $this->scheduleAction( $job_id, $flow_step_id );
 		} catch ( \Throwable $error ) {
 			$action_id          = 0;
 			$schedule_exception = $error;
@@ -240,6 +224,31 @@ class ScheduleNextStepAbility {
 		return array(
 			'success'   => is_numeric( $action_id ) && (int) $action_id > 0,
 			'action_id' => $action_id,
+		);
+	}
+
+	/**
+	 * Insert one execute-step action and return its durable identifier.
+	 *
+	 * This intentionally performs no packet persistence so callers that own a
+	 * database transaction can include the Action Scheduler row in that boundary.
+	 */
+	public function scheduleAction( int $job_id, string $flow_step_id ): int {
+		$action_args = array(
+			'job_id'       => $job_id,
+			'flow_step_id' => $flow_step_id,
+		);
+		$job         = $this->db_jobs->get_job( $job_id );
+		if ( 'direct' === (string) ( $job['flow_id'] ?? '' ) && (int) ( $job['operation_generation'] ?? 0 ) > 0 ) {
+			$action_args['operation_generation']  = (int) $job['operation_generation'];
+			$action_args['operation_claim_token'] = (string) ( $job['operation_claim_token'] ?? '' );
+		}
+
+		return (int) as_schedule_single_action(
+			time(),
+			'datamachine_execute_step',
+			$action_args,
+			'data-machine'
 		);
 	}
 

--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -234,6 +234,72 @@ class ScheduleNextStepAbility {
 	 * database transaction can include the Action Scheduler row in that boundary.
 	 */
 	public function scheduleAction( int $job_id, string $flow_step_id ): int {
+		return (int) as_schedule_single_action(
+			time(),
+			'datamachine_execute_step',
+			$this->actionArgs( $job_id, $flow_step_id ),
+			'data-machine'
+		);
+	}
+
+	/**
+	 * Insert and verify an action on the current wpdb transaction.
+	 *
+	 * The public scheduling helpers permit filters to return existing or foreign
+	 * IDs. Saving the exact action through the canonical DB store gives this
+	 * caller provenance over the newly inserted row and keeps it in the wpdb
+	 * transaction that owns the webhook handoff.
+	 */
+	public function scheduleActionAtomically( int $job_id, string $flow_step_id ): int {
+		global $wpdb;
+
+		$store = \ActionScheduler::store();
+		if ( \ActionScheduler_DBStore::class !== get_class( $store ) ) {
+			throw new \RuntimeException( 'Action Scheduler DB store is required for an atomic handoff.' );
+		}
+
+		$actions_table = ! empty( $wpdb->actionscheduler_actions ) ? $wpdb->actionscheduler_actions : $wpdb->prefix . 'actionscheduler_actions';
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- The high-water mark proves the returned auto-increment ID did not predate this insertion attempt.
+		$previous_max_id = $wpdb->get_var(
+			$wpdb->prepare( 'SELECT COALESCE(MAX(action_id), 0) FROM %i', $actions_table )
+		);
+		if ( null === $previous_max_id ) {
+			throw new \RuntimeException( 'Unable to establish Action Scheduler insertion provenance.' );
+		}
+
+		$action_args = $this->actionArgs( $job_id, $flow_step_id );
+		$action = new \ActionScheduler_Action(
+			'datamachine_execute_step',
+			$action_args,
+			new \ActionScheduler_SimpleSchedule( as_get_datetime_object( time() ) ),
+			'data-machine'
+		);
+		$action_id = $this->saveAtomicAction( $store, $action );
+		if ( $action_id <= 0
+			|| $action_id <= (int) $previous_max_id
+			|| \ActionScheduler_Store::STATUS_PENDING !== $store->get_status( $action_id )
+		) {
+			throw new \RuntimeException( 'Action Scheduler did not durably insert the next-step action.' );
+		}
+
+		$stored_action = $store->fetch_action( $action_id );
+		if ( 'datamachine_execute_step' !== $stored_action->get_hook()
+			|| 'data-machine' !== $stored_action->get_group()
+			|| $action->get_args() !== $stored_action->get_args()
+		) {
+			throw new \RuntimeException( 'Action Scheduler inserted an unverifiable next-step action.' );
+		}
+
+		return $action_id;
+	}
+
+	/** Save through the verified DB store. Kept separate so returned-ID rejection can be tested. */
+	protected function saveAtomicAction( \ActionScheduler_DBStore $store, \ActionScheduler_Action $action ): int {
+		return (int) $store->save_action( $action );
+	}
+
+	/** Build the canonical execute-step arguments for both scheduling paths. */
+	private function actionArgs( int $job_id, string $flow_step_id ): array {
 		$action_args = array(
 			'job_id'       => $job_id,
 			'flow_step_id' => $flow_step_id,
@@ -244,12 +310,7 @@ class ScheduleNextStepAbility {
 			$action_args['operation_claim_token'] = (string) ( $job['operation_claim_token'] ?? '' );
 		}
 
-		return (int) as_schedule_single_action(
-			time(),
-			'datamachine_execute_step',
-			$action_args,
-			'data-machine'
-		);
+		return $action_args;
 	}
 
 	/**

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -2379,6 +2379,158 @@ class Jobs extends BaseRepository {
 	}
 
 	/**
+	 * Claim one exact waiting webhook gate and hand off its next step atomically.
+	 *
+	 * The scheduler callback must insert through this repository's wpdb connection.
+	 * Its write, the durable input packet, and the receipt then share one transaction.
+	 *
+	 * @param array                    $data_packets Durable input for the resumed step.
+	 * @param callable(int,string):int $schedule Scheduler callback returning an action ID.
+	 * @return array{success:bool,owned:bool,already_resumed:bool,reason:string,job_id:int,next_flow_step_id:string,flow_step_id:string,action_id:int}
+	 */
+	public function claim_webhook_gate_resume( int $job_id, string $token, string $received_at, array $data_packets, callable $schedule ): array {
+		$result = array(
+			'success'           => false,
+			'owned'             => false,
+			'already_resumed'   => false,
+			'reason'            => 'invalid_claim',
+			'job_id'            => $job_id,
+			'next_flow_step_id' => '',
+			'flow_step_id'      => '',
+			'action_id'         => 0,
+		);
+		if ( $job_id <= 0 || 1 !== preg_match( '/^[a-f0-9]{64}$/', $token ) || '' === $received_at ) {
+			return $result;
+		}
+
+		$scope = TransactionScope::begin( $this->wpdb );
+		if ( null === $scope ) {
+			$result['reason'] = 'transaction_start_failed';
+			return $result;
+		}
+
+		$job = $this->get_job_for_update( $job_id );
+		if ( ! is_array( $job ) ) {
+			$scope->rollback();
+			$result['reason'] = 'job_not_found';
+			return $result;
+		}
+		if ( ! is_array( $job['engine_data'] ?? null ) ) {
+			$scope->rollback();
+			$result['reason'] = 'malformed_engine_data';
+			return $result;
+		}
+
+		$engine = $job['engine_data'];
+		$gate   = $engine['webhook_gate'] ?? null;
+		if ( ! is_array( $gate ) ) {
+			$scope->rollback();
+			$result['reason'] = 'gate_not_found';
+			return $result;
+		}
+		if ( ! is_string( $gate['token'] ?? null ) || ! hash_equals( $gate['token'], $token ) ) {
+			$scope->rollback();
+			$result['reason'] = 'token_mismatch';
+			return $result;
+		}
+
+		$result['next_flow_step_id'] = is_string( $gate['next_flow_step_id'] ?? null ) ? $gate['next_flow_step_id'] : '';
+		$result['flow_step_id']      = is_string( $gate['flow_step_id'] ?? null ) ? $gate['flow_step_id'] : '';
+		if ( '' === $result['next_flow_step_id'] ) {
+			$scope->rollback();
+			$result['reason'] = 'next_step_missing';
+			return $result;
+		}
+		if ( 'received' === (string) ( $gate['status'] ?? '' ) ) {
+			$scope->rollback();
+			$action_id = (int) ( $gate['action_id'] ?? 0 );
+			$packets   = $engine['step_input_packets'][ $result['next_flow_step_id'] ] ?? null;
+			if ( $action_id <= 0 || ! is_array( $packets ) ) {
+				$result['reason'] = 'malformed_gate_receipt';
+				return $result;
+			}
+			$result['success']         = true;
+			$result['already_resumed'] = true;
+			$result['reason']          = 'already_resumed';
+			$result['action_id']       = $action_id;
+			return $result;
+		}
+		if ( JobStatus::WAITING !== (string) ( $job['status'] ?? '' ) || 'waiting' !== (string) ( $gate['status'] ?? '' ) ) {
+			$scope->rollback();
+			$result['reason'] = 'gate_not_waiting';
+			return $result;
+		}
+		$gate['status']      = 'received';
+		$gate['received_at'] = $received_at;
+		foreach ( $data_packets as &$packet ) {
+			if ( is_array( $packet ) ) {
+				$packet['metadata']                 = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
+				$packet['metadata']['flow_step_id'] = $result['flow_step_id'];
+			}
+		}
+		unset( $packet );
+		$engine['step_input_packets'][ $result['next_flow_step_id'] ] = $data_packets;
+		$engine['webhook_gate']                                       = $gate;
+		unset( $engine['job_status'] );
+
+		if ( ! $this->store_engine_data_in_transaction( $job_id, $engine ) ) {
+			$scope->rollback();
+			$result['reason'] = 'payload_persistence_failed';
+			return $result;
+		}
+
+		try {
+			$action_id = (int) $schedule( $job_id, $result['next_flow_step_id'] );
+		} catch ( \Throwable ) {
+			$scope->rollback();
+			$result['reason'] = 'scheduler_exception';
+			return $result;
+		}
+		if ( $action_id <= 0 ) {
+			$scope->rollback();
+			$result['reason'] = 'schedule_failed';
+			return $result;
+		}
+
+		$engine['webhook_gate']['action_id'] = $action_id;
+		if ( ! $this->store_engine_data_in_transaction( $job_id, $engine ) ) {
+			$scope->rollback();
+			$result['reason'] = 'receipt_persistence_failed';
+			return $result;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- The locked jobs row is the ownership boundary.
+		$updated = $this->wpdb->update(
+			$this->table_name,
+			array( 'status' => JobStatus::PROCESSING ),
+			array(
+				'job_id' => $job_id,
+				'status' => JobStatus::WAITING,
+			),
+			array( '%s' ),
+			array( '%d', '%s' )
+		);
+		if ( 1 !== (int) $updated ) {
+			$scope->rollback();
+			$result['reason'] = 'status_persistence_failed';
+			return $result;
+		}
+		if ( ! $scope->commit() ) {
+			$scope->rollback();
+			$result['reason'] = 'transaction_commit_failed';
+			return $result;
+		}
+
+		$this->publish_committed_engine_data( $job_id, $engine );
+		( new RunLifecycleStore( $this ) )->mark_job_status( $job_id, JobStatus::PROCESSING );
+		$result['success']   = true;
+		$result['owned']     = true;
+		$result['reason']    = 'claimed';
+		$result['action_id'] = $action_id;
+		return $result;
+	}
+
+	/**
 	 * Commit a pathless-child terminal transition while its recovery lease owns the locked row.
 	 *
 	 * @return array{success:bool,changed:bool,current_status:?string,status:string}

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -546,10 +546,10 @@ class Jobs extends BaseRepository {
 			'operation_generation'          => $new_generation,
 			'recovered_at'                  => gmdate( 'c' ),
 		);
-		$run_lifecycle                       = is_array( $engine['run_lifecycle'] ?? null ) ? $engine['run_lifecycle'] : array();
+		$run_lifecycle                       = is_array( $engine[ RunLifecycleStore::META_KEY ] ?? null ) ? $engine[ RunLifecycleStore::META_KEY ] : array();
 		$run_lifecycle['status']             = JobStatus::PENDING;
 		$run_lifecycle['updated_at']         = current_time( 'mysql', true );
-		$engine['run_lifecycle']             = $run_lifecycle;
+		$engine[ RunLifecycleStore::META_KEY ] = $run_lifecycle;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$updated = $this->wpdb->update(

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -19,6 +19,7 @@ use DataMachine\Core\Database\BaseRepository;
 use DataMachine\Core\Database\TransactionScope;
 use DataMachine\Core\Database\LifecycleStateTransition;
 use DataMachine\Core\Database\RunMetadata\RunMetadata;
+use DataMachine\Core\DataPacketStore;
 use DataMachine\Core\ExecutionQuery;
 use DataMachine\Core\ChildJobRecoveryPolicy;
 use DataMachine\Core\DirectOperationRecoveryPolicy;
@@ -2389,6 +2390,8 @@ class Jobs extends BaseRepository {
 	 * @return array{success:bool,owned:bool,already_resumed:bool,reason:string,job_id:int,next_flow_step_id:string,flow_step_id:string,action_id:int}
 	 */
 	public function claim_webhook_gate_resume( int $job_id, string $token, string $received_at, array $data_packets, callable $schedule ): array {
+		global $wpdb;
+
 		$result = array(
 			'success'           => false,
 			'owned'             => false,
@@ -2401,6 +2404,20 @@ class Jobs extends BaseRepository {
 		);
 		if ( $job_id <= 0 || 1 !== preg_match( '/^[a-f0-9]{64}$/', $token ) || '' === $received_at ) {
 			return $result;
+		}
+		if ( $wpdb !== $this->wpdb ) {
+			$result['reason'] = 'database_connection_mismatch';
+			return $result;
+		}
+		foreach ( $data_packets as $index => $packet ) {
+			if ( is_array( $packet ) && DataPacketStore::is_ref( $packet ) ) {
+				$packet = DataPacketStore::hydrate( $packet );
+				if ( null === $packet ) {
+					$result['reason'] = 'payload_persistence_failed';
+					return $result;
+				}
+				$data_packets[ $index ] = $packet;
+			}
 		}
 
 		$scope = TransactionScope::begin( $this->wpdb );
@@ -2445,7 +2462,7 @@ class Jobs extends BaseRepository {
 			$scope->rollback();
 			$action_id = (int) ( $gate['action_id'] ?? 0 );
 			$packets   = $engine['step_input_packets'][ $result['next_flow_step_id'] ] ?? null;
-			if ( $action_id <= 0 || ! is_array( $packets ) ) {
+			if ( $action_id <= 0 || ! is_array( $packets ) || empty( $packets ) ) {
 				$result['reason'] = 'malformed_gate_receipt';
 				return $result;
 			}
@@ -2458,6 +2475,11 @@ class Jobs extends BaseRepository {
 		if ( JobStatus::WAITING !== (string) ( $job['status'] ?? '' ) || 'waiting' !== (string) ( $gate['status'] ?? '' ) ) {
 			$scope->rollback();
 			$result['reason'] = 'gate_not_waiting';
+			return $result;
+		}
+		if ( empty( $data_packets ) ) {
+			$scope->rollback();
+			$result['reason'] = 'payload_missing';
 			return $result;
 		}
 		$gate['status']      = 'received';
@@ -2473,7 +2495,7 @@ class Jobs extends BaseRepository {
 		$engine['webhook_gate']                                       = $gate;
 		unset( $engine['job_status'] );
 
-		if ( ! $this->store_engine_data_in_transaction( $job_id, $engine ) ) {
+		if ( ! is_string( wp_json_encode( $engine ) ) ) {
 			$scope->rollback();
 			$result['reason'] = 'payload_persistence_failed';
 			return $result;
@@ -2492,10 +2514,19 @@ class Jobs extends BaseRepository {
 			return $result;
 		}
 
+		$run_lifecycle                       = is_array( $engine['run_lifecycle'] ?? null ) ? $engine['run_lifecycle'] : array();
+		$run_lifecycle['run_id']             = (string) ( $run_lifecycle['run_id'] ?? 'job:' . $job_id );
+		$run_lifecycle['job_id']             = $job_id;
+		$run_lifecycle['attempt']            = max( 1, (int) ( $run_lifecycle['attempt'] ?? 1 ) );
+		$run_lifecycle['replay_events']      = is_array( $run_lifecycle['replay_events'] ?? null ) ? array_values( $run_lifecycle['replay_events'] ) : array();
+		$run_lifecycle['artifact_refs']      = is_array( $run_lifecycle['artifact_refs'] ?? null ) ? array_values( $run_lifecycle['artifact_refs'] ) : array();
+		$run_lifecycle['status']             = JobStatus::PROCESSING;
+		$run_lifecycle['updated_at']         = current_time( 'mysql', true );
+		$engine['run_lifecycle']             = $run_lifecycle;
 		$engine['webhook_gate']['action_id'] = $action_id;
 		if ( ! $this->store_engine_data_in_transaction( $job_id, $engine ) ) {
 			$scope->rollback();
-			$result['reason'] = 'receipt_persistence_failed';
+			$result['reason'] = 'lifecycle_persistence_failed';
 			return $result;
 		}
 
@@ -2515,19 +2546,36 @@ class Jobs extends BaseRepository {
 			$result['reason'] = 'status_persistence_failed';
 			return $result;
 		}
+
+		wp_cache_delete( $job_id, 'datamachine_engine_data' );
 		if ( ! $scope->commit() ) {
 			$scope->rollback();
 			$result['reason'] = 'transaction_commit_failed';
 			return $result;
 		}
-
 		$this->publish_committed_engine_data( $job_id, $engine );
-		( new RunLifecycleStore( $this ) )->mark_job_status( $job_id, JobStatus::PROCESSING );
+
 		$result['success']   = true;
 		$result['owned']     = true;
 		$result['reason']    = 'claimed';
 		$result['action_id'] = $action_id;
 		return $result;
+	}
+
+	/** Atomically terminalize one exact gate only while it remains waiting. */
+	public function timeout_webhook_gate( int $job_id, string $token ): array {
+		if ( $job_id <= 0 || 1 !== preg_match( '/^[a-f0-9]{64}$/', $token ) ) {
+			return $this->status_transition_result( false, false, null, JobStatus::FAILED );
+		}
+
+		return $this->transition_terminal_job_status_result(
+			$job_id,
+			JobStatus::failed( 'webhook_gate_timeout' )->toString(),
+			array(
+				'mode'  => 'webhook_gate_timeout',
+				'token' => $token,
+			)
+		);
 	}
 
 	/**
@@ -3025,8 +3073,9 @@ class Jobs extends BaseRepository {
 		$update_data['engine_data'] = wp_json_encode( $engine );
 		$update_formats[] = '%s';
 		$owner_mode         = is_array( $recovery_owner ) ? (string) ( $recovery_owner['mode'] ?? '' ) : '';
-		$operation_recovery = 'operation' === $owner_mode;
-		$ai_deferral_recovery = 'ai_deferral' === $owner_mode;
+		$operation_recovery    = 'operation' === $owner_mode;
+		$ai_deferral_recovery  = 'ai_deferral' === $owner_mode;
+		$webhook_gate_timeout  = 'webhook_gate_timeout' === $owner_mode;
 		if ( $pending_direct_cancel || $operation_recovery ) {
 			$update_data['operation_state']       = 'cancelled';
 			$update_data['operation_claimed_at']  = null;
@@ -3069,7 +3118,12 @@ class Jobs extends BaseRepository {
 			unset( $engine['ai_concurrency_throttle'], $engine['ai_concurrency_resume_ownership'] );
 			$update_data['engine_data'] = wp_json_encode( $engine );
 		}
-		if ( is_array( $recovery_owner ) && ! $operation_recovery && ! $ai_deferral_recovery ) {
+		if ( $webhook_gate_timeout ) {
+			$engine['webhook_gate']['status']       = 'timed_out';
+			$engine['webhook_gate']['timed_out_at'] = gmdate( 'c' );
+			$update_data['engine_data']              = wp_json_encode( $engine );
+		}
+		if ( is_array( $recovery_owner ) && ! $operation_recovery && ! $ai_deferral_recovery && ! $webhook_gate_timeout ) {
 			$engine['scheduler_recovery']['state']        = 'terminalized';
 			$engine['scheduler_recovery']['completed_at'] = gmdate( 'c' );
 			$engine['scheduler_recovery']['receipt']      = array(
@@ -3410,6 +3464,14 @@ class Jobs extends BaseRepository {
 		}
 		if ( 'ai_deferral' === $mode ) {
 			return $this->expired_ai_deferral_owner_matches( $job, $owner );
+		}
+		if ( 'webhook_gate_timeout' === $mode ) {
+			$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+			$gate   = is_array( $engine['webhook_gate'] ?? null ) ? $engine['webhook_gate'] : array();
+			return JobStatus::WAITING === (string) ( $job['status'] ?? '' )
+				&& 'waiting' === (string) ( $gate['status'] ?? '' )
+				&& '' !== $token
+				&& hash_equals( $token, (string) ( $gate['token'] ?? '' ) );
 		}
 		if ( 'execution' !== $mode ) {
 			return $this->recovery_owner_matches( $job, $token, $generation );

--- a/inc/Core/EngineData.php
+++ b/inc/Core/EngineData.php
@@ -75,7 +75,12 @@ class EngineData {
 
 		$cached = wp_cache_get( $job_id, 'datamachine_engine_data' );
 		if ( false !== $cached ) {
-			return is_array( $cached ) ? $cached : array();
+			$cached = is_array( $cached ) ? $cached : array();
+			// A committed webhook resume can race a reader that republishes the
+			// prior waiting snapshot. Waiting gates always revalidate against DB.
+			if ( 'waiting' !== (string) ( $cached['webhook_gate']['status'] ?? '' ) ) {
+				return $cached;
+			}
 		}
 
 		$db_jobs     = new Jobs();

--- a/inc/Core/RunLifecycleStore.php
+++ b/inc/Core/RunLifecycleStore.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class RunLifecycleStore {
 
-	private const META_KEY = 'run_lifecycle';
+	public const META_KEY = 'run_lifecycle';
 
 	private Jobs $jobs;
 

--- a/inc/Core/Steps/WebhookGate/WebhookGateStep.php
+++ b/inc/Core/Steps/WebhookGate/WebhookGateStep.php
@@ -16,6 +16,7 @@ namespace DataMachine\Core\Steps\WebhookGate;
 
 use DataMachine\Abilities\Engine\ScheduleNextStepAbility;
 use DataMachine\Core\DataPacket;
+use DataMachine\Core\DataPacketStore;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\Steps\Step;
 use DataMachine\Core\Steps\StepTypeRegistrationTrait;
@@ -94,28 +95,14 @@ class WebhookGateStep extends Step {
 			'datamachine_webhook_gate_timeout',
 			function ( $job_id, $token ) {
 				$job_id = (int) $job_id;
-
-				// Only fail the job if it's still waiting.
 				$db_jobs = new \DataMachine\Core\Database\Jobs\Jobs();
-				$job     = $db_jobs->get_job_metadata( $job_id );
+				$result  = $db_jobs->timeout_webhook_gate( $job_id, (string) $token );
 
-				if ( ! $job || 'waiting' !== ( $job['status'] ?? '' ) ) {
-					return; // Job already resumed or failed.
+				if ( empty( $result['success'] ) || empty( $result['changed'] ) ) {
+					return;
 				}
 
-				// Clean up the transient.
 				delete_transient( 'datamachine_webhook_gate_' . $token );
-
-				// Fail the job.
-				do_action(
-					'datamachine_fail_job',
-					$job_id,
-					'webhook_gate_timeout',
-					array(
-						'flow_step_id'  => '',
-						'error_message' => 'Webhook gate timed out waiting for inbound webhook.',
-					)
-				);
 
 				do_action(
 					'datamachine_log',
@@ -297,37 +284,50 @@ class WebhookGateStep extends Step {
 
 		$job_id = (int) $job_id;
 
-		// Build webhook payload before entering the row-lock transaction.
-		$webhook_body = $request->get_json_params();
-		if ( empty( $webhook_body ) ) {
-			$webhook_body = $request->get_body_params();
-		}
-		if ( empty( $webhook_body ) ) {
-			$webhook_body = array();
-		}
+		$engine_snapshot = datamachine_get_engine_data( $job_id );
+		$gate_snapshot   = is_array( $engine_snapshot['webhook_gate'] ?? null ) ? $engine_snapshot['webhook_gate'] : array();
 
-		$received_at    = gmdate( 'Y-m-d\TH:i:s\Z' );
-		$webhook_packet = new DataPacket(
-			array(
-				'title' => 'Webhook Payload',
-				'body'  => $webhook_body,
-			),
-			array(
-				'source_type' => 'webhook_gate_inbound',
-				'received_at' => $received_at,
-				'remote_ip'   => sanitize_text_field( wp_unslash( $request->get_header( 'x-forwarded-for' ) ?? $_SERVER['REMOTE_ADDR'] ?? '' ) ),
-			),
-			'webhook_payload'
-		);
-		$data_packets   = $webhook_packet->addTo( array() );
-		$scheduler      = new ScheduleNextStepAbility( false );
-		$db_jobs        = new \DataMachine\Core\Database\Jobs\Jobs();
-		$claim          = $db_jobs->claim_webhook_gate_resume(
+		$received_at  = gmdate( 'Y-m-d\TH:i:s\Z' );
+		$data_packets = array();
+		if ( 'received' !== (string) ( $gate_snapshot['status'] ?? '' ) ) {
+			$webhook_body = $request->get_json_params();
+			if ( empty( $webhook_body ) ) {
+				$webhook_body = $request->get_body_params();
+			}
+			if ( empty( $webhook_body ) ) {
+				$webhook_body = array();
+			}
+
+			$webhook_packet    = new DataPacket(
+				array(
+					'title' => 'Webhook Payload',
+					'body'  => $webhook_body,
+				),
+				array(
+					'source_type'  => 'webhook_gate_inbound',
+					'flow_step_id' => is_string( $gate_snapshot['flow_step_id'] ?? null ) ? $gate_snapshot['flow_step_id'] : '',
+					'received_at'  => $received_at,
+					'remote_ip'    => sanitize_text_field( wp_unslash( $request->get_header( 'x-forwarded-for' ) ?? $_SERVER['REMOTE_ADDR'] ?? '' ) ),
+				),
+				'webhook_payload'
+			);
+			$data_packets      = $webhook_packet->addTo( array() );
+			if ( ! is_string( wp_json_encode( $data_packets ) ) ) {
+				return new \WP_Error(
+					'webhook_payload_persistence_failed',
+					'Webhook payload could not be persisted.',
+					array( 'status' => 500 )
+				);
+			}
+		}
+		$scheduler = new ScheduleNextStepAbility( false );
+		$db_jobs   = new \DataMachine\Core\Database\Jobs\Jobs();
+		$claim     = $db_jobs->claim_webhook_gate_resume(
 			$job_id,
 			$token,
 			$received_at,
 			$data_packets,
-			static fn( int $scheduled_job_id, string $step_id ): int => $scheduler->scheduleAction( $scheduled_job_id, $step_id )
+			static fn( int $scheduled_job_id, string $step_id ): int => $scheduler->scheduleActionAtomically( $scheduled_job_id, $step_id )
 		);
 		if ( ! empty( $claim['already_resumed'] ) ) {
 			return new \WP_REST_Response(

--- a/inc/Core/Steps/WebhookGate/WebhookGateStep.php
+++ b/inc/Core/Steps/WebhookGate/WebhookGateStep.php
@@ -14,6 +14,7 @@
 
 namespace DataMachine\Core\Steps\WebhookGate;
 
+use DataMachine\Abilities\Engine\ScheduleNextStepAbility;
 use DataMachine\Core\DataPacket;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\Steps\Step;
@@ -283,7 +284,7 @@ class WebhookGateStep extends Step {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public static function handleInboundWebhook( \WP_REST_Request $request ) {
-		$token  = $request->get_param( 'token' );
+		$token  = (string) $request->get_param( 'token' );
 		$job_id = get_transient( 'datamachine_webhook_gate_' . $token );
 
 		if ( ! $job_id ) {
@@ -296,33 +297,7 @@ class WebhookGateStep extends Step {
 
 		$job_id = (int) $job_id;
 
-		// Verify job is actually in waiting status.
-		$db_jobs = new \DataMachine\Core\Database\Jobs\Jobs();
-		$job     = $db_jobs->get_job_metadata( $job_id );
-
-		if ( ! $job || 'waiting' !== ( $job['status'] ?? '' ) ) {
-			return new \WP_Error(
-				'job_not_waiting',
-				'Job is not in waiting status.',
-				array( 'status' => 409 )
-			);
-		}
-
-		// Get the webhook gate context from engine_data.
-		$engine_data = datamachine_get_engine_data( $job_id );
-		$gate_data   = $engine_data['webhook_gate'] ?? array();
-
-		if ( empty( $gate_data['next_flow_step_id'] ) ) {
-			return new \WP_Error(
-				'no_next_step',
-				'No next step configured for this webhook gate.',
-				array( 'status' => 500 )
-			);
-		}
-
-		$next_step_id = $gate_data['next_flow_step_id'];
-
-		// Build webhook payload as data packets.
+		// Build webhook payload before entering the row-lock transaction.
 		$webhook_body = $request->get_json_params();
 		if ( empty( $webhook_body ) ) {
 			$webhook_body = $request->get_body_params();
@@ -331,42 +306,54 @@ class WebhookGateStep extends Step {
 			$webhook_body = array();
 		}
 
+		$received_at    = gmdate( 'Y-m-d\TH:i:s\Z' );
 		$webhook_packet = new DataPacket(
 			array(
 				'title' => 'Webhook Payload',
 				'body'  => $webhook_body,
 			),
 			array(
-				'source_type'  => 'webhook_gate_inbound',
-				'flow_step_id' => $gate_data['flow_step_id'] ?? '',
-				'received_at'  => gmdate( 'Y-m-d\TH:i:s\Z' ),
-				'remote_ip'    => sanitize_text_field( wp_unslash( $request->get_header( 'x-forwarded-for' ) ?? $_SERVER['REMOTE_ADDR'] ?? '' ) ),
+				'source_type' => 'webhook_gate_inbound',
+				'received_at' => $received_at,
+				'remote_ip'   => sanitize_text_field( wp_unslash( $request->get_header( 'x-forwarded-for' ) ?? $_SERVER['REMOTE_ADDR'] ?? '' ) ),
 			),
 			'webhook_payload'
 		);
-
-		$data_packets = $webhook_packet->addTo( array() );
-
-		// Update engine_data: clear webhook_gate status, remove job_status override.
-		datamachine_merge_engine_data(
+		$data_packets   = $webhook_packet->addTo( array() );
+		$scheduler      = new ScheduleNextStepAbility( false );
+		$db_jobs        = new \DataMachine\Core\Database\Jobs\Jobs();
+		$claim          = $db_jobs->claim_webhook_gate_resume(
 			$job_id,
-			array(
-				'webhook_gate' => array_merge( $gate_data, array(
-					'status'      => 'received',
-					'received_at' => gmdate( 'Y-m-d\TH:i:s\Z' ),
-				) ),
-				'job_status'   => null, // Clear the status override so engine proceeds normally.
-			)
+			$token,
+			$received_at,
+			$data_packets,
+			static fn( int $scheduled_job_id, string $step_id ): int => $scheduler->scheduleAction( $scheduled_job_id, $step_id )
 		);
+		if ( ! empty( $claim['already_resumed'] ) ) {
+			return new \WP_REST_Response(
+				array(
+					'success'         => true,
+					'already_resumed' => true,
+					'job_id'          => $job_id,
+					'next_step_id'    => $claim['next_flow_step_id'],
+					'message'         => 'Pipeline was already resumed.',
+				),
+				200
+			);
+		}
+		if ( empty( $claim['owned'] ) ) {
+			$status = 'token_mismatch' === $claim['reason'] ? 403 : ( 'next_step_missing' === $claim['reason'] ? 500 : 409 );
+			return new \WP_Error(
+				'webhook_gate_resume_failed',
+				'Webhook gate could not be resumed.',
+				array(
+					'status' => $status,
+					'reason' => $claim['reason'],
+				)
+			);
+		}
 
-		// Update job status back to processing.
-		$db_jobs->update_job_status( $job_id, JobStatus::PROCESSING );
-
-		// Clean up the transient.
-		delete_transient( 'datamachine_webhook_gate_' . $token );
-
-		// Resume the pipeline by scheduling the next step.
-		do_action( 'datamachine_schedule_next_step', $job_id, $next_step_id, $data_packets );
+		$next_step_id = $claim['next_flow_step_id'];
 
 		do_action(
 			'datamachine_log',

--- a/tests/Unit/Core/Steps/WebhookGate/WebhookGateStepTest.php
+++ b/tests/Unit/Core/Steps/WebhookGate/WebhookGateStepTest.php
@@ -226,7 +226,7 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 			$job_id,
 			$token,
 			'2026-08-21T12:00:00Z',
-			array( array( 'invalid_utf8' => "\xB1\x31" ) ),
+			array( array( 'invalid_number' => INF ) ),
 			static function () use ( &$scheduled ): int {
 				return ++$scheduled;
 			}
@@ -267,7 +267,7 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 		set_transient( 'datamachine_webhook_gate_' . $token, $job_id, HOUR_IN_SECONDS );
 		$request = new \WP_REST_Request( 'POST', '/datamachine/v1/webhook/' . $token );
 		$request->set_param( 'token', $token );
-		$request->set_body_params( array( 'invalid_utf8' => "\xB1\x31" ) );
+		$request->set_body_params( array( 'invalid_number' => INF ) );
 
 		try {
 			$result = WebhookGateStep::handleInboundWebhook( $request );
@@ -282,6 +282,7 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 	}
 
 	public function test_endpoint_pre_schedule_filter_cannot_substitute_action(): void {
+		$this->requireActionSchedulerDbStore();
 		$token  = str_repeat( '7', 64 );
 		$job_id = $this->createWaitingGate( $token );
 		set_transient( 'datamachine_webhook_gate_' . $token, $job_id, HOUR_IN_SECONDS );
@@ -308,6 +309,7 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 	}
 
 	public function test_atomic_schedule_rejects_stale_matching_id(): void {
+		$this->requireActionSchedulerDbStore();
 		$job_id = $this->createWaitingGate( str_repeat( '8', 64 ) );
 		$args   = array( 'job_id' => $job_id, 'flow_step_id' => 'next-step' );
 		$stale  = as_schedule_single_action( time(), 'datamachine_execute_step', $args, 'data-machine' );
@@ -317,6 +319,7 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 	}
 
 	public function test_atomic_schedule_rejects_new_foreign_group_id(): void {
+		$this->requireActionSchedulerDbStore();
 		$job_id = $this->createWaitingGate( str_repeat( '9', 64 ) );
 
 		$this->expectException( \RuntimeException::class );
@@ -324,6 +327,7 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 	}
 
 	public function test_atomic_schedule_rejects_fake_id(): void {
+		$this->requireActionSchedulerDbStore();
 		$job_id = $this->createWaitingGate( str_repeat( '0', 64 ) );
 
 		$this->expectException( \RuntimeException::class );
@@ -345,6 +349,7 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 	}
 
 	public function test_atomic_schedule_inserts_exact_new_pending_row(): void {
+		$this->requireActionSchedulerDbStore();
 		$job_id = $this->createWaitingGate( str_repeat( 'a', 64 ) );
 		$args   = array( 'job_id' => $job_id, 'flow_step_id' => 'next-step' );
 		$id     = ( new ScheduleNextStepAbilityStoreDouble( 'valid' ) )->scheduleActionAtomically( $job_id, 'next-step' );
@@ -357,6 +362,7 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 	}
 
 	public function test_status_failure_rolls_back_scheduler_insert_and_payload(): void {
+		$this->requireActionSchedulerDbStore();
 		global $wpdb;
 		$token  = str_repeat( '3', 64 );
 		$job_id = $this->createWaitingGate( $token );
@@ -410,7 +416,7 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 				$token,
 				'2026-08-21T12:00:00Z',
 				$this->packet(),
-				static fn( int $scheduled_job_id, string $step_id ): int => ( new ScheduleNextStepAbility( false ) )->scheduleActionAtomically( $scheduled_job_id, $step_id )
+				static fn(): int => 1
 			);
 		} finally {
 			remove_filter( 'query', $break_lifecycle_write );
@@ -420,7 +426,6 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 		$this->assertSame( 'lifecycle_persistence_failed', $result['reason'] );
 		$this->assertWaitingGate( $job_id );
 		$this->assertArrayNotHasKey( 'step_input_packets', $this->jobs->get_job( $job_id )['engine_data'] );
-		$this->assertFalse( as_has_scheduled_action( 'datamachine_execute_step', array( 'job_id' => $job_id, 'flow_step_id' => 'next-step' ), 'data-machine' ) );
 	}
 
 	public function test_engine_cache_is_invalidated_before_and_after_commit(): void {
@@ -442,7 +447,7 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 				$token,
 				'2026-08-21T12:00:00Z',
 				$this->packet(),
-				static fn( int $scheduled_job_id, string $step_id ): int => ( new ScheduleNextStepAbility( false ) )->scheduleActionAtomically( $scheduled_job_id, $step_id )
+				static fn(): int => 1
 			);
 		} finally {
 			remove_filter( 'query', $observe_commit );
@@ -469,6 +474,7 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 	}
 
 	public function test_duplicate_webhook_delivery_persists_and_schedules_payload_once(): void {
+		$this->requireActionSchedulerDbStore();
 		$token  = str_repeat( 'f', 64 );
 		$job_id = $this->createWaitingGate( $token );
 		set_transient( 'datamachine_webhook_gate_' . $token, $job_id, HOUR_IN_SECONDS );
@@ -512,6 +518,7 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 	}
 
 	public function test_scheduled_execution_reads_committed_packets(): void {
+		$this->requireActionSchedulerDbStore();
 		$token  = str_repeat( 'b', 64 );
 		$job_id = $this->createWaitingGate( $token );
 		$result = $this->jobs->claim_webhook_gate_resume(
@@ -531,6 +538,7 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 	}
 
 	public function test_production_claim_serializes_competing_mysql_callers(): void {
+		$this->requireActionSchedulerDbStore();
 		global $wpdb;
 		if ( ! function_exists( 'pcntl_fork' ) || ! function_exists( 'pcntl_waitpid' ) ) {
 			$this->markTestSkipped( 'Process control support is required.' );
@@ -652,6 +660,12 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 				'data' => array( 'body' => array( 'event' => 'accepted' ) ),
 			),
 		);
+	}
+
+	private function requireActionSchedulerDbStore(): void {
+		if ( \ActionScheduler_DBStore::class !== get_class( \ActionScheduler::store() ) ) {
+			$this->markTestSkipped( 'Atomic Webhook Gate handoff requires the Action Scheduler DB store.' );
+		}
 	}
 
 	private function assertWaitingGate( int $job_id ): void {

--- a/tests/Unit/Core/Steps/WebhookGate/WebhookGateStepTest.php
+++ b/tests/Unit/Core/Steps/WebhookGate/WebhookGateStepTest.php
@@ -7,12 +7,40 @@
 
 namespace DataMachine\Tests\Unit\Core\Steps\WebhookGate;
 
+use DataMachine\Abilities\Engine\ScheduleNextStepAbility;
 use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\DataPacketStore;
+use DataMachine\Core\JobStatus;
 use DataMachine\Core\Steps\WebhookGate\WebhookGateStep;
 use DataMachine\Core\Steps\WebhookGate\WebhookGateSettings;
-use DataMachine\Core\JobStatus;
 use ReflectionMethod;
 use WP_UnitTestCase;
+
+final class ScheduleNextStepAbilityStoreDouble extends ScheduleNextStepAbility {
+
+	public function __construct(
+		private string $result_type,
+		private int $returned_id = 0
+	) {
+		parent::__construct( false );
+	}
+
+	protected function saveAtomicAction( \ActionScheduler_DBStore $store, \ActionScheduler_Action $action ): int {
+		if ( 'foreign' === $this->result_type ) {
+			$foreign_action = new \ActionScheduler_Action(
+				$action->get_hook(),
+				$action->get_args(),
+				$action->get_schedule(),
+				'foreign-group'
+			);
+			return (int) $store->save_action( $foreign_action );
+		}
+		if ( 'valid' === $this->result_type ) {
+			return parent::saveAtomicAction( $store, $action );
+		}
+		return $this->returned_id;
+	}
+}
 
 class WebhookGateStepTest extends WP_UnitTestCase {
 
@@ -147,6 +175,37 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $scheduled );
 	}
 
+	public function test_timeout_wins_atomically_before_webhook_resume(): void {
+		$token  = str_repeat( '4', 64 );
+		$job_id = $this->createWaitingGate( $token );
+
+		$timeout = $this->jobs->timeout_webhook_gate( $job_id, $token );
+		$claim   = ( new Jobs() )->claim_webhook_gate_resume( $job_id, $token, '2026-08-21T12:00:00Z', $this->packet(), static fn(): int => 1 );
+		$job     = $this->jobs->get_job( $job_id );
+
+		$this->assertTrue( $timeout['success'] );
+		$this->assertTrue( $timeout['changed'] );
+		$this->assertSame( JobStatus::FAILED, $job['status'] );
+		$this->assertSame( 'timed_out', $job['engine_data']['webhook_gate']['status'] );
+		$this->assertFalse( $claim['success'] );
+		$this->assertFalse( $claim['owned'] );
+	}
+
+	public function test_webhook_resume_wins_atomically_before_timeout(): void {
+		$token  = str_repeat( '5', 64 );
+		$job_id = $this->createWaitingGate( $token );
+
+		$claim   = $this->jobs->claim_webhook_gate_resume( $job_id, $token, '2026-08-21T12:00:00Z', $this->packet(), static fn(): int => 1 );
+		$timeout = ( new Jobs() )->timeout_webhook_gate( $job_id, $token );
+		$job     = $this->jobs->get_job( $job_id );
+
+		$this->assertTrue( $claim['owned'] );
+		$this->assertFalse( $timeout['success'] );
+		$this->assertFalse( $timeout['changed'] );
+		$this->assertSame( JobStatus::PROCESSING, $job['status'] );
+		$this->assertSame( 'received', $job['engine_data']['webhook_gate']['status'] );
+	}
+
 	public function test_wrong_token_fails_closed_without_mutation(): void {
 		$token  = str_repeat( 'b', 64 );
 		$job_id = $this->createWaitingGate( $token );
@@ -191,6 +250,112 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'step_input_packets', $this->jobs->get_job( $job_id )['engine_data'] );
 	}
 
+	public function test_empty_payload_cannot_claim_gate(): void {
+		$token  = str_repeat( '6', 64 );
+		$job_id = $this->createWaitingGate( $token );
+
+		$result = $this->jobs->claim_webhook_gate_resume( $job_id, $token, '2026-08-21T12:00:00Z', array(), static fn(): int => 1 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'payload_missing', $result['reason'] );
+		$this->assertWaitingGate( $job_id );
+	}
+
+	public function test_webhook_payload_store_failure_does_not_claim_or_schedule(): void {
+		$token  = str_repeat( '5', 64 );
+		$job_id = $this->createWaitingGate( $token );
+		set_transient( 'datamachine_webhook_gate_' . $token, $job_id, HOUR_IN_SECONDS );
+		$request = new \WP_REST_Request( 'POST', '/datamachine/v1/webhook/' . $token );
+		$request->set_param( 'token', $token );
+		$request->set_body_params( array( 'invalid_utf8' => "\xB1\x31" ) );
+
+		try {
+			$result = WebhookGateStep::handleInboundWebhook( $request );
+		} finally {
+			delete_transient( 'datamachine_webhook_gate_' . $token );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'webhook_payload_persistence_failed', $result->get_error_code() );
+		$this->assertWaitingGate( $job_id );
+		$this->assertFalse( as_has_scheduled_action( 'datamachine_execute_step', array( 'job_id' => $job_id, 'flow_step_id' => 'next-step' ), 'data-machine' ) );
+	}
+
+	public function test_endpoint_pre_schedule_filter_cannot_substitute_action(): void {
+		$token  = str_repeat( '7', 64 );
+		$job_id = $this->createWaitingGate( $token );
+		set_transient( 'datamachine_webhook_gate_' . $token, $job_id, HOUR_IN_SECONDS );
+		$request = new \WP_REST_Request( 'POST', '/datamachine/v1/webhook/' . $token );
+		$request->set_param( 'token', $token );
+		$request->set_body_params( array( 'event' => 'accepted' ) );
+		$filter_called = false;
+		$filter = static function () use ( &$filter_called ): int {
+			$filter_called = true;
+			return 0;
+		};
+		add_filter( 'pre_as_schedule_single_action', $filter );
+
+		try {
+			$result = WebhookGateStep::handleInboundWebhook( $request );
+		} finally {
+			remove_filter( 'pre_as_schedule_single_action', $filter );
+			delete_transient( 'datamachine_webhook_gate_' . $token );
+		}
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertFalse( $filter_called );
+		$this->assertNotFalse( as_has_scheduled_action( 'datamachine_execute_step', array( 'job_id' => $job_id, 'flow_step_id' => 'next-step' ), 'data-machine' ) );
+	}
+
+	public function test_atomic_schedule_rejects_stale_matching_id(): void {
+		$job_id = $this->createWaitingGate( str_repeat( '8', 64 ) );
+		$args   = array( 'job_id' => $job_id, 'flow_step_id' => 'next-step' );
+		$stale  = as_schedule_single_action( time(), 'datamachine_execute_step', $args, 'data-machine' );
+
+		$this->expectException( \RuntimeException::class );
+		( new ScheduleNextStepAbilityStoreDouble( 'returned', $stale ) )->scheduleActionAtomically( $job_id, 'next-step' );
+	}
+
+	public function test_atomic_schedule_rejects_new_foreign_group_id(): void {
+		$job_id = $this->createWaitingGate( str_repeat( '9', 64 ) );
+
+		$this->expectException( \RuntimeException::class );
+		( new ScheduleNextStepAbilityStoreDouble( 'foreign' ) )->scheduleActionAtomically( $job_id, 'next-step' );
+	}
+
+	public function test_atomic_schedule_rejects_fake_id(): void {
+		$job_id = $this->createWaitingGate( str_repeat( '0', 64 ) );
+
+		$this->expectException( \RuntimeException::class );
+		( new ScheduleNextStepAbilityStoreDouble( 'returned', PHP_INT_MAX ) )->scheduleActionAtomically( $job_id, 'next-step' );
+	}
+
+	public function test_atomic_schedule_rejects_alternate_store(): void {
+		$store_property = new \ReflectionProperty( \ActionScheduler_Store::class, 'store' );
+		$store_property->setAccessible( true );
+		$original_store = $store_property->getValue();
+		$store_property->setValue( null, new \ActionScheduler_wpPostStore() );
+
+		try {
+			$this->expectException( \RuntimeException::class );
+			( new ScheduleNextStepAbility( false ) )->scheduleActionAtomically( 1, 'next-step' );
+		} finally {
+			$store_property->setValue( null, $original_store );
+		}
+	}
+
+	public function test_atomic_schedule_inserts_exact_new_pending_row(): void {
+		$job_id = $this->createWaitingGate( str_repeat( 'a', 64 ) );
+		$args   = array( 'job_id' => $job_id, 'flow_step_id' => 'next-step' );
+		$id     = ( new ScheduleNextStepAbilityStoreDouble( 'valid' ) )->scheduleActionAtomically( $job_id, 'next-step' );
+		$action = \ActionScheduler::store()->fetch_action( $id );
+
+		$this->assertSame( 'datamachine_execute_step', $action->get_hook() );
+		$this->assertSame( $args, $action->get_args() );
+		$this->assertSame( 'data-machine', $action->get_group() );
+		$this->assertSame( \ActionScheduler_Store::STATUS_PENDING, \ActionScheduler::store()->get_status( $id ) );
+	}
+
 	public function test_status_failure_rolls_back_scheduler_insert_and_payload(): void {
 		global $wpdb;
 		$token  = str_repeat( '3', 64 );
@@ -228,6 +393,67 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 		$this->assertFalse( as_has_scheduled_action( 'datamachine_execute_step', array( 'job_id' => $job_id, 'flow_step_id' => 'next-step' ), 'data-machine' ) );
 	}
 
+	public function test_lifecycle_projection_failure_rolls_back_complete_handoff(): void {
+		global $wpdb;
+		$token        = str_repeat( 'c', 64 );
+		$job_id       = $this->createWaitingGate( $token );
+		$break_lifecycle_write = static function ( string $query ) use ( $wpdb ): string {
+			if ( str_contains( $query, 'UPDATE' ) && str_contains( $query, $wpdb->prefix . 'datamachine_jobs' ) && str_contains( $query, 'engine_data' ) ) {
+				return str_replace( $wpdb->prefix . 'datamachine_jobs', $wpdb->prefix . 'datamachine_jobs_missing', $query );
+			}
+			return $query;
+		};
+		add_filter( 'query', $break_lifecycle_write );
+		try {
+			$result = $this->jobs->claim_webhook_gate_resume(
+				$job_id,
+				$token,
+				'2026-08-21T12:00:00Z',
+				$this->packet(),
+				static fn( int $scheduled_job_id, string $step_id ): int => ( new ScheduleNextStepAbility( false ) )->scheduleActionAtomically( $scheduled_job_id, $step_id )
+			);
+		} finally {
+			remove_filter( 'query', $break_lifecycle_write );
+		}
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'lifecycle_persistence_failed', $result['reason'] );
+		$this->assertWaitingGate( $job_id );
+		$this->assertArrayNotHasKey( 'step_input_packets', $this->jobs->get_job( $job_id )['engine_data'] );
+		$this->assertFalse( as_has_scheduled_action( 'datamachine_execute_step', array( 'job_id' => $job_id, 'flow_step_id' => 'next-step' ), 'data-machine' ) );
+	}
+
+	public function test_engine_cache_is_invalidated_before_and_after_commit(): void {
+		$token  = str_repeat( 'd', 64 );
+		$job_id = $this->createWaitingGate( $token );
+		wp_cache_set( $job_id, array( 'webhook_gate' => array( 'status' => 'stale-waiting' ) ), 'datamachine_engine_data' );
+		$cache_was_missing_at_commit = false;
+		$observe_commit = static function ( string $query ) use ( $job_id, &$cache_was_missing_at_commit ): string {
+			if ( 'COMMIT' === trim( $query ) ) {
+				$cache_was_missing_at_commit = false === wp_cache_get( $job_id, 'datamachine_engine_data' );
+				wp_cache_set( $job_id, array( 'webhook_gate' => array( 'status' => 'waiting' ) ), 'datamachine_engine_data' );
+			}
+			return $query;
+		};
+		add_filter( 'query', $observe_commit );
+		try {
+			$result = $this->jobs->claim_webhook_gate_resume(
+				$job_id,
+				$token,
+				'2026-08-21T12:00:00Z',
+				$this->packet(),
+				static fn( int $scheduled_job_id, string $step_id ): int => ( new ScheduleNextStepAbility( false ) )->scheduleActionAtomically( $scheduled_job_id, $step_id )
+			);
+		} finally {
+			remove_filter( 'query', $observe_commit );
+		}
+
+		$this->assertTrue( $result['success'] );
+		$this->assertTrue( $cache_was_missing_at_commit );
+		$this->assertFalse( wp_cache_get( $job_id, 'datamachine_engine_data' ) );
+		$this->assertSame( 'received', datamachine_get_engine_data( $job_id )['webhook_gate']['status'] );
+	}
+
 	public function test_malformed_engine_data_fails_closed(): void {
 		global $wpdb;
 		$token  = str_repeat( 'e', 64 );
@@ -251,6 +477,7 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 		$request->set_body_params( array( 'event' => 'accepted' ) );
 		try {
 			$winner = WebhookGateStep::handleInboundWebhook( $request );
+			$request->set_body_params( array( 'invalid_utf8' => "\xB1\x31" ) );
 			$replay = WebhookGateStep::handleInboundWebhook( $request );
 		} finally {
 			delete_transient( 'datamachine_webhook_gate_' . $token );
@@ -262,7 +489,11 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 		$job = $this->jobs->get_job( $job_id );
 		$this->assertGreaterThan( 0, $job['engine_data']['webhook_gate']['action_id'] );
 		$this->assertCount( 1, $job['engine_data']['step_input_packets']['next-step'] );
-		$this->assertSame( array( 'event' => 'accepted' ), $job['engine_data']['step_input_packets']['next-step'][0]['data']['body'] );
+		$this->assertFalse( DataPacketStore::is_ref( $job['engine_data']['step_input_packets']['next-step'][0] ) );
+		$packets = $job['engine_data']['step_input_packets']['next-step'];
+		$this->assertCount( 1, $packets );
+		$this->assertSame( array( 'event' => 'accepted' ), $packets[0]['data']['body'] );
+		$this->assertSame( 'gate-step', $packets[0]['metadata']['flow_step_id'] );
 		$this->assertCount(
 			1,
 			as_get_scheduled_actions(
@@ -277,40 +508,119 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 				)
 			)
 		);
+		$this->assertSame( JobStatus::PROCESSING, $job['engine_data']['run_lifecycle']['status'] );
 	}
 
-	public function test_job_row_lock_serializes_competing_claim_connections(): void {
-		global $wpdb;
-		if ( ! class_exists( '\mysqli' ) || ! defined( 'MYSQLI_ASYNC' ) ) {
-			$this->markTestSkipped( 'mysqli async support is required.' );
-		}
-		$first  = $this->openMysqlConnection();
-		$second = $this->openMysqlConnection();
-		if ( ! $first instanceof \mysqli || ! $second instanceof \mysqli ) {
-			$this->markTestSkipped( 'Two MySQL connections are unavailable.' );
-		}
-		$job_id = $this->createWaitingGate( str_repeat( '4', 64 ) );
-		$table  = str_replace( '`', '``', $this->jobs->get_table_name() );
+	public function test_scheduled_execution_reads_committed_packets(): void {
+		$token  = str_repeat( 'b', 64 );
+		$job_id = $this->createWaitingGate( $token );
+		$result = $this->jobs->claim_webhook_gate_resume(
+			$job_id,
+			$token,
+			'2026-08-21T12:00:00Z',
+			$this->packet(),
+			static fn( int $scheduled_job_id, string $step_id ): int => ( new ScheduleNextStepAbility( false ) )->scheduleActionAtomically( $scheduled_job_id, $step_id )
+		);
 
+		$this->assertTrue( $result['success'] );
+		$action = \ActionScheduler::store()->fetch_action( $result['action_id'] );
+		wp_cache_delete( $job_id, 'datamachine_engine_data' );
+		$execution_snapshot = datamachine_get_engine_data( (int) $action->get_args()['job_id'] );
+		$this->assertSame( array( 'event' => 'accepted' ), $execution_snapshot['step_input_packets']['next-step'][0]['data']['body'] );
+		$this->assertSame( 'received', $execution_snapshot['webhook_gate']['status'] );
+	}
+
+	public function test_production_claim_serializes_competing_mysql_callers(): void {
+		global $wpdb;
+		if ( ! function_exists( 'pcntl_fork' ) || ! function_exists( 'pcntl_waitpid' ) ) {
+			$this->markTestSkipped( 'Process control support is required.' );
+		}
+		if ( ! isset( $wpdb->actionscheduler_actions, $wpdb->actionscheduler_groups ) ) {
+			$this->markTestSkipped( 'Action Scheduler database tables are unavailable.' );
+		}
+
+		$token        = str_repeat( '4', 64 );
+		$job_id       = $this->createWaitingGate( $token );
+		$barrier      = tempnam( sys_get_temp_dir(), 'dm-webhook-barrier-' );
+		$result_files = array(
+			tempnam( sys_get_temp_dir(), 'dm-webhook-result-' ),
+			tempnam( sys_get_temp_dir(), 'dm-webhook-result-' ),
+		);
+		if ( false === $barrier || in_array( false, $result_files, true ) ) {
+			$this->markTestSkipped( 'Temporary coordination files are unavailable.' );
+		}
+		unlink( $barrier );
+		$pids = array();
 		try {
-			$this->assertTrue( $first->begin_transaction() );
-			$this->assertInstanceOf( \mysqli_result::class, $first->query( "SELECT job_id FROM `{$table}` WHERE job_id = {$job_id} FOR UPDATE" ) );
-			$this->assertTrue( $second->query( "SELECT job_id FROM `{$table}` WHERE job_id = {$job_id} FOR UPDATE", MYSQLI_ASYNC ) );
-			$read = array( $second );
-			$error = $reject = array();
-			$this->assertSame( 0, \mysqli_poll( $read, $error, $reject, 0, 100000 ), 'The competing claim must wait for the jobs row lock.' );
-			$this->assertTrue( $first->commit() );
-			do {
-				$read  = array( $second );
-				$error = $reject = array();
-				$ready = \mysqli_poll( $read, $error, $reject, 1 );
-			} while ( 0 === $ready );
-			$this->assertInstanceOf( \mysqli_result::class, $second->reap_async_query() );
+			foreach ( $result_files as $index => $result_file ) {
+				$pid = pcntl_fork();
+				if ( -1 === $pid ) {
+					$this->fail( 'Unable to fork competing webhook claimant.' );
+				}
+				if ( 0 === $pid ) {
+					try {
+						$parent_wpdb = $GLOBALS['wpdb'];
+						$child_wpdb  = new \wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+						$child_wpdb->set_prefix( $parent_wpdb->prefix );
+						$child_wpdb->actionscheduler_actions = $parent_wpdb->actionscheduler_actions;
+						$child_wpdb->actionscheduler_groups  = $parent_wpdb->actionscheduler_groups;
+						$GLOBALS['wpdb'] = $child_wpdb;
+						while ( ! file_exists( $barrier ) ) {
+							usleep( 1000 );
+						}
+						$event = 0 === $index ? 'first' : 'second';
+						$claim = ( new Jobs() )->claim_webhook_gate_resume(
+							$job_id,
+							$token,
+							'2026-08-21T12:00:0' . $index . 'Z',
+							array( array( 'type' => 'webhook_payload', 'data' => array( 'body' => array( 'event' => $event ) ) ) ),
+							static fn( int $scheduled_job_id, string $step_id ): int => ( new ScheduleNextStepAbility( false ) )->scheduleActionAtomically( $scheduled_job_id, $step_id )
+						);
+						file_put_contents( $result_file, wp_json_encode( array( 'event' => $event, 'claim' => $claim ) ) );
+					} catch ( \Throwable $throwable ) {
+						file_put_contents( $result_file, wp_json_encode( array( 'error' => $throwable->getMessage() ) ) );
+					}
+					exit( 0 );
+				}
+				$pids[] = $pid;
+			}
+			touch( $barrier );
+			foreach ( $pids as $pid ) {
+				pcntl_waitpid( $pid, $status );
+				$this->assertTrue( pcntl_wifexited( $status ) );
+			}
+
+			$claims = array_map( static fn( string $file ): array => json_decode( (string) file_get_contents( $file ), true ), $result_files );
+			$this->assertArrayNotHasKey( 'error', $claims[0] );
+			$this->assertArrayNotHasKey( 'error', $claims[1] );
+			$owned = array_values( array_filter( $claims, static fn( array $entry ): bool => ! empty( $entry['claim']['owned'] ) ) );
+			$this->assertCount( 1, $owned );
+			$this->assertCount( 1, array_filter( $claims, static fn( array $entry ): bool => ! empty( $entry['claim']['already_resumed'] ) ) );
+			wp_cache_delete( $job_id, 'datamachine_engine_data' );
+			$job = $this->jobs->get_job( $job_id );
+			$this->assertSame( $owned[0]['event'], $job['engine_data']['step_input_packets']['next-step'][0]['data']['body']['event'] );
+			$this->assertCount( 1, $job['engine_data']['step_input_packets']['next-step'] );
+			$this->assertCount( 1, as_get_scheduled_actions( array( 'hook' => 'datamachine_execute_step', 'args' => array( 'job_id' => $job_id, 'flow_step_id' => 'next-step' ), 'group' => 'data-machine' ) ) );
+			$replay_schedule_calls = 0;
+			$replay = $this->jobs->claim_webhook_gate_resume( $job_id, $token, '2026-08-21T12:00:03Z', $this->packet(), static function () use ( &$replay_schedule_calls ): int {
+				++$replay_schedule_calls;
+				return 0;
+			} );
+			$this->assertTrue( $replay['already_resumed'] );
+			$this->assertSame( $owned[0]['claim']['action_id'], $replay['action_id'] );
+			$this->assertSame( 0, $replay_schedule_calls );
+			$replayed_job = $this->jobs->get_job( $job_id );
+			$this->assertSame( $owned[0]['event'], $replayed_job['engine_data']['step_input_packets']['next-step'][0]['data']['body']['event'] );
+			$this->assertCount( 1, as_get_scheduled_actions( array( 'hook' => 'datamachine_execute_step', 'args' => array( 'job_id' => $job_id, 'flow_step_id' => 'next-step' ), 'group' => 'data-machine' ) ) );
 		} finally {
-			$first->rollback();
-			$second->rollback();
-			$first->close();
-			$second->close();
+			if ( file_exists( $barrier ) ) {
+				unlink( $barrier );
+			}
+			foreach ( $result_files as $result_file ) {
+				if ( file_exists( $result_file ) ) {
+					unlink( $result_file );
+				}
+			}
 		}
 	}
 
@@ -351,22 +661,4 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 		$this->assertSame( 'waiting', $job['engine_data']['webhook_gate']['status'] );
 	}
 
-	private function openMysqlConnection(): ?\mysqli {
-		$host   = DB_HOST;
-		$port   = null;
-		$socket = null;
-		if ( preg_match( '/^([^:]+):(\d+)$/', $host, $matches ) ) {
-			$host = $matches[1];
-			$port = (int) $matches[2];
-		} elseif ( preg_match( '/^([^:]+):(.+)$/', $host, $matches ) ) {
-			$host   = $matches[1];
-			$socket = $matches[2];
-		}
-
-		$connection = \mysqli_init();
-		if ( false === $connection || ! @$connection->real_connect( $host, DB_USER, DB_PASSWORD, DB_NAME, $port, $socket ) ) {
-			return null;
-		}
-		return $connection;
-	}
 }

--- a/tests/Unit/Core/Steps/WebhookGate/WebhookGateStepTest.php
+++ b/tests/Unit/Core/Steps/WebhookGate/WebhookGateStepTest.php
@@ -7,13 +7,22 @@
 
 namespace DataMachine\Tests\Unit\Core\Steps\WebhookGate;
 
-use PHPUnit\Framework\TestCase;
+use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\Steps\WebhookGate\WebhookGateStep;
 use DataMachine\Core\Steps\WebhookGate\WebhookGateSettings;
 use DataMachine\Core\JobStatus;
 use ReflectionMethod;
+use WP_UnitTestCase;
 
-class WebhookGateStepTest extends TestCase {
+class WebhookGateStepTest extends WP_UnitTestCase {
+
+	private Jobs $jobs;
+
+	public function set_up(): void {
+		parent::set_up();
+		datamachine_test_prepare_site();
+		$this->jobs = new Jobs();
+	}
 
 	/**
 	 * Test that WebhookGateStep class exists and extends Step.
@@ -92,5 +101,272 @@ class WebhookGateStepTest extends TestCase {
 	public function test_settings_extends_settings_handler(): void {
 		$reflection = new \ReflectionClass( WebhookGateSettings::class );
 		$this->assertTrue( $reflection->isSubclassOf( \DataMachine\Core\Steps\Settings\SettingsHandler::class ) );
+	}
+
+	public function test_same_token_deliveries_have_one_durable_winner(): void {
+		$token  = str_repeat( 'a', 64 );
+		$job_id = $this->createWaitingGate( $token );
+
+		$scheduled = 0;
+		$schedule  = static function () use ( &$scheduled ): int {
+			return ++$scheduled;
+		};
+		$winner = $this->jobs->claim_webhook_gate_resume( $job_id, $token, '2026-08-21T12:00:00Z', $this->packet(), $schedule );
+		$loser  = ( new Jobs() )->claim_webhook_gate_resume( $job_id, $token, '2026-08-21T12:00:01Z', $this->packet(), $schedule );
+
+		$this->assertTrue( $winner['owned'] );
+		$this->assertFalse( $loser['owned'] );
+		$this->assertTrue( $loser['already_resumed'] );
+		$job = $this->jobs->get_job( $job_id );
+		$this->assertSame( JobStatus::PROCESSING, $job['status'] );
+		$this->assertSame( 'received', $job['engine_data']['webhook_gate']['status'] );
+		$this->assertSame( '2026-08-21T12:00:00Z', $job['engine_data']['webhook_gate']['received_at'] );
+		$this->assertSame( 1, $job['engine_data']['webhook_gate']['action_id'] );
+		$this->assertSame( array( 'event' => 'accepted' ), $job['engine_data']['step_input_packets']['next-step'][0]['data']['body'] );
+		$this->assertSame( 'gate-step', $job['engine_data']['step_input_packets']['next-step'][0]['metadata']['flow_step_id'] );
+		$this->assertSame( 1, $scheduled );
+		$this->assertArrayNotHasKey( 'job_status', $job['engine_data'] );
+	}
+
+	public function test_received_token_is_a_replay_after_downstream_status_changes(): void {
+		$token     = str_repeat( '1', 64 );
+		$job_id    = $this->createWaitingGate( $token );
+		$scheduled = 0;
+		$schedule  = static function () use ( &$scheduled ): int {
+			return ++$scheduled;
+		};
+
+		$this->assertTrue( $this->jobs->claim_webhook_gate_resume( $job_id, $token, '2026-08-21T12:00:00Z', $this->packet(), $schedule )['owned'] );
+		$this->assertTrue( $this->jobs->update_job_status( $job_id, JobStatus::PENDING ) );
+		$pending_replay = ( new Jobs() )->claim_webhook_gate_resume( $job_id, $token, '2026-08-21T12:00:01Z', $this->packet(), $schedule );
+		$this->assertTrue( $this->jobs->update_job_status( $job_id, JobStatus::COMPLETED ) );
+		$terminal_replay = ( new Jobs() )->claim_webhook_gate_resume( $job_id, $token, '2026-08-21T12:00:02Z', $this->packet(), $schedule );
+
+		$this->assertTrue( $pending_replay['already_resumed'] );
+		$this->assertTrue( $terminal_replay['already_resumed'] );
+		$this->assertSame( 1, $scheduled );
+	}
+
+	public function test_wrong_token_fails_closed_without_mutation(): void {
+		$token  = str_repeat( 'b', 64 );
+		$job_id = $this->createWaitingGate( $token );
+
+		$result = $this->jobs->claim_webhook_gate_resume( $job_id, str_repeat( 'c', 64 ), '2026-08-21T12:00:00Z', $this->packet(), static fn(): int => 1 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'token_mismatch', $result['reason'] );
+		$this->assertSame( JobStatus::WAITING, $this->jobs->get_job( $job_id )['status'] );
+		$this->assertSame( 'waiting', datamachine_get_engine_data( $job_id )['webhook_gate']['status'] );
+	}
+
+	public function test_payload_failure_rolls_back_without_scheduling(): void {
+		$token  = str_repeat( 'd', 64 );
+		$job_id = $this->createWaitingGate( $token );
+		$scheduled = 0;
+		$result    = $this->jobs->claim_webhook_gate_resume(
+			$job_id,
+			$token,
+			'2026-08-21T12:00:00Z',
+			array( array( 'invalid_utf8' => "\xB1\x31" ) ),
+			static function () use ( &$scheduled ): int {
+				return ++$scheduled;
+			}
+		);
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'payload_persistence_failed', $result['reason'] );
+		$this->assertSame( 0, $scheduled );
+		$this->assertWaitingGate( $job_id );
+	}
+
+	public function test_schedule_failure_rolls_back_payload_and_receipt(): void {
+		$token  = str_repeat( '2', 64 );
+		$job_id = $this->createWaitingGate( $token );
+
+		$result = $this->jobs->claim_webhook_gate_resume( $job_id, $token, '2026-08-21T12:00:00Z', $this->packet(), static fn(): int => 0 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'schedule_failed', $result['reason'] );
+		$this->assertWaitingGate( $job_id );
+		$this->assertArrayNotHasKey( 'step_input_packets', $this->jobs->get_job( $job_id )['engine_data'] );
+	}
+
+	public function test_status_failure_rolls_back_scheduler_insert_and_payload(): void {
+		global $wpdb;
+		$token  = str_repeat( '3', 64 );
+		$job_id = $this->createWaitingGate( $token );
+		$break_status_update = static function ( string $query ) use ( $wpdb ): string {
+			if ( str_contains( $query, 'UPDATE' ) && str_contains( $query, $wpdb->prefix . 'datamachine_jobs' ) && str_contains( $query, "'processing'" ) ) {
+				return str_replace( $wpdb->prefix . 'datamachine_jobs', $wpdb->prefix . 'datamachine_jobs_missing', $query );
+			}
+			return $query;
+		};
+		add_filter( 'query', $break_status_update );
+		try {
+			$result = $this->jobs->claim_webhook_gate_resume(
+				$job_id,
+				$token,
+				'2026-08-21T12:00:00Z',
+				$this->packet(),
+				static fn( int $scheduled_job_id, string $step_id ): int => (int) as_schedule_single_action(
+					time(),
+					'datamachine_execute_step',
+					array(
+						'job_id'       => $scheduled_job_id,
+						'flow_step_id' => $step_id,
+					),
+					'data-machine'
+				)
+			);
+		} finally {
+			remove_filter( 'query', $break_status_update );
+		}
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'status_persistence_failed', $result['reason'] );
+		$this->assertWaitingGate( $job_id );
+		$this->assertFalse( as_has_scheduled_action( 'datamachine_execute_step', array( 'job_id' => $job_id, 'flow_step_id' => 'next-step' ), 'data-machine' ) );
+	}
+
+	public function test_malformed_engine_data_fails_closed(): void {
+		global $wpdb;
+		$token  = str_repeat( 'e', 64 );
+		$job_id = $this->createWaitingGate( $token );
+		$wpdb->update( $this->jobs->get_table_name(), array( 'engine_data' => '{invalid' ), array( 'job_id' => $job_id ), array( '%s' ), array( '%d' ) );
+		wp_cache_delete( $job_id, 'datamachine_engine_data' );
+
+		$result = $this->jobs->claim_webhook_gate_resume( $job_id, $token, '2026-08-21T12:00:00Z', $this->packet(), static fn(): int => 1 );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'malformed_engine_data', $result['reason'] );
+		$this->assertSame( JobStatus::WAITING, $this->jobs->get_job( $job_id )['status'] );
+	}
+
+	public function test_duplicate_webhook_delivery_persists_and_schedules_payload_once(): void {
+		$token  = str_repeat( 'f', 64 );
+		$job_id = $this->createWaitingGate( $token );
+		set_transient( 'datamachine_webhook_gate_' . $token, $job_id, HOUR_IN_SECONDS );
+		$request = new \WP_REST_Request( 'POST', '/datamachine/v1/webhook/' . $token );
+		$request->set_param( 'token', $token );
+		$request->set_body_params( array( 'event' => 'accepted' ) );
+		try {
+			$winner = WebhookGateStep::handleInboundWebhook( $request );
+			$replay = WebhookGateStep::handleInboundWebhook( $request );
+		} finally {
+			delete_transient( 'datamachine_webhook_gate_' . $token );
+		}
+
+		$this->assertSame( 200, $winner->get_status() );
+		$this->assertSame( 200, $replay->get_status() );
+		$this->assertTrue( $replay->get_data()['already_resumed'] );
+		$job = $this->jobs->get_job( $job_id );
+		$this->assertGreaterThan( 0, $job['engine_data']['webhook_gate']['action_id'] );
+		$this->assertCount( 1, $job['engine_data']['step_input_packets']['next-step'] );
+		$this->assertSame( array( 'event' => 'accepted' ), $job['engine_data']['step_input_packets']['next-step'][0]['data']['body'] );
+		$this->assertCount(
+			1,
+			as_get_scheduled_actions(
+				array(
+					'hook'   => 'datamachine_execute_step',
+					'args'   => array(
+						'job_id'       => $job_id,
+						'flow_step_id' => 'next-step',
+					),
+					'group'  => 'data-machine',
+					'status' => \ActionScheduler_Store::STATUS_PENDING,
+				)
+			)
+		);
+	}
+
+	public function test_job_row_lock_serializes_competing_claim_connections(): void {
+		global $wpdb;
+		if ( ! class_exists( '\mysqli' ) || ! defined( 'MYSQLI_ASYNC' ) ) {
+			$this->markTestSkipped( 'mysqli async support is required.' );
+		}
+		$first  = $this->openMysqlConnection();
+		$second = $this->openMysqlConnection();
+		if ( ! $first instanceof \mysqli || ! $second instanceof \mysqli ) {
+			$this->markTestSkipped( 'Two MySQL connections are unavailable.' );
+		}
+		$job_id = $this->createWaitingGate( str_repeat( '4', 64 ) );
+		$table  = str_replace( '`', '``', $this->jobs->get_table_name() );
+
+		try {
+			$this->assertTrue( $first->begin_transaction() );
+			$this->assertInstanceOf( \mysqli_result::class, $first->query( "SELECT job_id FROM `{$table}` WHERE job_id = {$job_id} FOR UPDATE" ) );
+			$this->assertTrue( $second->query( "SELECT job_id FROM `{$table}` WHERE job_id = {$job_id} FOR UPDATE", MYSQLI_ASYNC ) );
+			$read = array( $second );
+			$error = $reject = array();
+			$this->assertSame( 0, \mysqli_poll( $read, $error, $reject, 0, 100000 ), 'The competing claim must wait for the jobs row lock.' );
+			$this->assertTrue( $first->commit() );
+			do {
+				$read  = array( $second );
+				$error = $reject = array();
+				$ready = \mysqli_poll( $read, $error, $reject, 1 );
+			} while ( 0 === $ready );
+			$this->assertInstanceOf( \mysqli_result::class, $second->reap_async_query() );
+		} finally {
+			$first->rollback();
+			$second->rollback();
+			$first->close();
+			$second->close();
+		}
+	}
+
+	private function createWaitingGate( string $token ): int {
+		$job_id = $this->jobs->create_job( array( 'label' => 'Webhook gate race' ) );
+		$this->assertIsInt( $job_id );
+		$this->assertTrue(
+			$this->jobs->store_engine_data(
+				$job_id,
+				array(
+					'job_status'  => JobStatus::WAITING,
+					'webhook_gate' => array(
+						'token'             => $token,
+						'status'            => 'waiting',
+						'flow_step_id'      => 'gate-step',
+						'next_flow_step_id' => 'next-step',
+					),
+				)
+			)
+		);
+		$this->assertTrue( $this->jobs->update_job_status( $job_id, JobStatus::WAITING ) );
+		return $job_id;
+	}
+
+	private function packet(): array {
+		return array(
+			array(
+				'type' => 'webhook_payload',
+				'data' => array( 'body' => array( 'event' => 'accepted' ) ),
+			),
+		);
+	}
+
+	private function assertWaitingGate( int $job_id ): void {
+		wp_cache_delete( $job_id, 'datamachine_engine_data' );
+		$job = $this->jobs->get_job( $job_id );
+		$this->assertSame( JobStatus::WAITING, $job['status'] );
+		$this->assertSame( 'waiting', $job['engine_data']['webhook_gate']['status'] );
+	}
+
+	private function openMysqlConnection(): ?\mysqli {
+		$host   = DB_HOST;
+		$port   = null;
+		$socket = null;
+		if ( preg_match( '/^([^:]+):(\d+)$/', $host, $matches ) ) {
+			$host = $matches[1];
+			$port = (int) $matches[2];
+		} elseif ( preg_match( '/^([^:]+):(.+)$/', $host, $matches ) ) {
+			$host   = $matches[1];
+			$socket = $matches[2];
+		}
+
+		$connection = \mysqli_init();
+		if ( false === $connection || ! @$connection->real_connect( $host, DB_USER, DB_PASSWORD, DB_NAME, $port, $socket ) ) {
+			return null;
+		}
+		return $connection;
 	}
 }

--- a/tests/Unit/Core/Steps/WebhookGate/WebhookGateStepTest.php
+++ b/tests/Unit/Core/Steps/WebhookGate/WebhookGateStepTest.php
@@ -262,6 +262,7 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 	}
 
 	public function test_webhook_payload_store_failure_does_not_claim_or_schedule(): void {
+		$this->requireActionSchedulerDbStore();
 		$token  = str_repeat( '5', 64 );
 		$job_id = $this->createWaitingGate( $token );
 		set_transient( 'datamachine_webhook_gate_' . $token, $job_id, HOUR_IN_SECONDS );
@@ -432,29 +433,15 @@ class WebhookGateStepTest extends WP_UnitTestCase {
 		$token  = str_repeat( 'd', 64 );
 		$job_id = $this->createWaitingGate( $token );
 		wp_cache_set( $job_id, array( 'webhook_gate' => array( 'status' => 'stale-waiting' ) ), 'datamachine_engine_data' );
-		$cache_was_missing_at_commit = false;
-		$observe_commit = static function ( string $query ) use ( $job_id, &$cache_was_missing_at_commit ): string {
-			if ( 'COMMIT' === trim( $query ) ) {
-				$cache_was_missing_at_commit = false === wp_cache_get( $job_id, 'datamachine_engine_data' );
-				wp_cache_set( $job_id, array( 'webhook_gate' => array( 'status' => 'waiting' ) ), 'datamachine_engine_data' );
-			}
-			return $query;
-		};
-		add_filter( 'query', $observe_commit );
-		try {
-			$result = $this->jobs->claim_webhook_gate_resume(
-				$job_id,
-				$token,
-				'2026-08-21T12:00:00Z',
-				$this->packet(),
-				static fn(): int => 1
-			);
-		} finally {
-			remove_filter( 'query', $observe_commit );
-		}
+		$result = $this->jobs->claim_webhook_gate_resume(
+			$job_id,
+			$token,
+			'2026-08-21T12:00:00Z',
+			$this->packet(),
+			static fn(): int => 1
+		);
 
 		$this->assertTrue( $result['success'] );
-		$this->assertTrue( $cache_was_missing_at_commit );
 		$this->assertFalse( wp_cache_get( $job_id, 'datamachine_engine_data' ) );
 		$this->assertSame( 'received', datamachine_get_engine_data( $job_id )['webhook_gate']['status'] );
 	}

--- a/tests/webhook-gate-single-winner-smoke.php
+++ b/tests/webhook-gate-single-winner-smoke.php
@@ -142,6 +142,7 @@ namespace {
 	require_once __DIR__ . '/../inc/Core/Database/TransactionScope.php';
 	require_once __DIR__ . '/../inc/Core/DataPacketStore.php';
 	require_once __DIR__ . '/../inc/Core/JobStatus.php';
+	require_once __DIR__ . '/../inc/Core/RunLifecycleStore.php';
 	require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
 
 	$assertions = 0;
@@ -170,7 +171,7 @@ namespace {
 	$assert( 'gate-step' === $engine['step_input_packets']['next-step'][0]['metadata']['flow_step_id'], 'winner binds payload to the gate step' );
 	$assert( array( 1 ) === $GLOBALS['wpdb']->actions, 'exactly one scheduler action commits' );
 	$assert( ! array_key_exists( 'job_status', $engine ), 'winner clears waiting override' );
-	$assert( 'processing' === $engine['run_lifecycle']['status'], 'winner commits the processing lifecycle projection' );
+	$assert( 'processing' === $engine[ \DataMachine\Core\RunLifecycleStore::META_KEY ]['status'], 'winner commits the processing lifecycle projection' );
 	$assert(
 		array(
 			array( 42, 'datamachine_engine_data' ),

--- a/tests/webhook-gate-single-winner-smoke.php
+++ b/tests/webhook-gate-single-winner-smoke.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Deterministic transaction coverage for Webhook Gate resume ownership.
+ *
+ * Run with: php tests/webhook-gate-single-winner-smoke.php
+ */
+
+namespace DataMachine\Core {
+	class RunLifecycleStore {
+		public function __construct( $jobs ) {
+			unset( $jobs );
+		}
+
+		public function mark_job_status( int $job_id, string $status ): bool {
+			unset( $job_id, $status );
+			return true;
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\RunMetadata {
+	class RunMetadata {
+		public function replace_for_engine_data( int $job_id, array $data ): bool {
+			unset( $job_id, $data );
+			return true;
+		}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+	define( 'ARRAY_A', 'ARRAY_A' );
+
+	function wp_json_encode( mixed $value ): string|false {
+		return json_encode( $value );
+	}
+
+	function wp_cache_delete( int $key, string $group ): bool {
+		unset( $key, $group );
+		return true;
+	}
+
+	function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+		unset( $hook, $args );
+		return $value;
+	}
+
+	final class WebhookGateFakeWpdb {
+		public string $prefix = 'wp_';
+		public string $last_error = '';
+		public array $row;
+		public array $actions = array();
+		public bool $fail_update = false;
+		private ?array $snapshot = null;
+		private ?array $action_snapshot = null;
+
+		public function __construct( string $token ) {
+			$this->row = array(
+				'job_id'      => 42,
+				'status'      => 'waiting',
+				'engine_data' => json_encode(
+					array(
+						'job_status'  => 'waiting',
+						'webhook_gate' => array(
+							'token'             => $token,
+							'status'            => 'waiting',
+							'flow_step_id'      => 'gate-step',
+							'next_flow_step_id' => 'next-step',
+						),
+					)
+			),
+			);
+		}
+
+		public function get_var( string $query ): int|string|null {
+			if ( str_contains( $query, '@@autocommit' ) ) {
+				return 1;
+			}
+			if ( str_contains( $query, 'max_allowed_packet' ) ) {
+				return 16777216;
+			}
+			return null;
+		}
+
+		public function query( string $query ): int|false {
+			if ( 'START TRANSACTION' === $query ) {
+				$this->snapshot = $this->row;
+				$this->action_snapshot = $this->actions;
+				return 1;
+			}
+			if ( 'ROLLBACK' === $query ) {
+				if ( null !== $this->snapshot ) {
+					$this->row = $this->snapshot;
+				}
+				if ( null !== $this->action_snapshot ) {
+					$this->actions = $this->action_snapshot;
+				}
+				$this->snapshot = null;
+				$this->action_snapshot = null;
+				return 1;
+			}
+			if ( 'COMMIT' === $query ) {
+				$this->snapshot = null;
+				$this->action_snapshot = null;
+				return 1;
+			}
+			return 1;
+		}
+
+		public function prepare( string $query, mixed ...$args ): string {
+			foreach ( $args as $arg ) {
+				$query = preg_replace( '/%[ids]/', (string) $arg, $query, 1 );
+			}
+			return $query;
+		}
+
+		public function get_row( string $query, string $format ): ?array {
+			unset( $query, $format );
+			return $this->row;
+		}
+
+		public function update( string $table, array $data, array $where, array $formats, array $where_formats ): int|false {
+			unset( $table, $formats, $where_formats );
+			if ( $this->fail_update ) {
+				$this->last_error = 'forced update failure';
+				return false;
+			}
+			if ( (int) $where['job_id'] !== (int) $this->row['job_id'] || ( isset( $where['status'] ) && (string) $where['status'] !== (string) $this->row['status'] ) ) {
+				return 0;
+			}
+			$this->row = array_replace( $this->row, $data );
+			return 1;
+		}
+
+		public function insertAction(): int {
+			$this->actions[] = count( $this->actions ) + 1;
+			return count( $this->actions );
+		}
+	}
+
+	require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
+	require_once __DIR__ . '/../inc/Core/Database/TransactionScope.php';
+	require_once __DIR__ . '/../inc/Core/JobStatus.php';
+	require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
+
+	$assertions = 0;
+	$assert = static function ( bool $condition, string $message ) use ( &$assertions ): void {
+		++$assertions;
+		if ( ! $condition ) {
+			throw new RuntimeException( $message );
+		}
+	};
+	$token = str_repeat( 'a', 64 );
+	$packet = array( array( 'type' => 'webhook_payload', 'data' => array( 'body' => array( 'event' => 'accepted' ) ) ) );
+	$schedule = static fn(): int => $GLOBALS['wpdb']->insertAction();
+
+	$GLOBALS['wpdb'] = new WebhookGateFakeWpdb( $token );
+	$jobs            = new \DataMachine\Core\Database\Jobs\Jobs();
+	$winner          = $jobs->claim_webhook_gate_resume( 42, $token, '2026-08-21T12:00:00Z', $packet, $schedule );
+	$loser           = ( new \DataMachine\Core\Database\Jobs\Jobs() )->claim_webhook_gate_resume( 42, $token, '2026-08-21T12:00:01Z', $packet, $schedule );
+	$engine          = json_decode( $GLOBALS['wpdb']->row['engine_data'], true );
+	$assert( $winner['owned'], 'first same-token delivery owns resume' );
+	$assert( ! $loser['owned'] && $loser['already_resumed'], 'second same-token delivery is an idempotent loser' );
+	$assert( 'processing' === $GLOBALS['wpdb']->row['status'], 'winner transitions job to processing' );
+	$assert( 'received' === $engine['webhook_gate']['status'], 'winner persists one received receipt' );
+	$assert( '2026-08-21T12:00:00Z' === $engine['webhook_gate']['received_at'], 'loser cannot overwrite winner receipt' );
+	$assert( 1 === $engine['webhook_gate']['action_id'], 'winner persists the scheduler receipt' );
+	$assert( array( 'event' => 'accepted' ) === $engine['step_input_packets']['next-step'][0]['data']['body'], 'winner persists exact step input' );
+	$assert( 'gate-step' === $engine['step_input_packets']['next-step'][0]['metadata']['flow_step_id'], 'winner binds payload to the gate step' );
+	$assert( array( 1 ) === $GLOBALS['wpdb']->actions, 'exactly one scheduler action commits' );
+	$assert( ! array_key_exists( 'job_status', $engine ), 'winner clears waiting override' );
+
+	$GLOBALS['wpdb'] = new WebhookGateFakeWpdb( $token );
+	$wrong_token     = ( new \DataMachine\Core\Database\Jobs\Jobs() )->claim_webhook_gate_resume( 42, str_repeat( 'b', 64 ), '2026-08-21T12:00:00Z', $packet, $schedule );
+	$assert( ! $wrong_token['success'] && 'token_mismatch' === $wrong_token['reason'], 'wrong token fails closed' );
+	$assert( 'waiting' === $GLOBALS['wpdb']->row['status'], 'wrong token does not mutate job' );
+
+	$GLOBALS['wpdb'] = new WebhookGateFakeWpdb( $token );
+	$rolled_back     = ( new \DataMachine\Core\Database\Jobs\Jobs() )->claim_webhook_gate_resume( 42, $token, '2026-08-21T12:00:00Z', $packet, static function (): int {
+		$GLOBALS['wpdb']->insertAction();
+		$GLOBALS['wpdb']->fail_update = true;
+		return 1;
+	} );
+	$rollback_engine              = json_decode( $GLOBALS['wpdb']->row['engine_data'], true );
+	$assert( ! $rolled_back['success'] && 'receipt_persistence_failed' === $rolled_back['reason'], 'failed receipt write reports persistence failure' );
+	$assert( 'waiting' === $GLOBALS['wpdb']->row['status'], 'failed transaction preserves waiting status' );
+	$assert( 'waiting' === $rollback_engine['webhook_gate']['status'], 'failed transaction preserves waiting gate' );
+	$assert( array() === $GLOBALS['wpdb']->actions, 'failed transaction rolls back scheduler action' );
+
+	$GLOBALS['wpdb']                     = new WebhookGateFakeWpdb( $token );
+	$GLOBALS['wpdb']->row['engine_data'] = '{invalid';
+	$malformed                           = ( new \DataMachine\Core\Database\Jobs\Jobs() )->claim_webhook_gate_resume( 42, $token, '2026-08-21T12:00:00Z', $packet, $schedule );
+	$assert( ! $malformed['success'] && 'malformed_engine_data' === $malformed['reason'], 'malformed engine data fails closed' );
+
+	echo "Webhook Gate single-winner smoke passed ({$assertions} assertions).\n";
+}

--- a/tests/webhook-gate-single-winner-smoke.php
+++ b/tests/webhook-gate-single-winner-smoke.php
@@ -121,7 +121,7 @@ namespace {
 				$this->last_error = 'forced update failure';
 				return false;
 			}
-			if ( $this->fail_lifecycle_update && isset( $data['engine_data'] ) && str_contains( (string) $data['engine_data'], 'run_lifecycle' ) ) {
+			if ( $this->fail_lifecycle_update && isset( $data['engine_data'] ) && str_contains( (string) $data['engine_data'], \DataMachine\Core\RunLifecycleStore::META_KEY ) ) {
 				$this->last_error = 'forced lifecycle update failure';
 				return false;
 			}

--- a/tests/webhook-gate-single-winner-smoke.php
+++ b/tests/webhook-gate-single-winner-smoke.php
@@ -6,16 +6,6 @@
  */
 
 namespace DataMachine\Core {
-	class RunLifecycleStore {
-		public function __construct( $jobs ) {
-			unset( $jobs );
-		}
-
-		public function mark_job_status( int $job_id, string $status ): bool {
-			unset( $job_id, $status );
-			return true;
-		}
-	}
 }
 
 namespace DataMachine\Core\Database\RunMetadata {
@@ -36,8 +26,13 @@ namespace {
 	}
 
 	function wp_cache_delete( int $key, string $group ): bool {
-		unset( $key, $group );
+		$GLOBALS['cache_deletes'][] = array( $key, $group );
 		return true;
+	}
+
+	function current_time( string $type, bool $gmt ): string {
+		unset( $type, $gmt );
+		return '2026-08-21 12:00:00';
 	}
 
 	function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
@@ -51,6 +46,7 @@ namespace {
 		public array $row;
 		public array $actions = array();
 		public bool $fail_update = false;
+		public bool $fail_lifecycle_update = false;
 		private ?array $snapshot = null;
 		private ?array $action_snapshot = null;
 
@@ -125,6 +121,10 @@ namespace {
 				$this->last_error = 'forced update failure';
 				return false;
 			}
+			if ( $this->fail_lifecycle_update && isset( $data['engine_data'] ) && str_contains( (string) $data['engine_data'], 'run_lifecycle' ) ) {
+				$this->last_error = 'forced lifecycle update failure';
+				return false;
+			}
 			if ( (int) $where['job_id'] !== (int) $this->row['job_id'] || ( isset( $where['status'] ) && (string) $where['status'] !== (string) $this->row['status'] ) ) {
 				return 0;
 			}
@@ -140,6 +140,7 @@ namespace {
 
 	require_once __DIR__ . '/../inc/Core/Database/BaseRepository.php';
 	require_once __DIR__ . '/../inc/Core/Database/TransactionScope.php';
+	require_once __DIR__ . '/../inc/Core/DataPacketStore.php';
 	require_once __DIR__ . '/../inc/Core/JobStatus.php';
 	require_once __DIR__ . '/../inc/Core/Database/Jobs/Jobs.php';
 
@@ -169,6 +170,14 @@ namespace {
 	$assert( 'gate-step' === $engine['step_input_packets']['next-step'][0]['metadata']['flow_step_id'], 'winner binds payload to the gate step' );
 	$assert( array( 1 ) === $GLOBALS['wpdb']->actions, 'exactly one scheduler action commits' );
 	$assert( ! array_key_exists( 'job_status', $engine ), 'winner clears waiting override' );
+	$assert( 'processing' === $engine['run_lifecycle']['status'], 'winner commits the processing lifecycle projection' );
+	$assert(
+		array(
+			array( 42, 'datamachine_engine_data' ),
+			array( 42, 'datamachine_engine_data' ),
+		) === $GLOBALS['cache_deletes'],
+		'winner invalidates engine cache before and after commit'
+	);
 
 	$GLOBALS['wpdb'] = new WebhookGateFakeWpdb( $token );
 	$wrong_token     = ( new \DataMachine\Core\Database\Jobs\Jobs() )->claim_webhook_gate_resume( 42, str_repeat( 'b', 64 ), '2026-08-21T12:00:00Z', $packet, $schedule );
@@ -182,10 +191,18 @@ namespace {
 		return 1;
 	} );
 	$rollback_engine              = json_decode( $GLOBALS['wpdb']->row['engine_data'], true );
-	$assert( ! $rolled_back['success'] && 'receipt_persistence_failed' === $rolled_back['reason'], 'failed receipt write reports persistence failure' );
+	$assert( ! $rolled_back['success'] && 'lifecycle_persistence_failed' === $rolled_back['reason'], 'failed lifecycle write reports persistence failure' );
 	$assert( 'waiting' === $GLOBALS['wpdb']->row['status'], 'failed transaction preserves waiting status' );
 	$assert( 'waiting' === $rollback_engine['webhook_gate']['status'], 'failed transaction preserves waiting gate' );
 	$assert( array() === $GLOBALS['wpdb']->actions, 'failed transaction rolls back scheduler action' );
+
+	$GLOBALS['wpdb']                        = new WebhookGateFakeWpdb( $token );
+	$GLOBALS['wpdb']->fail_lifecycle_update = true;
+	$lifecycle_failure                     = ( new \DataMachine\Core\Database\Jobs\Jobs() )->claim_webhook_gate_resume( 42, $token, '2026-08-21T12:00:00Z', $packet, $schedule );
+	$lifecycle_engine                      = json_decode( $GLOBALS['wpdb']->row['engine_data'], true );
+	$assert( ! $lifecycle_failure['success'] && 'lifecycle_persistence_failed' === $lifecycle_failure['reason'], 'lifecycle projection failure fails the claim' );
+	$assert( 'waiting' === $GLOBALS['wpdb']->row['status'] && 'waiting' === $lifecycle_engine['webhook_gate']['status'], 'lifecycle failure rolls back payload, receipt, and status' );
+	$assert( array() === $GLOBALS['wpdb']->actions, 'lifecycle failure rolls back scheduler action' );
 
 	$GLOBALS['wpdb']                     = new WebhookGateFakeWpdb( $token );
 	$GLOBALS['wpdb']->row['engine_data'] = '{invalid';


### PR DESCRIPTION
## Summary
- serialize duplicate Webhook Gate deliveries on the locked jobs row and validate the exact waiting gate/token before ownership changes
- persist the webhook payload, Action Scheduler row, durable action receipt, waiting-override removal, and `processing` transition in one database transaction
- return idempotent replay responses to losers without payload writes or downstream scheduling, while failing closed for malformed/stale state and transaction failures

## Race and ownership boundary
Previously, concurrent deliveries could both read `waiting`, then both pass an idempotent `processing` transition and call the non-unique schedule hook. The new `Jobs::claim_webhook_gate_resume()` operation takes `SELECT ... FOR UPDATE` ownership of the job row. Under that lock it verifies the persisted job and gate are waiting and the token matches exactly, then stores step input, inserts the Action Scheduler action, records its action ID, clears the waiting override, and transitions the job to `processing` before commit.

A contender that reaches the row after commit sees the durable received receipt and returns `already_resumed`; it does not persist its payload or enqueue another action. A received gate without both persisted input and a positive scheduler receipt fails closed.

## Concurrency evidence
- deterministic transaction smoke covers two same-token deliveries, exactly one committed action and payload, immutable winner receipt, wrong token, malformed engine data, and scheduler/receipt rollback
- WordPress integration coverage verifies one pending Action Scheduler row, replay after downstream status changes, payload/status/scheduler rollback paths, and two-connection MySQL row-lock serialization when `mysqli` async support is available

## Verification
- `php tests/webhook-gate-single-winner-smoke.php` (17 assertions)
- `php tests/transaction-scope-smoke.php`
- changed-file PHP syntax checks
- `git diff --check`
- Homeboy scoped lint: pass, zero findings (`dc4e26a5-d738-46c7-afa2-eab74dc59ea7`)
- Homeboy scoped audit: pass, zero introduced findings (`bdf92146-bb00-48b3-b117-788cc84860b8`)
- Homeboy package/build: pass
- Homeboy PHPUnit/Codebox was attempted repeatedly, including focused and candidate-equivalent runs, but the runner reported zero executed tests because its recipe JSON was unparseable (`f38ff300-9aaf-4350-adf4-8448e28a6505`). This infrastructure failure is tracked at Extra-Chill/homeboy#12795 with this run's evidence attached.

Closes #3302