### PR TITLE
fix: encrypt queued email payloads at rest

### DIFF
--- a/inc/Abilities/Publish/SendEmailQueuedAbility.php
+++ b/inc/Abilities/Publish/SendEmailQueuedAbility.php
@@ -58,9 +58,11 @@ class SendEmailQueuedAbility {
 	/**
 	 * Retry backoff in seconds applied between attempts.
 	 */
-	private const RETRY_BACKOFF_SECONDS     = 300;
-	private const CLEANUP_RETENTION_SECONDS = 604800;
-	private const LOCK_TIMEOUT_SECONDS      = 5;
+	private const RETRY_BACKOFF_SECONDS      = 300;
+	private const CLEANUP_RETENTION_SECONDS  = 604800;
+	private const CLEANUP_LOCK_RETRY_SECONDS = 300;
+	private const MAX_CLEANUP_LOCK_RETRIES   = 1;
+	private const LOCK_TIMEOUT_SECONDS       = 5;
 
 	/**
 	 * Authenticated queue payload and compact reference formats.
@@ -347,15 +349,21 @@ class SendEmailQueuedAbility {
 
 		// Action Scheduler receives only a compact authenticated reference. The
 		// encrypted envelope remains in a non-autoloaded option until dispatch.
-		$as_args = array( $reference );
+		$as_args       = array( $reference );
+		$scheduled_for = null === $timestamp ? time() : $timestamp;
+
+		// Establish bounded orphan cleanup before making the send runnable. If
+		// cleanup cannot be scheduled, no send action may retain this payload.
+		if ( ! $this->schedulePayloadCleanup( $reference, $scheduled_for ) ) {
+			$this->deleteStoredPayload( $reference );
+			return $this->queueError( 'email_queue_cleanup_failed', 'Failed to schedule email payload cleanup.', 500, $logs );
+		}
 
 		try {
 			if ( null === $timestamp ) {
-				$action_id     = as_enqueue_async_action( self::WORKER_HOOK, $as_args, self::GROUP );
-				$scheduled_for = time();
+				$action_id = as_enqueue_async_action( self::WORKER_HOOK, $as_args, self::GROUP );
 			} else {
-				$action_id     = as_schedule_single_action( $timestamp, self::WORKER_HOOK, $as_args, self::GROUP );
-				$scheduled_for = $timestamp;
+				$action_id = as_schedule_single_action( $timestamp, self::WORKER_HOOK, $as_args, self::GROUP );
 			}
 		} catch ( \Throwable ) {
 			$this->deleteStoredPayload( $reference );
@@ -369,15 +377,6 @@ class SendEmailQueuedAbility {
 				'message' => 'Email queue: Action Scheduler did not return an action id',
 			);
 			return $this->queueError( 'email_queue_failed', 'Failed to schedule email action.', 500, $logs );
-		}
-
-		if ( ! $this->schedulePayloadCleanup( $reference, $scheduled_for ) ) {
-			// The send action already owns this payload. Never roll it back merely
-			// because best-effort orphan cleanup could not be scheduled.
-			$logs[] = array(
-				'level'   => 'warning',
-				'message' => 'Email queue: payload cleanup could not be scheduled',
-			);
 		}
 
 		$logs[] = array(
@@ -473,7 +472,17 @@ class SendEmailQueuedAbility {
 			return;
 		}
 		if ( ! $this->acquireReferenceLock( $reference_id ) ) {
-			do_action( 'datamachine_log', 'warning', 'Email queue cleanup: payload dispatch still active', array( 'reason' => 'email_queue_cleanup_locked' ) );
+			$retry_reference = $this->nextCleanupReference( $reference );
+			$retry_scheduled = ! is_wp_error( $retry_reference ) && $this->scheduleCleanupLockRetry( $retry_reference );
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Email queue cleanup: payload dispatch still active',
+				array(
+					'reason'          => 'email_queue_cleanup_locked',
+					'retry_scheduled' => $retry_scheduled,
+				)
+			);
 			return;
 		}
 		try {
@@ -559,6 +568,11 @@ class SendEmailQueuedAbility {
 			);
 			return;
 		}
+		if ( $created_retry_store && ! $this->schedulePayloadCleanup( $retry_reference, $retry_at ) ) {
+			$this->deleteStoredPayload( $retry_reference );
+			do_action( 'datamachine_log', 'error', 'Email worker: retry payload cleanup scheduling failed', array( 'attempt' => $attempt ) );
+			return;
+		}
 
 		try {
 			$retry_action_id = as_schedule_single_action( $retry_at, self::WORKER_HOOK, array( $retry_reference ), self::GROUP );
@@ -572,10 +586,6 @@ class SendEmailQueuedAbility {
 			do_action( 'datamachine_log', 'error', 'Email worker: retry scheduling failed', array( 'attempt' => $attempt ) );
 			return;
 		}
-		if ( $created_retry_store && ! $this->schedulePayloadCleanup( $retry_reference, $retry_at ) ) {
-			do_action( 'datamachine_log', 'warning', 'Email worker: retry payload cleanup could not be scheduled', array( 'attempt' => $attempt ) );
-		}
-
 		do_action(
 			'datamachine_log',
 			'warning',
@@ -729,6 +739,17 @@ class SendEmailQueuedAbility {
 	}
 
 	/**
+	 * Reschedule cleanup once when a live dispatch owns the reference lock.
+	 */
+	private function scheduleCleanupLockRetry( array $reference ): bool {
+		try {
+			return ! empty( as_schedule_single_action( time() + self::CLEANUP_LOCK_RETRY_SECONDS, self::CLEANUP_HOOK, array( $reference ), self::GROUP ) );
+		} catch ( \Throwable ) {
+			return false;
+		}
+	}
+
+	/**
 	 * Acquire a bounded connection-scoped MySQL lock for one opaque reference.
 	 */
 	private function acquireReferenceLock( string $reference_id ): bool {
@@ -762,14 +783,30 @@ class SendEmailQueuedAbility {
 	/**
 	 * Build an authenticated opaque scheduler reference.
 	 */
-	private function payloadReference( string $reference_id ): array {
+	private function payloadReference( string $reference_id, int $cleanup_attempt = 0 ): array {
 		return array(
 			self::REFERENCE_KEY => array(
-				'version' => self::REFERENCE_VERSION,
-				'id'      => $reference_id,
-				'mac'     => hash_hmac( 'sha256', self::REFERENCE_CONTEXT . '|' . $reference_id, $this->queuedPayloadKey() ),
+				'version'         => self::REFERENCE_VERSION,
+				'id'              => $reference_id,
+				'cleanup_attempt' => $cleanup_attempt,
+				'mac'             => $this->referenceMac( $reference_id, $cleanup_attempt ),
 			),
 		);
+	}
+
+	/**
+	 * Advance the authenticated cleanup generation at most once.
+	 */
+	private function nextCleanupReference( array $reference ): array|\WP_Error {
+		$reference_id = $this->validatePayloadReference( $reference );
+		if ( is_wp_error( $reference_id ) ) {
+			return $reference_id;
+		}
+		$cleanup_attempt = (int) $reference[ self::REFERENCE_KEY ]['cleanup_attempt'];
+		if ( $cleanup_attempt >= self::MAX_CLEANUP_LOCK_RETRIES ) {
+			return new \WP_Error( 'email_queue_cleanup_retry_exhausted', 'Queued email cleanup retry is exhausted.' );
+		}
+		return $this->payloadReference( $reference_id, $cleanup_attempt + 1 );
 	}
 
 	/**
@@ -781,16 +818,20 @@ class SendEmailQueuedAbility {
 		}
 
 		$value = $reference[ self::REFERENCE_KEY ];
-		if ( array( 'version', 'id', 'mac' ) !== array_keys( $value ) || self::REFERENCE_VERSION !== $value['version'] || ! is_string( $value['id'] ) || ! is_string( $value['mac'] ) || 1 !== preg_match( '/^[a-f0-9]{32}$/D', $value['id'] ) ) {
+		if ( array( 'version', 'id', 'cleanup_attempt', 'mac' ) !== array_keys( $value ) || self::REFERENCE_VERSION !== $value['version'] || ! is_string( $value['id'] ) || ! is_int( $value['cleanup_attempt'] ) || $value['cleanup_attempt'] < 0 || $value['cleanup_attempt'] > self::MAX_CLEANUP_LOCK_RETRIES || ! is_string( $value['mac'] ) || 1 !== preg_match( '/^[a-f0-9]{32}$/D', $value['id'] ) ) {
 			return new \WP_Error( 'email_queue_reference_malformed', 'Queued email payload reference is malformed.' );
 		}
 
-		$expected = hash_hmac( 'sha256', self::REFERENCE_CONTEXT . '|' . $value['id'], $this->queuedPayloadKey() );
+		$expected = $this->referenceMac( $value['id'], $value['cleanup_attempt'] );
 		if ( ! hash_equals( $expected, $value['mac'] ) ) {
 			return new \WP_Error( 'email_queue_reference_invalid', 'Queued email payload reference is invalid.' );
 		}
 
 		return $value['id'];
+	}
+
+	private function referenceMac( string $reference_id, int $cleanup_attempt ): string {
+		return hash_hmac( 'sha256', self::REFERENCE_CONTEXT . '|' . $reference_id . '|' . $cleanup_attempt, $this->queuedPayloadKey() );
 	}
 
 	private function deleteStoredPayload( ?array $reference ): void {
@@ -810,7 +851,7 @@ class SendEmailQueuedAbility {
 	 */
 	private function deleteReferencedOptionByShape( array $reference ): void {
 		$value = $reference[ self::REFERENCE_KEY ] ?? null;
-		if ( ! is_array( $value ) || array( 'version', 'id', 'mac' ) !== array_keys( $value ) || ! is_string( $value['id'] ) || 1 !== preg_match( '/^[a-f0-9]{32}$/D', $value['id'] ) ) {
+		if ( ! is_array( $value ) || array( 'version', 'id', 'cleanup_attempt', 'mac' ) !== array_keys( $value ) || ! is_string( $value['id'] ) || 1 !== preg_match( '/^[a-f0-9]{32}$/D', $value['id'] ) ) {
 			return;
 		}
 		if ( ! $this->acquireReferenceLock( $value['id'] ) ) {

--- a/inc/Abilities/Publish/SendEmailQueuedAbility.php
+++ b/inc/Abilities/Publish/SendEmailQueuedAbility.php
@@ -41,6 +41,11 @@ class SendEmailQueuedAbility {
 	public const WORKER_HOOK = 'datamachine_send_email_worker';
 
 	/**
+	 * Action Scheduler hook for bounded orphan payload cleanup.
+	 */
+	public const CLEANUP_HOOK = 'datamachine_cleanup_queued_email_payload';
+
+	/**
 	 * Action Scheduler group for queued email actions.
 	 */
 	public const GROUP = 'data-machine-email';
@@ -53,7 +58,24 @@ class SendEmailQueuedAbility {
 	/**
 	 * Retry backoff in seconds applied between attempts.
 	 */
-	private const RETRY_BACKOFF_SECONDS = 300;
+	private const RETRY_BACKOFF_SECONDS     = 300;
+	private const CLEANUP_RETENTION_SECONDS = 604800;
+	private const LOCK_TIMEOUT_SECONDS      = 5;
+
+	/**
+	 * Authenticated queue payload and compact reference formats.
+	 */
+	private const ENVELOPE_KEY      = '_datamachine_encrypted_email';
+	private const ENVELOPE_VERSION  = 1;
+	private const REFERENCE_KEY     = '_datamachine_email_payload';
+	private const REFERENCE_VERSION = 1;
+	private const OPTION_PREFIX     = 'datamachine_email_payload_';
+	private const CIPHER_ALGORITHM  = 'aes-256-gcm';
+	private const IV_LENGTH         = 12;
+	private const AUTH_TAG_LENGTH   = 16;
+	private const KEY_CONTEXT       = 'datamachine-send-email-queued-v1';
+	private const REFERENCE_CONTEXT = 'datamachine-send-email-queued-reference-v1';
+	private const AAD               = 'datamachine/send-email-queued|v1|aes-256-gcm';
 
 	public function __construct() {
 		if ( null === self::$instance ) {
@@ -251,6 +273,7 @@ class SendEmailQueuedAbility {
 		}
 
 		add_action( self::WORKER_HOOK, array( $instance, 'runWorker' ), 10, 1 );
+		add_action( self::CLEANUP_HOOK, array( $instance, 'runCleanup' ), 10, 1 );
 		self::$worker_registered = true;
 	}
 
@@ -275,7 +298,7 @@ class SendEmailQueuedAbility {
 			'user_id'  => PermissionHelper::acting_user_id(),
 			'agent_id' => absint( PermissionHelper::get_acting_agent_id() ),
 			'token_id' => absint( PermissionHelper::get_acting_token_id() ),
-			'system'   => method_exists( PermissionHelper::class, 'is_authenticated_context' ) && PermissionHelper::is_authenticated_context(),
+			'system'   => PermissionHelper::is_authenticated_context(),
 		);
 		if ( $context['user_id'] <= 0 && ! $context['system'] ) {
 			return $this->queueError( 'email_queue_issuer_required', 'An identified issuer is required to queue email.', 403, $logs );
@@ -283,7 +306,7 @@ class SendEmailQueuedAbility {
 		if ( ! empty( $input['auth_ref'] ) ) {
 			$providers = apply_filters( 'datamachine_auth_providers', array() );
 			$auth      = $providers['email_imap'] ?? null;
-			if ( ! $auth || ! method_exists( $auth, 'resolve_mailbox' ) || is_wp_error( $auth->resolve_mailbox( $input['auth_ref'], 'send' ) ) ) {
+			if ( ! is_object( $auth ) || ! method_exists( $auth, 'resolve_mailbox' ) || is_wp_error( $auth->resolve_mailbox( $input['auth_ref'], 'send' ) ) ) {
 				return $this->queueError( 'email_queue_authorization_failed', 'Mailbox send authorization failed.', 403, $logs );
 			}
 		} elseif ( ! $this->canUseLegacySender() ) {
@@ -317,24 +340,44 @@ class SendEmailQueuedAbility {
 			return new \WP_Error( $timestamp->get_error_code(), $timestamp->get_error_message(), array_merge( array( 'status' => 400 ), is_array( $timestamp->get_error_data() ) ? $timestamp->get_error_data() : array(), array( 'logs' => $logs ) ) );
 		}
 
-		// Action Scheduler payload — wrap in an indexed array so the hook
-		// receives a single $payload argument.
-		$as_args = array( $input );
+		$reference = $this->storeQueuedPayload( $input );
+		if ( is_wp_error( $reference ) ) {
+			return $this->queueError( 'email_queue_encryption_failed', 'Failed to protect queued email payload.', 500, $logs );
+		}
 
-		if ( null === $timestamp ) {
-			$action_id     = as_enqueue_async_action( self::WORKER_HOOK, $as_args, self::GROUP );
-			$scheduled_for = time();
-		} else {
-			$action_id     = as_schedule_single_action( $timestamp, self::WORKER_HOOK, $as_args, self::GROUP );
-			$scheduled_for = $timestamp;
+		// Action Scheduler receives only a compact authenticated reference. The
+		// encrypted envelope remains in a non-autoloaded option until dispatch.
+		$as_args = array( $reference );
+
+		try {
+			if ( null === $timestamp ) {
+				$action_id     = as_enqueue_async_action( self::WORKER_HOOK, $as_args, self::GROUP );
+				$scheduled_for = time();
+			} else {
+				$action_id     = as_schedule_single_action( $timestamp, self::WORKER_HOOK, $as_args, self::GROUP );
+				$scheduled_for = $timestamp;
+			}
+		} catch ( \Throwable ) {
+			$this->deleteStoredPayload( $reference );
+			return $this->queueError( 'email_queue_failed', 'Failed to schedule email action.', 500, $logs );
 		}
 
 		if ( empty( $action_id ) ) {
+			$this->deleteStoredPayload( $reference );
 			$logs[] = array(
 				'level'   => 'error',
 				'message' => 'Email queue: Action Scheduler did not return an action id',
 			);
 			return $this->queueError( 'email_queue_failed', 'Failed to schedule email action.', 500, $logs );
+		}
+
+		if ( ! $this->schedulePayloadCleanup( $reference, $scheduled_for ) ) {
+			// The send action already owns this payload. Never roll it back merely
+			// because best-effort orphan cleanup could not be scheduled.
+			$logs[] = array(
+				'level'   => 'warning',
+				'message' => 'Email queue: payload cleanup could not be scheduled',
+			);
 		}
 
 		$logs[] = array(
@@ -375,15 +418,87 @@ class SendEmailQueuedAbility {
 			return;
 		}
 
+		if ( array_key_exists( self::REFERENCE_KEY, $payload ) ) {
+			$reference_id = $this->validatePayloadReference( $payload );
+			if ( is_wp_error( $reference_id ) ) {
+				$this->deleteReferencedOptionByShape( $payload );
+				do_action( 'datamachine_log', 'error', 'Email worker: stored payload reference rejected', array( 'reason' => $reference_id->get_error_code() ) );
+				return;
+			}
+
+			if ( ! $this->acquireReferenceLock( $reference_id ) ) {
+				do_action( 'datamachine_log', 'warning', 'Email worker: payload dispatch already active', array( 'reason' => 'email_queue_dispatch_locked' ) );
+				return;
+			}
+
+			try {
+				// Re-read only after acquiring the lock. A prior worker may have sent
+				// and deleted the option while this worker waited.
+				$envelope = get_option( $this->payloadOptionName( $reference_id ), null );
+				if ( ! is_array( $envelope ) ) {
+					do_action( 'datamachine_log', 'error', 'Email worker: stored payload unavailable', array( 'reason' => 'email_queue_payload_missing' ) );
+					return;
+				}
+
+				$decrypted = $this->decryptQueuedPayload( $envelope, $reference_id );
+				if ( is_wp_error( $decrypted ) ) {
+					$this->deleteStoredPayload( $payload );
+					do_action( 'datamachine_log', 'error', 'Email worker: stored payload rejected', array( 'reason' => $decrypted->get_error_code() ) );
+					return;
+				}
+
+				$this->dispatchPayload( $decrypted, $payload );
+			} finally {
+				$this->releaseReferenceLock( $reference_id );
+			}
+			return;
+		}
+
+		// Already-persisted legacy Action Scheduler jobs carry plaintext arrays.
+		$this->dispatchPayload( $payload, null );
+	}
+
+	/**
+	 * Delete an orphaned encrypted payload after its bounded retention window.
+	 *
+	 * @param mixed $reference Compact authenticated payload reference.
+	 */
+	public function runCleanup( $reference ): void {
+		if ( ! is_array( $reference ) ) {
+			return;
+		}
+		$reference_id = $this->validatePayloadReference( $reference );
+		if ( is_wp_error( $reference_id ) ) {
+			$this->deleteReferencedOptionByShape( $reference );
+			return;
+		}
+		if ( ! $this->acquireReferenceLock( $reference_id ) ) {
+			do_action( 'datamachine_log', 'warning', 'Email queue cleanup: payload dispatch still active', array( 'reason' => 'email_queue_cleanup_locked' ) );
+			return;
+		}
+		try {
+			delete_option( $this->payloadOptionName( $reference_id ) );
+		} finally {
+			$this->releaseReferenceLock( $reference_id );
+		}
+	}
+
+	/**
+	 * Verify authorization and dispatch one decrypted or legacy payload.
+	 */
+	private function dispatchPayload( array $payload, ?array $reference ): void {
+
 		$attempt = isset( $payload['_attempt'] ) ? max( 1, (int) $payload['_attempt'] ) : 1;
 		$grant   = $this->verifyMailboxGrant( $payload );
 		if ( is_wp_error( $grant ) || ! $this->currentIssuerAuthorized( $grant ) ) {
+			$this->deleteStoredPayload( $reference );
 			do_action( 'datamachine_log', 'error', 'Email worker: queued authorization denied', array( 'attempt' => $attempt ) );
 			return;
 		}
 
 		$ability = wp_get_ability( 'datamachine/send-email' );
 		if ( ! $ability ) {
+			$this->deleteStoredPayload( $reference );
 			do_action(
 				'datamachine_log',
 				'error',
@@ -397,27 +512,26 @@ class SendEmailQueuedAbility {
 		$ability_input = $payload;
 		unset( $ability_input['_attempt'] );
 
+		// Delivery is intentionally at-least-once. A process crash after the mail
+		// provider accepts the message but before local option deletion can replay
+		// it; exactly-once requires provider-supported idempotency.
 		$result = $ability->execute( $ability_input );
 
 		$success = is_array( $result ) && ! empty( $result['success'] );
 
 		if ( $success ) {
+			$this->deleteStoredPayload( $reference );
 			do_action(
 				'datamachine_log',
 				'info',
 				'Email worker: send succeeded',
-				array(
-					'attempt'    => $attempt,
-					'recipients' => $result['recipients'] ?? array(),
-					'subject'    => $result['subject'] ?? '',
-				)
+				array( 'attempt' => $attempt )
 			);
 			return;
 		}
 
-		$error_msg = is_wp_error( $result ) ? $result->get_error_message() : ( $result['error'] ?? 'invalid result' );
-
 		if ( $attempt >= self::MAX_ATTEMPTS ) {
+			$this->deleteStoredPayload( $reference );
 			do_action(
 				'datamachine_log',
 				'error',
@@ -425,7 +539,6 @@ class SendEmailQueuedAbility {
 				array(
 					'attempt'      => $attempt,
 					'max_attempts' => self::MAX_ATTEMPTS,
-					'error'        => $error_msg,
 				)
 			);
 			return;
@@ -434,8 +547,34 @@ class SendEmailQueuedAbility {
 		// Re-enqueue with backoff. Bump the attempt counter on the payload.
 		$payload['_attempt'] = $attempt + 1;
 		$retry_at            = time() + self::RETRY_BACKOFF_SECONDS;
+		$created_retry_store = null === $reference;
+		$retry_reference     = $created_retry_store ? $this->storeQueuedPayload( $payload ) : $this->replaceStoredPayload( $reference, $payload );
+		if ( is_wp_error( $retry_reference ) ) {
+			$this->deleteStoredPayload( $reference );
+			do_action(
+				'datamachine_log',
+				'error',
+				'Email worker: retry payload encryption failed',
+				array( 'attempt' => $attempt )
+			);
+			return;
+		}
 
-		$retry_action_id = as_schedule_single_action( $retry_at, self::WORKER_HOOK, array( $payload ), self::GROUP );
+		try {
+			$retry_action_id = as_schedule_single_action( $retry_at, self::WORKER_HOOK, array( $retry_reference ), self::GROUP );
+		} catch ( \Throwable ) {
+			$this->deleteStoredPayload( $retry_reference );
+			do_action( 'datamachine_log', 'error', 'Email worker: retry scheduling failed', array( 'attempt' => $attempt ) );
+			return;
+		}
+		if ( empty( $retry_action_id ) ) {
+			$this->deleteStoredPayload( $retry_reference );
+			do_action( 'datamachine_log', 'error', 'Email worker: retry scheduling failed', array( 'attempt' => $attempt ) );
+			return;
+		}
+		if ( $created_retry_store && ! $this->schedulePayloadCleanup( $retry_reference, $retry_at ) ) {
+			do_action( 'datamachine_log', 'warning', 'Email worker: retry payload cleanup could not be scheduled', array( 'attempt' => $attempt ) );
+		}
 
 		do_action(
 			'datamachine_log',
@@ -446,9 +585,257 @@ class SendEmailQueuedAbility {
 				'next_attempt'    => $attempt + 1,
 				'retry_at'        => $retry_at,
 				'retry_action_id' => $retry_action_id,
-				'error'           => $error_msg,
 			)
 		);
+	}
+
+	/**
+	 * Encrypt a complete worker payload before it enters scheduler storage.
+	 *
+	 * The key is deliberately domain-separated from OAuth credential storage.
+	 * There is no key ring: rotating WordPress auth salts makes outstanding jobs
+	 * undecryptable, and the worker rejects them with a non-secret reason code.
+	 *
+	 * @param array $payload Plaintext worker payload.
+	 * @return array<string, array<string, int|string>>|\WP_Error
+	 */
+	private function encryptQueuedPayload( array $payload, ?string $reference_id = null ): array|\WP_Error {
+		try {
+			$iv = random_bytes( self::IV_LENGTH );
+		} catch ( \Throwable ) {
+			return new \WP_Error( 'email_queue_random_failed', 'Queued email encryption could not generate a nonce.' );
+		}
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Authenticated internal payload preserves exact PHP values across dispatch.
+		$plaintext  = serialize( $payload );
+		$tag        = '';
+		$ciphertext = openssl_encrypt( $plaintext, self::CIPHER_ALGORITHM, $this->queuedPayloadKey(), OPENSSL_RAW_DATA, $iv, $tag, $this->envelopeAad( $reference_id ), self::AUTH_TAG_LENGTH );
+		if ( false === $ciphertext || self::AUTH_TAG_LENGTH !== strlen( $tag ) ) {
+			return new \WP_Error( 'email_queue_encryption_failed', 'Queued email encryption failed.' );
+		}
+
+		return array(
+			self::ENVELOPE_KEY => array(
+				'version'    => self::ENVELOPE_VERSION,
+				'algorithm'  => self::CIPHER_ALGORITHM,
+				// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encoding binary authenticated-envelope fields.
+				'iv'         => base64_encode( $iv ),
+				'tag'        => base64_encode( $tag ),
+				'ciphertext' => base64_encode( $ciphertext ),
+				// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			),
+		);
+	}
+
+	/**
+	 * Validate and decrypt a scheduler envelope at dispatch time.
+	 *
+	 * @param array $payload Raw worker argument.
+	 * @return array|\WP_Error
+	 */
+	private function decryptQueuedPayload( array $payload, ?string $reference_id = null ): array|\WP_Error {
+		if ( array( self::ENVELOPE_KEY ) !== array_keys( $payload ) || ! is_array( $payload[ self::ENVELOPE_KEY ] ) ) {
+			return new \WP_Error( 'email_queue_envelope_malformed', 'Encrypted queued email payload is malformed.' );
+		}
+
+		$envelope = $payload[ self::ENVELOPE_KEY ];
+		if ( array( 'version', 'algorithm', 'iv', 'tag', 'ciphertext' ) !== array_keys( $envelope ) ) {
+			return new \WP_Error( 'email_queue_envelope_malformed', 'Encrypted queued email payload is malformed.' );
+		}
+		if ( self::ENVELOPE_VERSION !== $envelope['version'] || self::CIPHER_ALGORITHM !== $envelope['algorithm'] ) {
+			return new \WP_Error( 'email_queue_envelope_unsupported', 'Encrypted queued email payload version is unsupported.' );
+		}
+		if ( ! is_string( $envelope['iv'] ) || ! is_string( $envelope['tag'] ) || ! is_string( $envelope['ciphertext'] ) ) {
+			return new \WP_Error( 'email_queue_envelope_malformed', 'Encrypted queued email payload is malformed.' );
+		}
+
+		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding binary authenticated-envelope fields.
+		$iv         = base64_decode( $envelope['iv'], true );
+		$tag        = base64_decode( $envelope['tag'], true );
+		$ciphertext = base64_decode( $envelope['ciphertext'], true );
+		// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		if ( false === $iv || false === $tag || false === $ciphertext || self::IV_LENGTH !== strlen( $iv ) || self::AUTH_TAG_LENGTH !== strlen( $tag ) || '' === $ciphertext ) {
+			return new \WP_Error( 'email_queue_envelope_malformed', 'Encrypted queued email payload is malformed.' );
+		}
+
+		$plaintext = openssl_decrypt( $ciphertext, self::CIPHER_ALGORITHM, $this->queuedPayloadKey(), OPENSSL_RAW_DATA, $iv, $tag, $this->envelopeAad( $reference_id ) );
+		if ( false === $plaintext ) {
+			return new \WP_Error( 'email_queue_envelope_decryption_failed', 'Encrypted queued email payload could not be decrypted.' );
+		}
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- Only authenticated ciphertext created by this class reaches unserialize.
+		$decrypted = unserialize( $plaintext, array( 'allowed_classes' => false ) );
+		if ( ! is_array( $decrypted ) ) {
+			return new \WP_Error( 'email_queue_envelope_payload_invalid', 'Encrypted queued email payload is invalid.' );
+		}
+
+		return $decrypted;
+	}
+
+	/**
+	 * Persist an encrypted payload and return its compact scheduler reference.
+	 */
+	private function storeQueuedPayload( array $payload ): array|\WP_Error {
+		for ( $attempt = 0; $attempt < 3; ++$attempt ) {
+			try {
+				$reference_id = bin2hex( random_bytes( 16 ) );
+			} catch ( \Throwable ) {
+				return new \WP_Error( 'email_queue_random_failed', 'Queued email storage could not generate a reference.' );
+			}
+
+			$envelope = $this->encryptQueuedPayload( $payload, $reference_id );
+			if ( is_wp_error( $envelope ) ) {
+				return $envelope;
+			}
+			if ( add_option( $this->payloadOptionName( $reference_id ), $envelope, '', false ) ) {
+				return $this->payloadReference( $reference_id );
+			}
+		}
+
+		return new \WP_Error( 'email_queue_storage_failed', 'Queued email payload could not be stored.' );
+	}
+
+	/**
+	 * Replace a stored envelope before scheduling its retry.
+	 */
+	private function replaceStoredPayload( array $reference, array $payload ): array|\WP_Error {
+		$reference_id = $this->validatePayloadReference( $reference );
+		if ( is_wp_error( $reference_id ) ) {
+			return $reference_id;
+		}
+
+		$envelope = $this->encryptQueuedPayload( $payload, $reference_id );
+		if ( is_wp_error( $envelope ) ) {
+			return $envelope;
+		}
+		if ( ! update_option( $this->payloadOptionName( $reference_id ), $envelope, false ) ) {
+			return new \WP_Error( 'email_queue_storage_failed', 'Queued email retry payload could not be stored.' );
+		}
+
+		return $reference;
+	}
+
+	/**
+	 * Schedule idempotent orphan cleanup well beyond the maximum retry horizon.
+	 */
+	private function schedulePayloadCleanup( array $reference, int $scheduled_for ): bool {
+		$retry_window = ( self::MAX_ATTEMPTS - 1 ) * self::RETRY_BACKOFF_SECONDS;
+		$cleanup_at   = $scheduled_for + $retry_window + self::CLEANUP_RETENTION_SECONDS;
+		try {
+			return ! empty( as_schedule_single_action( $cleanup_at, self::CLEANUP_HOOK, array( $reference ), self::GROUP ) );
+		} catch ( \Throwable ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Acquire a bounded connection-scoped MySQL lock for one opaque reference.
+	 */
+	private function acquireReferenceLock( string $reference_id ): bool {
+		global $wpdb;
+		if ( ! isset( $wpdb ) || ! is_object( $wpdb ) || ! method_exists( $wpdb, 'get_var' ) || ! method_exists( $wpdb, 'prepare' ) ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared -- MySQL advisory locks have no WordPress API.
+		$acquired = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $this->referenceLockName( $reference_id ), self::LOCK_TIMEOUT_SECONDS ) );
+		return '1' === (string) $acquired;
+	}
+
+	/**
+	 * Release a connection-scoped lock on every worker exit path.
+	 */
+	private function releaseReferenceLock( string $reference_id ): void {
+		global $wpdb;
+		if ( ! isset( $wpdb ) || ! is_object( $wpdb ) || ! method_exists( $wpdb, 'get_var' ) || ! method_exists( $wpdb, 'prepare' ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared -- Releases the matching connection-scoped advisory lock.
+		$wpdb->get_var( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $this->referenceLockName( $reference_id ) ) );
+	}
+
+	private function referenceLockName( string $reference_id ): string {
+		return 'datamachine_email_' . $reference_id;
+	}
+
+	/**
+	 * Build an authenticated opaque scheduler reference.
+	 */
+	private function payloadReference( string $reference_id ): array {
+		return array(
+			self::REFERENCE_KEY => array(
+				'version' => self::REFERENCE_VERSION,
+				'id'      => $reference_id,
+				'mac'     => hash_hmac( 'sha256', self::REFERENCE_CONTEXT . '|' . $reference_id, $this->queuedPayloadKey() ),
+			),
+		);
+	}
+
+	/**
+	 * Validate a scheduler reference before using it as an option key.
+	 */
+	private function validatePayloadReference( array $reference ): string|\WP_Error {
+		if ( array( self::REFERENCE_KEY ) !== array_keys( $reference ) || ! is_array( $reference[ self::REFERENCE_KEY ] ) ) {
+			return new \WP_Error( 'email_queue_reference_malformed', 'Queued email payload reference is malformed.' );
+		}
+
+		$value = $reference[ self::REFERENCE_KEY ];
+		if ( array( 'version', 'id', 'mac' ) !== array_keys( $value ) || self::REFERENCE_VERSION !== $value['version'] || ! is_string( $value['id'] ) || ! is_string( $value['mac'] ) || 1 !== preg_match( '/^[a-f0-9]{32}$/D', $value['id'] ) ) {
+			return new \WP_Error( 'email_queue_reference_malformed', 'Queued email payload reference is malformed.' );
+		}
+
+		$expected = hash_hmac( 'sha256', self::REFERENCE_CONTEXT . '|' . $value['id'], $this->queuedPayloadKey() );
+		if ( ! hash_equals( $expected, $value['mac'] ) ) {
+			return new \WP_Error( 'email_queue_reference_invalid', 'Queued email payload reference is invalid.' );
+		}
+
+		return $value['id'];
+	}
+
+	private function deleteStoredPayload( ?array $reference ): void {
+		if ( null === $reference ) {
+			return;
+		}
+		$reference_id = $this->validatePayloadReference( $reference );
+		if ( ! is_wp_error( $reference_id ) ) {
+			delete_option( $this->payloadOptionName( $reference_id ) );
+		}
+	}
+
+	/**
+	 * Remove storage for a syntactically bounded reference that cannot be
+	 * authenticated, including after salt rotation. The opaque 128-bit id is
+	 * accepted only in the exact reference schema and cannot select other options.
+	 */
+	private function deleteReferencedOptionByShape( array $reference ): void {
+		$value = $reference[ self::REFERENCE_KEY ] ?? null;
+		if ( ! is_array( $value ) || array( 'version', 'id', 'mac' ) !== array_keys( $value ) || ! is_string( $value['id'] ) || 1 !== preg_match( '/^[a-f0-9]{32}$/D', $value['id'] ) ) {
+			return;
+		}
+		if ( ! $this->acquireReferenceLock( $value['id'] ) ) {
+			return;
+		}
+		try {
+			delete_option( $this->payloadOptionName( $value['id'] ) );
+		} finally {
+			$this->releaseReferenceLock( $value['id'] );
+		}
+	}
+
+	private function payloadOptionName( string $reference_id ): string {
+		return self::OPTION_PREFIX . $reference_id;
+	}
+
+	private function envelopeAad( ?string $reference_id ): string {
+		return null === $reference_id ? self::AAD : self::AAD . '|' . $reference_id;
+	}
+
+	/**
+	 * Derive a queue-only 256-bit key from the WordPress auth salts.
+	 */
+	private function queuedPayloadKey(): string {
+		return hash_hmac( 'sha256', self::KEY_CONTEXT, wp_salt( 'auth' ), true );
 	}
 
 	private function createMailboxGrant( array $input, array $context ): array {

--- a/tests/send-email-template-smoke.php
+++ b/tests/send-email-template-smoke.php
@@ -44,6 +44,40 @@ $GLOBALS['ec_abilities']       = array();
 $GLOBALS['ec_action_id_seq']   = 1000;
 $GLOBALS['ec_manage_users']    = array( 1 => true );
 $GLOBALS['ec_users']           = array( 1 => true, 42 => true );
+$GLOBALS['ec_auth_salt']       = 'send-email-smoke-auth';
+$GLOBALS['ec_options']         = array();
+$GLOBALS['ec_option_autoload'] = array();
+$GLOBALS['ec_schedule_result'] = true;
+$GLOBALS['ec_schedule_throw']  = false;
+$GLOBALS['ec_options_at_schedule'] = array();
+$GLOBALS['ec_schedule_fail_hook'] = '';
+$GLOBALS['ec_wp_mail_callback'] = null;
+
+class EC_Email_Lock_Wpdb {
+	public array $locks = array();
+	public array $timeouts = array();
+
+	public function prepare( string $query, ...$args ): array {
+		return array( $query, $args );
+	}
+
+	public function get_var( array $prepared ): string {
+		list( $query, $args ) = $prepared;
+		$lock_name = (string) ( $args[0] ?? '' );
+		if ( str_contains( $query, 'GET_LOCK' ) ) {
+			$this->timeouts[] = (int) ( $args[1] ?? 0 );
+			if ( isset( $this->locks[ $lock_name ] ) ) {
+				return '0';
+			}
+			$this->locks[ $lock_name ] = true;
+			return '1';
+		}
+		unset( $this->locks[ $lock_name ] );
+		return '1';
+	}
+}
+
+$GLOBALS['wpdb'] = new EC_Email_Lock_Wpdb();
 
 if ( ! function_exists( 'add_filter' ) ) {
     function add_filter( string $hook, callable $cb, int $priority = 10, int $accepted_args = 1 ): bool {
@@ -145,7 +179,10 @@ if ( ! function_exists( 'get_bloginfo' ) ) {
 
 if ( ! function_exists( 'get_option' ) ) {
     function get_option( string $key, $default_value = null ) {
-    	if ( 'admin_email' === $key ) {
+		if ( array_key_exists( $key, $GLOBALS['ec_options'] ) ) {
+			return $GLOBALS['ec_options'][ $key ];
+		}
+		if ( 'admin_email' === $key ) {
     		return 'admin@example.com';
     	}
     	if ( 'date_format' === $key ) {
@@ -153,6 +190,32 @@ if ( ! function_exists( 'get_option' ) ) {
     	}
     	return $default_value;
     }
+}
+
+function add_option( string $key, $value, string $deprecated = '', bool $autoload = true ): bool {
+	if ( array_key_exists( $key, $GLOBALS['ec_options'] ) ) {
+		return false;
+	}
+	$GLOBALS['ec_options'][ $key ]         = $value;
+	$GLOBALS['ec_option_autoload'][ $key ] = $autoload;
+	return true;
+}
+
+function update_option( string $key, $value, bool $autoload = true ): bool {
+	if ( ! array_key_exists( $key, $GLOBALS['ec_options'] ) || $GLOBALS['ec_options'][ $key ] === $value ) {
+		return false;
+	}
+	$GLOBALS['ec_options'][ $key ]         = $value;
+	$GLOBALS['ec_option_autoload'][ $key ] = $autoload;
+	return true;
+}
+
+function delete_option( string $key ): bool {
+	if ( ! array_key_exists( $key, $GLOBALS['ec_options'] ) ) {
+		return false;
+	}
+	unset( $GLOBALS['ec_options'][ $key ], $GLOBALS['ec_option_autoload'][ $key ] );
+	return true;
 }
 
 function wp_date( string $format, ?int $timestamp = null ): string {
@@ -167,9 +230,14 @@ if ( ! function_exists( 'wp_mail' ) ) {
     		'body'        => $body,
     		'headers'     => $headers,
     		'attachments' => $attachments,
-    		'blog'        => $GLOBALS['ec_current_blog'],
-    	);
-    	return (bool) $GLOBALS['ec_wp_mail_result'];
+			'blog'        => $GLOBALS['ec_current_blog'],
+		);
+		if ( is_callable( $GLOBALS['ec_wp_mail_callback'] ) ) {
+			$callback = $GLOBALS['ec_wp_mail_callback'];
+			$GLOBALS['ec_wp_mail_callback'] = null;
+			$callback();
+		}
+		return (bool) $GLOBALS['ec_wp_mail_result'];
     }
 }
 
@@ -200,16 +268,40 @@ if ( ! function_exists( 'restore_current_blog' ) ) {
     }
 }
 
-function as_schedule_single_action( int $timestamp, string $hook, array $args = array(), string $group = '' ): int {
+function as_schedule_single_action( int $timestamp, string $hook, array $args = array(), string $group = '' ): int|false {
+	if ( $GLOBALS['ec_schedule_throw'] ) {
+		throw new RuntimeException( 'scheduler unavailable' );
+	}
+	if ( ! $GLOBALS['ec_schedule_result'] ) {
+		return false;
+	}
+	if ( $hook === $GLOBALS['ec_schedule_fail_hook'] ) {
+		return false;
+	}
+	$GLOBALS['ec_options_at_schedule'][] = count( $GLOBALS['ec_options'] );
 	$id                            = ++$GLOBALS['ec_action_id_seq'];
 	$GLOBALS['ec_scheduled'][ $id ] = array( 'kind' => 'single', 'timestamp' => $timestamp, 'hook' => $hook, 'args' => $args, 'group' => $group );
 	return $id;
 }
 
-function as_enqueue_async_action( string $hook, array $args = array(), string $group = '' ): int {
+function as_enqueue_async_action( string $hook, array $args = array(), string $group = '' ): int|false {
+	if ( $GLOBALS['ec_schedule_throw'] ) {
+		throw new RuntimeException( 'scheduler unavailable' );
+	}
+	if ( ! $GLOBALS['ec_schedule_result'] ) {
+		return false;
+	}
+	if ( $hook === $GLOBALS['ec_schedule_fail_hook'] ) {
+		return false;
+	}
+	$GLOBALS['ec_options_at_schedule'][] = count( $GLOBALS['ec_options'] );
 	$id                            = ++$GLOBALS['ec_action_id_seq'];
 	$GLOBALS['ec_scheduled'][ $id ] = array( 'kind' => 'async', 'timestamp' => time(), 'hook' => $hook, 'args' => $args, 'group' => $group );
 	return $id;
+}
+
+function ec_scheduled_for_hook( string $hook ): array {
+	return array_values( array_filter( $GLOBALS['ec_scheduled'], static fn( array $action ): bool => $hook === $action['hook'] ) );
 }
 
 if ( ! function_exists( '__' ) ) {
@@ -223,7 +315,7 @@ if ( ! function_exists( '__' ) ) {
  * -------------------------------------------------------------------------*/
 
 if ( ! class_exists( '\\DataMachine\\Abilities\\PermissionHelper' ) ) {
-	eval( 'namespace DataMachine\\Abilities; class PermissionHelper { public static bool $manage = true; public static int $user_id = 1; public static int $agent_id = 0; public static int $token_id = 0; public static function can_manage(): bool { return self::$manage; } public static function can( string $action ): bool { return self::$manage; } public static function acting_user_id(): int { return self::$user_id; } public static function get_acting_agent_id(): ?int { return self::$agent_id ?: null; } public static function get_acting_token_id(): ?int { return self::$token_id ?: null; } }' );
+	eval( 'namespace DataMachine\\Abilities; class PermissionHelper { public static bool $manage = true; public static int $user_id = 1; public static int $agent_id = 0; public static int $token_id = 0; public static function can_manage(): bool { return self::$manage; } public static function can( string $action ): bool { return self::$manage; } public static function acting_user_id(): int { return self::$user_id; } public static function get_acting_agent_id(): ?int { return self::$agent_id ?: null; } public static function get_acting_token_id(): ?int { return self::$token_id ?: null; } public static function is_authenticated_context(): bool { return false; } }' );
 }
 
 if ( ! class_exists( 'WP_Agent_Token' ) ) {
@@ -273,7 +365,7 @@ if ( ! function_exists( 'absint' ) ) {
 
 if ( ! function_exists( 'wp_salt' ) ) {
 	function wp_salt( string $scheme = 'auth' ): string {
-		return 'send-email-smoke-' . $scheme;
+		return 'auth' === $scheme ? $GLOBALS['ec_auth_salt'] : 'send-email-smoke-' . $scheme;
 	}
 }
 
@@ -296,6 +388,10 @@ new \DataMachine\Abilities\Publish\SendEmailQueuedAbility();
 
 ec_assert( 'send-email ability registered', isset( $GLOBALS['ec_abilities']['datamachine/send-email'] ) );
 ec_assert( 'send-email-queued ability registered', isset( $GLOBALS['ec_abilities']['datamachine/send-email-queued'] ) );
+$queued_definition = $GLOBALS['ec_abilities']['datamachine/send-email-queued'];
+$expected_queue_inputs = array( 'auth_ref', 'to', 'cc', 'bcc', 'subject', 'body', 'template', 'context', 'mail_site_id', 'content_type', 'from_name', 'from_email', 'reply_to', 'attachments', 'send_at', 'priority' );
+ec_assert( 'queued input contract remains unchanged', array( 'to', 'subject' ) === $queued_definition['input_schema']['required'] && $expected_queue_inputs === array_keys( $queued_definition['input_schema']['properties'] ) );
+ec_assert( 'queued output contract remains unchanged', array( 'success', 'action_id', 'scheduled_for', 'error', 'logs' ) === array_keys( $queued_definition['output_schema']['properties'] ) );
 
 $send = wp_get_ability( 'datamachine/send-email' );
 ec_assert( 'send-email resolvable via wp_get_ability', null !== $send );
@@ -441,10 +537,20 @@ $GLOBALS['ec_scheduled'] = array();
 
 \DataMachine\Abilities\PermissionHelper::$user_id = 1;
 
+$large_body = 'body secret recovery-code-123 ' . str_repeat( 'large-private-email-content-', 240 );
+$GLOBALS['ec_options']         = array();
+$GLOBALS['ec_option_autoload'] = array();
 $res = $queued->execute( array(
-	'to'      => 'user@example.com',
-	'subject' => 'Subject',
-	'body'    => 'body',
+	'to'          => 'user@example.com',
+	'cc'          => 'private-cc@example.com',
+	'bcc'         => 'private-bcc@example.com',
+	'subject'     => 'Subject',
+	'body'        => $large_body,
+	'context'     => array( 'authorization' => 'Bearer secret-auth-material' ),
+	'from_name'   => 'Private Sender',
+	'from_email'  => 'private-sender@example.com',
+	'reply_to'    => 'private-reply@example.com',
+	'attachments' => array( '/private/mailbox-grant-file.pdf' ),
 ) );
 
 ec_assert( 'queued async success', true === ( $res['success'] ?? false ), $res['error'] ?? '' );
@@ -452,13 +558,59 @@ ec_assert( 'queued async returned action_id > 0', ( $res['action_id'] ?? 0 ) > 0
 $first = reset( $GLOBALS['ec_scheduled'] );
 ec_assert( 'queued async used async action', ( $first['kind'] ?? '' ) === 'async' );
 ec_assert( 'queued async hook is worker', ( $first['hook'] ?? '' ) === 'datamachine_send_email_worker' );
-$legacy_payload = $first['args'][0] ?? array();
+$cleanup_actions = ec_scheduled_for_hook( \DataMachine\Abilities\Publish\SendEmailQueuedAbility::CLEANUP_HOOK );
+ec_assert( 'queue schedules one generic orphan cleanup action', 1 === count( $cleanup_actions ) );
+$cleanup_action = $cleanup_actions[0] ?? array();
+ec_assert( 'cleanup action uses compact reference without sensitive args', ( $cleanup_action['args'][0] ?? null ) === ( $first['args'][0] ?? null ) && strlen( serialize( $cleanup_action['args'] ?? array() ) ) < 8000 && ! str_contains( serialize( $cleanup_action['args'] ?? array() ), 'user@example.com' ) && ! str_contains( serialize( $cleanup_action['args'] ?? array() ), 'recovery-code-123' ) );
+ec_assert( 'cleanup deadline exceeds delayed send and retry horizon', ( $cleanup_action['timestamp'] ?? 0 ) > ( $first['timestamp'] ?? 0 ) + 600 );
+$queued_reference = $first['args'][0] ?? array();
+$raw_args          = serialize( $first['args'] );
+$json_args         = json_encode( $first['args'] );
+foreach ( array( 'user@example.com', 'private-cc@example.com', 'private-bcc@example.com', 'Subject', 'recovery-code-123', 'Bearer secret-auth-material', 'Private Sender', 'private-sender@example.com', 'private-reply@example.com', '/private/mailbox-grant-file.pdf', '_mailbox_grant', 'auth_ref' ) as $sensitive_value ) {
+	ec_assert( 'raw scheduler args omit plaintext ' . $sensitive_value, ! str_contains( $raw_args, $sensitive_value ) );
+}
+ec_assert( 'raw scheduler args contain compact payload reference only', array( '_datamachine_email_payload' ) === array_keys( $queued_reference ) && ! str_contains( $raw_args, 'ciphertext' ) );
+ec_assert( 'serialized and JSON scheduler args remain below Action Scheduler limit', strlen( $raw_args ) < 8000 && is_string( $json_args ) && strlen( $json_args ) < 8000, sprintf( 'serialize=%d json=%d', strlen( $raw_args ), is_string( $json_args ) ? strlen( $json_args ) : -1 ) );
+$reference_id = $queued_reference['_datamachine_email_payload']['id'] ?? '';
+$option_name  = 'datamachine_email_payload_' . $reference_id;
+$stored_envelope = $GLOBALS['ec_options'][ $option_name ] ?? null;
+ec_assert( 'encrypted payload stored in uniquely keyed option', is_array( $stored_envelope ) && 1 === count( $GLOBALS['ec_options'] ) );
+ec_assert( 'encrypted payload option is non-autoloaded', false === ( $GLOBALS['ec_option_autoload'][ $option_name ] ?? null ) );
+ec_assert( 'large encrypted option may exceed scheduler args ceiling', strlen( serialize( $stored_envelope ) ) > 8000, (string) strlen( serialize( $stored_envelope ) ) );
+ec_assert( 'stored option contains no plaintext', ! str_contains( serialize( $stored_envelope ), 'user@example.com' ) && ! str_contains( serialize( $stored_envelope ), 'recovery-code-123' ) && ! str_contains( serialize( $stored_envelope ), 'Bearer secret-auth-material' ) );
+$decrypt_method = new ReflectionMethod( \DataMachine\Abilities\Publish\SendEmailQueuedAbility::class, 'decryptQueuedPayload' );
+$decrypt_method->setAccessible( true );
+$decrypted_payload = $decrypt_method->invoke( new \DataMachine\Abilities\Publish\SendEmailQueuedAbility(), $stored_envelope, $reference_id );
+ec_assert( 'encrypted queue payload decrypts exactly for delivery', 'user@example.com' === ( $decrypted_payload['to'] ?? '' ) && 'Subject' === ( $decrypted_payload['subject'] ?? '' ) && $large_body === ( $decrypted_payload['body'] ?? '' ) && 'private-reply@example.com' === ( $decrypted_payload['reply_to'] ?? '' ) && 'Bearer secret-auth-material' === ( $decrypted_payload['context']['authorization'] ?? '' ) );
+$legacy_payload = $decrypted_payload;
 
+$GLOBALS['ec_wp_mail_calls'] = array();
+$GLOBALS['ec_logs']          = array();
+$worker_for_delivery = new \DataMachine\Abilities\Publish\SendEmailQueuedAbility();
+$GLOBALS['ec_wp_mail_callback'] = static function () use ( $worker_for_delivery, $queued_reference ): void {
+	$worker_for_delivery->runWorker( $queued_reference );
+};
+$worker_for_delivery->runWorker( $queued_reference );
+ec_assert( 'stored payload delivers exact large body', 1 === count( $GLOBALS['ec_wp_mail_calls'] ) && $large_body === $GLOBALS['ec_wp_mail_calls'][0]['body'] );
+ec_assert( 'concurrent duplicate is serialized with bounded lock wait', 1 === count( $GLOBALS['ec_wp_mail_calls'] ) && 5 === max( $GLOBALS['wpdb']->timeouts ) );
+ec_assert( 'serialized duplicate diagnostics omit plaintext', ! str_contains( serialize( $GLOBALS['ec_logs'] ), 'user@example.com' ) && ! str_contains( serialize( $GLOBALS['ec_logs'] ), 'recovery-code-123' ) );
+ec_assert( 'successful worker deletes stored envelope', ! isset( $GLOBALS['ec_options'][ $option_name ] ) );
+$worker_for_delivery->runCleanup( $cleanup_action['args'][0] ?? array() );
+ec_assert( 'scheduled cleanup after immediate success is an idempotent no-op', 1 === count( $GLOBALS['ec_wp_mail_calls'] ) && ! isset( $GLOBALS['ec_options'][ $option_name ] ) );
+$worker_for_delivery->runWorker( $queued_reference );
+ec_assert( 'duplicate worker after cleanup does not resend', 1 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+
+$GLOBALS['ec_scheduled'] = array();
+$queued->execute( array( 'to' => 'user@example.com', 'subject' => 'Demotion', 'body' => 'private demotion body' ) );
+$demotion_action    = reset( $GLOBALS['ec_scheduled'] );
+$demotion_reference = $demotion_action['args'][0] ?? array();
+$demotion_option    = 'datamachine_email_payload_' . ( $demotion_reference['_datamachine_email_payload']['id'] ?? '' );
 $GLOBALS['ec_manage_users'][1] = false;
 $GLOBALS['ec_wp_mail_calls']    = array();
 $worker_for_demotion = new \DataMachine\Abilities\Publish\SendEmailQueuedAbility();
-$worker_for_demotion->runWorker( $legacy_payload );
-ec_assert( 'legacy queued send denies issuer demoted after enqueue', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+$worker_for_demotion->runWorker( $demotion_reference );
+ec_assert( 'stored queued send denies issuer demoted after enqueue', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+ec_assert( 'authorization denial deletes stored envelope', ! isset( $GLOBALS['ec_options'][ $demotion_option ] ) );
 $GLOBALS['ec_manage_users'][1] = true;
 
 \DataMachine\Abilities\PermissionHelper::$manage  = false;
@@ -493,6 +645,7 @@ ec_assert( 'queued ISO success', true === ( $res['success'] ?? false ), $res['er
 $first = reset( $GLOBALS['ec_scheduled'] );
 ec_assert( 'queued ISO used single action', ( $first['kind'] ?? '' ) === 'single' );
 ec_assert( 'queued ISO timestamp roughly matches', abs( ( $first['timestamp'] ?? 0 ) - ( time() + 3600 ) ) < 5 );
+$worker_for_delivery->runWorker( $first['args'][0] ?? array() );
 
 /* ---------------------------------------------------------------------------
  * Case 8 — invalid send_at rejected.
@@ -517,23 +670,44 @@ echo "\nCase 9: worker retry + give up\n";
 // First call: wp_mail() will fail, worker should re-enqueue.
 $GLOBALS['ec_wp_mail_result'] = false;
 $GLOBALS['ec_scheduled'] = array();
+$GLOBALS['ec_logs']      = array();
+$GLOBALS['ec_options']   = array();
+$GLOBALS['ec_option_autoload'] = array();
 
 $worker = new \DataMachine\Abilities\Publish\SendEmailQueuedAbility();
 $legacy_payload['_attempt'] = 1;
 $worker->runWorker( $legacy_payload );
 
-ec_assert( 'worker scheduled a retry on first failure', count( $GLOBALS['ec_scheduled'] ) === 1 );
-$retry = reset( $GLOBALS['ec_scheduled'] );
+ec_assert( 'worker scheduled retry and bounded cleanup on first legacy failure', 1 === count( ec_scheduled_for_hook( 'datamachine_send_email_worker' ) ) && 1 === count( ec_scheduled_for_hook( \DataMachine\Abilities\Publish\SendEmailQueuedAbility::CLEANUP_HOOK ) ) );
+$retry_actions = ec_scheduled_for_hook( 'datamachine_send_email_worker' );
+$retry = $retry_actions[0] ?? array();
 ec_assert( 'retry uses worker hook', ( $retry['hook'] ?? '' ) === 'datamachine_send_email_worker' );
-$retry_payload = $retry['args'][0] ?? array();
-ec_assert( 'retry payload increments _attempt', ( $retry_payload['_attempt'] ?? 0 ) === 2 );
+$retry_reference = $retry['args'][0] ?? array();
+$retry_raw       = serialize( $retry['args'] );
+ec_assert( 'legacy retry scheduler args contain compact reference only', array( '_datamachine_email_payload' ) === array_keys( $retry_reference ) && strlen( $retry_raw ) < 8000 );
+ec_assert( 'retry scheduler args omit recipient, subject, body, and auth material', ! str_contains( $retry_raw, 'user@example.com' ) && ! str_contains( $retry_raw, 'Subject' ) && ! str_contains( $retry_raw, 'recovery-code-123' ) && ! str_contains( $retry_raw, 'Bearer secret-auth-material' ) );
+ec_assert( 'retry failure log omits queued plaintext', ! str_contains( serialize( $GLOBALS['ec_logs'] ), 'user@example.com' ) && ! str_contains( serialize( $GLOBALS['ec_logs'] ), 'Subject' ) && ! str_contains( serialize( $GLOBALS['ec_logs'] ), 'recovery-code-123' ) && ! str_contains( serialize( $GLOBALS['ec_logs'] ), 'Bearer secret-auth-material' ) );
+$retry_reference_id = $retry_reference['_datamachine_email_payload']['id'] ?? '';
+$retry_option_name  = 'datamachine_email_payload_' . $retry_reference_id;
+$retry_payload = $decrypt_method->invoke( $worker, $GLOBALS['ec_options'][ $retry_option_name ] ?? array(), $retry_reference_id );
+ec_assert( 'encrypted retry payload increments _attempt', ( $retry_payload['_attempt'] ?? 0 ) === 2 );
+ec_assert( 'retry keeps encrypted option durable before scheduling', isset( $GLOBALS['ec_options'][ $retry_option_name ] ) && 0 < end( $GLOBALS['ec_options_at_schedule'] ) );
 ec_assert( 'retry scheduled ~5 min out', abs( ( $retry['timestamp'] ?? 0 ) - ( time() + 300 ) ) < 5 );
 
-// Third attempt (max): should NOT re-enqueue.
+// Second failure updates the same encrypted option and schedules attempt 3.
 $GLOBALS['ec_scheduled'] = array();
-$legacy_payload['_attempt'] = 3;
-$worker->runWorker( $legacy_payload );
+$worker->runWorker( $retry_reference );
+$second_retry = reset( $GLOBALS['ec_scheduled'] );
+$second_retry_reference = $second_retry['args'][0] ?? array();
+ec_assert( 'stored retry reuses compact authenticated reference', $retry_reference === $second_retry_reference );
+$third_payload = $decrypt_method->invoke( $worker, $GLOBALS['ec_options'][ $retry_option_name ] ?? array(), $retry_reference_id );
+ec_assert( 'stored retry persists incremented third attempt encrypted', 3 === ( $third_payload['_attempt'] ?? 0 ) );
+
+// Third attempt (max): should not re-enqueue and must clean up storage.
+$GLOBALS['ec_scheduled'] = array();
+$worker->runWorker( $second_retry_reference );
 ec_assert( 'worker gives up at MAX_ATTEMPTS', count( $GLOBALS['ec_scheduled'] ) === 0 );
+ec_assert( 'terminal send failure deletes stored envelope', ! isset( $GLOBALS['ec_options'][ $retry_option_name ] ) );
 
 // Restore wp_mail success and verify worker succeeds and does NOT re-enqueue.
 $GLOBALS['ec_wp_mail_result'] = true;
@@ -544,6 +718,7 @@ $worker->runWorker( $legacy_payload );
 ec_assert( 'worker success: no retry', count( $GLOBALS['ec_scheduled'] ) === 0 );
 ec_assert( 'worker success: wp_mail invoked', count( $GLOBALS['ec_wp_mail_calls'] ) === 1 );
 ec_assert( 'worker strips _attempt before forwarding', ! isset( $GLOBALS['ec_wp_mail_calls'][0]['_attempt'] ) );
+ec_assert( 'already-persisted legacy plaintext payload remains consumable', array( 'user@example.com' ) === $GLOBALS['ec_wp_mail_calls'][0]['to'] && 'Subject' === $GLOBALS['ec_wp_mail_calls'][0]['subject'] && $large_body === $GLOBALS['ec_wp_mail_calls'][0]['body'] );
 
 $GLOBALS['ec_wp_mail_calls'] = array();
 $worker->runWorker( array( 'to' => 'user@example.com', 'subject' => 'Ambient bypass', 'body' => 'body' ) );
@@ -561,6 +736,103 @@ $tampered['body'] = 'replacement body';
 $GLOBALS['ec_wp_mail_calls'] = array();
 $worker->runWorker( $tampered );
 ec_assert( 'worker denies tampered recipient and body payload', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+
+echo "\nCase 9b: durable storage failures are closed and cleaned up\n";
+$queue_fixture = static function () use ( $queued, $large_body ): array {
+	$GLOBALS['ec_scheduled'] = array();
+	$result = $queued->execute( array( 'to' => 'user@example.com', 'subject' => 'Subject', 'body' => $large_body ) );
+	$action = reset( $GLOBALS['ec_scheduled'] );
+	$reference = $action['args'][0] ?? array();
+	$option_name = 'datamachine_email_payload_' . ( $reference['_datamachine_email_payload']['id'] ?? '' );
+	return array( $result, $reference, $option_name );
+};
+
+$GLOBALS['ec_options']         = array();
+$GLOBALS['ec_option_autoload'] = array();
+$GLOBALS['ec_schedule_fail_hook'] = \DataMachine\Abilities\Publish\SendEmailQueuedAbility::CLEANUP_HOOK;
+list( $cleanup_failure_result, $cleanup_failure_reference, $cleanup_failure_option ) = $queue_fixture();
+$cleanup_failure_logs = serialize( is_array( $cleanup_failure_result ) ? ( $cleanup_failure_result['logs'] ?? array() ) : array() );
+ec_assert( 'cleanup scheduling failure preserves runnable queued payload', is_array( $cleanup_failure_result ) && isset( $GLOBALS['ec_options'][ $cleanup_failure_option ] ) && 1 === count( ec_scheduled_for_hook( 'datamachine_send_email_worker' ) ) );
+ec_assert( 'cleanup scheduling failure logs no plaintext', ! str_contains( $cleanup_failure_logs, 'user@example.com' ) && ! str_contains( $cleanup_failure_logs, 'recovery-code-123' ) );
+$GLOBALS['ec_schedule_fail_hook'] = '';
+$GLOBALS['ec_wp_mail_calls'] = array();
+$worker->runWorker( $cleanup_failure_reference );
+ec_assert( 'payload still delivers after cleanup scheduling failure', 1 === count( $GLOBALS['ec_wp_mail_calls'] ) && ! isset( $GLOBALS['ec_options'][ $cleanup_failure_option ] ) );
+
+$GLOBALS['ec_schedule_result'] = false;
+$failed_initial = $queued->execute( array( 'to' => 'user@example.com', 'subject' => 'Initial failure', 'body' => $large_body ) );
+ec_assert( 'initial scheduler failure returns error and cleans storage', is_wp_error( $failed_initial ) && array() === $GLOBALS['ec_options'] );
+$GLOBALS['ec_schedule_result'] = true;
+$GLOBALS['ec_schedule_throw']  = true;
+$thrown_initial = $queued->execute( array( 'to' => 'user@example.com', 'subject' => 'Initial exception', 'body' => $large_body ) );
+ec_assert( 'initial scheduler exception returns error and cleans storage', is_wp_error( $thrown_initial ) && array() === $GLOBALS['ec_options'] );
+$GLOBALS['ec_schedule_throw'] = false;
+
+$GLOBALS['ec_wp_mail_result']  = false;
+$GLOBALS['ec_schedule_result'] = false;
+$worker->runWorker( $legacy_payload );
+ec_assert( 'retry scheduler failure cleans newly stored envelope', array() === $GLOBALS['ec_options'] );
+$GLOBALS['ec_schedule_result'] = true;
+$GLOBALS['ec_wp_mail_result']  = true;
+
+list( , $missing_reference, $missing_option ) = $queue_fixture();
+delete_option( $missing_option );
+$GLOBALS['ec_wp_mail_calls'] = array();
+$worker->runWorker( $missing_reference );
+ec_assert( 'missing stored envelope fails closed', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+
+list( , $orphan_reference, $orphan_option ) = $queue_fixture();
+$orphan_cleanup_actions = ec_scheduled_for_hook( \DataMachine\Abilities\Publish\SendEmailQueuedAbility::CLEANUP_HOOK );
+$orphan_cleanup = $orphan_cleanup_actions[0] ?? array();
+$worker->runCleanup( $orphan_cleanup['args'][0] ?? array() );
+$GLOBALS['ec_wp_mail_calls'] = array();
+$worker->runWorker( $orphan_reference );
+ec_assert( 'retention cleanup deletes orphan and later worker does not send', ! isset( $GLOBALS['ec_options'][ $orphan_option ] ) && 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+
+list( , $crash_reference, $crash_option ) = $queue_fixture();
+$GLOBALS['ec_wp_mail_calls'] = array();
+$GLOBALS['ec_wp_mail_callback'] = static function (): void {
+	throw new RuntimeException( 'simulated crash after provider acceptance' );
+};
+try {
+	$worker->runWorker( $crash_reference );
+} catch ( RuntimeException $exception ) {
+	// The provider accepted the first attempt, but local cleanup did not run.
+}
+ec_assert( 'post-acceptance crash retains payload and releases dispatch lock', 1 === count( $GLOBALS['ec_wp_mail_calls'] ) && isset( $GLOBALS['ec_options'][ $crash_option ] ) && array() === $GLOBALS['wpdb']->locks );
+$worker->runWorker( $crash_reference );
+ec_assert( 'at-least-once replay may send twice after post-acceptance crash', 2 === count( $GLOBALS['ec_wp_mail_calls'] ) && ! isset( $GLOBALS['ec_options'][ $crash_option ] ) );
+
+list( , $tampered_reference, $tampered_option ) = $queue_fixture();
+$GLOBALS['ec_options'][ $tampered_option ]['_datamachine_encrypted_email']['ciphertext'][0] = 'A' === $GLOBALS['ec_options'][ $tampered_option ]['_datamachine_encrypted_email']['ciphertext'][0] ? 'B' : 'A';
+$GLOBALS['ec_logs']          = array();
+$GLOBALS['ec_wp_mail_calls'] = array();
+$worker->runWorker( $tampered_reference );
+$tampered_logs = serialize( $GLOBALS['ec_logs'] );
+ec_assert( 'tampered stored envelope fails closed and is deleted', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) && ! isset( $GLOBALS['ec_options'][ $tampered_option ] ) );
+ec_assert( 'tampered storage logs omit plaintext', ! str_contains( $tampered_logs, 'user@example.com' ) && ! str_contains( $tampered_logs, 'recovery-code-123' ) );
+
+list( , $malformed_reference, $malformed_option ) = $queue_fixture();
+$GLOBALS['ec_options'][ $malformed_option ]['_datamachine_encrypted_email']['version'] = 2;
+$GLOBALS['ec_wp_mail_calls'] = array();
+$worker->runWorker( $malformed_reference );
+ec_assert( 'unsupported stored envelope fails closed and is deleted', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) && ! isset( $GLOBALS['ec_options'][ $malformed_option ] ) );
+
+list( , $invalid_reference, $invalid_option ) = $queue_fixture();
+$invalid_reference['_datamachine_email_payload']['mac'][0] = 'a' === $invalid_reference['_datamachine_email_payload']['mac'][0] ? 'b' : 'a';
+$GLOBALS['ec_wp_mail_calls'] = array();
+$worker->runWorker( $invalid_reference );
+ec_assert( 'tampered reference fails closed and cleans selected storage', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) && ! isset( $GLOBALS['ec_options'][ $invalid_option ] ) );
+
+list( , $rotation_reference, $rotation_option ) = $queue_fixture();
+$GLOBALS['ec_logs']          = array();
+$GLOBALS['ec_wp_mail_calls'] = array();
+$GLOBALS['ec_auth_salt']     = 'rotated-send-email-smoke-auth';
+$worker->runWorker( $rotation_reference );
+$rotation_logs = serialize( $GLOBALS['ec_logs'] );
+ec_assert( 'salt rotation fails closed and cleans stored envelope', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) && ! isset( $GLOBALS['ec_options'][ $rotation_option ] ) );
+ec_assert( 'salt rotation diagnostic omits queued plaintext', ! str_contains( $rotation_logs, 'user@example.com' ) && ! str_contains( $rotation_logs, 'Subject' ) && ! str_contains( $rotation_logs, 'recovery-code-123' ) );
+$GLOBALS['ec_auth_salt'] = 'send-email-smoke-auth';
 
 $GLOBALS['ec_mailbox_revoked'] = false;
 $fake_mailbox_auth = new class() {
@@ -598,10 +870,20 @@ $queued->execute( array(
 ) );
 $scheduled = reset( $GLOBALS['ec_scheduled'] );
 $revoked_payload = $scheduled['args'][0] ?? array();
+$named_raw = serialize( $scheduled['args'] );
+ec_assert( 'named mailbox scheduler args omit auth ref and grant', ! str_contains( $named_raw, 'email_imap:delegated' ) && ! str_contains( $named_raw, '_mailbox_grant' ) && ! str_contains( $named_raw, 'user@example.com' ) );
 $GLOBALS['ec_mailbox_revoked'] = true;
 $GLOBALS['ec_wp_mail_calls']    = array();
+$GLOBALS['ec_scheduled']        = array();
 $worker->runWorker( $revoked_payload );
 ec_assert( 'worker rechecks and denies revoked mailbox grant', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+$revoked_retry = reset( $GLOBALS['ec_scheduled'] );
+$GLOBALS['ec_scheduled'] = array();
+$worker->runWorker( $revoked_retry['args'][0] ?? array() );
+$revoked_final = reset( $GLOBALS['ec_scheduled'] );
+$GLOBALS['ec_scheduled'] = array();
+$worker->runWorker( $revoked_final['args'][0] ?? array() );
+ec_assert( 'revoked mailbox terminal retry cleans stored envelope', 0 === count( $GLOBALS['ec_scheduled'] ) );
 \DataMachine\Abilities\PermissionHelper::$manage   = true;
 \DataMachine\Abilities\PermissionHelper::$user_id  = 1;
 \DataMachine\Abilities\PermissionHelper::$agent_id = 0;
@@ -676,6 +958,8 @@ $GLOBALS['ec_wp_mail_calls'] = array();
 $worker->runWorker( $token_payload );
 ec_assert( 'named queue denies revoked token ability scope', 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
 \DataMachine\Abilities\PermissionHelper::$token_id = 0;
+
+ec_assert( 'durable email payload options are cleaned after terminal outcomes', array() === $GLOBALS['ec_options'], implode( ', ', array_keys( $GLOBALS['ec_options'] ) ) );
 
 /* ---------------------------------------------------------------------------
  * Summary

--- a/tests/send-email-template-smoke.php
+++ b/tests/send-email-template-smoke.php
@@ -555,12 +555,14 @@ $res = $queued->execute( array(
 
 ec_assert( 'queued async success', true === ( $res['success'] ?? false ), $res['error'] ?? '' );
 ec_assert( 'queued async returned action_id > 0', ( $res['action_id'] ?? 0 ) > 0 );
-$first = reset( $GLOBALS['ec_scheduled'] );
+$worker_actions = ec_scheduled_for_hook( 'datamachine_send_email_worker' );
+$first = $worker_actions[0] ?? array();
 ec_assert( 'queued async used async action', ( $first['kind'] ?? '' ) === 'async' );
 ec_assert( 'queued async hook is worker', ( $first['hook'] ?? '' ) === 'datamachine_send_email_worker' );
 $cleanup_actions = ec_scheduled_for_hook( \DataMachine\Abilities\Publish\SendEmailQueuedAbility::CLEANUP_HOOK );
 ec_assert( 'queue schedules one generic orphan cleanup action', 1 === count( $cleanup_actions ) );
 $cleanup_action = $cleanup_actions[0] ?? array();
+ec_assert( 'orphan cleanup is scheduled before send action', array_keys( $GLOBALS['ec_scheduled'] )[0] === array_search( $cleanup_action, $GLOBALS['ec_scheduled'], true ) && array_keys( $GLOBALS['ec_scheduled'] )[1] === array_search( $first, $GLOBALS['ec_scheduled'], true ) );
 ec_assert( 'cleanup action uses compact reference without sensitive args', ( $cleanup_action['args'][0] ?? null ) === ( $first['args'][0] ?? null ) && strlen( serialize( $cleanup_action['args'] ?? array() ) ) < 8000 && ! str_contains( serialize( $cleanup_action['args'] ?? array() ), 'user@example.com' ) && ! str_contains( serialize( $cleanup_action['args'] ?? array() ), 'recovery-code-123' ) );
 ec_assert( 'cleanup deadline exceeds delayed send and retry horizon', ( $cleanup_action['timestamp'] ?? 0 ) > ( $first['timestamp'] ?? 0 ) + 600 );
 $queued_reference = $first['args'][0] ?? array();
@@ -602,7 +604,8 @@ ec_assert( 'duplicate worker after cleanup does not resend', 1 === count( $GLOBA
 
 $GLOBALS['ec_scheduled'] = array();
 $queued->execute( array( 'to' => 'user@example.com', 'subject' => 'Demotion', 'body' => 'private demotion body' ) );
-$demotion_action    = reset( $GLOBALS['ec_scheduled'] );
+$demotion_actions   = ec_scheduled_for_hook( 'datamachine_send_email_worker' );
+$demotion_action    = $demotion_actions[0] ?? array();
 $demotion_reference = $demotion_action['args'][0] ?? array();
 $demotion_option    = 'datamachine_email_payload_' . ( $demotion_reference['_datamachine_email_payload']['id'] ?? '' );
 $GLOBALS['ec_manage_users'][1] = false;
@@ -642,7 +645,8 @@ $res = $queued->execute( array(
 	'send_at' => $future_iso,
 ) );
 ec_assert( 'queued ISO success', true === ( $res['success'] ?? false ), $res['error'] ?? '' );
-$first = reset( $GLOBALS['ec_scheduled'] );
+$iso_actions = ec_scheduled_for_hook( 'datamachine_send_email_worker' );
+$first = $iso_actions[0] ?? array();
 ec_assert( 'queued ISO used single action', ( $first['kind'] ?? '' ) === 'single' );
 ec_assert( 'queued ISO timestamp roughly matches', abs( ( $first['timestamp'] ?? 0 ) - ( time() + 3600 ) ) < 5 );
 $worker_for_delivery->runWorker( $first['args'][0] ?? array() );
@@ -679,6 +683,8 @@ $legacy_payload['_attempt'] = 1;
 $worker->runWorker( $legacy_payload );
 
 ec_assert( 'worker scheduled retry and bounded cleanup on first legacy failure', 1 === count( ec_scheduled_for_hook( 'datamachine_send_email_worker' ) ) && 1 === count( ec_scheduled_for_hook( \DataMachine\Abilities\Publish\SendEmailQueuedAbility::CLEANUP_HOOK ) ) );
+$legacy_retry_order = array_values( $GLOBALS['ec_scheduled'] );
+ec_assert( 'legacy retry cleanup is scheduled before retry send', \DataMachine\Abilities\Publish\SendEmailQueuedAbility::CLEANUP_HOOK === ( $legacy_retry_order[0]['hook'] ?? '' ) && 'datamachine_send_email_worker' === ( $legacy_retry_order[1]['hook'] ?? '' ) );
 $retry_actions = ec_scheduled_for_hook( 'datamachine_send_email_worker' );
 $retry = $retry_actions[0] ?? array();
 ec_assert( 'retry uses worker hook', ( $retry['hook'] ?? '' ) === 'datamachine_send_email_worker' );
@@ -741,7 +747,8 @@ echo "\nCase 9b: durable storage failures are closed and cleaned up\n";
 $queue_fixture = static function () use ( $queued, $large_body ): array {
 	$GLOBALS['ec_scheduled'] = array();
 	$result = $queued->execute( array( 'to' => 'user@example.com', 'subject' => 'Subject', 'body' => $large_body ) );
-	$action = reset( $GLOBALS['ec_scheduled'] );
+	$worker_actions = ec_scheduled_for_hook( 'datamachine_send_email_worker' );
+	$action = $worker_actions[0] ?? array();
 	$reference = $action['args'][0] ?? array();
 	$option_name = 'datamachine_email_payload_' . ( $reference['_datamachine_email_payload']['id'] ?? '' );
 	return array( $result, $reference, $option_name );
@@ -750,14 +757,21 @@ $queue_fixture = static function () use ( $queued, $large_body ): array {
 $GLOBALS['ec_options']         = array();
 $GLOBALS['ec_option_autoload'] = array();
 $GLOBALS['ec_schedule_fail_hook'] = \DataMachine\Abilities\Publish\SendEmailQueuedAbility::CLEANUP_HOOK;
-list( $cleanup_failure_result, $cleanup_failure_reference, $cleanup_failure_option ) = $queue_fixture();
-$cleanup_failure_logs = serialize( is_array( $cleanup_failure_result ) ? ( $cleanup_failure_result['logs'] ?? array() ) : array() );
-ec_assert( 'cleanup scheduling failure preserves runnable queued payload', is_array( $cleanup_failure_result ) && isset( $GLOBALS['ec_options'][ $cleanup_failure_option ] ) && 1 === count( ec_scheduled_for_hook( 'datamachine_send_email_worker' ) ) );
+$GLOBALS['ec_scheduled'] = array();
+$cleanup_failure_result = $queued->execute( array( 'to' => 'user@example.com', 'subject' => 'Cleanup failure', 'body' => $large_body ) );
+$cleanup_failure_logs = serialize( is_wp_error( $cleanup_failure_result ) ? $cleanup_failure_result->get_error_data() : array() );
+ec_assert( 'cleanup scheduling failure leaves no send action or storage', is_wp_error( $cleanup_failure_result ) && array() === $GLOBALS['ec_options'] && 0 === count( ec_scheduled_for_hook( 'datamachine_send_email_worker' ) ) );
 ec_assert( 'cleanup scheduling failure logs no plaintext', ! str_contains( $cleanup_failure_logs, 'user@example.com' ) && ! str_contains( $cleanup_failure_logs, 'recovery-code-123' ) );
 $GLOBALS['ec_schedule_fail_hook'] = '';
-$GLOBALS['ec_wp_mail_calls'] = array();
-$worker->runWorker( $cleanup_failure_reference );
-ec_assert( 'payload still delivers after cleanup scheduling failure', 1 === count( $GLOBALS['ec_wp_mail_calls'] ) && ! isset( $GLOBALS['ec_options'][ $cleanup_failure_option ] ) );
+
+$GLOBALS['ec_schedule_fail_hook'] = 'datamachine_send_email_worker';
+$GLOBALS['ec_scheduled'] = array();
+$send_failure_result = $queued->execute( array( 'to' => 'user@example.com', 'subject' => 'Send failure', 'body' => $large_body ) );
+$prescheduled_cleanup = ec_scheduled_for_hook( \DataMachine\Abilities\Publish\SendEmailQueuedAbility::CLEANUP_HOOK );
+ec_assert( 'send scheduling failure cleans storage but leaves harmless cleanup', is_wp_error( $send_failure_result ) && array() === $GLOBALS['ec_options'] && 1 === count( $prescheduled_cleanup ) && 0 === count( ec_scheduled_for_hook( 'datamachine_send_email_worker' ) ) );
+$GLOBALS['ec_schedule_fail_hook'] = '';
+$worker->runCleanup( $prescheduled_cleanup[0]['args'][0] ?? array() );
+ec_assert( 'pre-scheduled cleanup after send failure no-ops', array() === $GLOBALS['ec_options'] );
 
 $GLOBALS['ec_schedule_result'] = false;
 $failed_initial = $queued->execute( array( 'to' => 'user@example.com', 'subject' => 'Initial failure', 'body' => $large_body ) );
@@ -770,9 +784,16 @@ $GLOBALS['ec_schedule_throw'] = false;
 
 $GLOBALS['ec_wp_mail_result']  = false;
 $GLOBALS['ec_schedule_result'] = false;
+$GLOBALS['ec_scheduled']       = array();
 $worker->runWorker( $legacy_payload );
-ec_assert( 'retry scheduler failure cleans newly stored envelope', array() === $GLOBALS['ec_options'] );
+ec_assert( 'legacy retry cleanup failure leaves no retry or storage', array() === $GLOBALS['ec_options'] && 0 === count( ec_scheduled_for_hook( 'datamachine_send_email_worker' ) ) );
 $GLOBALS['ec_schedule_result'] = true;
+$GLOBALS['ec_schedule_fail_hook'] = 'datamachine_send_email_worker';
+$GLOBALS['ec_scheduled'] = array();
+$worker->runWorker( $legacy_payload );
+$legacy_failed_cleanup = ec_scheduled_for_hook( \DataMachine\Abilities\Publish\SendEmailQueuedAbility::CLEANUP_HOOK );
+ec_assert( 'legacy retry send failure cleans storage with harmless cleanup left', array() === $GLOBALS['ec_options'] && 1 === count( $legacy_failed_cleanup ) && 0 === count( ec_scheduled_for_hook( 'datamachine_send_email_worker' ) ) );
+$GLOBALS['ec_schedule_fail_hook'] = '';
 $GLOBALS['ec_wp_mail_result']  = true;
 
 list( , $missing_reference, $missing_option ) = $queue_fixture();
@@ -788,6 +809,25 @@ $worker->runCleanup( $orphan_cleanup['args'][0] ?? array() );
 $GLOBALS['ec_wp_mail_calls'] = array();
 $worker->runWorker( $orphan_reference );
 ec_assert( 'retention cleanup deletes orphan and later worker does not send', ! isset( $GLOBALS['ec_options'][ $orphan_option ] ) && 0 === count( $GLOBALS['ec_wp_mail_calls'] ) );
+
+list( , $contended_reference, $contended_option ) = $queue_fixture();
+$contended_id = $contended_reference['_datamachine_email_payload']['id'] ?? '';
+$contended_lock = 'datamachine_email_' . $contended_id;
+$GLOBALS['wpdb']->locks[ $contended_lock ] = true;
+$GLOBALS['ec_scheduled'] = array();
+$GLOBALS['ec_logs']      = array();
+$worker->runCleanup( $contended_reference );
+$cleanup_retries = ec_scheduled_for_hook( \DataMachine\Abilities\Publish\SendEmailQueuedAbility::CLEANUP_HOOK );
+$cleanup_retry_reference = $cleanup_retries[0]['args'][0] ?? array();
+$cleanup_retry_raw = serialize( $cleanup_retries[0]['args'] ?? array() );
+ec_assert( 'lock contention schedules one compact cleanup retry', 1 === count( $cleanup_retries ) && 1 === ( $cleanup_retry_reference['_datamachine_email_payload']['cleanup_attempt'] ?? 0 ) && strlen( $cleanup_retry_raw ) < 8000 && ! str_contains( $cleanup_retry_raw, 'user@example.com' ) );
+$GLOBALS['ec_scheduled'] = array();
+$worker->runCleanup( $cleanup_retry_reference );
+ec_assert( 'cleanup lock retry is bounded to one reschedule', 0 === count( ec_scheduled_for_hook( \DataMachine\Abilities\Publish\SendEmailQueuedAbility::CLEANUP_HOOK ) ) && isset( $GLOBALS['ec_options'][ $contended_option ] ) );
+unset( $GLOBALS['wpdb']->locks[ $contended_lock ] );
+$worker->runCleanup( $cleanup_retry_reference );
+ec_assert( 'bounded cleanup retry deletes orphan after contention clears', ! isset( $GLOBALS['ec_options'][ $contended_option ] ) );
+ec_assert( 'cleanup contention logs omit plaintext', ! str_contains( serialize( $GLOBALS['ec_logs'] ), 'user@example.com' ) && ! str_contains( serialize( $GLOBALS['ec_logs'] ), 'recovery-code-123' ) );
 
 list( , $crash_reference, $crash_option ) = $queue_fixture();
 $GLOBALS['ec_wp_mail_calls'] = array();
@@ -868,7 +908,8 @@ $queued->execute( array(
 	'subject'  => 'Revocation',
 	'body'     => 'body',
 ) );
-$scheduled = reset( $GLOBALS['ec_scheduled'] );
+$scheduled_actions = ec_scheduled_for_hook( 'datamachine_send_email_worker' );
+$scheduled = $scheduled_actions[0] ?? array();
 $revoked_payload = $scheduled['args'][0] ?? array();
 $named_raw = serialize( $scheduled['args'] );
 ec_assert( 'named mailbox scheduler args omit auth ref and grant', ! str_contains( $named_raw, 'email_imap:delegated' ) && ! str_contains( $named_raw, '_mailbox_grant' ) && ! str_contains( $named_raw, 'user@example.com' ) );
@@ -893,7 +934,8 @@ $enqueue_named = static function () use ( $queued ): array {
 	$GLOBALS['ec_mailbox_revoked'] = false;
 	$GLOBALS['ec_scheduled']       = array();
 	$queued->execute( array( 'auth_ref' => 'email_imap:delegated', 'to' => 'user@example.com', 'subject' => 'Authority', 'body' => 'body' ) );
-	$scheduled = reset( $GLOBALS['ec_scheduled'] );
+	$scheduled_actions = ec_scheduled_for_hook( 'datamachine_send_email_worker' );
+	$scheduled = $scheduled_actions[0] ?? array();
 	return $scheduled['args'][0] ?? array();
 };
 


### PR DESCRIPTION
## Summary
- encrypt complete queued email payloads with authenticated AES-256-GCM envelopes before persistence
- keep Action Scheduler arguments compact and secret-free through opaque authenticated references
- preserve legacy queued jobs, bounded retries, issuer revalidation, advisory-lock serialization, and orphan cleanup

## Why
Action Scheduler currently stores recipient, subject, body, mailbox grants, and other sensitive email data as plaintext arguments. This blocks safe delivery of recovery credentials and leaks private message content into scheduler storage.

## Verification
- queued email smoke: 121 assertions
- ability load-order smoke: 21 assertions
- lazy-definition and named-mailbox security smoke: pass
- PHPCS and PHPStan level 7: pass
- architecture audit, PHP syntax, and `git diff --check`: pass

## Operational Notes
- existing plaintext queued jobs remain consumable
- new jobs and retries are encrypted at rest
- salt rotation fails outstanding encrypted jobs closed
- delivery remains at-least-once because provider acceptance cannot be atomically coupled to local acknowledgement

Closes #3308.