### PR TITLE
fix(chat): retry migration updates after deadlocks

### DIFF
--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -374,7 +374,8 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			}
 		}
 
-		$sql      = 'UPDATE %i SET ' . implode( ', ', $set ) . ' WHERE ' . implode( ' AND ', $predicates );
+		$sql = 'UPDATE %i SET ' . implode( ', ', $set ) . ' WHERE ' . implode( ' AND ', $predicates );
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$prepared = $wpdb->prepare( $sql, ...$arguments );
 		for ( $attempt = 1; $attempt <= self::MIGRATION_DEADLOCK_ATTEMPTS; ++$attempt ) {
 			$previous_suppression = method_exists( $wpdb, 'suppress_errors' ) ? $wpdb->suppress_errors( true ) : null;
@@ -394,10 +395,10 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				'warning',
 				'Chat session migration update deadlocked; retrying',
 				array(
-					'session_id'  => (string) ( $canonical['session_id'] ?? '' ),
-					'attempt'     => $attempt,
+					'session_id'   => (string) ( $canonical['session_id'] ?? '' ),
+					'attempt'      => $attempt,
 					'max_attempts' => self::MIGRATION_DEADLOCK_ATTEMPTS,
-					'db_error'    => $db_error,
+					'db_error'     => $db_error,
 				)
 			);
 

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -15,6 +15,7 @@ use DataMachine\Core\Admin\DateFormatter;
 use DataMachine\Abilities\Chat\ChatTranscriptOwner;
 use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\Database\BaseRepository;
+use DataMachine\Core\Database\LifecycleStateTransition;
 use AgentsAPI\AI\WP_Agent_Execution_Principal;
 use AgentsAPI\AI\WP_Agent_Message;
 use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
