### PR TITLE
fix: make pipeline CSV flow export lossless

### DIFF
--- a/docs/core-system/import-export.md
+++ b/docs/core-system/import-export.md
@@ -13,16 +13,20 @@ The import/export system handles pipeline structures including steps, configurat
 Pipeline export generates a CSV file containing complete pipeline and flow configuration data:
 
 ```csv
-pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,settings
-1,"News Pipeline",0,"fetch","{""step_type"":""fetch""}","","",""
+format_version,row_type,pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,settings
+1.0,flow,1,"News Pipeline",,,,10,"Morning News","{""scheduling_config"":{""interval"":""hourly"",""enabled"":true},""portable_slug"":""morning-news""}"
+1.0,pipeline_step,1,"News Pipeline",0,"fetch","{""step_type"":""fetch""}",,,
 ```
 
 ### Export Structure
 
-The CSV export includes two types of rows:
+The canonical 1.0 CSV export includes three typed rows:
 
-1. **Pipeline Structure Rows**: Define the pipeline steps and their configurations
-2. **Flow Configuration Rows**: Detail how each flow implements the pipeline steps with canonical settings such as `handler_slugs` and `handler_configs`
+1. **`pipeline_step` rows**: Define pipeline steps and their configurations.
+2. **`flow` rows**: Represent every flow independently of its step settings. The `settings` object contains canonical `scheduling_config` desired state and a stable, per-pipeline `portable_slug` used for idempotent identity even when flows share a name.
+3. **`flow_step` rows**: Detail how a flow implements a pipeline step. Portable settings include handler selection/configuration, handler-free settings, tool allow/deny lists, queues and queue mode, completion assertions, tool runtime rules, and enabled/disabled state.
+
+The `format_version` value is `1.0`. Import rejects an unversioned, differently versioned, incorrectly typed, or malformed metadata row rather than guessing and silently dropping behavior. The lossy unversioned header used during pre-1.0 development is intentionally unsupported under the 1.0 baseline.
 
 Export through `POST /wp-json/wp-abilities/v1/abilities/datamachine/export-pipelines/run`. The curated `GET /wp-json/datamachine/v1/pipelines?format=csv&ids=1,2` endpoint is also available when a raw CSV download response is required.
 
