### PR TITLE
fix: stop serializing source-derived block attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=8.2",
 		"wordpress/agents-api": "dev-main",
 		"woocommerce/action-scheduler": "^3.9",
-		"automattic/blocks-engine-php-transformer": "0.1.0"
+		"automattic/blocks-engine-php-transformer": "dev-trunk"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.6",
@@ -57,12 +57,12 @@
 			"type": "package",
 			"package": {
 				"name": "automattic/blocks-engine-php-transformer",
-				"version": "0.1.0",
+				"version": "dev-trunk",
 				"type": "library",
 				"source": {
 					"type": "git",
 					"url": "https://github.com/Automattic/blocks-engine.git",
-					"reference": "php-transformer-v0.1.0"
+					"reference": "d8842683cb7928a0ae1f56878de93cf0bc8b7343"
 				},
 				"autoload": {
 					"psr-4": {
@@ -74,7 +74,7 @@
 				},
 				"require": {
 					"php": ">=8.1",
-					"league/commonmark": "^2.9.0",
+					"league/commonmark": "^2.5",
 					"league/html-to-markdown": "^5.1"
 				}
 			}

--- a/composer.lock
+++ b/composer.lock
@@ -4,15 +4,15 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "370284267aa43f8613f9c0304be072de",
+    "content-hash": "c5a6d0a68e649d3643d26e66efea0cf8",
     "packages": [
         {
             "name": "automattic/blocks-engine-php-transformer",
-            "version": "0.1.0",
+            "version": "dev-trunk",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/blocks-engine.git",
-                "reference": "php-transformer-v0.1.0"
+                "reference": "d8842683cb7928a0ae1f56878de93cf0bc8b7343"
             },
             "require": {
                 "league/commonmark": "^2.5",
@@ -3433,7 +3433,8 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "wordpress/agents-api": 20
+        "wordpress/agents-api": 20,
+        "automattic/blocks-engine-php-transformer": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/inc/Cli/Commands/BlocksCommand.php
+++ b/inc/Cli/Commands/BlocksCommand.php
@@ -330,7 +330,7 @@ class BlocksCommand extends BaseCommand {
 			if ( ! get_post( $post_id ) ) {
 				WP_CLI::error( sprintf( 'Post #%d does not exist on the selected site.', $post_id ) );
 			}
-			$post_ids = array( $post_id );
+			$post_ids   = array( $post_id );
 			$post_types = array( get_post_type( $post_id ) );
 		} else {
 			try {
@@ -350,11 +350,11 @@ class BlocksCommand extends BaseCommand {
 				WP_CLI::error( 'Bulk --apply requires an explicit --post_type that is not "any".' );
 			}
 
-			$query = new \WP_Query( self::bulkQueryArgs( $post_types, $assoc_args['post_status'] ?? 'any', $limit, $paged ) );
+			$query    = new \WP_Query( self::bulkQueryArgs( $post_types, $assoc_args['post_status'] ?? 'any', $limit, $paged ) );
 			$post_ids = array_map( 'intval', $query->posts );
 		}
 
-		$repair = new SourceDerivedBlockAttributeRepair();
+		$repair   = new SourceDerivedBlockAttributeRepair();
 		$findings = array();
 		foreach ( $post_ids as $candidate_id ) {
 			$post = get_post( $candidate_id );
@@ -387,22 +387,25 @@ class BlocksCommand extends BaseCommand {
 		}
 
 		$summary = array(
-			'mode'            => $apply ? 'apply' : 'dry-run',
-			'site_url'        => home_url( '/' ),
-			'post_types'      => array_values( array_filter( $post_types ) ),
-			'limit'           => $limit,
-			'paged'           => $paged,
-			'posts_inspected' => count( $post_ids ),
+			'mode'                => $apply ? 'apply' : 'dry-run',
+			'site_url'            => home_url( '/' ),
+			'post_types'          => array_values( array_filter( $post_types ) ),
+			'limit'               => $limit,
+			'paged'               => $paged,
+			'posts_inspected'     => count( $post_ids ),
 			'posts_with_findings' => count( array_unique( array_column( $findings, 'post_id' ) ) ),
-			'findings'        => count( $findings ),
-			'repairable'      => count( array_filter( $findings, static fn ( array $finding ): bool => in_array( $finding['status'], array( 'would_remove', 'removed' ), true ) ) ),
-			'skipped'         => count( array_filter( $findings, static fn ( array $finding ): bool => 'skipped' === $finding['status'] ) ),
-			'errors'          => count( array_filter( $findings, static fn ( array $finding ): bool => 'error' === $finding['status'] ) ),
+			'findings'            => count( $findings ),
+			'repairable'          => count( array_filter( $findings, static fn ( array $finding ): bool => in_array( $finding['status'], array( 'would_remove', 'removed' ), true ) ) ),
+			'skipped'             => count( array_filter( $findings, static fn ( array $finding ): bool => 'skipped' === $finding['status'] ) ),
+			'errors'              => count( array_filter( $findings, static fn ( array $finding ): bool => 'error' === $finding['status'] ) ),
 		);
 		$fields  = array( 'post_id', 'block_path', 'block_name', 'attribute', 'status', 'reason', 'value_type', 'value_bytes', 'value_sha256' );
 
 		if ( 'json' === $format ) {
-			WP_CLI::line( (string) wp_json_encode( array( 'findings' => $findings, 'summary' => $summary ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			WP_CLI::line( (string) wp_json_encode( array(
+				'findings' => $findings,
+				'summary'  => $summary,
+			), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 		} else {
 			WP_CLI\Utils\format_items( $format, $findings, $fields );
 			if ( 'table' === $format ) {
@@ -438,6 +441,7 @@ class BlocksCommand extends BaseCommand {
 	private static function parsePositiveInteger( $value, string $option, int $maximum = PHP_INT_MAX ): int {
 		$raw = is_string( $value ) || is_int( $value ) ? (string) $value : '';
 		if ( ! preg_match( '/^[1-9][0-9]*$/', $raw ) || (string) (int) $raw !== $raw || (int) $raw > $maximum ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- CLI-only validation uses trusted option labels and integers.
 			throw new \InvalidArgumentException( sprintf( '%s must be a positive canonical integer%s.', $option, PHP_INT_MAX === $maximum ? '' : sprintf( ' no greater than %d', $maximum ) ) );
 		}
 
@@ -469,9 +473,11 @@ class BlocksCommand extends BaseCommand {
 	 * @return array
 	 */
 	private static function bulkQueryArgs( array $post_types, $post_status, int $limit, int $paged ): array {
+		$normalized_post_status = sanitize_key( (string) $post_status );
+
 		return array(
 			'post_type'              => 1 === count( $post_types ) ? $post_types[0] : $post_types,
-			'post_status'            => sanitize_key( (string) $post_status ) ?: 'any',
+			'post_status'            => $normalized_post_status ? $normalized_post_status : 'any',
 			'fields'                 => 'ids',
 			'posts_per_page'         => $limit,
 			'paged'                  => $paged,

--- a/inc/Cli/Commands/BlocksCommand.php
+++ b/inc/Cli/Commands/BlocksCommand.php
@@ -17,6 +17,7 @@ use DataMachine\Abilities\Content\GetPostBlocksAbility;
 use DataMachine\Abilities\Content\EditPostBlocksAbility;
 use DataMachine\Abilities\Content\ReplacePostBlocksAbility;
 use DataMachine\Core\AbilityResult;
+use DataMachine\Core\Content\SourceDerivedBlockAttributeRepair;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -255,5 +256,233 @@ class BlocksCommand extends BaseCommand {
 		if ( 'json' === ( $assoc_args['format'] ?? '' ) ) {
 			WP_CLI::log( wp_json_encode( $result['blocks_replaced'], JSON_PRETTY_PRINT ) );
 		}
+	}
+
+	/**
+	 * Inventory or repair the known malformed RichText content attributes.
+	 *
+	 * This is an operator-only maintenance command. On multisite, always pass the
+	 * intended site's `--url`; the command inspects only that site's posts.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--post_id=<id>]
+	 * : Inspect one post. By default all posts of the selected type are inspected.
+	 *
+	 * [--post_type=<type>]
+	 * : Comma-separated post types to inspect. Bulk apply requires this option.
+	 * Reusable `wp_block` records are inspected only when explicitly selected.
+	 * ---
+	 * default: page
+	 * ---
+	 *
+	 * [--post_status=<status>]
+	 * : Post status to inspect.
+	 * ---
+	 * default: any
+	 * ---
+	 *
+	 * [--limit=<number>]
+	 * : Maximum bulk posts per page. Default 100; maximum 500.
+	 *
+	 * [--paged=<number>]
+	 * : One-based bulk result page, ordered by ascending post ID.
+	 *
+	 * [--apply]
+	 * : Persist repairs. Without this flag the command is an inventory-only dry run.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp --url=https://example.com datamachine blocks repair-source-attributes --post_type=page
+	 *     wp --url=https://example.com datamachine blocks repair-source-attributes --post_id=123 --apply
+	 *
+	 * @subcommand repair-source-attributes
+	 */
+	public function repair_source_attributes( array $args, array $assoc_args ): void {
+		$apply  = isset( $assoc_args['apply'] );
+		$format = (string) ( $assoc_args['format'] ?? 'table' );
+		if ( ! in_array( $format, array( 'table', 'json', 'csv' ), true ) ) {
+			WP_CLI::error( '--format must be table, json, or csv.' );
+		}
+
+		$post_id = 0;
+		if ( array_key_exists( 'post_id', $assoc_args ) ) {
+			try {
+				$post_id = self::parsePositiveInteger( $assoc_args['post_id'], '--post_id' );
+			} catch ( \InvalidArgumentException $exception ) {
+				WP_CLI::error( $exception->getMessage() );
+			}
+		}
+
+		$limit = 1;
+		$paged = 1;
+		if ( $post_id > 0 ) {
+			if ( ! get_post( $post_id ) ) {
+				WP_CLI::error( sprintf( 'Post #%d does not exist on the selected site.', $post_id ) );
+			}
+			$post_ids = array( $post_id );
+			$post_types = array( get_post_type( $post_id ) );
+		} else {
+			try {
+				$limit = self::parsePositiveInteger( $assoc_args['limit'] ?? '100', '--limit', 500 );
+				$paged = self::parsePositiveInteger( $assoc_args['paged'] ?? '1', '--paged' );
+			} catch ( \InvalidArgumentException $exception ) {
+				WP_CLI::error( $exception->getMessage() );
+			}
+
+			$post_type_supplied = isset( $assoc_args['post_type'] ) && '' !== trim( (string) $assoc_args['post_type'] );
+			try {
+				$post_types = self::parsePostTypes( $assoc_args['post_type'] ?? 'page' );
+			} catch ( \InvalidArgumentException $exception ) {
+				WP_CLI::error( $exception->getMessage() );
+			}
+			if ( $apply && ( ! $post_type_supplied || in_array( 'any', $post_types, true ) ) ) {
+				WP_CLI::error( 'Bulk --apply requires an explicit --post_type that is not "any".' );
+			}
+
+			$query = new \WP_Query( self::bulkQueryArgs( $post_types, $assoc_args['post_status'] ?? 'any', $limit, $paged ) );
+			$post_ids = array_map( 'intval', $query->posts );
+		}
+
+		$repair = new SourceDerivedBlockAttributeRepair();
+		$findings = array();
+		foreach ( $post_ids as $candidate_id ) {
+			$post = get_post( $candidate_id );
+			if ( ! $post || ! is_string( $post->post_content ?? null ) || false === strpos( $post->post_content, '<!-- wp:' ) ) {
+				continue;
+			}
+
+			$result = $repair->processPost( (int) $candidate_id, $post->post_content, $apply );
+			foreach ( $result['findings'] as $finding ) {
+				$status = $finding['status'];
+				$reason = $finding['reason'];
+				if ( isset( $result['error_code'] ) && ( 'repairable' === $status || 'integrity_verification_failed' === $reason ) ) {
+					$status = 'error';
+					$reason = $result['error_code'];
+				} elseif ( $result['applied'] && 'repairable' === $status ) {
+					$status = 'removed';
+				} elseif ( 'repairable' === $status ) {
+					$status = 'would_remove';
+				}
+
+				$findings[] = array_merge(
+					$finding,
+					array(
+						'post_id' => (int) $candidate_id,
+						'status'  => $status,
+						'reason'  => $reason,
+					)
+				);
+			}
+		}
+
+		$summary = array(
+			'mode'            => $apply ? 'apply' : 'dry-run',
+			'site_url'        => home_url( '/' ),
+			'post_types'      => array_values( array_filter( $post_types ) ),
+			'limit'           => $limit,
+			'paged'           => $paged,
+			'posts_inspected' => count( $post_ids ),
+			'posts_with_findings' => count( array_unique( array_column( $findings, 'post_id' ) ) ),
+			'findings'        => count( $findings ),
+			'repairable'      => count( array_filter( $findings, static fn ( array $finding ): bool => in_array( $finding['status'], array( 'would_remove', 'removed' ), true ) ) ),
+			'skipped'         => count( array_filter( $findings, static fn ( array $finding ): bool => 'skipped' === $finding['status'] ) ),
+			'errors'          => count( array_filter( $findings, static fn ( array $finding ): bool => 'error' === $finding['status'] ) ),
+		);
+		$fields  = array( 'post_id', 'block_path', 'block_name', 'attribute', 'status', 'reason', 'value_type', 'value_bytes', 'value_sha256' );
+
+		if ( 'json' === $format ) {
+			WP_CLI::line( (string) wp_json_encode( array( 'findings' => $findings, 'summary' => $summary ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+		} else {
+			WP_CLI\Utils\format_items( $format, $findings, $fields );
+			if ( 'table' === $format ) {
+				WP_CLI::log( 'Summary: ' . (string) wp_json_encode( $summary, JSON_UNESCAPED_SLASHES ) );
+			}
+		}
+
+		if ( 0 !== self::applyExitCode( $apply, $summary ) ) {
+			if ( 'table' === $format ) {
+				WP_CLI::warning( 'One or more repairs failed; review error findings. Successful repairs remain committed.' );
+			}
+			WP_CLI::halt( 1 );
+		}
+	}
+
+	/**
+	 * Return a nonzero exit only when an apply run contains errors.
+	 *
+	 * @param bool  $apply Whether mutation was requested.
+	 * @param array $summary Output summary.
+	 */
+	private static function applyExitCode( bool $apply, array $summary ): int {
+		return $apply && 0 < (int) ( $summary['errors'] ?? 0 ) ? 1 : 0;
+	}
+
+	/**
+	 * Parse one positive canonical integer CLI value.
+	 *
+	 * @param mixed  $value Raw CLI value.
+	 * @param string $option Option name for errors.
+	 * @param int    $maximum Optional maximum.
+	 */
+	private static function parsePositiveInteger( $value, string $option, int $maximum = PHP_INT_MAX ): int {
+		$raw = is_string( $value ) || is_int( $value ) ? (string) $value : '';
+		if ( ! preg_match( '/^[1-9][0-9]*$/', $raw ) || (string) (int) $raw !== $raw || (int) $raw > $maximum ) {
+			throw new \InvalidArgumentException( sprintf( '%s must be a positive canonical integer%s.', $option, PHP_INT_MAX === $maximum ? '' : sprintf( ' no greater than %d', $maximum ) ) );
+		}
+
+		return (int) $raw;
+	}
+
+	/**
+	 * Parse selected post types without implicitly following reusable references.
+	 *
+	 * @param mixed $value Raw post type list.
+	 * @return string[]
+	 */
+	private static function parsePostTypes( $value ): array {
+		$types = array_values( array_unique( array_filter( array_map( 'sanitize_key', explode( ',', (string) $value ) ) ) ) );
+		if ( empty( $types ) ) {
+			throw new \InvalidArgumentException( '--post_type must contain at least one post type.' );
+		}
+
+		return $types;
+	}
+
+	/**
+	 * Build the bounded, cache-free bulk query.
+	 *
+	 * @param string[] $post_types Selected post types.
+	 * @param mixed    $post_status Raw post status.
+	 * @param int      $limit Page size.
+	 * @param int      $paged Result page.
+	 * @return array
+	 */
+	private static function bulkQueryArgs( array $post_types, $post_status, int $limit, int $paged ): array {
+		return array(
+			'post_type'              => 1 === count( $post_types ) ? $post_types[0] : $post_types,
+			'post_status'            => sanitize_key( (string) $post_status ) ?: 'any',
+			'fields'                 => 'ids',
+			'posts_per_page'         => $limit,
+			'paged'                  => $paged,
+			'orderby'                => 'ID',
+			'order'                  => 'ASC',
+			'no_found_rows'          => true,
+			'cache_results'          => false,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'lazy_load_term_meta'    => false,
+			'suppress_filters'       => true,
+		);
 	}
 }

--- a/inc/Core/Content/SourceDerivedBlockAttributeRepair.php
+++ b/inc/Core/Content/SourceDerivedBlockAttributeRepair.php
@@ -1,0 +1,337 @@
+<?php
+/**
+ * Conservative repair for the known Blocks Engine RichText corruption.
+ *
+ * @package DataMachine\Core\Content
+ */
+
+namespace DataMachine\Core\Content;
+
+use WP_Block_Type_Registry;
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+class SourceDerivedBlockAttributeRepair {
+
+	private const TARGET_BLOCKS = array(
+		'core/heading',
+		'core/paragraph',
+		'core/list-item',
+	);
+
+	/**
+	 * Inspect serialized blocks and prepare a verified, narrowly scoped repair.
+	 *
+	 * @param string $content Serialized post content.
+	 * @return array Repair result.
+	 */
+	public function inspect( string $content ): array {
+		$blocks   = $this->parse( $content );
+		$findings = array();
+
+		$this->inspectBlocks( $blocks, $findings );
+
+		$repairable = count( array_filter( $findings, static fn ( array $finding ): bool => 'repairable' === $finding['status'] ) );
+		$result     = array(
+			'content'         => $content,
+			'findings'        => $findings,
+			'repairable_count' => $repairable,
+			'skipped_count'    => count( $findings ) - $repairable,
+			'integrity_valid'  => true,
+		);
+
+		if ( 0 === $repairable ) {
+			return $result;
+		}
+
+		$repaired = $this->serialize( $blocks );
+		if ( $this->parse( $repaired ) !== $blocks ) {
+			foreach ( $result['findings'] as &$finding ) {
+				if ( 'repairable' === $finding['status'] ) {
+					$finding['status'] = 'skipped';
+					$finding['reason'] = 'integrity_verification_failed';
+				}
+			}
+			unset( $finding );
+
+			$result['repairable_count'] = 0;
+			$result['skipped_count']    = count( $result['findings'] );
+			$result['integrity_valid']  = false;
+			$result['error_code']       = 'datamachine_blocks_repair_integrity_failed';
+			$result['error']            = 'Repaired content did not round-trip to the exact expected block tree.';
+			return $result;
+		}
+
+		$result['content'] = $repaired;
+		return $result;
+	}
+
+	/**
+	 * Process one post, defaulting to an inventory-only dry run.
+	 *
+	 * The updater receives the post ID, repaired content, and originally inspected
+	 * content. The default implementation locks the current site's exact posts row,
+	 * compares post_content, and updates while holding that lock.
+	 *
+	 * @param int           $post_id Post ID.
+	 * @param string        $content Serialized post content.
+	 * @param bool          $apply Whether to persist the repair.
+	 * @param callable|null $updater Optional updater for deterministic tests.
+	 * @return array Repair result.
+	 */
+	public function processPost( int $post_id, string $content, bool $apply = false, ?callable $updater = null ): array {
+		$result            = $this->inspect( $content );
+		$result['post_id'] = $post_id;
+		$result['applied'] = false;
+
+		if ( ! $apply || 0 === $result['repairable_count'] || ! $result['integrity_valid'] ) {
+			return $result;
+		}
+
+		$updater ??= array( $this, 'updatePostAtomically' );
+		$updated    = $updater( $post_id, $result['content'], $content );
+		if ( is_wp_error( $updated ) ) {
+			$result['error_code'] = $updated->get_error_code();
+			$result['error']      = $updated->get_error_message();
+			return $result;
+		}
+
+		if ( $post_id !== $updated ) {
+			$result['error_code'] = 'datamachine_blocks_repair_update_failed';
+			$result['error']      = 'The post updater did not return the expected post ID.';
+			return $result;
+		}
+
+		$result['applied'] = true;
+		return $result;
+	}
+
+	/**
+	 * Atomically update a post only when its content is unchanged.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $repaired_content Verified repaired content.
+	 * @param string $inspected_content Content used to build the repair.
+	 * @param object|null $database Optional wpdb-compatible test double.
+	 * @param callable|null $writer Optional writer used to instrument the locked path.
+	 * @return int|WP_Error
+	 */
+	public function updatePostAtomically( int $post_id, string $repaired_content, string $inspected_content, $database = null, ?callable $writer = null ) {
+		global $wpdb;
+
+		$database ??= $wpdb;
+		$writer   ??= 'wp_update_post';
+		$open       = false;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- This bounded operator repair owns the transaction.
+		if ( false === $database->query( 'START TRANSACTION' ) ) {
+			return new WP_Error( 'datamachine_blocks_repair_transaction_failed', 'Could not start the repair transaction.' );
+		}
+		$open = true;
+
+		try {
+			$query = $database->prepare( 'SELECT post_content FROM %i WHERE ID = %d FOR UPDATE', $database->posts, $post_id );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Prepared exact-row lock is required for atomic compare-and-update.
+			$current = $database->get_var( $query );
+			if ( null === $current ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Close the owned transaction on every exit.
+				$database->query( 'ROLLBACK' );
+				$open = false;
+				return new WP_Error( 'datamachine_blocks_repair_post_missing', 'The post no longer exists.' );
+			}
+
+			if ( $current !== $inspected_content ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Close the owned transaction on conflict.
+				$database->query( 'ROLLBACK' );
+				$open = false;
+				return new WP_Error( 'datamachine_blocks_repair_conflict', 'Post content changed after inspection; no repair was applied.' );
+			}
+
+			$updated = $writer(
+				array(
+					'ID'           => $post_id,
+					'post_content' => $repaired_content,
+				),
+				true
+			);
+			if ( is_wp_error( $updated ) || $post_id !== $updated ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Never commit a failed update.
+				$database->query( 'ROLLBACK' );
+				$open = false;
+				return is_wp_error( $updated ) ? $updated : new WP_Error( 'datamachine_blocks_repair_update_failed', 'The post updater did not return the expected post ID.' );
+			}
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Commit only the exact successful update.
+			if ( false === $database->query( 'COMMIT' ) ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Best-effort cleanup if COMMIT failed.
+				$database->query( 'ROLLBACK' );
+				$open = false;
+				return new WP_Error( 'datamachine_blocks_repair_commit_failed', 'Could not commit the repair transaction.' );
+			}
+
+			$open = false;
+			return $updated;
+		} catch ( \Throwable $throwable ) {
+			if ( $open ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Exceptions must not leak transactions.
+				$database->query( 'ROLLBACK' );
+				$open = false;
+			}
+			return new WP_Error( 'datamachine_blocks_repair_exception', 'The atomic repair failed before commit.' );
+		} finally {
+			if ( $open ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Defensive transaction cleanup.
+				$database->query( 'ROLLBACK' );
+			}
+		}
+	}
+
+	/**
+	 * Parse content through WordPress's canonical block parser.
+	 *
+	 * @param string $content Serialized content.
+	 * @return array
+	 */
+	protected function parse( string $content ): array {
+		return parse_blocks( $content );
+	}
+
+	/**
+	 * Serialize the expected repaired tree through WordPress core.
+	 *
+	 * @param array $blocks Parsed block tree.
+	 */
+	protected function serialize( array $blocks ): string {
+		return serialize_blocks( $blocks );
+	}
+
+	/**
+	 * Find only the proven malformed RichText content signature.
+	 *
+	 * @param array  $blocks Parsed blocks, modified in place for repairable findings.
+	 * @param array  $findings Redacted finding inventory, modified in place.
+	 * @param string $parent_path Parent block path.
+	 */
+	private function inspectBlocks( array &$blocks, array &$findings, string $parent_path = '' ): void {
+		foreach ( $blocks as $index => &$block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			$path       = '' === $parent_path ? (string) $index : $parent_path . '.' . $index;
+			$block_name = is_string( $block['blockName'] ?? null ) ? $block['blockName'] : '';
+			if ( in_array( $block_name, self::TARGET_BLOCKS, true ) && array_key_exists( 'content', $block['attrs'] ?? array() ) ) {
+				$value      = $block['attrs']['content'];
+				$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
+				$schema     = is_object( $block_type ) && is_array( $block_type->attributes['content'] ?? null ) ? $block_type->attributes['content'] : array();
+				$reason     = $this->nonRepairableReason( $block_name, $schema, $value, (string) ( $block['innerHTML'] ?? '' ) );
+
+				$findings[] = $this->finding( $path, $block_name, $value, $reason );
+				if ( '' === $reason ) {
+					unset( $block['attrs']['content'] );
+				}
+			}
+
+			if ( is_array( $block['innerBlocks'] ?? null ) ) {
+				$this->inspectBlocks( $block['innerBlocks'], $findings, $path );
+			}
+		}
+		unset( $block );
+	}
+
+	/**
+	 * Return why a candidate cannot be repaired, or an empty string when safe.
+	 *
+	 * @param string $block_name Core block name.
+	 * @param array  $schema Registered content attribute schema.
+	 * @param mixed  $value Stored delimiter value.
+	 * @param string $inner_html Saved block HTML.
+	 */
+	private function nonRepairableReason( string $block_name, array $schema, $value, string $inner_html ): string {
+		if ( 'rich-text' !== ( $schema['type'] ?? null ) || 'rich-text' !== ( $schema['source'] ?? null ) ) {
+			return 'schema_not_proven_rich_text';
+		}
+
+		if ( ! is_string( $value ) ) {
+			return 'content_value_not_string';
+		}
+
+		if ( '' === $value ) {
+			return 'content_value_empty';
+		}
+
+		$root_content = $this->canonicalRootRichText( $block_name, $inner_html );
+		if ( null === $root_content ) {
+			return 'canonical_root_ambiguous';
+		}
+
+		if ( $root_content !== $value ) {
+			return 'content_not_exact_root_rich_text';
+		}
+
+		return '';
+	}
+
+	/**
+	 * Build a redacted finding without exposing full content.
+	 *
+	 * @param string $path Block path.
+	 * @param string $block_name Block name.
+	 * @param mixed  $value Stored delimiter value.
+	 * @param string $reason Skip reason, or empty when repairable.
+	 * @return array Redacted finding.
+	 */
+	private function finding( string $path, string $block_name, $value, string $reason ): array {
+		$value_type = get_debug_type( $value );
+		$string     = is_string( $value ) ? $value : wp_json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		$string     = is_string( $string ) ? $string : '';
+
+		return array(
+			'block_path'  => $path,
+			'block_name'  => $block_name,
+			'attribute'   => 'content',
+			'status'      => '' === $reason ? 'repairable' : 'skipped',
+			'reason'      => $reason,
+			'value_type'  => $value_type,
+			'value_bytes' => strlen( $string ),
+			'value_sha256' => hash( 'sha256', $string ),
+		);
+	}
+
+	/**
+	 * Extract exact RichText bytes from the one canonical root element.
+	 *
+	 * No entity decoding, tag stripping, or substring matching is permitted.
+	 * Ambiguous or non-canonical structures fail closed.
+	 *
+	 * @param string $block_name Core block name.
+	 * @param string $inner_html Saved inner HTML.
+	 */
+	private function canonicalRootRichText( string $block_name, string $inner_html ): ?string {
+		$attributes = '(?:\s+[^\s"\'=<>`]+(?:\s*=\s*(?:"[^"]*"|\'[^\']*\'|[^\s"\'=<>`]+))?)*\s*';
+		if ( 'core/heading' === $block_name ) {
+			$pattern = '~\A<h([1-6])' . $attributes . '>(.*)</h\1>\z~s';
+			$content_group = 2;
+		} elseif ( 'core/paragraph' === $block_name ) {
+			$pattern = '~\A<p' . $attributes . '>(.*)</p>\z~s';
+			$content_group = 1;
+		} elseif ( 'core/list-item' === $block_name ) {
+			$pattern = '~\A<li' . $attributes . '>(.*)</li>\z~s';
+			$content_group = 1;
+		} else {
+			return null;
+		}
+
+		if ( ! preg_match( $pattern, $inner_html, $matches ) ) {
+			return null;
+		}
+
+		$content = $matches[ $content_group ];
+		if ( preg_match( '~</?(?:p|li|h[1-6])(?:\s|>)~i', $content ) ) {
+			return null;
+		}
+
+		return $content;
+	}
+}

--- a/inc/Core/Content/SourceDerivedBlockAttributeRepair.php
+++ b/inc/Core/Content/SourceDerivedBlockAttributeRepair.php
@@ -34,8 +34,8 @@ class SourceDerivedBlockAttributeRepair {
 
 		$repairable = count( array_filter( $findings, static fn ( array $finding ): bool => 'repairable' === $finding['status'] ) );
 		$result     = array(
-			'content'         => $content,
-			'findings'        => $findings,
+			'content'          => $content,
+			'findings'         => $findings,
 			'repairable_count' => $repairable,
 			'skipped_count'    => count( $findings ) - $repairable,
 			'integrity_valid'  => true,
@@ -90,7 +90,7 @@ class SourceDerivedBlockAttributeRepair {
 		}
 
 		$updater ??= array( $this, 'updatePostAtomically' );
-		$updated    = $updater( $post_id, $result['content'], $content );
+		$updated   = $updater( $post_id, $result['content'], $content );
 		if ( is_wp_error( $updated ) ) {
 			$result['error_code'] = $updated->get_error_code();
 			$result['error']      = $updated->get_error_message();
@@ -288,13 +288,13 @@ class SourceDerivedBlockAttributeRepair {
 		$string     = is_string( $string ) ? $string : '';
 
 		return array(
-			'block_path'  => $path,
-			'block_name'  => $block_name,
-			'attribute'   => 'content',
-			'status'      => '' === $reason ? 'repairable' : 'skipped',
-			'reason'      => $reason,
-			'value_type'  => $value_type,
-			'value_bytes' => strlen( $string ),
+			'block_path'   => $path,
+			'block_name'   => $block_name,
+			'attribute'    => 'content',
+			'status'       => '' === $reason ? 'repairable' : 'skipped',
+			'reason'       => $reason,
+			'value_type'   => $value_type,
+			'value_bytes'  => strlen( $string ),
 			'value_sha256' => hash( 'sha256', $string ),
 		);
 	}
@@ -311,13 +311,13 @@ class SourceDerivedBlockAttributeRepair {
 	private function canonicalRootRichText( string $block_name, string $inner_html ): ?string {
 		$attributes = '(?:\s+[^\s"\'=<>`]+(?:\s*=\s*(?:"[^"]*"|\'[^\']*\'|[^\s"\'=<>`]+))?)*\s*';
 		if ( 'core/heading' === $block_name ) {
-			$pattern = '~\A<h([1-6])' . $attributes . '>(.*)</h\1>\z~s';
+			$pattern       = '~\A<h([1-6])' . $attributes . '>(.*)</h\1>\z~s';
 			$content_group = 2;
 		} elseif ( 'core/paragraph' === $block_name ) {
-			$pattern = '~\A<p' . $attributes . '>(.*)</p>\z~s';
+			$pattern       = '~\A<p' . $attributes . '>(.*)</p>\z~s';
 			$content_group = 1;
 		} elseif ( 'core/list-item' === $block_name ) {
-			$pattern = '~\A<li' . $attributes . '>(.*)</li>\z~s';
+			$pattern       = '~\A<li' . $attributes . '>(.*)</li>\z~s';
 			$content_group = 1;
 		} else {
 			return null;

--- a/tests/Unit/Core/Content/SourceDerivedBlockAttributeRepairTest.php
+++ b/tests/Unit/Core/Content/SourceDerivedBlockAttributeRepairTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Atomic RichText attribute repair integration tests.
+ *
+ * @package DataMachine\Tests\Unit\Core\Content
+ */
+
+namespace DataMachine\Tests\Unit\Core\Content;
+
+use DataMachine\Core\Content\SourceDerivedBlockAttributeRepair;
+use WP_UnitTestCase;
+
+final class SourceDerivedBlockAttributeRepairTest extends WP_UnitTestCase {
+
+	public function test_atomic_update_holds_post_row_lock_through_wp_update_post(): void {
+		if ( ! class_exists( '\mysqli' ) || ! defined( 'MYSQLI_ASYNC' ) ) {
+			$this->markTestSkipped( 'MySQLi async support is unavailable.' );
+		}
+
+		$second = $this->openMysqlConnection();
+		if ( ! $second instanceof \mysqli ) {
+			$this->markTestSkipped( 'A second direct test database connection is unavailable.' );
+		}
+
+		global $wpdb;
+		$original   = '<!-- wp:paragraph --><p>Original</p><!-- /wp:paragraph -->';
+		$repaired   = '<!-- wp:paragraph --><p>Repaired</p><!-- /wp:paragraph -->';
+		$competing  = '<!-- wp:paragraph --><p>Concurrent editor</p><!-- /wp:paragraph -->';
+		$post_id    = self::factory()->post->create( array( 'post_content' => $original ) );
+		$table      = str_replace( '`', '``', $wpdb->posts );
+		$escaped    = $second->real_escape_string( $competing );
+		$blocked    = false;
+		$async_sent = false;
+
+		try {
+			$this->assertTrue( $second->query( 'SET SESSION innodb_lock_wait_timeout = 2' ) );
+			$repair = new SourceDerivedBlockAttributeRepair();
+			$result = $repair->updatePostAtomically(
+				$post_id,
+				$repaired,
+				$original,
+				null,
+				function ( array $post_data, bool $wp_error ) use ( $second, $table, $escaped, $post_id, &$blocked, &$async_sent ) {
+					$async_sent = $second->query( "UPDATE `{$table}` SET post_content = '{$escaped}' WHERE ID = {$post_id}", MYSQLI_ASYNC );
+					$read       = array( $second );
+					$error      = array();
+					$reject     = array();
+					$blocked    = 0 === \mysqli_poll( $read, $error, $reject, 0, 100000 );
+
+					return wp_update_post( $post_data, $wp_error );
+				}
+			);
+
+			$this->assertSame( $post_id, $result );
+			$this->assertTrue( $async_sent );
+			$this->assertTrue( $blocked, 'The competing editor must wait for the post row lock.' );
+
+			$ready = 0;
+			for ( $attempt = 0; $attempt < 20 && 0 === $ready; ++$attempt ) {
+				$read   = array( $second );
+				$error  = array();
+				$reject = array();
+				$ready  = \mysqli_poll( $read, $error, $reject, 0, 100000 );
+			}
+			$this->assertSame( 1, $ready, 'The competing editor should resume after commit.' );
+			$this->assertTrue( $second->reap_async_query() );
+
+			clean_post_cache( $post_id );
+			$this->assertSame( $competing, get_post( $post_id )->post_content );
+		} finally {
+			$second->query( 'ROLLBACK' );
+			$second->close();
+			wp_delete_post( $post_id, true );
+		}
+	}
+
+	private function openMysqlConnection(): ?\mysqli {
+		$host   = DB_HOST;
+		$port   = null;
+		$socket = null;
+		if ( preg_match( '/^([^:]+):(\d+)$/', $host, $matches ) ) {
+			$host = $matches[1];
+			$port = (int) $matches[2];
+		} elseif ( preg_match( '/^([^:]+):(.+)$/', $host, $matches ) ) {
+			$host   = $matches[1];
+			$socket = $matches[2];
+		}
+
+		$connection = \mysqli_init();
+		if ( false === $connection || ! @$connection->real_connect( $host, DB_USER, DB_PASSWORD, DB_NAME, $port, $socket ) ) {
+			return null;
+		}
+
+		return $connection;
+	}
+}

--- a/tests/blocks-engine-rich-text-attributes-smoke.php
+++ b/tests/blocks-engine-rich-text-attributes-smoke.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * Smoke test for Blocks Engine RichText attributes and conservative repair.
+ *
+ * Run standalone for the CI source contract, and through WP-CLI for the real
+ * transformer, WordPress parser, serializer, renderer, and registered schemas:
+ * wp --path=/path/to/wordpress --skip-plugins --skip-themes eval-file tests/blocks-engine-rich-text-attributes-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$root = dirname( __DIR__ );
+
+if ( ! defined( 'ABSPATH' ) || ! function_exists( 'parse_blocks' ) ) {
+	$repair_source  = file_get_contents( $root . '/inc/Core/Content/SourceDerivedBlockAttributeRepair.php' );
+	$command_source = file_get_contents( $root . '/inc/Cli/Commands/BlocksCommand.php' );
+	$checks         = array(
+		'allowlists only three proven blocks' => false !== strpos( $repair_source, "'core/heading'" ) && false !== strpos( $repair_source, "'core/paragraph'" ) && false !== strpos( $repair_source, "'core/list-item'" ),
+		'requires exact rich-text schema'     => 2 === substr_count( $repair_source, "'rich-text'" ),
+		'requires exact canonical root markup' => false !== strpos( $repair_source, "\$root_content !== \$value" ) && false === strpos( $repair_source, "strpos( \$inner_html, \$value )" ),
+		'uses optimistic conflict guard'      => false !== strpos( $repair_source, 'datamachine_blocks_repair_conflict' ),
+		'uses an exact row lock'               => false !== strpos( $repair_source, 'SELECT post_content FROM %i WHERE ID = %d FOR UPDATE' ),
+		'uses integrity round-trip guard'     => false !== strpos( $repair_source, 'datamachine_blocks_repair_integrity_failed' ),
+		'bulk query is bounded'               => false !== strpos( $command_source, "'posts_per_page'" ) && false !== strpos( $command_source, "'no_found_rows'" ),
+		'bulk query disables cache priming'   => false !== strpos( $command_source, "'cache_results'" ) && false !== strpos( $command_source, "'update_post_meta_cache'" ) && false !== strpos( $command_source, "'update_post_term_cache'" ),
+		'JSON emits one findings envelope'    => false !== strpos( $command_source, "array( 'findings' => \$findings, 'summary' => \$summary )" ),
+		'structured findings expose no preview' => false === strpos( $command_source, "'preview'" ) && false === strpos( $repair_source, "'preview'" ),
+		'apply errors halt after output'       => strpos( $command_source, 'WP_CLI::halt( 1 )' ) > strpos( $command_source, "array( 'findings' => \$findings, 'summary' => \$summary )" ),
+	);
+
+	foreach ( $checks as $name => $passed ) {
+		echo sprintf( "%s: %s\n", $passed ? 'PASS' : 'FAIL', $name );
+		if ( ! $passed ) {
+			exit( 1 );
+		}
+	}
+	return;
+}
+
+require_once $root . '/vendor/autoload.php';
+require_once $root . '/inc/Core/Content/SourceDerivedBlockAttributeRepair.php';
+require_once $root . '/inc/Core/Content/ContentFormat.php';
+require_once $root . '/inc/Cli/BaseCommand.php';
+require_once $root . '/inc/Cli/Commands/BlocksCommand.php';
+
+use Automattic\BlocksEngine\PhpTransformer\WordPress\Runtime;
+use DataMachine\Cli\Commands\BlocksCommand;
+use DataMachine\Core\Content\ContentFormat;
+use DataMachine\Core\Content\SourceDerivedBlockAttributeRepair;
+
+$GLOBALS['blocks_engine_rich_text_failed'] = 0;
+$GLOBALS['blocks_engine_rich_text_total']  = 0;
+
+function assert_blocks_engine_rich_text( string $name, bool $condition ): void {
+	++$GLOBALS['blocks_engine_rich_text_total'];
+	if ( $condition ) {
+		echo "  PASS: {$name}\n";
+		return;
+	}
+
+	echo "  FAIL: {$name}\n";
+	++$GLOBALS['blocks_engine_rich_text_failed'];
+}
+
+$html          = '<h3>Heading <em>rich text</em></h3><p>Paragraph <strong>rich text</strong></p>';
+$direct_result = blocks_engine_php_transformer_convert_format( $html, 'html', 'blocks' );
+$direct_saved  = $direct_result['serialized_blocks'] ?? '';
+$saved         = ContentFormat::convert( $html, 'html', 'blocks' );
+$blocks        = is_string( $saved ) ? parse_blocks( $saved ) : array();
+
+assert_blocks_engine_rich_text( 'real transformer reports success', 'success' === ( $direct_result['status'] ?? '' ) );
+assert_blocks_engine_rich_text( 'Data Machine ContentFormat uses real transformer output', $direct_saved === $saved );
+assert_blocks_engine_rich_text( 'heading RichText remains in saved HTML', '<h3 class="wp-block-heading">Heading <em>rich text</em></h3>' === ( $blocks[0]['innerHTML'] ?? '' ) );
+assert_blocks_engine_rich_text( 'paragraph RichText remains in saved HTML', '<p>Paragraph <strong>rich text</strong></p>' === ( $blocks[1]['innerHTML'] ?? '' ) );
+assert_blocks_engine_rich_text( 'heading RichText is absent from delimiter attrs', ! array_key_exists( 'content', $blocks[0]['attrs'] ?? array() ) );
+assert_blocks_engine_rich_text( 'paragraph RichText is absent from delimiter attrs', ! array_key_exists( 'content', $blocks[1]['attrs'] ?? array() ) );
+assert_blocks_engine_rich_text( 'legitimate heading level remains', 3 === ( $blocks[0]['attrs']['level'] ?? null ) );
+
+$runtime    = new Runtime();
+$ordinary   = $blocks[0];
+$ordinary['attrs']['content']    = 'duplicate';
+$ordinary['attrs']['className']  = 'kept-class';
+$ordinary['attrs']['customFlag'] = 'kept-value';
+$canonical  = parse_blocks( $runtime->serializeBlocks( array( $ordinary ) ) )[0] ?? array();
+
+assert_blocks_engine_rich_text( 'runtime removes source-derived content', ! array_key_exists( 'content', $canonical['attrs'] ?? array() ) );
+assert_blocks_engine_rich_text( 'runtime preserves ordinary className', 'kept-class' === ( $canonical['attrs']['className'] ?? null ) );
+assert_blocks_engine_rich_text( 'runtime preserves unknown ordinary attrs', 'kept-value' === ( $canonical['attrs']['customFlag'] ?? null ) );
+
+$incorrect_usage = array();
+$notice_listener = static function ( string $function_name, string $message ) use ( &$incorrect_usage ): void {
+	if ( 'rest_validate_value_from_schema' === $function_name ) {
+		$incorrect_usage[] = $message;
+	}
+};
+add_action( 'doing_it_wrong_run', $notice_listener, 10, 2 );
+$rendered = $runtime->renderBlocks( parse_blocks( (string) $saved ) );
+remove_action( 'doing_it_wrong_run', $notice_listener, 10 );
+
+assert_blocks_engine_rich_text( 'real WordPress renders transformed RichText', false !== strpos( $rendered, 'Heading <em>rich text</em>' ) );
+assert_blocks_engine_rich_text( 'render emits no REST schema incorrect-usage notice', array() === $incorrect_usage );
+
+$fixture = '<aside data-free="x&amp;y">Loose &amp; free</aside>'
+	. '<!-- wp:group {"className":"outer","customFlag":"stay"} --><div class="wp-block-group">'
+	. '<!-- wp:heading {"content":"Heading &amp; <em>odd</em>","level":4,"anchor":"keep"} --><h4 class="wp-block-heading" id="keep">Heading &amp; <em>odd</em></h4><!-- /wp:heading -->'
+	. '<!-- wp:paragraph {"content":"Not represented","className":"skip"} --><p class="skip">Different saved text</p><!-- /wp:paragraph -->'
+	. '<!-- wp:list --><ul class="wp-block-list"><!-- wp:list-item {"content":"Nested &amp; odd","className":"nested"} --><li class="nested">Nested &amp; odd</li><!-- /wp:list-item --></ul><!-- /wp:list -->'
+	. '<!-- wp:image {"id":9,"url":"https://example.com/keep.jpg","className":"image-keep"} --><figure class="wp-block-image image-keep"><img src="https://example.com/keep.jpg" alt="" class="wp-image-9"/></figure><!-- /wp:image -->'
+	. '</div><!-- /wp:group --><span data-tail="1">Tail</span>';
+$expected = '<aside data-free="x&amp;y">Loose &amp; free</aside>'
+	. '<!-- wp:group {"className":"outer","customFlag":"stay"} --><div class="wp-block-group">'
+	. '<!-- wp:heading {"level":4,"anchor":"keep"} --><h4 class="wp-block-heading" id="keep">Heading &amp; <em>odd</em></h4><!-- /wp:heading -->'
+	. '<!-- wp:paragraph {"content":"Not represented","className":"skip"} --><p class="skip">Different saved text</p><!-- /wp:paragraph -->'
+	. '<!-- wp:list --><ul class="wp-block-list"><!-- wp:list-item {"className":"nested"} --><li class="nested">Nested &amp; odd</li><!-- /wp:list-item --></ul><!-- /wp:list -->'
+	. '<!-- wp:image {"id":9,"url":"https://example.com/keep.jpg","className":"image-keep"} --><figure class="wp-block-image image-keep"><img src="https://example.com/keep.jpg" alt="" class="wp-image-9"/></figure><!-- /wp:image -->'
+	. '</div><!-- /wp:group --><span data-tail="1">Tail</span>';
+$repair  = new SourceDerivedBlockAttributeRepair();
+$updates = array();
+$dry_run = $repair->processPost(
+	321,
+	$fixture,
+	false,
+	static function () use ( &$updates ): int {
+		$updates[] = 'unexpected';
+		return 321;
+	}
+);
+
+assert_blocks_engine_rich_text( 'whole-document repair output is exact', $expected === $dry_run['content'] );
+assert_blocks_engine_rich_text( 'repair identifies only proven represented RichText', 2 === $dry_run['repairable_count'] && 1 === $dry_run['skipped_count'] );
+assert_blocks_engine_rich_text( 'unrepresented content is skipped', 'content_not_exact_root_rich_text' === ( $dry_run['findings'][1]['reason'] ?? '' ) );
+assert_blocks_engine_rich_text( 'dry run never invokes updater', array() === $updates && false === $dry_run['applied'] );
+assert_blocks_engine_rich_text( 'findings redact full values', ! array_key_exists( 'value', $dry_run['findings'][0] ) && 64 === strlen( $dry_run['findings'][0]['value_sha256'] ?? '' ) );
+assert_blocks_engine_rich_text( 'findings expose no preview content', ! array_key_exists( 'preview', $dry_run['findings'][0] ) );
+
+$applied = $repair->processPost(
+	321,
+	$fixture,
+	true,
+	static function ( int $post_id, string $content, string $inspected ) use ( &$updates ): int {
+		$updates[] = compact( 'post_id', 'content', 'inspected' );
+		return $post_id;
+	}
+);
+assert_blocks_engine_rich_text( 'apply invokes updater once with exact expected document', 1 === count( $updates ) && $expected === $updates[0]['content'] && $fixture === $updates[0]['inspected'] && true === $applied['applied'] );
+
+$database = new class( $fixture ) {
+	public string $posts = 'wp_posts';
+	public array $queries = array();
+	public string $current;
+	public bool $fail_commit = false;
+	public function __construct( string $current ) {
+		$this->current = $current;
+	}
+	public function query( string $query ) {
+		$this->queries[] = $query;
+		if ( 'COMMIT' === $query && $this->fail_commit ) {
+			return false;
+		}
+		return 1;
+	}
+	public function prepare( string $query, ...$args ): string {
+		return str_replace( array( '%i', '%d' ), array( $args[0], (string) $args[1] ), $query );
+	}
+	public function get_var( string $query ): string {
+		$this->queries[] = $query;
+		return $this->current;
+	}
+};
+$atomic = $repair->updatePostAtomically( 321, $expected, $fixture, $database, static fn (): int => 321 );
+assert_blocks_engine_rich_text( 'atomic update locks exact row before commit', 321 === $atomic && array( 'START TRANSACTION', 'SELECT post_content FROM wp_posts WHERE ID = 321 FOR UPDATE', 'COMMIT' ) === $database->queries );
+
+$conflict_database = clone $database;
+$conflict_database->queries = array();
+$conflict_database->current = 'concurrent edit';
+$conflict = $repair->updatePostAtomically(
+	321,
+	$expected,
+	$fixture,
+	$conflict_database,
+	static function (): void {
+		throw new RuntimeException( 'Conflict must abort before the writer.' );
+	}
+);
+assert_blocks_engine_rich_text( 'atomic conflict rolls back with stable error', is_wp_error( $conflict ) && 'datamachine_blocks_repair_conflict' === $conflict->get_error_code() && 'ROLLBACK' === end( $conflict_database->queries ) );
+
+$writer_failure_database = clone $database;
+$writer_failure_database->queries = array();
+$writer_failure = $repair->updatePostAtomically( 321, $expected, $fixture, $writer_failure_database, static fn (): bool => false );
+assert_blocks_engine_rich_text( 'atomic writer failure rolls back without leaking transaction', is_wp_error( $writer_failure ) && 'datamachine_blocks_repair_update_failed' === $writer_failure->get_error_code() && 'ROLLBACK' === end( $writer_failure_database->queries ) );
+
+$exception_database = clone $database;
+$exception_database->queries = array();
+$exception_result = $repair->updatePostAtomically(
+	321,
+	$expected,
+	$fixture,
+	$exception_database,
+	static function (): void {
+		throw new RuntimeException( 'writer failed' );
+	}
+);
+assert_blocks_engine_rich_text( 'atomic writer exception rolls back without leaking transaction', is_wp_error( $exception_result ) && 'datamachine_blocks_repair_exception' === $exception_result->get_error_code() && 'ROLLBACK' === end( $exception_database->queries ) );
+
+$commit_failure_database = clone $database;
+$commit_failure_database->queries = array();
+$commit_failure_database->fail_commit = true;
+$commit_failure = $repair->updatePostAtomically( 321, $expected, $fixture, $commit_failure_database, static fn (): int => 321 );
+assert_blocks_engine_rich_text( 'atomic commit failure attempts rollback', is_wp_error( $commit_failure ) && 'datamachine_blocks_repair_commit_failed' === $commit_failure->get_error_code() && array( 'COMMIT', 'ROLLBACK' ) === array_slice( $commit_failure_database->queries, -2 ) );
+
+$false_update  = $repair->processPost( 321, $fixture, true, static fn (): bool => false );
+$failed_update = $repair->processPost( 321, $fixture, true, static fn (): int => 0 );
+$wrong_update  = $repair->processPost( 321, $fixture, true, static fn (): int => 999 );
+assert_blocks_engine_rich_text( 'false and zero updater results are errors', false === $false_update['applied'] && false === $failed_update['applied'] && 'datamachine_blocks_repair_update_failed' === ( $false_update['error_code'] ?? '' ) && 'datamachine_blocks_repair_update_failed' === ( $failed_update['error_code'] ?? '' ) );
+assert_blocks_engine_rich_text( 'unexpected updater post ID is an error', false === $wrong_update['applied'] && 'datamachine_blocks_repair_update_failed' === ( $wrong_update['error_code'] ?? '' ) );
+
+$integrity_failure = new class() extends SourceDerivedBlockAttributeRepair {
+	protected function serialize( array $blocks ): string {
+		return parent::serialize( $blocks ) . '<div>unexpected drift</div>';
+	}
+};
+$integrity_result = $integrity_failure->processPost( 321, $fixture, true, static fn (): int => 321 );
+assert_blocks_engine_rich_text( 'integrity mismatch aborts apply with stable error', false === $integrity_result['applied'] && 'datamachine_blocks_repair_integrity_failed' === ( $integrity_result['error_code'] ?? '' ) );
+
+$equivalence_fixture = '<!-- wp:heading {"content":"secret"} --><h2 class="wp-block-heading">not secret anymore</h2><!-- /wp:heading -->'
+	. '<!-- wp:paragraph {"content":"prefix"} --><p>prefix suffix</p><!-- /wp:paragraph -->'
+	. '<!-- wp:list-item {"content":"suffix"} --><li>prefix suffix</li><!-- /wp:list-item -->'
+	. '<!-- wp:paragraph {"content":"Fish \u0026 Chips"} --><p>Fish &amp; Chips</p><!-- /wp:paragraph -->'
+	. '<!-- wp:paragraph {"content":"Fish &amp; Chips"} --><p>Fish &amp; Chips</p><!-- /wp:paragraph -->'
+	. '<!-- wp:heading {"content":"Inline <strong>markup</strong>"} --><h3 class="wp-block-heading">Inline <strong>markup</strong></h3><!-- /wp:heading -->'
+	. '<!-- wp:list-item {"content":"<strong><em>Nested</em></strong>"} --><li><strong><em>Nested</em></strong></li><!-- /wp:list-item -->';
+$equivalence_expected = '<!-- wp:heading {"content":"secret"} --><h2 class="wp-block-heading">not secret anymore</h2><!-- /wp:heading -->'
+	. '<!-- wp:paragraph {"content":"prefix"} --><p>prefix suffix</p><!-- /wp:paragraph -->'
+	. '<!-- wp:list-item {"content":"suffix"} --><li>prefix suffix</li><!-- /wp:list-item -->'
+	. '<!-- wp:paragraph {"content":"Fish \u0026 Chips"} --><p>Fish &amp; Chips</p><!-- /wp:paragraph -->'
+	. '<!-- wp:paragraph --><p>Fish &amp; Chips</p><!-- /wp:paragraph -->'
+	. '<!-- wp:heading --><h3 class="wp-block-heading">Inline <strong>markup</strong></h3><!-- /wp:heading -->'
+	. '<!-- wp:list-item --><li><strong><em>Nested</em></strong></li><!-- /wp:list-item -->';
+$equivalence = $repair->inspect( $equivalence_fixture );
+assert_blocks_engine_rich_text( 'substring prefix suffix and decoded-entity matches are skipped', 3 === $equivalence['repairable_count'] && 4 === $equivalence['skipped_count'] );
+assert_blocks_engine_rich_text( 'escaped inline and nested exact markup is repairable', $equivalence_expected === $equivalence['content'] );
+assert_blocks_engine_rich_text( 'all false positives use exact-root mismatch reason', array( 'content_not_exact_root_rich_text' ) === array_values( array_unique( array_column( array_slice( $equivalence['findings'], 0, 4 ), 'reason' ) ) ) );
+
+$formula = $repair->inspect( '<!-- wp:paragraph {"content":"=HYPERLINK(\"https://bad.example\",\"secret\")"} --><p>=HYPERLINK(&quot;https://bad.example&quot;,&quot;secret&quot;)</p><!-- /wp:paragraph -->' );
+$formula_json = wp_json_encode( $formula['findings'] );
+$formula_table = implode( "\t", array_values( $formula['findings'][0] ) );
+$csv_stream   = fopen( 'php://memory', 'w+' );
+fputcsv( $csv_stream, array_keys( $formula['findings'][0] ), ',', '"', '' );
+fputcsv( $csv_stream, array_values( $formula['findings'][0] ), ',', '"', '' );
+rewind( $csv_stream );
+$formula_csv = stream_get_contents( $csv_stream );
+fclose( $csv_stream );
+assert_blocks_engine_rich_text( 'table JSON and CSV leak no formula or source text', false === strpos( $formula_table, 'HYPERLINK' ) && false === strpos( $formula_table, 'secret' ) && false === strpos( $formula_json, 'HYPERLINK' ) && false === strpos( $formula_json, 'secret' ) && false === strpos( $formula_csv, 'HYPERLINK' ) && false === strpos( $formula_csv, 'secret' ) );
+
+$parse_integer = new ReflectionMethod( BlocksCommand::class, 'parsePositiveInteger' );
+$bulk_args     = new ReflectionMethod( BlocksCommand::class, 'bulkQueryArgs' );
+$exit_code     = new ReflectionMethod( BlocksCommand::class, 'applyExitCode' );
+$valid_id      = $parse_integer->invoke( null, '42', '--post_id' );
+$invalid_ids   = array( '0', '-1', '01', '1.0', '', ' 1', '1 ' );
+$rejected      = 0;
+foreach ( $invalid_ids as $invalid_id ) {
+	try {
+		$parse_integer->invoke( null, $invalid_id, '--post_id' );
+	} catch ( ReflectionException | InvalidArgumentException $exception ) {
+		++$rejected;
+	}
+}
+$query_args = $bulk_args->invoke( null, array( 'page' ), 'any', 100, 2 );
+
+assert_blocks_engine_rich_text( 'command accepts positive canonical post ID', 42 === $valid_id );
+assert_blocks_engine_rich_text( 'command rejects every malformed post ID', count( $invalid_ids ) === $rejected );
+assert_blocks_engine_rich_text( 'bulk query is bounded and ordered', 100 === $query_args['posts_per_page'] && 2 === $query_args['paged'] && 'ID' === $query_args['orderby'] && 'ASC' === $query_args['order'] );
+assert_blocks_engine_rich_text( 'bulk query disables all cache priming', false === $query_args['cache_results'] && false === $query_args['update_post_meta_cache'] && false === $query_args['update_post_term_cache'] );
+assert_blocks_engine_rich_text( 'partial apply failures exit nonzero', 1 === $exit_code->invoke( null, true, array( 'errors' => 1, 'repairable' => 2 ) ) );
+assert_blocks_engine_rich_text( 'total apply failures exit nonzero', 1 === $exit_code->invoke( null, true, array( 'errors' => 3, 'repairable' => 0 ) ) );
+assert_blocks_engine_rich_text( 'dry-run findings never force failure exit', 0 === $exit_code->invoke( null, false, array( 'errors' => 3 ) ) );
+
+$total  = $GLOBALS['blocks_engine_rich_text_total'];
+$failed = $GLOBALS['blocks_engine_rich_text_failed'];
+echo "\nBlocks Engine RichText attributes smoke: {$total} assertions, {$failed} failures.\n";
+exit( min( 1, $failed ) );

--- a/tests/blocks-engine-rich-text-attributes-smoke.php
+++ b/tests/blocks-engine-rich-text-attributes-smoke.php
@@ -23,9 +23,9 @@ if ( ! defined( 'ABSPATH' ) || ! function_exists( 'parse_blocks' ) ) {
 		'uses integrity round-trip guard'     => false !== strpos( $repair_source, 'datamachine_blocks_repair_integrity_failed' ),
 		'bulk query is bounded'               => false !== strpos( $command_source, "'posts_per_page'" ) && false !== strpos( $command_source, "'no_found_rows'" ),
 		'bulk query disables cache priming'   => false !== strpos( $command_source, "'cache_results'" ) && false !== strpos( $command_source, "'update_post_meta_cache'" ) && false !== strpos( $command_source, "'update_post_term_cache'" ),
-		'JSON emits one findings envelope'    => false !== strpos( $command_source, "array( 'findings' => \$findings, 'summary' => \$summary )" ),
+		'JSON emits one findings envelope'    => 1 === substr_count( $command_source, "'findings' => \$findings" ) && 1 === substr_count( $command_source, "'summary'  => \$summary" ),
 		'structured findings expose no preview' => false === strpos( $command_source, "'preview'" ) && false === strpos( $repair_source, "'preview'" ),
-		'apply errors halt after output'       => strpos( $command_source, 'WP_CLI::halt( 1 )' ) > strpos( $command_source, "array( 'findings' => \$findings, 'summary' => \$summary )" ),
+		'apply errors halt after output'       => strpos( $command_source, 'WP_CLI::halt( 1 )' ) > strpos( $command_source, 'WP_CLI::line' ),
 	);
 
 	foreach ( $checks as $name => $passed ) {

--- a/tests/content-format-blocks-engine-smoke.php
+++ b/tests/content-format-blocks-engine-smoke.php
@@ -132,6 +132,10 @@ $failure = ContentFormat::convert( 'FAIL', 'markdown', 'blocks' );
 assert_content_format_blocks_engine( 'blocks-engine-failure-becomes-wp-error', is_wp_error( $failure ) );
 assert_content_format_blocks_engine( 'blocks-engine-failure-code-preserved', is_wp_error( $failure ) && 'datamachine_content_format_fixture_failed' === $failure->get_error_code() );
 
+$rich_text_smoke_status = 0;
+passthru( escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( __DIR__ . '/blocks-engine-rich-text-attributes-smoke.php' ), $rich_text_smoke_status );
+assert_content_format_blocks_engine( 'rich-text-attributes-smoke-is-in-aggregated-content-format-suite', 0 === $rich_text_smoke_status );
+
 echo "\nContentFormat Blocks Engine smoke: {$total} assertions, {$failed} failures.\n";
 
 exit( min( 1, $failed ) );


### PR DESCRIPTION
## Summary
- pin Blocks Engine PHP Transformer to immutable upstream fix commit `d8842683cb7928a0ae1f56878de93cf0bc8b7343`, containing #907 and #911
- prove heading, paragraph, and list-item RichText remains in inner HTML and is omitted from block delimiters
- add a conservative dry-run-first repair command for already persisted malformed RichText attributes
- protect apply with exact HTML equivalence, full-tree integrity checks, bounded queries, redacted output, and row-locked optimistic updates

## Root Cause
The bundled transformer `0.1.0` serialized source-derived `content` into Gutenberg block delimiter attributes. Core then attempted to validate block metadata type `rich-text` through REST JSON Schema, producing approximately 140,000 notices since August 13.

Upstream references:
- Automattic/blocks-engine#906
- Automattic/blocks-engine#907
- Automattic/blocks-engine#910
- Automattic/blocks-engine#911

## Repair Command
Dry run by default, scoped to the selected multisite URL:

```bash
wp --url=https://docs.extrachill.com datamachine blocks repair-source-attributes --post_type=page --limit=100 --format=json
```

Mutation requires explicit `--apply`. Bulk apply also requires an explicit non-`any` post type. Findings expose hashes and byte counts, never complete content.

Read-only production inventory found 196 exactly repairable and 60 deliberately skipped attributes across 13 Documentation pages. No production content was mutated.

## Verification
- real WordPress transformer/repair smoke: 38 assertions
- aggregated ContentFormat transformer smoke: 7 assertions
- existing content abilities: 44 assertions
- publish conversion smoke: 24 assertions
- dependency install dry run and Composer validation: pass
- PHPCS, PHP syntax, and `git diff --check`: pass
- two-connection MySQL row-lock test included; local execution awaits a runner with Docker/MySQL availability

Closes #3314.