### PR TITLE
Refactor conversation runtime tool mediation

### DIFF
--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -195,7 +195,7 @@ function datamachine_run_conversation(
 		$completion_policy
 	);
 
-	$tool_executor     = datamachine_build_loop_tool_executor( $tools, $loop_payload, $mode, $modes, $event_sink, $base_log_context );
+	$tool_executor     = datamachine_build_loop_tool_executor( $tools, $loop_payload, $mode );
 	$pre_tool_mediator = datamachine_build_pre_tool_mediator(
 		$tools,
 		$loop_payload,
@@ -534,12 +534,9 @@ function datamachine_normalize_typed_artifact_outputs( array $result ): array {
  * @param array<string,array<string,mixed>> $tools        Tool declarations keyed by name.
  * @param array<string,mixed>              $loop_payload Cleaned loop payload.
  * @param string                           $mode         Comma-separated execution mode label.
- * @param array<int,string>                $modes        Execution mode slugs.
- * @param LoopEventSinkInterface           $event_sink   Event sink.
- * @param array<string,mixed>              $base_log_context Base log context.
  */
-function datamachine_build_loop_tool_executor( array $tools, array $loop_payload, string $mode, array $modes, LoopEventSinkInterface $event_sink, array $base_log_context ): WP_Agent_Tool_Executor {
-	return new class( $tools, $loop_payload, $mode, $modes, $event_sink, $base_log_context ) implements WP_Agent_Tool_Executor {
+function datamachine_build_loop_tool_executor( array $tools, array $loop_payload, string $mode ): WP_Agent_Tool_Executor {
+	return new class( $tools, $loop_payload, $mode ) implements WP_Agent_Tool_Executor {
 		/** @var array<string,array<string,mixed>> */
 		private array $tools;
 
@@ -548,29 +545,15 @@ function datamachine_build_loop_tool_executor( array $tools, array $loop_payload
 
 		private string $mode;
 
-		/** @var array<int,string> */
-		private array $modes;
-
-		private LoopEventSinkInterface $event_sink;
-
-		/** @var array<string,mixed> */
-		private array $base_log_context;
-
 		/**
 		 * @param array<string,array<string,mixed>> $tools        Tool declarations keyed by name.
 		 * @param array<string,mixed>              $loop_payload Cleaned loop payload.
 		 * @param string                           $mode         Comma-separated execution mode label.
-		 * @param array<int,string>                $modes        Execution mode slugs.
-		 * @param LoopEventSinkInterface           $event_sink   Event sink.
-		 * @param array<string,mixed>              $base_log_context Base log context.
 		 */
-		public function __construct( array $tools, array $loop_payload, string $mode, array $modes, LoopEventSinkInterface $event_sink, array $base_log_context ) {
-			$this->tools            = $tools;
-			$this->loop_payload     = $loop_payload;
-			$this->mode             = $mode;
-			$this->modes            = $modes;
-			$this->event_sink       = $event_sink;
-			$this->base_log_context = $base_log_context;
+		public function __construct( array $tools, array $loop_payload, string $mode ) {
+			$this->tools        = $tools;
+			$this->loop_payload = $loop_payload;
+			$this->mode         = $mode;
 		}
 
 		/** @inheritDoc */
@@ -582,7 +565,6 @@ function datamachine_build_loop_tool_executor( array $tools, array $loop_payload
 			$tool_payload['prior_tool_results'] = $prior_results;
 			$client_context                     = is_array( $tool_payload['client_context'] ?? null ) ? $tool_payload['client_context'] : array();
 			$disposition_id                     = '';
-			$reservation_token                  = '';
 			if ( ! empty( $tool_definition['packet_disposition_bound'] ) ) {
 				$engine_data = is_array( $tool_payload['engine_data'] ?? null ) ? $tool_payload['engine_data'] : array();
 				$provided_id = is_string( $parameters['disposition_id'] ?? null ) ? trim( $parameters['disposition_id'] ) : '';
@@ -601,76 +583,17 @@ function datamachine_build_loop_tool_executor( array $tools, array $loop_payload
 				$parameters['disposition_id'] = $disposition_id;
 			}
 
-			if ( datamachine_is_external_runtime_tool( $tool_definition ) ) {
-				if ( '' !== $disposition_id ) {
-					$reservation = ToolExecutor::beginPacketExecution( $tool_name, $disposition_id, $tool_payload );
-					if ( empty( $reservation['acquired'] ) ) {
-						return $reservation['result'];
-					}
-					$reservation_token                         = (string) $reservation['token'];
-					$tool_payload['packet_execution_identity'] = array(
-						'job_id'         => (int) ( $tool_payload['job_id'] ?? 0 ),
-						'tool_name'      => $tool_name,
-						'disposition_id' => $disposition_id,
-					);
-				}
-				try {
-					$result = datamachine_fulfill_runtime_tool_call(
-						array_merge(
-							$tool_call,
-							array(
-								'name'       => $tool_name,
-								'parameters' => $parameters,
-							)
-						),
-						$tool_definition,
-						$tool_payload,
-						$this->mode,
-						$this->modes,
-						(int) ( $context['turn'] ?? 0 ),
-						$this->event_sink,
-						$this->base_log_context
-					);
-				} catch ( \Throwable $exception ) {
-					if ( '' !== $reservation_token ) {
-						ToolExecutor::finishPacketExecution( $tool_name, $disposition_id, $tool_payload, $reservation_token, 'ambiguous' );
-					}
-					return array(
-						'success'                  => false,
-						'tool_name'                => $tool_name,
-						'disposition_id'           => $disposition_id,
-						'code'                     => 'packet_execution_outcome_ambiguous',
-						'automatic_replay_blocked' => true,
-						'error'                    => $exception->getMessage(),
-					);
-				}
-			} else {
-				$result = ToolExecutor::executeTool(
-					$tool_name,
-					$parameters,
-					$this->tools,
-					$tool_payload,
-					$this->mode,
-					(int) ( $tool_payload['agent_id'] ?? 0 ),
-					$client_context
-				);
-			}
+			$result = ToolExecutor::executeTool(
+				$tool_name,
+				$parameters,
+				$this->tools,
+				$tool_payload,
+				$this->mode,
+				(int) ( $tool_payload['agent_id'] ?? 0 ),
+				$client_context
+			);
 			if ( '' !== $disposition_id ) {
 				$result['disposition_id'] = $disposition_id;
-				if ( '' !== $reservation_token ) {
-					$state      = ! empty( $result['pending'] ) ? 'pending' : ( ! empty( $result['success'] ) ? 'succeeded' : 'failed' );
-					$request_id = is_array( $result['runtime_tool_request'] ?? null ) ? (string) ( $result['runtime_tool_request']['request_id'] ?? '' ) : '';
-					if ( ! ToolExecutor::finishPacketExecution( $tool_name, $disposition_id, $tool_payload, $reservation_token, $state, $request_id ) ) {
-						return array(
-							'success'                  => false,
-							'tool_name'                => $tool_name,
-							'disposition_id'           => $disposition_id,
-							'code'                     => 'packet_execution_outcome_ambiguous',
-							'automatic_replay_blocked' => true,
-							'error'                    => 'Runtime handler returned, but its durable execution outcome could not be persisted.',
-						);
-					}
-				}
 			}
 
 			$metadata                              = is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array();
@@ -1652,36 +1575,6 @@ function datamachine_should_defer_runtime_tool_call( array $request, array $payl
 	}
 
 	return '' !== (string) ( $request['session_id'] ?? '' );
-}
-
-/**
- * Persist a pending runtime tool request and schedule its timeout.
- *
- * @param array<string,mixed> $request Runtime tool request.
- * @param array<string,mixed> $payload Loop/tool payload.
- * @return array<string,mixed>|\WP_Error Pending tool result or persistence error.
- */
-function datamachine_defer_runtime_tool_call( array $request, array $payload ): array|\WP_Error {
-	$pending_request = datamachine_prepare_runtime_tool_request( $request, $payload );
-	if ( $pending_request instanceof \WP_Error ) {
-		return $pending_request;
-	}
-
-	$pending_request = WP_Agent_Runtime_Tool_Lifecycle::create_pending_request(
-		datamachine_runtime_tool_request_store(),
-		$pending_request,
-		array( 'payload' => $payload )
-	);
-	return array(
-		'success'              => false,
-		'pending'              => true,
-		'status'               => WP_Agent_Runtime_Tool_Request::STATUS_PENDING,
-		'tool_name'            => $pending_request['tool_name'],
-		'executor'             => 'client',
-		'code'                 => WP_Agent_Runtime_Tool_Request::STATUS_PENDING,
-		'error'                => 'Runtime tool request is pending client fulfillment.',
-		'runtime_tool_request' => $pending_request,
-	);
 }
 
 /** Return Data Machine's Agents API runtime-tool request store adapter. */

--- a/inc/Engine/AI/conversation-loop.php
+++ b/inc/Engine/AI/conversation-loop.php
@@ -773,10 +773,11 @@ function datamachine_build_pre_tool_mediator( array $tools, array $loop_payload,
 				$tool_result['metadata']['status'] = DataMachineConversationStatus::RUNTIME_TOOL_PENDING;
 			}
 
+			$is_pending = ! empty( $tool_result['pending'] );
 			return array(
-				'action'   => ! empty( $tool_result['pending'] ) ? 'pending' : 'replace_result',
+				'action'   => 'replace_result',
 				'result'   => $tool_result,
-				'complete' => ! empty( $tool_result['pending'] ),
+				'complete' => $is_pending,
 			);
 		}
 

--- a/tests/agent-conversation-runner-request-smoke.php
+++ b/tests/agent-conversation-runner-request-smoke.php
@@ -69,6 +69,12 @@ if ( ! function_exists( 'get_option' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return 0;
+	}
+}
+
 require_once __DIR__ . '/bootstrap-unit.php';
 require_once __DIR__ . '/Unit/Support/WpAiClientTestDoubles.php';
 

--- a/tests/runtime-tool-contract-store-smoke.php
+++ b/tests/runtime-tool-contract-store-smoke.php
@@ -124,6 +124,16 @@ namespace DataMachine\Core\Database\Chat {
 
 namespace DataMachine\Engine\AI {
 	class ConversationManager {
+		public static function validateToolCall( string $tool_name, array $tool_parameters, array $messages, ?array $tool_definition ): array {
+			unset( $tool_name, $tool_parameters, $messages, $tool_definition );
+			return array( 'is_duplicate' => false );
+		}
+
+		public static function duplicateToolCallError( string $tool_name, string $mode ): string {
+			unset( $tool_name, $mode );
+			return 'Duplicate tool call.';
+		}
+
 		public static function formatToolResultMessage( string $tool_name, array $tool_result, array $tool_parameters, bool $is_handler_tool = false, int $turn_count = 0 ): array {
 			unset( $tool_parameters, $is_handler_tool );
 
@@ -141,8 +151,13 @@ namespace {
 	use AgentsAPI\AI\WP_Agent_Runtime_Tool_Request;
 	use AgentsAPI\AI\WP_Agent_Runtime_Tool_Result;
 	use AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle;
+	use AgentsAPI\AI\WP_Agent_Conversation_Loop;
+	use AgentsAPI\AI\Tools\WP_Agent_Tool_Executor;
 	use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 	use DataMachine\Core\Database\Jobs\Jobs;
+	use DataMachine\Engine\AI\DataMachineToolRuntimeRules;
+	use DataMachine\Engine\AI\LoopEventSinkInterface;
+	use function DataMachine\Engine\AI\datamachine_build_pre_tool_mediator;
 	use function DataMachine\Engine\AI\datamachine_prepare_runtime_tool_pending_result;
 	use function DataMachine\Engine\AI\datamachine_prepare_runtime_tool_request;
 	use function DataMachine\Engine\AI\datamachine_runtime_tool_request_store;
@@ -181,6 +196,12 @@ namespace {
 		}
 	}
 
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( $data, int $flags = 0, int $depth = 512 ) {
+			return json_encode( $data, $flags, $depth );
+		}
+	}
+
 	$GLOBALS['datamachine_runtime_tool_scheduled'] = array();
 	$GLOBALS['datamachine_runtime_tool_enqueued']  = array();
 
@@ -209,21 +230,46 @@ namespace {
 		}
 	}
 
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( string $hook, $value, ...$args ) {
+			unset( $hook, $args );
+			return $value;
+		}
+	}
+
+	if ( ! function_exists( 'add_filter' ) ) {
+		function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+			unset( $hook, $callback, $priority, $accepted_args );
+		}
+	}
+
+	if ( ! function_exists( 'did_action' ) ) {
+		function did_action( string $hook = '' ): int {
+			unset( $hook );
+			return 0;
+		}
+	}
+
 	if ( ! function_exists( 'add_action' ) ) {
 		function add_action( string $hook, callable|string $callback ): void {
 			unset( $hook, $callback );
 		}
 	}
 
-	require __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-citation-metadata.php';
-	require __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-runtime-tool-request.php';
-	require __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-runtime-tool-result.php';
-	require __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-runtime-tool-request-store.php';
-	require __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-runtime-tool-continuation.php';
-	require __DIR__ . '/../vendor/wordpress/agents-api/src/Runtime/class-wp-agent-runtime-tool-lifecycle.php';
-	require __DIR__ . '/../inc/Engine/AI/RuntimeToolRunStateStore.php';
-	require __DIR__ . '/../inc/Engine/AI/Tools/ToolExecutor.php';
-	require __DIR__ . '/../inc/Engine/AI/conversation-loop.php';
+	require __DIR__ . '/../vendor/autoload.php';
+	require_once __DIR__ . '/../inc/Engine/AI/RuntimeToolRunStateStore.php';
+	require_once __DIR__ . '/../inc/Engine/AI/Tools/ToolExecutor.php';
+	require_once __DIR__ . '/../inc/Engine/AI/conversation-loop.php';
+
+	class RuntimeToolContractStoreSmokeExecutor implements WP_Agent_Tool_Executor {
+		public int $calls = 0;
+
+		public function executeWP_Agent_Tool_Call( array $tool_call, array $tool_definition, array $context = array() ): array {
+			unset( $tool_call, $tool_definition, $context );
+			++$this->calls;
+			return array( 'success' => false, 'error' => 'Deferred tools must not reach the PHP executor.' );
+		}
+	}
 
 	function prepare_and_persist_runtime_tool_request( array $request, array $payload ): array|WP_Error {
 		$pending = datamachine_prepare_runtime_tool_pending_result( $request, $payload );
@@ -452,6 +498,67 @@ namespace {
 	$client_execution = $client_request['metadata']['datamachine']['packet_execution'] ?? array();
 	$assert( ! str_contains( (string) json_encode( $client_pending ), 'reservation_token' ) && ! str_contains( (string) json_encode( $client_pending ), 'must-never-leave-engine-state' ), 'actual client-visible deferred request output contains no reservation token' );
 	$assert( 808 === ( $client_execution['job_id'] ?? null ) && 'client/packet_handler' === ( $client_execution['tool_name'] ?? null ) && $packet_id === ( $client_execution['disposition_id'] ?? null ), 'client-visible deferred request retains only safe packet execution identity' );
+
+	$chat_db->sessions['session-integrated'] = array( 'messages' => array(), 'metadata' => array(), 'provider' => 'openai', 'model' => 'gpt' );
+	$integrated_tool = array(
+		'name'              => 'client/deferred_action',
+		'description'       => 'A deferred client action.',
+		'parameters'        => array( 'type' => 'object', 'properties' => array() ),
+		'executor'          => 'client',
+		'external_executor' => true,
+		'runtime_tool'      => true,
+	);
+	$integrated_tools = array( 'client/deferred_action' => $integrated_tool );
+	$integrated_payload = array(
+		'user_id'        => 7,
+		'agent_id'       => 11,
+		'session_id'     => 'session-integrated',
+		'client_context' => array(
+			'session_id'         => 'session-integrated',
+			'runtime_tool_async' => true,
+		),
+	);
+	$integrated_executor = new RuntimeToolContractStoreSmokeExecutor();
+	$integrated_result   = WP_Agent_Conversation_Loop::run(
+		array( array( 'role' => 'user', 'content' => 'Run the deferred action.' ) ),
+		static fn( array $messages ): array => array(
+			'messages'   => $messages,
+			'tool_calls' => array(
+				array(
+					'id'         => 'call-integrated',
+					'name'       => 'client/deferred_action',
+					'parameters' => array(),
+				),
+			),
+		),
+		array(
+			'max_turns'         => 1,
+			'tool_executor'     => $integrated_executor,
+			'tool_declarations' => $integrated_tools,
+			'pre_tool_mediator' => datamachine_build_pre_tool_mediator(
+				$integrated_tools,
+				$integrated_payload,
+				'chat',
+				array( 'chat' ),
+				new DataMachineToolRuntimeRules(),
+				new class() implements LoopEventSinkInterface {
+					public function emit( string $event, array $payload = array() ): void {
+						unset( $event, $payload );
+					}
+				},
+				array()
+			),
+			'runtime_tool_store' => datamachine_runtime_tool_request_store(),
+		)
+	);
+	$integrated_request    = is_array( $integrated_result['runtime_tool_pending'] ?? null ) ? $integrated_result['runtime_tool_pending'] : array();
+	$integrated_request_id = (string) ( $integrated_request['request_id'] ?? '' );
+	$integrated_job_id     = (int) substr( $integrated_request_id, strlen( 'runtime_tool_' ) );
+	$assert( str_starts_with( $integrated_request_id, 'runtime_tool_' ) && $integrated_job_id > 0, 'integrated async mediation preserves the preallocated Data Machine request id' );
+	$assert( 'call-integrated' === ( $integrated_request['tool_call_id'] ?? '' ), 'integrated async mediation preserves the provider tool call id' );
+	$assert( $integrated_request_id === ( Jobs::$engine_data[ $integrated_job_id ]['runtime_tool_request']['request_id'] ?? '' ), 'Agents API persists the canonical mediated request in the Data Machine store' );
+	$assert( isset( $chat_db->sessions['session-integrated']['metadata']['runtime_tool_requests'][ $integrated_request_id ] ), 'integrated async mediation mirrors the canonical request into session state' );
+	$assert( 0 === $integrated_executor->calls, 'integrated async mediation bypasses the PHP executor' );
 	if ( $failures ) {
 		echo "\nFAILED: " . count( $failures ) . " runtime tool contract store assertions failed.\n";
 		exit( 1 );

--- a/tests/runtime-tool-contract-store-smoke.php
+++ b/tests/runtime-tool-contract-store-smoke.php
@@ -140,9 +140,10 @@ namespace DataMachine\Engine\AI {
 namespace {
 	use AgentsAPI\AI\WP_Agent_Runtime_Tool_Request;
 	use AgentsAPI\AI\WP_Agent_Runtime_Tool_Result;
+	use AgentsAPI\AI\WP_Agent_Runtime_Tool_Lifecycle;
 	use DataMachine\Core\Database\Chat\ConversationStoreFactory;
 	use DataMachine\Core\Database\Jobs\Jobs;
-	use function DataMachine\Engine\AI\datamachine_defer_runtime_tool_call;
+	use function DataMachine\Engine\AI\datamachine_prepare_runtime_tool_pending_result;
 	use function DataMachine\Engine\AI\datamachine_prepare_runtime_tool_request;
 	use function DataMachine\Engine\AI\datamachine_runtime_tool_request_store;
 	use function DataMachine\Engine\AI\datamachine_resume_runtime_tool_request;
@@ -224,6 +225,20 @@ namespace {
 	require __DIR__ . '/../inc/Engine/AI/Tools/ToolExecutor.php';
 	require __DIR__ . '/../inc/Engine/AI/conversation-loop.php';
 
+	function prepare_and_persist_runtime_tool_request( array $request, array $payload ): array|WP_Error {
+		$pending = datamachine_prepare_runtime_tool_pending_result( $request, $payload );
+		if ( $pending instanceof WP_Error ) {
+			return $pending;
+		}
+
+		$pending['runtime_tool_request'] = WP_Agent_Runtime_Tool_Lifecycle::create_pending_request(
+			datamachine_runtime_tool_request_store(),
+			$pending['runtime_tool_request'],
+			array( 'payload' => $payload )
+		);
+		return $pending;
+	}
+
 	$failures = array();
 	$passes   = 0;
 
@@ -244,7 +259,7 @@ namespace {
 	$chat_db->sessions['session-1']       = array( 'messages' => array(), 'metadata' => array(), 'provider' => 'openai', 'model' => 'gpt' );
 	$chat_db->sessions['session-timeout'] = array( 'messages' => array(), 'metadata' => array(), 'provider' => 'openai', 'model' => 'gpt' );
 
-	$pending = datamachine_defer_runtime_tool_call(
+	$pending = prepare_and_persist_runtime_tool_request(
 		array(
 			'tool_name'  => 'client/select_block',
 			'call_id'    => 'call-1',
@@ -298,7 +313,7 @@ namespace {
 	$assert( array( 'owner_tool' ) === ( $delegated_resume['tools'] ?? null ), 'delegated caller-scoped tools remain visible after async resume' );
 	$assert( 52 === ( Jobs::$engine_data[1]['runtime_tool_run_state']['resume_payload']['calling_user_id'] ?? null ), 'runtime run-state records the delegated caller in its resume payload' );
 
-	$timeout_pending = datamachine_defer_runtime_tool_call(
+	$timeout_pending = prepare_and_persist_runtime_tool_request(
 		array(
 			'tool_name'  => 'client/confirm',
 			'call_id'    => 'call-timeout',
@@ -315,7 +330,7 @@ namespace {
 	$assert( 'failed' === ( Jobs::$jobs[2]['status'] ?? '' ), 'timeout fails the Data Machine job' );
 
 	$chat_db->sessions['session-system'] = array( 'messages' => array(), 'metadata' => array(), 'provider' => 'openai', 'model' => 'gpt' );
-	$system_pending = datamachine_defer_runtime_tool_call(
+	$system_pending = prepare_and_persist_runtime_tool_request(
 		array(
 			'tool_name'  => 'client/select_block',
 			'call_id'    => 'call-system',
@@ -414,7 +429,7 @@ namespace {
 	$assert( array() === datamachine_runtime_tool_request_store()->recent_pending(), 'store adapter implements the Agents API recent-pending contract' );
 
 	$chat_db->sessions['session-client-output'] = array( 'messages' => array(), 'metadata' => array(), 'provider' => 'openai', 'model' => 'gpt' );
-	$client_pending = datamachine_defer_runtime_tool_call(
+	$client_pending = prepare_and_persist_runtime_tool_request(
 		array(
 			'tool_name'  => 'client/packet_handler',
 			'call_id'    => 'call-client-output',

--- a/tests/runtime-tool-delegated-result-smoke.php
+++ b/tests/runtime-tool-delegated-result-smoke.php
@@ -51,7 +51,10 @@ require_once __DIR__ . '/bootstrap-unit.php';
 require_once __DIR__ . '/../inc/Engine/AI/conversation-loop.php';
 
 use DataMachine\Engine\AI\LoopEventSinkInterface;
-use function DataMachine\Engine\AI\datamachine_build_loop_tool_executor;
+use AgentsAPI\AI\Tools\WP_Agent_Tool_Executor;
+use AgentsAPI\AI\WP_Agent_Conversation_Loop;
+use DataMachine\Engine\AI\DataMachineToolRuntimeRules;
+use function DataMachine\Engine\AI\datamachine_build_pre_tool_mediator;
 
 class DelegatedRuntimeToolSmokeSink implements LoopEventSinkInterface {
 	public array $events = array();
@@ -60,6 +63,20 @@ class DelegatedRuntimeToolSmokeSink implements LoopEventSinkInterface {
 		$this->events[] = array(
 			'event'   => $event,
 			'payload' => $payload,
+		);
+	}
+}
+
+class DelegatedRuntimeToolUnexpectedExecutor implements WP_Agent_Tool_Executor {
+	public int $calls = 0;
+
+	public function executeWP_Agent_Tool_Call( array $tool_call, array $tool_definition, array $context = array() ): array {
+		unset( $tool_call, $tool_definition, $context );
+		++$this->calls;
+
+		return array(
+			'success' => false,
+			'error'   => 'External runtime tools must not reach the PHP executor.',
 		);
 	}
 }
@@ -94,6 +111,52 @@ $delegated_tool = array(
 $delegated_tools = array( 'delegated_action' => $delegated_tool );
 $sink            = new DelegatedRuntimeToolSmokeSink();
 
+$run_delegated_tool = static function ( string $call_id, string $value, array $payload = array() ) use ( $delegated_tools, $sink ): array {
+	$executor = new DelegatedRuntimeToolUnexpectedExecutor();
+	$turns    = 0;
+	$mediator = datamachine_build_pre_tool_mediator(
+		$delegated_tools,
+		$payload,
+		'chat',
+		array( 'chat' ),
+		new DataMachineToolRuntimeRules(),
+		$sink,
+		array()
+	);
+	$result   = WP_Agent_Conversation_Loop::run(
+		array( array( 'role' => 'user', 'content' => 'Run the delegated action.' ) ),
+		static function ( array $messages ) use ( &$turns, $call_id, $value ): array {
+			++$turns;
+			if ( 1 === $turns ) {
+				return array(
+					'messages'   => $messages,
+					'tool_calls' => array(
+						array(
+							'id'         => $call_id,
+							'name'       => 'delegated_action',
+							'parameters' => array( 'value' => $value ),
+						),
+					),
+				);
+			}
+
+			return array(
+				'messages'   => $messages,
+				'content'    => 'Delegated action complete.',
+				'tool_calls' => array(),
+			);
+		},
+		array(
+			'max_turns'         => 2,
+			'tool_executor'     => $executor,
+			'tool_declarations' => $delegated_tools,
+			'pre_tool_mediator' => $mediator,
+		)
+	);
+
+	return array( $result, $executor, $turns );
+};
+
 echo "runtime-tool-delegated-result-smoke\n\n";
 
 add_filter(
@@ -112,23 +175,22 @@ add_filter(
 	2
 );
 
-$filter_executor = datamachine_build_loop_tool_executor( $delegated_tools, array(), 'chat', array( 'chat' ), $sink, array() );
-$filter_result   = $filter_executor->executeWP_Agent_Tool_Call(
-	array(
-		'tool_name'  => 'delegated_action',
-		'id'         => 'delegated-filter-call',
-		'parameters' => array( 'value' => 'from-filter' ),
-	),
-	$delegated_tool,
-	array( 'turn' => 1 )
-);
-$assert( true === ( $filter_result['success'] ?? null ), 'filter result succeeds through delegated executor fallback' );
-$assert( 'client' === ( $filter_result['executor'] ?? null ), 'filter result is normalized as client-executed' );
-$assert( true === ( $filter_result['filtered'] ?? null ), 'filter payload is preserved' );
-$assert( 'from-filter' === ( $filter_result['value'] ?? null ), 'filter receives model parameters' );
+$filter_run      = $run_delegated_tool( 'delegated-filter-call', 'from-filter' );
+$filter_result   = $filter_run[0]['tool_execution_results'][0]['result'] ?? array();
+$filter_payload  = is_array( $filter_result['result'] ?? null ) ? $filter_result['result'] : array();
+$filter_executor = $filter_run[1];
+$assert( true === ( $filter_result['success'] ?? null ), 'filter result succeeds through the integrated mediator path' );
+$assert( 'client' === ( $filter_payload['executor'] ?? null ), 'filter result is normalized as client-executed' );
+$assert( true === ( $filter_payload['filtered'] ?? null ), 'filter payload is preserved' );
+$assert( 'from-filter' === ( $filter_payload['value'] ?? null ), 'filter receives model parameters' );
+$assert( 0 === $filter_executor->calls, 'filter fulfillment bypasses the PHP executor' );
+$assert( 2 === $filter_run[2], 'filter fulfillment continues to the next provider turn' );
+$assert( 'Delegated action complete.' === ( $filter_run[0]['final_content'] ?? null ), 'filter fulfillment preserves continuation content' );
+$assert( array( 'tool_call', 'tool_result' ) === array_column( $filter_run[0]['tool_events'] ?? array(), 'type' ), 'filter fulfillment preserves canonical tool events' );
 
-$callback_executor = datamachine_build_loop_tool_executor(
-	$delegated_tools,
+$callback_run = $run_delegated_tool(
+	'delegated-callback-call',
+	'from-callback',
 	array(
 		'client_context' => array(
 			'runtime_tool_callback' => static function ( array $request ): array {
@@ -138,28 +200,19 @@ $callback_executor = datamachine_build_loop_tool_executor(
 				);
 			},
 		),
-	),
-	'chat',
-	array( 'chat' ),
-	$sink,
-	array()
+	)
 );
-$callback_result   = $callback_executor->executeWP_Agent_Tool_Call(
-	array(
-		'tool_name'  => 'delegated_action',
-		'id'         => 'delegated-callback-call',
-		'parameters' => array( 'value' => 'from-callback' ),
-	),
-	$delegated_tool,
-	array( 'turn' => 2 )
-);
-$assert( true === ( $callback_result['success'] ?? null ), 'runtime_tool_callback result succeeds through delegated executor fallback' );
-$assert( 'client' === ( $callback_result['executor'] ?? null ), 'runtime_tool_callback result is normalized as client-executed' );
-$assert( true === ( $callback_result['callback'] ?? null ), 'runtime_tool_callback payload is preserved' );
-$assert( 'from-callback' === ( $callback_result['value'] ?? null ), 'runtime_tool_callback receives model parameters' );
+$callback_result = $callback_run[0]['tool_execution_results'][0]['result'] ?? array();
+$callback_payload = is_array( $callback_result['result'] ?? null ) ? $callback_result['result'] : array();
+$assert( true === ( $callback_result['success'] ?? null ), 'runtime_tool_callback result succeeds through the integrated mediator path' );
+$assert( 'client' === ( $callback_payload['executor'] ?? null ), 'runtime_tool_callback result is normalized as client-executed' );
+$assert( true === ( $callback_payload['callback'] ?? null ), 'runtime_tool_callback payload is preserved' );
+$assert( 'from-callback' === ( $callback_payload['value'] ?? null ), 'runtime_tool_callback receives model parameters' );
+$assert( 0 === $callback_run[1]->calls, 'runtime_tool_callback fulfillment bypasses the PHP executor' );
 
-$preseed_executor = datamachine_build_loop_tool_executor(
-	$delegated_tools,
+$preseed_run = $run_delegated_tool(
+	'delegated-preseed-call',
+	'ignored',
 	array(
 		'client_context' => array(
 			'runtime_tool_results' => array(
@@ -169,27 +222,17 @@ $preseed_executor = datamachine_build_loop_tool_executor(
 				),
 			),
 		),
-	),
-	'chat',
-	array( 'chat' ),
-	$sink,
-	array()
+	)
 );
-$preseed_result   = $preseed_executor->executeWP_Agent_Tool_Call(
-	array(
-		'tool_name'  => 'delegated_action',
-		'id'         => 'delegated-preseed-call',
-		'parameters' => array( 'value' => 'ignored' ),
-	),
-	$delegated_tool,
-	array( 'turn' => 3 )
-);
-$assert( true === ( $preseed_result['success'] ?? null ), 'runtime_tool_results pre-seeded result succeeds through delegated executor fallback' );
-$assert( 'client' === ( $preseed_result['executor'] ?? null ), 'runtime_tool_results result is normalized as client-executed' );
-$assert( true === ( $preseed_result['preseeded'] ?? null ), 'runtime_tool_results payload is preserved' );
-$assert( 'from-preseed' === ( $preseed_result['value'] ?? null ), 'runtime_tool_results result is selected by call id' );
-$assert( str_contains( wp_json_encode( $sink->events ), 'runtime_tool_call' ), 'delegated executor fallback emits runtime_tool_call events' );
-$assert( str_contains( wp_json_encode( $sink->events ), 'runtime_tool_result' ), 'delegated executor fallback emits runtime_tool_result events' );
+$preseed_result = $preseed_run[0]['tool_execution_results'][0]['result'] ?? array();
+$preseed_payload = is_array( $preseed_result['result'] ?? null ) ? $preseed_result['result'] : array();
+$assert( true === ( $preseed_result['success'] ?? null ), 'runtime_tool_results pre-seeded result succeeds through the integrated mediator path' );
+$assert( 'client' === ( $preseed_payload['executor'] ?? null ), 'runtime_tool_results result is normalized as client-executed' );
+$assert( true === ( $preseed_payload['preseeded'] ?? null ), 'runtime_tool_results payload is preserved' );
+$assert( 'from-preseed' === ( $preseed_payload['value'] ?? null ), 'runtime_tool_results result is selected by call id' );
+$assert( 0 === $preseed_run[1]->calls, 'runtime_tool_results fulfillment bypasses the PHP executor' );
+$assert( str_contains( wp_json_encode( $sink->events ), 'runtime_tool_call' ), 'integrated mediator emits runtime_tool_call events' );
+$assert( str_contains( wp_json_encode( $sink->events ), 'runtime_tool_result' ), 'integrated mediator emits runtime_tool_result events' );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " delegated runtime tool assertions failed.\n";


### PR DESCRIPTION
## Summary

- remove the unreachable external-runtime branch from `datamachine_build_loop_tool_executor()`, leaving the executor responsible only for local/PHP tools
- remove the test-only `datamachine_defer_runtime_tool_call()` wrapper and exercise pending persistence through the canonical prepared request plus Agents API lifecycle
- route delegated filter, callback, and preseed result coverage through Data Machine's mediator and the integrated Agents API conversation loop, with assertions that the PHP executor is never called

## Deleted paths and reachability proof

- Deleted the external-tool disposition/reservation/fulfillment branch inside `datamachine_build_loop_tool_executor()`.
- Deleted `datamachine_defer_runtime_tool_call()`.
- Removed executor state used only by the deleted branch: `modes`, `event_sink`, and `base_log_context`.
- Repository-wide grep before editing found the executor builder in the production loop plus direct delegated-result test calls only. The defer wrapper had no production caller and was referenced only by `tests/runtime-tool-contract-store-smoke.php`.
- Locked Agents API revision `4b88bfba005adc65f49dddfaa2dfc0bf336d8bf6` proves `reject`, `replace_result`, and `pending` mediator decisions bypass `executePreparedTool()`; only `proceed` reaches the executor. Pending decisions are persisted centrally with `WP_Agent_Runtime_Tool_Lifecycle::create_pending_request()`.
- After deletion, `datamachine_fulfill_runtime_tool_call()` has one call site, in `datamachine_build_pre_tool_mediator()`. The `datamachine_runtime_tool_result` filter and runtime result submission/fulfillment seams remain intact.

## Complexity metrics

Measured with the same tokenizer-based script against `origin/main` and this branch:

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Lines | 3,239 | 3,132 | -107 |
| Bytes | 130,674 | 125,981 | -4,693 |
| Functions/closures | 83 | 82 | -1 |
| Parameters | 183 | 175 | -8 |
| By-reference parameters | 0 | 0 | 0 |
| Runtime fulfillment call sites | 2 | 1 | -1 duplicate path |

## Behavioral evidence

Passed focused coverage:

- `php tests/runtime-tool-delegated-result-smoke.php` (20 assertions)
- `php tests/runtime-tool-contract-store-smoke.php` (49 assertions)
- `php tests/runtime-tool-declaration-smoke.php` (26 assertions)
- `php tests/agent-conversation-runner-request-smoke.php`
- `php tests/agent-conversation-runtime-policy-smoke.php` (105 assertions)
- `php vendor/wordpress/agents-api/tests/conversation-loop-tool-execution-smoke.php` (115 assertions)

This covers local PHP tools; external filter/callback/preseed fulfillment; pending request persistence; fulfilled submission; timeout and duplicate recovery; rejection; revised retry; continuation; transcript projection; canonical tool events; and explicit external executor bypass.

Passed candidate/supporting gates:

- candidate changed-file lint: PHPCS, ESLint, and PHPStan, zero findings
- candidate PR audit: zero introduced findings
- direct PHPCS and PHP syntax checks on every changed PHP file
- `npm run build`
- Homeboy build/package gate, including packaged PHP syntax and structure validation; produced `build/data-machine.zip`
- `composer validate --strict --no-check-publish`
- `composer audit --locked`: no advisories
- `npm audit --omit=dev`: zero vulnerabilities
- `homeboy deps status data-machine`
- `git diff --check`

The four WP Codebox-backed candidate test shards were invoked but executed zero tests because the shared Homeboy cache is missing `wp-codebox/source/packages/cli/dist/index.js`; every sandbox recipe failed before test execution. This infrastructure defect is tracked in Extra-Chill/homeboy#13010. Direct focused tests and the deterministic package gate passed. A pre-existing missing `get_current_user_id()` standalone smoke double discovered during focused verification is fixed here and tracked in #3319.

## Remaining #2803 phases

- separate runtime-tool fulfillment/store responsibilities from the procedural file after this duplicate path is gone
- continue decomposing provider-turn state/adapter responsibilities only where the locked Agents API contract permits it
- simplify result normalization and remaining procedural orchestration without changing provider, transcript, status, or lifecycle contracts
- run the full four-shard WP Codebox candidate suite once Extra-Chill/homeboy#13010 restores executable cache hydration

Refs #2803