### PR TITLE
chore: adopt pending mediation normalization fix

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -794,12 +794,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "4b88bfba005adc65f49dddfaa2dfc0bf336d8bf6"
+                "reference": "c930b9afeb2019e83a60f62a80104b90833dd81d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/4b88bfba005adc65f49dddfaa2dfc0bf336d8bf6",
-                "reference": "4b88bfba005adc65f49dddfaa2dfc0bf336d8bf6",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/c930b9afeb2019e83a60f62a80104b90833dd81d",
+                "reference": "c930b9afeb2019e83a60f62a80104b90833dd81d",
                 "shasum": ""
             },
             "require": {
@@ -964,7 +964,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-08-19T16:49:56+00:00"
+            "time": "2026-08-23T00:35:11+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## Summary
- advance the locked `wordpress/agents-api` dependency from `4b88bfba` to merged PR Automattic/agents-api#522 at `c930b9af`
- bring the idempotent pending mediation normalizer and custom request-ID regression into Data Machine's bundled substrate
- leave Data Machine source behavior unchanged

## Verification
- `composer validate --strict` completed with only the repository's existing version-field warning
- `php tests/runtime-tool-contract-store-smoke.php` passed 54 assertions
- `php tests/runtime-tool-delegated-result-smoke.php` passed 20 assertions
- `php tests/release-bundled-agents-api-smoke.php` passed 14 assertions
- `php vendor/wordpress/agents-api/tests/conversation-loop-tool-execution-smoke.php` passed 123 assertions
- Composer reported no security vulnerability advisories

Relates to Automattic/agents-api#521 and Automattic/agents-api#522.