@@ -32,19 +36,21 @@ Export through `POST /wp-json/wp-abilities/v1/abilities/datamachine/export-pipel
 
 Pipeline import processes CSV data to recreate pipeline structures and flow configurations:
 
-1. Parses CSV rows to identify pipeline names and step configurations
-2. Creates pipelines if they don't exist
-3. Adds pipeline steps with proper execution ordering
-4. Maintains flow-specific handler configurations
+1. Validates the complete CSV before making writes.
+2. Creates or reuses pipelines and position-matched steps.
+3. Creates or reuses every named flow and applies its schedule through the canonical create/update flow abilities.
+4. Restores portable flow-step behavior against freshly generated step IDs.
 
 Import through `POST /wp-json/wp-abilities/v1/abilities/datamachine/import-pipelines/run`. Successful ability payloads include the imported pipeline IDs. The curated `datamachine/v1/pipelines` controller does not provide CSV import.
 
 ### Import Behavior
 
-- **Pipeline Creation**: Automatically creates pipelines with default flow configurations
-- **Step Synchronization**: Adds steps to existing pipelines without duplication
-- **Flow Preservation**: Maintains existing flow configurations while adding new pipeline steps
-- **Error Handling**: Skips invalid rows and logs issues for troubleshooting
+- **Pipeline Creation**: Creates pipelines without a synthetic fallback flow; exported flow metadata is authoritative.
+- **Step Synchronization**: Reuses position- and type-matched steps on repeated imports instead of duplicating them.
+- **Flow Preservation**: Preserves distinct named and handler-free flows in export order.
+- **Schedule Reconciliation**: Restores manual, recurring, cron, one-time, paused, webhook, rate-limit, and run-artifact desired state while allowing the scheduling layer to regenerate Action Scheduler metadata.
+- **Error Handling**: Rejects malformed canonical rows and logs the reason.
+- **Idempotency**: Reimporting the same CSV reuses pipeline steps and flows and reconciles schedules rather than adding duplicates.
 
 ## Security & Permissions
 
@@ -70,3 +76,6 @@ Store pipeline configurations in external version control systems for change tra
 - **Execution Ordering**: Pipeline steps are sorted by `execution_order` during export
 - **Flow Isolation**: Each flow's handler configurations are preserved independently
 - **Database Integration**: Import/export is implemented by `DataMachine\Engine\Actions\ImportExport` and surfaced through `inc/Abilities/Pipeline/ImportExportAbility.php`; the WordPress Abilities REST runner and curated CSV export route use that same action layer.
+- **Portable Boundary**: Database IDs identify relationships inside one CSV but are remapped on import. Installation-scoped `user_id` and `agent_id` ownership is not portable and is resolved by the canonical create-flow ability on the target installation.
+- **Scheduler Metadata**: `interval_seconds`, `first_run`, `scheduled_time`, `action_id`, reconciliation records, and last-suppressed-run observations are runtime state, not desired behavior. Export omits them explicitly; create/update flow abilities regenerate current scheduler metadata.
+- **Secret Scope**: The canonical action layer currently carries handler and webhook configuration verbatim. Secret projection is a separate contract and is not changed by the lossless flow format.

--- a/docs/development/1-0-baseline.md
+++ b/docs/development/1-0-baseline.md
@@ -14,7 +14,7 @@ Data Machine 1.0 supports one current schema and one current runtime contract. F
 
 - Ability failures are `WP_Error`; successful callbacks return their documented payload.
 - REST, WP-CLI, and AI tools may shape native results at their presentation boundary, but internal code does not accept legacy failure arrays.
-- Pipeline CSV uses `pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,settings`. `settings` contains canonical portable flow-step fields; the redundant scalar handler column is not accepted.
+- Pipeline CSV uses `format_version,row_type,pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,settings`. Every row declares format version `1.0` and one of `pipeline_step`, `flow`, or `flow_step`. A durable `flow` metadata row carries canonical schedule desired state independently of step settings; `flow_step.settings` carries canonical portable flow-step fields. The lossy unversioned pre-1.0 header and redundant scalar handler column are not accepted.
 - Pending actions use the canonical `agents/resolve-pending-action` ability. The deprecated `datamachine/resolve-pending-action` alias remains a bounded active edge only because installed Intelligence releases consume it; it maps directly to the canonical ability.
 
 Compatibility is retained only for a named current external or persisted contract. New compatibility paths require that consumer or data requirement to be documented alongside the code.

--- a/inc/Api/Flows/FlowScheduling.php
+++ b/inc/Api/Flows/FlowScheduling.php
@@ -35,45 +35,24 @@ class FlowScheduling {
 	 *
 	 * @param array       $current         Current scheduling_config from DB.
 	 * @param string|null $interval        Incoming interval key.
-	 * @param string|null $cron_expression Incoming cron expression.
 	 * @param array       $incoming        Full incoming scheduling_config.
 	 * @param int         $flow_id         Flow ID for AS action verification.
 	 * @return bool True if scheduling hasn't changed and can be skipped.
 	 */
-	private static function scheduling_unchanged( array $current, ?string $interval, ?string $cron_expression, array $incoming, int $flow_id = 0 ): bool {
-		$current_interval = $current['interval'] ?? null;
+	private static function scheduling_unchanged( array $current, ?string $interval, array $incoming, int $flow_id = 0 ): bool {
+		$current_desired  = self::portable_desired_config( $current );
+		$incoming_desired = self::portable_desired_config( $incoming );
 
-		// If current is empty/unset and incoming is non-manual, it's a change.
-		if ( empty( $current_interval ) && null !== $interval && 'manual' !== $interval ) {
+		$current_desired['interval']  = $current_desired['interval'] ?? 'manual';
+		$incoming_desired['interval'] = $interval ?? 'manual';
+
+		if ( $current_desired !== $incoming_desired ) {
 			return false;
 		}
 
-		// Both manual — only unchanged when no stale schedule still owns coverage.
-		if ( ( 'manual' === $current_interval || null === $current_interval )
-			&& ( 'manual' === $interval || null === $interval ) ) {
+		// Manual desired state is converged only when no stale action remains.
+		if ( 'manual' === $incoming_desired['interval'] || false === ( $incoming_desired['enabled'] ?? true ) ) {
 			return $flow_id <= 0 || ! RecurringScheduler::hasLogicalCoverage( self::FLOW_HOOK, array( $flow_id ) );
-		}
-
-		// Config matches — but verify the AS action actually exists.
-		$config_matches = false;
-
-		if ( $current_interval === $interval && 'cron' !== $interval && 'one_time' !== $interval ) {
-			$config_matches = true;
-		}
-
-		if ( 'cron' === $current_interval && 'cron' === $interval ) {
-			$current_cron   = $current['cron_expression'] ?? '';
-			$config_matches = ( $current_cron === $cron_expression );
-		}
-
-		if ( 'one_time' === $current_interval && 'one_time' === $interval ) {
-			$current_ts     = $current['timestamp'] ?? null;
-			$incoming_ts    = $incoming['timestamp'] ?? null;
-			$config_matches = ( $current_ts === $incoming_ts );
-		}
-
-		if ( ! $config_matches ) {
-			return false;
 		}
 
 		// Verify AS action is actually pending.
@@ -82,6 +61,17 @@ class FlowScheduling {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Compare portable desired state without scheduler-owned observations.
+	 */
+	public static function portable_desired_config( array $config ): array {
+		foreach ( array( 'interval_seconds', 'first_run', 'scheduled_time', 'action_id', self::RECONCILIATION_KEY, 'datamachine_last_suppressed_run' ) as $runtime_key ) {
+			unset( $config[ $runtime_key ] );
+		}
+
+		return $config;
 	}
 
 	/**
@@ -121,7 +111,7 @@ class FlowScheduling {
 
 		// Skip re-scheduling if unchanged (prevents timer resets on flow updates).
 		if ( ! $force ) {
-			if ( self::scheduling_unchanged( $current_scheduling, $interval, $cron_expression, $scheduling_config, (int) $flow_id ) ) {
+			if ( self::scheduling_unchanged( $current_scheduling, $interval, $scheduling_config, (int) $flow_id ) ) {
 				return true;
 			}
 		}

--- a/inc/Engine/Actions/ImportExport.php
+++ b/inc/Engine/Actions/ImportExport.php
@@ -11,6 +11,7 @@
 
 namespace DataMachine\Engine\Actions;
 
+use DataMachine\Api\Flows\FlowScheduling;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\FlowStepConfigFactory;
 use DataMachine\Engine\PortableFlowStepFields;
@@ -22,13 +23,18 @@ if ( ! defined( 'WPINC' ) ) {
 
 class ImportExport {
 
+	private const CSV_FORMAT_VERSION = '1.0';
+	private const CSV_HEADER         = array( 'format_version', 'row_type', 'pipeline_id', 'pipeline_name', 'step_position', 'step_type', 'step_config', 'flow_id', 'flow_name', 'settings' );
+
 	/**
 	 * Import canonical pipeline CSV.
 	 *
-	 * Two-pass CSV import:
-	 *   Pass 1 — pipeline-structure rows (flow_id empty): create pipelines and add steps
+	 * Three-pass CSV import:
+	 *   Pass 1 — pipeline rows: create pipelines and add or reuse steps
 	 *            with their full step_config (#1133 step 1).
-	 *   Pass 2 — flow-step rows (flow_id present): ensure target flows exist, then write
+	 *   Pass 2 — flow metadata rows: create or update every named flow with its
+	 *            canonical scheduling configuration.
+	 *   Pass 3 — flow-step rows: write
 	 *            canonical handler fields into each flow_config entry keyed by the
 	 *            freshly-generated flow_step_id (#1133 step 2, #1293 shape cleanup).
 	 *
@@ -64,38 +70,37 @@ class ImportExport {
 
 		// Pass 1: pipelines + steps.
 		foreach ( $parsed_rows as $row ) {
-			if ( '' !== $row['flow_id'] ) {
-				continue;
-			}
-
 			$pipeline_name = $row['pipeline_name'];
 
 			if ( ! isset( $pipeline_ids_by_name[ $pipeline_name ] ) ) {
 				$pipeline_id = $this->ensure_pipeline( $pipeline_name );
 				if ( ! $pipeline_id ) {
-					continue;
+					return false;
 				}
 				$pipeline_ids_by_name[ $pipeline_name ] = $pipeline_id;
 				$imported_pipelines[]                   = $pipeline_id;
 			}
 
-			if ( ! $row['step_type'] ) {
+			if ( 'pipeline_step' !== $row['row_type'] ) {
 				continue;
 			}
 
-			$pipeline_step_id = $this->add_step_to_pipeline(
+			$pipeline_step_id = $this->ensure_pipeline_step(
 				$pipeline_ids_by_name[ $pipeline_name ],
+				$row['step_position'],
 				$row['step_type'],
 				$row['step_config']
 			);
 			if ( $pipeline_step_id ) {
 				$step_id_map[ $pipeline_name ][ $row['step_position'] ] = $pipeline_step_id;
+			} else {
+				return false;
 			}
 		}
 
-		// Pass 2: flows + handler configs.
+		// Pass 2: durable flow metadata.
 		foreach ( $parsed_rows as $row ) {
-			if ( '' === $row['flow_id'] ) {
+			if ( 'flow' !== $row['row_type'] ) {
 				continue;
 			}
 
@@ -106,42 +111,48 @@ class ImportExport {
 
 			$imported_pipeline_id = $pipeline_ids_by_name[ $pipeline_name ];
 			$source_flow_id       = $row['flow_id'];
-			$flow_name            = '' !== $row['flow_name'] ? $row['flow_name'] : 'Flow';
+			$flow_name            = $row['flow_name'];
 
+			$new_flow_id = $this->ensure_flow( $imported_pipeline_id, $flow_name, $row['metadata'] );
+			if ( ! $new_flow_id ) {
+				return false;
+			}
+			$flow_id_map[ $pipeline_name ][ $source_flow_id ] = $new_flow_id;
+		}
+
+		// Pass 3: flow-step settings.
+		foreach ( $parsed_rows as $row ) {
+			if ( 'flow_step' !== $row['row_type'] ) {
+				continue;
+			}
+
+			$pipeline_name  = $row['pipeline_name'];
+			$source_flow_id = $row['flow_id'];
 			if ( ! isset( $flow_id_map[ $pipeline_name ][ $source_flow_id ] ) ) {
-				$new_flow_id = $this->ensure_flow( $imported_pipeline_id, $flow_name );
-				if ( ! $new_flow_id ) {
-					continue;
-				}
-				$flow_id_map[ $pipeline_name ][ $source_flow_id ] = $new_flow_id;
+				return false;
 			}
 
 			$imported_flow_id = $flow_id_map[ $pipeline_name ][ $source_flow_id ];
 			$pipeline_step_id = $step_id_map[ $pipeline_name ][ $row['step_position'] ] ?? null;
 			if ( ! $pipeline_step_id ) {
-				continue;
+				return false;
 			}
 
 			$settings = $row['settings'];
 
 			try {
-				$this->restore_flow_step_config(
+				$restored = $this->restore_flow_step_config(
 					$imported_flow_id,
 					$pipeline_step_id,
 					$row['step_type'],
 					$settings
 				);
+				if ( ! $restored ) {
+					return false;
+				}
 			} catch ( \InvalidArgumentException $e ) {
 				do_action( 'datamachine_log', 'error', 'Import: malformed portable flow-step settings: ' . $e->getMessage() );
 				return false;
-			}
-		}
-
-		// Ensure every imported pipeline has at least one flow (fallback for exports with
-		// no flow rows — e.g. a pipeline containing only AI steps with no handlers).
-		foreach ( $pipeline_ids_by_name as $pipeline_name => $imported_pipeline_id ) {
-			if ( ! isset( $flow_id_map[ $pipeline_name ] ) ) {
-				$this->ensure_flow( $imported_pipeline_id, 'Default Flow' );
 			}
 		}
 
@@ -156,17 +167,17 @@ class ImportExport {
 	 *
 	 * @param string $data Raw CSV content.
 	 * @return array<int, array{
-	 *     pipeline_name:string, step_position:int, step_type:string, step_config:array,
-	 *     flow_id:string, flow_name:string, settings:array
+	 *     row_type:string, pipeline_name:string, step_position:int, step_type:string,
+	 *     step_config:array, flow_id:string, flow_name:string, settings:array, metadata:array
 	 * }>
 	 */
+	// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation exceptions are logged, not rendered.
 	private function parse_csv_rows( string $data ): array {
-		$rows            = str_getcsv( $data, "\n" );
-		$parsed          = array();
-		$header          = isset( $rows[0] ) ? str_getcsv( $rows[0] ) : array();
-		$expected_header = array( 'pipeline_id', 'pipeline_name', 'step_position', 'step_type', 'step_config', 'flow_id', 'flow_name', 'settings' );
-		if ( $expected_header !== $header ) {
-			throw new \InvalidArgumentException( 'CSV header does not match the Data Machine 1.0 pipeline format.' );
+		$rows   = str_getcsv( $data, "\n" );
+		$parsed = array();
+		$header = isset( $rows[0] ) ? str_getcsv( $rows[0] ) : array();
+		if ( self::CSV_HEADER !== $header ) {
+			throw $this->csv_error( 'CSV header does not match the Data Machine 1.0 pipeline format.' );
 		}
 
 		foreach ( $rows as $index => $row ) {
@@ -175,41 +186,99 @@ class ImportExport {
 			}
 
 			$cols = str_getcsv( $row );
-			if ( count( $cols ) < 8 ) {
+			if ( 1 === count( $cols ) && '' === trim( (string) $cols[0] ) ) {
 				continue;
 			}
-
-			$step_config = json_decode( $cols[4], true );
-			if ( ! is_array( $step_config ) ) {
-				$step_config = array();
+			if ( count( $cols ) !== count( self::CSV_HEADER ) ) {
+				throw $this->csv_error( sprintf( 'CSV row %d must contain exactly %d columns.', $index + 1, count( self::CSV_HEADER ) ) );
+			}
+			if ( self::CSV_FORMAT_VERSION !== $cols[0] ) {
+				throw $this->csv_error( sprintf( 'CSV row %d uses unsupported format version %s.', $index + 1, (string) $cols[0] ) );
 			}
 
-			$settings_raw = $cols[7] ?? '';
-			$settings     = json_decode( $settings_raw, true );
-			if ( ! is_array( $settings ) ) {
-				$settings = array();
+			$row_type = (string) $cols[1];
+			if ( ! in_array( $row_type, array( 'pipeline_step', 'flow', 'flow_step' ), true ) ) {
+				throw $this->csv_error( sprintf( 'CSV row %d has invalid row_type.', $index + 1 ) );
+			}
+
+			$pipeline_name = (string) $cols[3];
+			if ( '' === trim( $pipeline_name ) ) {
+				throw $this->csv_error( sprintf( 'CSV row %d is missing pipeline_name.', $index + 1 ) );
+			}
+
+			$step_config = array();
+			if ( 'pipeline_step' === $row_type ) {
+				$step_config = json_decode( $cols[6], true );
+				if ( ! is_array( $step_config ) ) {
+					throw $this->csv_error( sprintf( 'CSV pipeline_step row %d has malformed step_config.', $index + 1 ) );
+				}
+				if ( '' === (string) $cols[5] ) {
+					throw $this->csv_error( sprintf( 'CSV pipeline_step row %d is missing step_type.', $index + 1 ) );
+				}
+			}
+
+			$settings = array();
+			if ( in_array( $row_type, array( 'flow', 'flow_step' ), true ) ) {
+				$settings = json_decode( $cols[9], true );
+				if ( ! is_array( $settings ) ) {
+					throw $this->csv_error( sprintf( 'CSV %s row %d has malformed settings.', $row_type, $index + 1 ) );
+				}
+				if ( '' === (string) $cols[7] ) {
+					throw $this->csv_error( sprintf( 'CSV %s row %d is missing flow_id.', $row_type, $index + 1 ) );
+				}
+				if ( 'flow_step' === $row_type && empty( $settings ) ) {
+					throw $this->csv_error( sprintf( 'CSV flow_step row %d must contain portable settings.', $index + 1 ) );
+				}
+			}
+
+			$metadata = array();
+			if ( 'flow' === $row_type ) {
+				if ( '' === trim( (string) $cols[8] ) ) {
+					throw $this->csv_error( sprintf( 'CSV flow row %d is missing flow_name.', $index + 1 ) );
+				}
+				if ( ! array_key_exists( 'scheduling_config', $settings ) || ! is_array( $settings['scheduling_config'] ) ) {
+					throw $this->csv_error( sprintf( 'CSV flow row %d must contain an object scheduling_config.', $index + 1 ) );
+				}
+				if ( empty( $settings['portable_slug'] ) || ! is_string( $settings['portable_slug'] ) ) {
+					throw $this->csv_error( sprintf( 'CSV flow row %d must contain a non-empty portable_slug.', $index + 1 ) );
+				}
+				$unsupported_metadata = array_diff( array_keys( $settings ), array( 'scheduling_config', 'portable_slug' ) );
+				if ( ! empty( $unsupported_metadata ) ) {
+					throw $this->csv_error( sprintf( 'CSV flow row %d contains unsupported metadata: %s.', $index + 1, implode( ', ', $unsupported_metadata ) ) );
+				}
+				$metadata = $settings;
 			}
 
 			$parsed[] = array(
-				'pipeline_name' => (string) $cols[1],
-				'step_position' => (int) $cols[2],
-				'step_type'     => (string) $cols[3],
+				'row_type'      => $row_type,
+				'pipeline_name' => $pipeline_name,
+				'step_position' => '' === $cols[4] ? -1 : (int) $cols[4],
+				'step_type'     => (string) $cols[5],
 				'step_config'   => $step_config,
-				'flow_id'       => (string) ( $cols[5] ?? '' ),
-				'flow_name'     => (string) ( $cols[6] ?? '' ),
+				'flow_id'       => (string) $cols[7],
+				'flow_name'     => (string) $cols[8],
 				'settings'      => $settings,
+				'metadata'      => $metadata,
 			);
 		}
 
 		return $parsed;
 	}
+	// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+
+	/**
+	 * Build a CSV validation exception whose text is logged, never rendered.
+	 */
+	private function csv_error( string $message ): \InvalidArgumentException {
+		// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception text is logged, not rendered.
+		return new \InvalidArgumentException( $message );
+	}
 
 	/**
 	 * Ensure a pipeline with the given name exists; return its id.
 	 *
-	 * Reuses any existing pipeline with a matching name. When a new pipeline is created we
-	 * deliberately skip auto-flow-creation (no flow_config) — flows are created in pass 2
-	 * from the CSV, with a final "Default Flow" fallback for exports that carry no flow rows.
+	 * Reuses any existing pipeline with a matching name. New pipelines deliberately skip
+	 * auto-flow-creation because durable flow metadata rows are authoritative in pass 2.
 	 */
 	private function ensure_pipeline( string $pipeline_name ): ?int {
 		$existing_id = $this->find_pipeline_by_name( $pipeline_name );
@@ -242,9 +311,33 @@ class ImportExport {
 	}
 
 	/**
-	 * Add a step to a pipeline with its full step_config; return the new pipeline_step_id.
+	 * Reuse the step already at this position or add it with its full step_config.
 	 */
-	private function add_step_to_pipeline( int $pipeline_id, string $step_type, array $step_config ): ?string {
+	private function ensure_pipeline_step( int $pipeline_id, int $position, string $step_type, array $step_config ): ?string {
+		$db_pipelines = new \DataMachine\Core\Database\Pipelines\Pipelines();
+		$pipeline     = $db_pipelines->get_pipeline( $pipeline_id );
+		$existing     = is_array( $pipeline['pipeline_config'] ?? null ) ? $pipeline['pipeline_config'] : array();
+		uasort(
+			$existing,
+			static fn( $a, $b ) => ( $a['execution_order'] ?? 0 ) <=> ( $b['execution_order'] ?? 0 )
+		);
+		$existing_step = array_values( $existing )[ $position ] ?? null;
+		if ( is_array( $existing_step ) ) {
+			if ( ( $existing_step['step_type'] ?? '' ) !== $step_type ) {
+				do_action(
+					'datamachine_log',
+					'error',
+					'Import: existing pipeline step type does not match CSV',
+					array(
+						'pipeline_id'   => $pipeline_id,
+						'step_position' => $position,
+					)
+				);
+				return null;
+			}
+			return isset( $existing_step['pipeline_step_id'] ) ? (string) $existing_step['pipeline_step_id'] : null;
+		}
+
 		$ability = wp_get_ability( 'datamachine/add-pipeline-step' );
 		if ( ! $ability ) {
 			return null;
@@ -268,46 +361,79 @@ class ImportExport {
 	/**
 	 * Ensure a flow matching the given name exists on the pipeline; return its id.
 	 *
-	 * Reuses an existing flow by exact name match (case-sensitive) so repeated imports of
-	 * the same export don't spawn duplicate flows. Otherwise creates a new flow.
+	 * Reuses stable portable identity first. The name fallback claims only an unkeyed flow,
+	 * allowing one pre-format import to converge without collapsing duplicate names.
 	 */
-	private function ensure_flow( int $pipeline_id, string $flow_name ): ?int {
-		$db_flows = new \DataMachine\Core\Database\Flows\Flows();
+	private function ensure_flow( int $pipeline_id, string $flow_name, array $metadata ): ?int {
+		$db_flows      = new \DataMachine\Core\Database\Flows\Flows();
+		$portable_slug = $metadata['portable_slug'];
+		$matched_flow  = $db_flows->get_by_portable_slug( $pipeline_id, $portable_slug );
+		$flow_id       = $matched_flow ? (int) $matched_flow['flow_id'] : null;
 
-		$existing = $db_flows->get_flows_for_pipeline( $pipeline_id );
-		foreach ( $existing as $flow ) {
-			if ( isset( $flow['flow_name'] ) && $flow['flow_name'] === $flow_name ) {
-				return (int) $flow['flow_id'];
+		if ( null === $flow_id ) {
+			$existing = $db_flows->get_flows_for_pipeline( $pipeline_id );
+			foreach ( $existing as $flow ) {
+				if ( empty( $flow['portable_slug'] ) && isset( $flow['flow_name'] ) && $flow['flow_name'] === $flow_name ) {
+					$flow_id = (int) $flow['flow_id'];
+					break;
+				}
 			}
 		}
 
-		$create_flow = wp_get_ability( 'datamachine/create-flow' );
-		if ( ! $create_flow ) {
-			do_action( 'datamachine_log', 'error', 'Import: create-flow ability not available' );
-			return null;
-		}
+		$scheduling_config = $metadata['scheduling_config'];
+		if ( null === $flow_id ) {
+			$create_flow = wp_get_ability( 'datamachine/create-flow' );
+			if ( ! $create_flow ) {
+				do_action( 'datamachine_log', 'error', 'Import: create-flow ability not available' );
+				return null;
+			}
 
-		$result = $create_flow->execute(
-			array(
-				'pipeline_id' => $pipeline_id,
-				'flow_name'   => $flow_name,
-			)
-		);
-
-		if ( is_wp_error( $result ) || empty( $result['success'] ) || empty( $result['flow_id'] ) ) {
-			do_action(
-				'datamachine_log',
-				'error',
-				'Import: failed to create flow',
+			$result = $create_flow->execute(
 				array(
-					'pipeline_id' => $pipeline_id,
-					'flow_name'   => $flow_name,
+					'pipeline_id'       => $pipeline_id,
+					'flow_name'         => $flow_name,
+					'scheduling_config' => $scheduling_config,
 				)
 			);
+
+			if ( is_wp_error( $result ) || empty( $result['success'] ) || empty( $result['flow_id'] ) ) {
+				do_action(
+					'datamachine_log',
+					'error',
+					'Import: failed to create flow',
+					array(
+						'pipeline_id' => $pipeline_id,
+						'flow_name'   => $flow_name,
+					)
+				);
+				return null;
+			}
+			$flow_id = (int) $result['flow_id'];
+		} else {
+			$update_flow = wp_get_ability( 'datamachine/update-flow' );
+			if ( ! $update_flow ) {
+				do_action( 'datamachine_log', 'error', 'Import: update-flow ability not available' );
+				return null;
+			}
+			$result = $update_flow->execute(
+				array(
+					'flow_id'           => $flow_id,
+					'flow_name'         => $flow_name,
+					'scheduling_config' => $scheduling_config,
+				)
+			);
+			if ( is_wp_error( $result ) || empty( $result['success'] ) ) {
+				do_action( 'datamachine_log', 'error', 'Import: failed to reconcile existing flow schedule', array( 'flow_id' => $flow_id ) );
+				return null;
+			}
+		}
+
+		if ( ! $db_flows->update_flow( $flow_id, array( 'portable_slug' => $portable_slug ) ) ) {
+			do_action( 'datamachine_log', 'error', 'Import: failed to restore flow portable_slug', array( 'flow_id' => $flow_id ) );
 			return null;
 		}
 
-		return (int) $result['flow_id'];
+		return $flow_id;
 	}
 
 	/**
@@ -362,8 +488,6 @@ class ImportExport {
 
 		$flow_config[ $flow_step_id ] = $step;
 
-		$flow_config[ $flow_step_id ]['enabled'] = true;
-
 		return (bool) $db_flows->update_flow(
 			$flow_id,
 			array( 'flow_config' => $flow_config )
@@ -391,7 +515,7 @@ class ImportExport {
 
 		// Build CSV using WordPress-compliant string approach
 		$csv_rows   = array();
-		$csv_rows[] = array( 'pipeline_id', 'pipeline_name', 'step_position', 'step_type', 'step_config', 'flow_id', 'flow_name', 'settings' );
+		$csv_rows[] = self::CSV_HEADER;
 
 		foreach ( $ids as $pipeline_id ) {
 			$pipeline = $db_pipelines->get_pipeline( $pipeline_id );
@@ -403,6 +527,37 @@ class ImportExport {
 			? ( json_decode( $pipeline['pipeline_config'], true ) ?? array() )
 			: ( $pipeline['pipeline_config'] ?? array() );
 			$flows           = $db_flows->get_flows_for_pipeline( $pipeline_id );
+			$used_flow_slugs = array();
+
+			foreach ( $flows as $flow ) {
+				$portable_slug = ! empty( $flow['portable_slug'] ) ? sanitize_title( (string) $flow['portable_slug'] ) : sanitize_title( (string) $flow['flow_name'] );
+				if ( '' === $portable_slug ) {
+					$portable_slug = 'flow';
+				}
+				$slug_base   = $portable_slug;
+				$slug_suffix = (int) $flow['flow_id'];
+				while ( in_array( $portable_slug, $used_flow_slugs, true ) ) {
+					$portable_slug = $slug_base . '-' . $slug_suffix;
+					++$slug_suffix;
+				}
+				$used_flow_slugs[] = $portable_slug;
+				$metadata          = array(
+					'scheduling_config' => $this->export_scheduling_config( is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array() ),
+					'portable_slug'     => $portable_slug,
+				);
+				$csv_rows[]        = array(
+					self::CSV_FORMAT_VERSION,
+					'flow',
+					$pipeline_id,
+					$pipeline['pipeline_name'],
+					'',
+					'',
+					'',
+					$flow['flow_id'],
+					$flow['flow_name'],
+					wp_json_encode( $metadata ),
+				);
+			}
 
 			$position = 0;
 			// Sort steps by execution_order for consistent export
@@ -419,12 +574,13 @@ class ImportExport {
 			foreach ( $sorted_steps as $step ) {
 				// Export pipeline structure
 				$csv_rows[] = array(
+					self::CSV_FORMAT_VERSION,
+					'pipeline_step',
 					$pipeline_id,
 					$pipeline['pipeline_name'],
 					$position++,
 					$step['step_type'] ?? '',
 					wp_json_encode( $step ),
-					'',
 					'',
 					'',
 					'',
@@ -443,6 +599,8 @@ class ImportExport {
 
 					if ( ! empty( $settings ) ) {
 						$csv_rows[] = array(
+							self::CSV_FORMAT_VERSION,
+							'flow_step',
 							$pipeline_id,
 							$pipeline['pipeline_name'],
 							$position - 1,
@@ -494,6 +652,13 @@ class ImportExport {
 	 */
 	private function normalize_portable_flow_step_settings( array $source ): array {
 		return PortableFlowStepFields::normalize_settings( $source );
+	}
+
+	/**
+	 * Remove scheduler-owned runtime observations from portable desired state.
+	 */
+	private function export_scheduling_config( array $scheduling_config ): array {
+		return FlowScheduling::portable_desired_config( $scheduling_config );
 	}
 
 	/**

--- a/inc/Engine/PortableFlowStepFields.php
+++ b/inc/Engine/PortableFlowStepFields.php
@@ -48,6 +48,12 @@ final class PortableFlowStepFields {
 			$normalized['queue_mode'] = $source['queue_mode'];
 		}
 
+		foreach ( array( 'completion_assertions', 'tool_runtime_rules', 'enabled' ) as $field ) {
+			if ( array_key_exists( $field, $source ) ) {
+				$normalized[ $field ] = self::normalize_field( $field, $source[ $field ], $message_prefix );
+			}
+		}
+
 		return $normalized;
 	}
 

--- a/tests/Unit/Engine/ImportExportStepConfigTest.php
+++ b/tests/Unit/Engine/ImportExportStepConfigTest.php
@@ -132,9 +132,10 @@ class ImportExportStepConfigTest extends WP_UnitTestCase {
 			)
 		);
 
-		$csv  = "pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,settings\n";
-		$csv .= '999,"Flow Row Guard Test",0,fetch,' . $this->csv_field( $step_config_json ) . ',,,' . "\n";
-		$csv .= '999,"Flow Row Guard Test",0,fetch,' . $this->csv_field( $step_config_json ) . ',42,"Default Flow",' . $this->csv_field( $settings_json ) . "\n";
+		$csv  = "format_version,row_type,pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,settings\n";
+		$csv .= '1.0,pipeline_step,999,"Flow Row Guard Test",0,fetch,' . $this->csv_field( $step_config_json ) . ',,,' . "\n";
+		$csv .= '1.0,flow,999,"Flow Row Guard Test",,,,42,"Default Flow",' . $this->csv_field( wp_json_encode( array( 'scheduling_config' => array( 'interval' => 'manual' ), 'portable_slug' => 'default-flow' ) ) ) . "\n";
+		$csv .= '1.0,flow_step,999,"Flow Row Guard Test",0,fetch,' . $this->csv_field( $step_config_json ) . ',42,"Default Flow",' . $this->csv_field( $settings_json ) . "\n";
 
 		$result = $this->import_export->handle_import( 'pipelines', $csv );
 		$this->assertIsArray( $result );
@@ -180,7 +181,9 @@ class ImportExportStepConfigTest extends WP_UnitTestCase {
 				'max_items' => 25,
 			),
 		);
-		$flow_config[ $source_flow_step ]['enabled'] = true;
+		$flow_config[ $source_flow_step ]['completion_assertions'] = array( 'required_tool_names' => array( 'publish_result' ) );
+		$flow_config[ $source_flow_step ]['tool_runtime_rules']    = array( array( 'id' => 'publish-result', 'max_calls' => 1 ) );
+		$flow_config[ $source_flow_step ]['enabled']               = false;
 		$this->db_flows->update_flow( (int) $source_flow_id, array( 'flow_config' => $flow_config ) );
 
 		// Export.
@@ -234,37 +237,154 @@ class ImportExportStepConfigTest extends WP_UnitTestCase {
 			),
 			FlowStepConfig::getPrimaryHandlerConfig( $imported_step )
 		);
-		$this->assertTrue( $imported_step['enabled'] );
+		$this->assertFalse( $imported_step['enabled'] );
+		$this->assertSame( array( 'required_tool_names' => array( 'publish_result' ) ), $imported_step['completion_assertions'] );
+		$this->assertSame( array( array( 'id' => 'publish-result', 'max_calls' => 1 ) ), $imported_step['tool_runtime_rules'] );
 	}
 
-	public function test_import_without_flow_rows_creates_default_flow_fallback(): void {
-		// Pipeline with only an AI step and no handler-bearing flow — export emits no flow
-		// rows, so import should still leave the pipeline with at least one flow.
+	public function test_round_trip_preserves_handler_free_flows_schedules_and_is_idempotent(): void {
 		$created            = $this->create_pipeline_ability->execute(
-			array( 'pipeline_name' => 'Empty Flow Source' )
+			array( 'pipeline_name' => 'Lossless Flow Source' )
 		);
 		$source_pipeline_id = $created['pipeline_id'];
-		$this->step_abilities->executeAddPipelineStep(
+		$add_result         = $this->step_abilities->executeAddPipelineStep(
 			array(
 				'pipeline_id' => $source_pipeline_id,
 				'step_type'   => 'ai',
 			)
 		);
+		$source_step_id = $add_result['pipeline_step_id'];
 
-		// Delete any auto-created flows on the source so the export has no flow rows.
-		foreach ( $this->db_flows->get_flows_for_pipeline( $source_pipeline_id ) as $flow ) {
-			$this->db_flows->delete_flow( (int) $flow['flow_id'] );
-		}
+		$create_flow = wp_get_ability( 'datamachine/create-flow' );
+		$this->assertNotNull( $create_flow );
+
+		$paused_schedule = array(
+			'interval'           => 'manual',
+			'enabled'            => false,
+			'webhook_enabled'    => true,
+			'webhook_auth_mode'  => 'hmac',
+			'webhook_rate_limit' => array( 'requests' => 12, 'window' => 60 ),
+			'run_artifacts'      => array( 'completion_assertions' => array( 'egress' => array( 'artifact' ) ) ),
+		);
+		$recurring_schedule = array(
+			'interval'      => 'qtrdaily',
+			'enabled'       => true,
+			'run_artifacts' => array( 'completion_assertions' => array( 'egress' => array( 'artifact', 'bundle-file' ) ) ),
+		);
+
+		$paused_result = $create_flow->execute(
+			array(
+				'pipeline_id'       => $source_pipeline_id,
+				'flow_name'         => 'Paused Webhook Flow',
+				'scheduling_config' => $paused_schedule,
+			)
+		);
+		$recurring_result = $create_flow->execute(
+			array(
+				'pipeline_id'       => $source_pipeline_id,
+				'flow_name'         => 'Recurring Artifact Flow',
+				'scheduling_config' => $recurring_schedule,
+			)
+		);
+		$this->assertNotWPError( $paused_result );
+		$this->assertNotWPError( $recurring_result );
+
+		$paused_flow_id = (int) $paused_result['flow_id'];
+		$this->db_flows->update_flow( $paused_flow_id, array( 'portable_slug' => 'paused-webhook' ) );
+		$paused_flow         = $this->db_flows->get_flow( $paused_flow_id );
+		$paused_flow_step_id = apply_filters( 'datamachine_generate_flow_step_id', '', $source_step_id, $paused_flow_id );
+		$paused_flow['flow_config'][ $paused_flow_step_id ]['completion_assertions'] = array( 'required_tool_names' => array( 'publish_result' ) );
+		$paused_flow['flow_config'][ $paused_flow_step_id ]['tool_runtime_rules']    = array( array( 'id' => 'publish-result', 'max_calls' => 1 ) );
+		$paused_flow['flow_config'][ $paused_flow_step_id ]['enabled']               = false;
+		$this->db_flows->update_flow( $paused_flow_id, array( 'flow_config' => $paused_flow['flow_config'] ) );
 
 		$csv         = $this->import_export->handle_export( 'pipelines', array( $source_pipeline_id ) );
-		$csv_renamed = str_replace( 'Empty Flow Source', 'Empty Flow Target', $csv );
+		$csv_renamed = str_replace( 'Lossless Flow Source', 'Lossless Flow Target', $csv );
+		$this->assertSame( 2, substr_count( $csv_renamed, ',flow,' ), 'Every flow must have exactly one durable metadata row.' );
 
 		$result = $this->import_export->handle_import( 'pipelines', $csv_renamed );
 		$this->assertCount( 1, $result['imported'] );
+		$imported_pipeline_id = (int) $result['imported'][0];
 
-		$imported_flows = $this->db_flows->get_flows_for_pipeline( (int) $result['imported'][0] );
-		$this->assertCount( 1, $imported_flows, 'Exports with no flow rows should still produce one default flow on import.' );
-		$this->assertSame( 'Default Flow', $imported_flows[0]['flow_name'] );
+		$imported_flows = $this->db_flows->get_flows_for_pipeline( $imported_pipeline_id );
+		$this->assertCount( 2, $imported_flows );
+		$this->assertSame( array( 'Paused Webhook Flow', 'Recurring Artifact Flow' ), array_column( $imported_flows, 'flow_name' ) );
+
+		$imported_paused = $imported_flows[0];
+		$this->assertSame( 'paused-webhook', $imported_paused['portable_slug'] );
+		foreach ( $paused_schedule as $key => $value ) {
+			$this->assertSame( $value, $imported_paused['scheduling_config'][ $key ] ?? null, "Paused schedule field {$key} must round-trip." );
+		}
+		foreach ( $recurring_schedule as $key => $value ) {
+			$this->assertSame( $value, $imported_flows[1]['scheduling_config'][ $key ] ?? null, "Recurring schedule field {$key} must round-trip." );
+		}
+
+		$steps_result     = $this->step_abilities->executeGetPipelineSteps( array( 'pipeline_id' => $imported_pipeline_id ) );
+		$imported_step_id = $steps_result['steps'][0]['pipeline_step_id'];
+		$imported_flow_step_id = apply_filters( 'datamachine_generate_flow_step_id', '', $imported_step_id, (int) $imported_paused['flow_id'] );
+		$imported_step = $imported_paused['flow_config'][ $imported_flow_step_id ];
+		$this->assertFalse( $imported_step['enabled'] );
+		$this->assertSame( array( 'required_tool_names' => array( 'publish_result' ) ), $imported_step['completion_assertions'] );
+		$this->assertSame( array( array( 'id' => 'publish-result', 'max_calls' => 1 ) ), $imported_step['tool_runtime_rules'] );
+
+		$flow_ids_before = array_map( 'intval', array_column( $imported_flows, 'flow_id' ) );
+		$second_result   = $this->import_export->handle_import( 'pipelines', $csv_renamed );
+		$this->assertSame( array( $imported_pipeline_id ), array_values( $second_result['imported'] ) );
+		$flows_after = $this->db_flows->get_flows_for_pipeline( $imported_pipeline_id );
+		$this->assertSame( $flow_ids_before, array_map( 'intval', array_column( $flows_after, 'flow_id' ) ) );
+		$steps_after = $this->step_abilities->executeGetPipelineSteps( array( 'pipeline_id' => $imported_pipeline_id ) );
+		$this->assertCount( 1, $steps_after['steps'], 'Repeated import must not duplicate pipeline steps.' );
+	}
+
+	public function test_round_trip_keeps_distinct_zero_step_flows_with_the_same_name(): void {
+		$created            = $this->create_pipeline_ability->execute( array( 'pipeline_name' => 'Duplicate Flow Source' ) );
+		$source_pipeline_id = (int) $created['pipeline_id'];
+		$create_flow        = wp_get_ability( 'datamachine/create-flow' );
+
+		foreach ( array( false, true ) as $enabled ) {
+			$result = $create_flow->execute(
+				array(
+					'pipeline_id'       => $source_pipeline_id,
+					'flow_name'         => 'Shared Name',
+					'scheduling_config' => array(
+						'interval' => 'manual',
+						'enabled'  => $enabled,
+					),
+				)
+			);
+			$this->assertNotWPError( $result );
+		}
+
+		$csv = $this->import_export->handle_export( 'pipelines', array( $source_pipeline_id ) );
+		$csv = str_replace( 'Duplicate Flow Source', 'Duplicate Flow Target', $csv );
+
+		$first_import = $this->import_export->handle_import( 'pipelines', $csv );
+		$pipeline_id  = (int) $first_import['imported'][0];
+		$flows        = $this->db_flows->get_flows_for_pipeline( $pipeline_id );
+		$this->assertCount( 2, $flows );
+		$this->assertSame( array( 'Shared Name', 'Shared Name' ), array_column( $flows, 'flow_name' ) );
+		$this->assertCount( 2, array_unique( array_column( $flows, 'portable_slug' ) ) );
+		$this->assertSame( array( false, true ), array_column( array_column( $flows, 'scheduling_config' ), 'enabled' ) );
+
+		$this->import_export->handle_import( 'pipelines', $csv );
+		$this->assertCount( 2, $this->db_flows->get_flows_for_pipeline( $pipeline_id ), 'Repeated import must not collapse or duplicate same-name flows.' );
+	}
+
+	public function test_import_rejects_malformed_flow_metadata_before_writes(): void {
+		$csv  = "format_version,row_type,pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,settings\n";
+		$csv .= '1.0,flow,77,"Malformed Metadata",,,,42,"Named Flow",{}' . "\n";
+
+		$this->assertFalse( $this->import_export->handle_import( 'pipelines', $csv ) );
+		$this->assertNull( $this->find_pipeline_id( 'Malformed Metadata' ) );
+	}
+
+	private function find_pipeline_id( string $name ): ?int {
+		foreach ( $this->db_pipelines->get_all_pipelines() as $pipeline ) {
+			if ( $name === $pipeline['pipeline_name'] ) {
+				return (int) $pipeline['pipeline_id'];
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/tests/import-export-portable-flow-settings-smoke.php
+++ b/tests/import-export-portable-flow-settings-smoke.php
@@ -84,7 +84,7 @@ $import_export = new ImportExport();
 $parse_csv = new ReflectionMethod( ImportExport::class, 'parse_csv_rows' );
 $canonical_rows = $parse_csv->invoke(
 	$import_export,
-	"pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,settings\n1,Example,0,fetch,{},,,{}"
+	"format_version,row_type,pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,settings\n1.0,pipeline_step,1,Example,0,fetch,{},,,"
 );
 assert_csv_equals( 1, count( $canonical_rows ), 'canonical 1.0 CSV header is accepted', $failures, $passes );
 
@@ -92,7 +92,7 @@ $old_header_rejected = false;
 try {
 	$parse_csv->invoke(
 		$import_export,
-		"pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,handler,settings\n1,Example,0,fetch,{},,,rss,{}"
+		"pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,settings\n1,Example,0,fetch,{},,,{}"
 	);
 } catch ( InvalidArgumentException $e ) {
 	$old_header_rejected = true;
@@ -152,15 +152,21 @@ $normalized = call_import_export_private(
 	$import_export,
 	'normalize_portable_flow_step_settings',
 	array(
-		'enabled_tools' => array( 'datamachine/read-github-file' ),
-		'queue_mode'    => 'static',
-		'prompt_queue'  => array( array( 'prompt' => 'Pinned prompt.' ) ),
+		'enabled_tools'        => array( 'datamachine/read-github-file' ),
+		'queue_mode'           => 'static',
+		'prompt_queue'         => array( array( 'prompt' => 'Pinned prompt.' ) ),
+		'completion_assertions' => array( 'required_tool_names' => array( 'publish_result' ) ),
+		'tool_runtime_rules'    => array( array( 'id' => 'publish-result', 'max_calls' => 1 ) ),
+		'enabled'               => false,
 	)
 );
 
 assert_csv_equals( array( 'datamachine/read-github-file' ), $normalized['enabled_tools'] ?? null, 'import normalization keeps enabled_tools', $failures, $passes );
 assert_csv_equals( array( array( 'prompt' => 'Pinned prompt.' ) ), $normalized['prompt_queue'] ?? null, 'import normalization keeps prompt_queue', $failures, $passes );
 assert_csv_equals( 'static', $normalized['queue_mode'] ?? null, 'import normalization keeps queue_mode', $failures, $passes );
+assert_csv_equals( array( 'required_tool_names' => array( 'publish_result' ) ), $normalized['completion_assertions'] ?? null, 'import normalization keeps completion_assertions', $failures, $passes );
+assert_csv_equals( array( array( 'id' => 'publish-result', 'max_calls' => 1 ) ), $normalized['tool_runtime_rules'] ?? null, 'import normalization keeps tool_runtime_rules', $failures, $passes );
+assert_csv_equals( false, $normalized['enabled'] ?? null, 'import normalization keeps disabled step state', $failures, $passes );
 assert_csv_equals( false, array_key_exists( 'handler_slug', $normalized ), 'portable normalization does not duplicate handler fields', $failures, $passes );
 
 $normalized_patch = call_import_export_private(
@@ -200,6 +206,17 @@ try {
 	$threw = str_contains( $e->getMessage(), 'config_patch_queue entries must include an object patch' );
 }
 assert_csv_equals( true, $threw, 'malformed config_patch_queue fails clearly', $failures, $passes );
+
+$threw = false;
+try {
+	$parse_csv->invoke(
+		$import_export,
+		"format_version,row_type,pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,settings\n1.0,flow,1,Example,,,,42,Named Flow,{}"
+	);
+} catch ( InvalidArgumentException $e ) {
+	$threw = str_contains( $e->getMessage(), 'must contain an object scheduling_config' );
+}
+assert_csv_equals( true, $threw, 'flow metadata without scheduling_config fails clearly', $failures, $passes );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " portable flow settings assertions failed.\n";


### PR DESCRIPTION
## Summary
- evolve the canonical 1.0 pipeline CSV into an explicitly versioned, typed-row format with one durable metadata row per flow
- preserve flow identity, count, order, schedules, webhook/rate-limit/run-artifact policy, and portable step behavior across import/export
- make repeated imports reuse stable flow and pipeline-step identities while failing closed on malformed or incomplete rows

## Format evolution

The canonical header is now `format_version,row_type,pipeline_id,pipeline_name,step_position,step_type,step_config,flow_id,flow_name,settings`. Version `1.0` supports `pipeline_step`, `flow`, and `flow_step` rows. Every flow receives a `flow` row containing its desired `scheduling_config` and a stable per-pipeline `portable_slug`, independent of whether any step has settings.

The lossy unversioned pre-1.0 header is intentionally rejected. This follows the 1.0 baseline policy rather than adding a compatibility transform for a format that has not shipped as a supported legacy contract.

## Lossless semantics

- distinct and same-name handler-free flows survive through stable portable identity
- flow-step settings preserve enabled state, completion assertions, tool runtime rules, tool policies, queues, handler-free settings, and canonical handler configuration
- runtime-only scheduler observations are explicitly excluded and documented; installation-scoped user/agent ownership remains target-resolved
- malformed metadata, unsupported metadata fields, missing mappings, and persistence failures reject the import instead of silently dropping state

## Schedule reconciliation

Flow creation and updates pass the imported desired schedule through the canonical create/update flow abilities. The scheduling no-op guard now compares the complete portable desired state, not only interval/cron timing, so paused state and webhook, rate-limit, and run-artifact changes persist while existing Action Scheduler coverage remains idempotent and missing coverage is repaired.

## Tests

- `php tests/import-export-portable-flow-settings-smoke.php`
- `php tests/flow-schedule-reconciler-smoke.php`
- `php tests/flow-schedule-reconciliation-deferred-smoke.php`
- `php tests/flow-schedule-reconciliation-lock-smoke.php`
- changed-file PHP syntax checks and `git diff --check`
- `homeboy review lint --changed-since=origin/main --summary --placement=local` (zero findings)
- `homeboy review audit --changed-since=origin/main --summary --placement=local` (no introduced drift)
- `homeboy --placement local review build data-machine` (frontend build, package validation, PHP syntax, and production ZIP passed)

Database-backed round-trip tests were added for multiple handler-free flows, same-name zero-step flows, non-default schedules, step behavior, malformed metadata, and idempotent import. The local candidate PHPUnit transport was attempted twice but WP Codebox returned `recipe_run_payload_unparseable` with zero executed tests; the direct local WordPress harness was also unavailable because no test-database credentials were exposed. PR CI remains the authoritative database-backed run.

Closes #3301