@@ -36,6 +37,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Chat extends BaseRepository implements ConversationStoreInterface {
 	private const MIGRATION_BATCH_SIZE            = 100;
 	private const MIGRATION_COLLISION_PROBE_LIMIT = 100;
+	private const MIGRATION_DEADLOCK_ATTEMPTS     = 5;
+	private const MIGRATION_DEADLOCK_BACKOFF_US   = 20000;
 	private const MIGRATION_NUMERIC_COLUMNS       = array( 'user_id', 'agent_id' );
 
 	/**
@@ -371,9 +374,37 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 			}
 		}
 
-		$sql = 'UPDATE %i SET ' . implode( ', ', $set ) . ' WHERE ' . implode( ' AND ', $predicates );
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
-		return $wpdb->query( $wpdb->prepare( $sql, ...$arguments ) );
+		$sql      = 'UPDATE %i SET ' . implode( ', ', $set ) . ' WHERE ' . implode( ' AND ', $predicates );
+		$prepared = $wpdb->prepare( $sql, ...$arguments );
+		for ( $attempt = 1; $attempt <= self::MIGRATION_DEADLOCK_ATTEMPTS; ++$attempt ) {
+			$previous_suppression = method_exists( $wpdb, 'suppress_errors' ) ? $wpdb->suppress_errors( true ) : null;
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+			$updated  = $wpdb->query( $prepared );
+			$db_error = (string) $wpdb->last_error;
+			if ( null !== $previous_suppression ) {
+				$wpdb->suppress_errors( $previous_suppression );
+			}
+
+			if ( false !== $updated || ! LifecycleStateTransition::is_deadlock_error( $db_error ) || $attempt >= self::MIGRATION_DEADLOCK_ATTEMPTS ) {
+				return $updated;
+			}
+
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Chat session migration update deadlocked; retrying',
+				array(
+					'session_id'  => (string) ( $canonical['session_id'] ?? '' ),
+					'attempt'     => $attempt,
+					'max_attempts' => self::MIGRATION_DEADLOCK_ATTEMPTS,
+					'db_error'    => $db_error,
+				)
+			);
+
+			usleep( self::MIGRATION_DEADLOCK_BACKOFF_US * $attempt + random_int( 0, self::MIGRATION_DEADLOCK_BACKOFF_US ) );
+		}
+
+		return false;
 	}
 
 	private static function migration_row_is_unscoped( array $row ): bool {

--- a/inc/Core/Database/LifecycleStateTransition.php
+++ b/inc/Core/Database/LifecycleStateTransition.php
@@ -113,7 +113,7 @@ class LifecycleStateTransition {
 	 * @param string $error The wpdb last_error string.
 	 * @return bool True when the error is a deadlock or lock-wait timeout.
 	 */
-	private static function is_deadlock_error( string $error ): bool {
+	public static function is_deadlock_error( string $error ): bool {
 		if ( '' === $error ) {
 			return false;
 		}

--- a/tests/chat-sessions-network-convergence-smoke.php
+++ b/tests/chat-sessions-network-convergence-smoke.php
@@ -216,6 +216,11 @@ namespace {
 		public string $last_error = '';
 		public bool $fail_insert = false;
 		public bool $force_update_zero = false;
+		public bool $errors_suppressed = false;
+		public int $leaked_errors = 0;
+		public array $deadlocks_remaining = array();
+		public array $migration_update_queries = array();
+		public function suppress_errors( bool $suppress = true ): bool { $previous = $this->errors_suppressed; $this->errors_suppressed = $suppress; return $previous; }
 		public function get_blog_prefix( int $blog_id ): string { return 1 === $blog_id ? 'wp_' : 'wp_' . $blog_id . '_'; }
 		public function prepare( string $query, ...$args ): string {
 			$prepared_query = $query;
@@ -307,11 +312,19 @@ namespace {
 			$GLOBALS['chat_tables'][ $table ][ $id ] = array_merge( $GLOBALS['chat_tables'][ $table ][ $id ], $data );
 			return empty( $changed ) ? 0 : 1;
 		}
-		public function query( string $query ): int {
+		public function query( string $query ): int|false {
 			if ( preg_match( "/^UPDATE '([^']+)' SET (.*) WHERE (.*)$/", $query, $matches ) && str_contains( $matches[3], 'BINARY ' ) ) {
 				$table = $matches[1];
 				preg_match( "/BINARY 'session_id' = BINARY ('(?:''|[^'])*')/", $matches[3], $id_match );
 				$id = isset( $id_match[1] ) ? $this->unquote( $id_match[1] ) : '';
+				$this->migration_update_queries[] = $query;
+				if ( 0 < ( $this->deadlocks_remaining[ $id ] ?? 0 ) ) {
+					--$this->deadlocks_remaining[ $id ];
+					$this->last_error = 'Deadlock found when trying to get lock; try restarting transaction';
+					if ( ! $this->errors_suppressed ) { ++$this->leaked_errors; }
+					return false;
+				}
+				$this->last_error = '';
 				if ( ! isset( $GLOBALS['chat_tables'][ $table ][ $id ] ) ) { return 0; }
 				if ( isset( $GLOBALS['chat_concurrent_updates'][ $id ] ) ) {
 					$GLOBALS['chat_tables'][ $table ][ $id ] = array_merge( $GLOBALS['chat_tables'][ $table ][ $id ], $GLOBALS['chat_concurrent_updates'][ $id ] );
@@ -383,6 +396,7 @@ namespace {
 	function delete_site_option( string $key ): bool { unset( $GLOBALS['chat_site_options'][ $key ] ); return true; }
 	function do_action( string $hook, ...$args ): void { $GLOBALS['chat_logs'][] = array( $hook, $args ); }
 
+	require_once dirname( __DIR__ ) . '/inc/Core/Database/LifecycleStateTransition.php';
 	require_once dirname( __DIR__ ) . '/inc/Core/Database/Chat/Chat.php';
 	require_once dirname( __DIR__ ) . '/inc/setup/chat-sessions-network.php';
 
@@ -462,6 +476,24 @@ namespace {
 	);
 	$assert( '2026-01-01 00:00:00' === $read_at, 'same-second scoped mark-read is an idempotent success after ownership verification' );
 	$GLOBALS['wpdb']->force_update_zero = false;
+
+	$update_target = new \ReflectionMethod( \DataMachine\Core\Database\Chat\Chat::class, 'update_migration_target' );
+	$observed      = $GLOBALS['chat_tables']['wp_datamachine_chat_sessions']['legacy-user'];
+	$query_offset  = count( $GLOBALS['wpdb']->migration_update_queries );
+	$GLOBALS['wpdb']->deadlocks_remaining['legacy-user'] = 2;
+	$updated = $update_target->invoke( null, 'wp_datamachine_chat_sessions', $observed, $observed );
+	$retry_queries = array_slice( $GLOBALS['wpdb']->migration_update_queries, $query_offset );
+	$assert( 0 === $updated && 3 === count( $retry_queries ), 'transient migration deadlocks retry until the exact CAS succeeds' );
+	$assert( 1 === count( array_unique( $retry_queries ) ), 'deadlock retries preserve the complete optimistic row-match predicate' );
+	$assert( 0 === $GLOBALS['wpdb']->leaked_errors && ! $GLOBALS['wpdb']->errors_suppressed, 'recovered deadlocks do not leak database output or alter caller suppression state' );
+
+	$query_offset = count( $GLOBALS['wpdb']->migration_update_queries );
+	$GLOBALS['wpdb']->deadlocks_remaining['legacy-user'] = 5;
+	$updated = $update_target->invoke( null, 'wp_datamachine_chat_sessions', $observed, $observed );
+	$retry_queries = array_slice( $GLOBALS['wpdb']->migration_update_queries, $query_offset );
+	$assert( false === $updated && 5 === count( $retry_queries ), 'persistent migration deadlocks stop after the bounded attempt budget' );
+	$assert( 1 === count( array_unique( $retry_queries ) ) && str_contains( $GLOBALS['wpdb']->last_error, 'Deadlock found' ), 'exhaustion retains the exact CAS and database error for convergence reporting' );
+	$assert( 0 === $GLOBALS['wpdb']->leaked_errors && ! $GLOBALS['wpdb']->errors_suppressed, 'exhausted retries remain contained and restore caller suppression state' );
 
 	$GLOBALS['chat_tables']['wp_7_datamachine_chat_sessions']['unmappable'] = array( 'session_id' => 'unmappable', 'user_id' => 1, 'messages' => '[]', 'metadata' => '{}', 'context' => 'chat' );
 	$GLOBALS['chat_home_urls'][7] = '';


### PR DESCRIPTION
## Summary
- retry chat-session migration compare-and-set updates after transient MySQL/MariaDB deadlocks or lock-wait timeouts
- suppress recoverable `wpdb` error output during the bounded retry window while restoring the caller's suppression state
- cover transient recovery, exhausted retries, unchanged optimistic predicates, and idempotent convergence

## Root cause
Concurrent multisite bootstraps can enumerate the same immutable per-site source tables and converge the same `session_id` into the shared network table. There is no explicit migration transaction or inconsistent application lock ordering; each process independently reaches the same primary-key target row. InnoDB/MariaDB can choose one optimistic `UPDATE ... WHERE <complete observed row>` as a deadlock victim while another bootstrap or chat writer holds conflicting row/index locks. The migration previously treated the transient `wpdb::query()` failure as terminal, so bootstrap leaked the database error into unrelated WP-CLI commands.

## Safety
The migration retries only errors recognized by Data Machine's existing transient-lock classifier (`Deadlock found` and `Lock wait timeout exceeded`). The policy is bounded at five total attempts with linear jittered backoff, matching the existing lifecycle-transition retry budget and giving competing transactions time to release locks.

Every attempt replays the exact same prepared compare-and-set statement, including the complete byte-exact observed-row predicates. A concurrent row change therefore produces a normal zero-row match, after which the existing convergence loop re-reads and reconciles the new snapshot. No unconditional write is introduced, and convergence remains idempotent. Non-transient SQL failures and exhausted transient failures still return through the existing convergence failure path with `wpdb::last_error` intact.

## Tests
Passed:
- `php tests/chat-sessions-network-convergence-smoke.php`
- `php -l inc/Core/Database/Chat/Chat.php && php -l inc/Core/Database/LifecycleStateTransition.php && php -l tests/chat-sessions-network-convergence-smoke.php`
- `vendor/bin/phpcs inc/Core/Database/Chat/Chat.php inc/Core/Database/LifecycleStateTransition.php tests/chat-sessions-network-convergence-smoke.php`
- `git diff --check`

Additional adjacent smoke commands were attempted but fail on current `main`-derived code before exercising this change:
- `php tests/job-status-transition-smoke.php`: missing `DataMachine\\Core\\Database\\TransactionScope` in the standalone harness
- `php tests/run-lifecycle-store-smoke.php`: standalone fake `wpdb` lacks `get_var()`

## Residual risk
This policy relies on MySQL/MariaDB-compatible `wpdb::last_error` text for error classification. It does not inspect vendor error numbers, which `wpdb` does not expose through this call path. A persistent lock cycle still fails convergence after five attempts, but remains contained and reportable rather than retrying indefinitely.

Fixes #3311