### PR TITLE
fix: stop repeated chat migration convergence

### DIFF
--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -16,6 +16,7 @@ use DataMachine\Abilities\Chat\ChatTranscriptOwner;
 use DataMachine\Core\Agents\AgentIdentityResolver;
 use DataMachine\Core\Database\BaseRepository;
 use DataMachine\Core\Database\LifecycleStateTransition;
+use DataMachine\Core\Database\TransactionScope;
 use AgentsAPI\AI\WP_Agent_Execution_Principal;
 use AgentsAPI\AI\WP_Agent_Message;
 use AgentsAPI\Core\Workspace\WP_Agent_Workspace_Scope;
@@ -323,6 +324,10 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 				continue;
 			}
 
+			if ( self::migration_rows_match( $observed, $canonical ) && self::migration_has_provenance( $observed, $blog_id, $source_session_id ) ) {
+				return $canonical;
+			}
+
 			$updated = self::update_migration_target( $table_name, $canonical, $observed );
 			if ( false === $updated ) {
 				return null;
@@ -337,56 +342,81 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		return null;
 	}
 
-	/** Update a target only when its complete observed version remains unchanged. */
+	/** Update changed columns only while holding an exact lock on the observed row. */
 	private static function update_migration_target( string $table_name, array $canonical, array $observed ) {
 		global $wpdb;
 
-		$set        = array();
-		$predicates = array();
-		$arguments  = array( $table_name );
-		foreach ( $canonical as $column => $value ) {
-			if ( null === $value ) {
-				$set[]       = '%i = NULL';
-				$arguments[] = $column;
-			} elseif ( in_array( $column, self::MIGRATION_NUMERIC_COLUMNS, true ) ) {
-				$set[]       = '%i = %d';
-				$arguments[] = $column;
-				$arguments[] = (int) $value;
-			} else {
-				$set[]       = '%i = %s';
-				$arguments[] = $column;
-				$arguments[] = (string) $value;
-			}
-		}
-
-		foreach ( $observed as $column => $value ) {
-			if ( null === $value ) {
-				$predicates[] = '%i IS NULL';
-				$arguments[]  = $column;
-			} elseif ( in_array( $column, self::MIGRATION_NUMERIC_COLUMNS, true ) ) {
-				$predicates[] = '%i = %d';
-				$arguments[]  = $column;
-				$arguments[]  = (int) $value;
-			} else {
-				$predicates[] = 'BINARY %i = BINARY %s';
-				$arguments[]  = $column;
-				$arguments[]  = (string) $value;
-			}
-		}
-
-		$sql = 'UPDATE %i SET ' . implode( ', ', $set ) . ' WHERE ' . implode( ' AND ', $predicates );
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$prepared = $wpdb->prepare( $sql, ...$arguments );
 		for ( $attempt = 1; $attempt <= self::MIGRATION_DEADLOCK_ATTEMPTS; ++$attempt ) {
 			$previous_suppression = method_exists( $wpdb, 'suppress_errors' ) ? $wpdb->suppress_errors( true ) : null;
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
-			$updated  = $wpdb->query( $prepared );
-			$db_error = (string) $wpdb->last_error;
+			$scope                = TransactionScope::begin( $wpdb );
+			$updated              = false;
+			$db_error             = null === $scope ? (string) $wpdb->last_error : '';
+
+			if ( null !== $scope ) {
+				$locked = self::migration_target_row_for_update( $table_name, (string) ( $canonical['session_id'] ?? '' ) );
+				if ( ! is_array( $locked ) ) {
+					$db_error = (string) $wpdb->last_error;
+					$scope->rollback();
+					$updated = '' !== $db_error ? false : 0;
+				} elseif ( ! self::migration_observation_matches( $locked, $observed ) ) {
+					$scope->rollback();
+					$updated = 0;
+				} else {
+					$changes = array_filter(
+						$canonical,
+						static fn( $value, string $column ): bool => ! self::migration_values_match( $locked[ $column ] ?? null, $value, $column ),
+						ARRAY_FILTER_USE_BOTH
+					);
+					if ( ! empty( $changes ) && array_key_exists( 'updated_at', $canonical ) && ! array_key_exists( 'updated_at', $changes ) ) {
+						// Prevent the table's ON UPDATE clause from replacing the canonical source version.
+						$changes['updated_at'] = $canonical['updated_at'];
+					}
+
+					if ( empty( $changes ) ) {
+						$updated = $scope->commit() ? 0 : false;
+						$db_error = false === $updated ? (string) $wpdb->last_error : '';
+					} else {
+						$set       = array();
+						$arguments = array( $table_name );
+						foreach ( $changes as $column => $value ) {
+							if ( null === $value ) {
+								$set[]       = '%i = NULL';
+								$arguments[] = $column;
+							} elseif ( in_array( $column, self::MIGRATION_NUMERIC_COLUMNS, true ) ) {
+								$set[]       = '%i = %d';
+								$arguments[] = $column;
+								$arguments[] = (int) $value;
+							} else {
+								$set[]       = '%i = %s';
+								$arguments[] = $column;
+								$arguments[] = (string) $value;
+							}
+						}
+						$arguments[] = 'session_id';
+						$arguments[] = (string) $canonical['session_id'];
+						$sql         = 'UPDATE %i SET ' . implode( ', ', $set ) . ' WHERE %i = %s';
+						// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
+						$updated = $wpdb->query( $wpdb->prepare( $sql, ...$arguments ) );
+						if ( false === $updated ) {
+							$db_error = (string) $wpdb->last_error;
+							$scope->rollback();
+						} elseif ( ! $scope->commit() ) {
+							$db_error = (string) $wpdb->last_error;
+							$scope->rollback();
+							$updated  = false;
+						}
+					}
+				}
+			}
+
 			if ( null !== $previous_suppression ) {
 				$wpdb->suppress_errors( $previous_suppression );
 			}
 
 			if ( false !== $updated || ! LifecycleStateTransition::is_deadlock_error( $db_error ) || $attempt >= self::MIGRATION_DEADLOCK_ATTEMPTS ) {
+				if ( false === $updated && '' !== $db_error ) {
+					$wpdb->last_error = $db_error;
+				}
 				return $updated;
 			}
 
@@ -406,6 +436,37 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		}
 
 		return false;
+	}
+
+	/** Read and lock one migration target for an atomic compare-and-update. */
+	private static function migration_target_row_for_update( string $table_name, string $session_id ): ?array {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$row = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM %i WHERE session_id = %s FOR UPDATE', $table_name, $session_id ), ARRAY_A );
+		return is_array( $row ) ? $row : null;
+	}
+
+	/** Confirm the locked row is still the exact snapshot observed before locking. */
+	private static function migration_observation_matches( array $locked, array $observed ): bool {
+		foreach ( $observed as $column => $value ) {
+			if ( ! array_key_exists( $column, $locked ) || ! self::migration_values_match( $locked[ $column ], $value, $column ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static function migration_values_match( $stored, $expected, string $column ): bool {
+		if ( null === $stored || null === $expected ) {
+			return null === $stored && null === $expected;
+		}
+		if ( in_array( $column, self::MIGRATION_NUMERIC_COLUMNS, true ) ) {
+			return (int) $stored === (int) $expected;
+		}
+
+		return (string) $stored === (string) $expected;
 	}
 
 	private static function migration_row_is_unscoped( array $row ): bool {

--- a/inc/setup/chat-sessions-network.php
+++ b/inc/setup/chat-sessions-network.php
@@ -10,13 +10,18 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Preserve per-site chat history in the canonical network table.
  *
- * The completion marker is evidence, not a one-shot guard. Every schema setup
- * pass re-runs the idempotent copy and anti-join verification so rows missed by
- * an interrupted or older deployment are recovered later.
+ * A verified completion marker prevents every per-site schema pass from
+ * reconverging the same immutable legacy tables into the network target.
  */
 function datamachine_converge_chat_sessions_to_network(): bool {
 	if ( ! function_exists( 'is_multisite' ) || ! is_multisite() ) {
 		return true;
+	}
+	if ( function_exists( 'get_site_option' ) ) {
+		$marker = get_site_option( 'datamachine_chat_sessions_network_migrated' );
+		if ( is_array( $marker ) && true === ( $marker['verified'] ?? false ) ) {
+			return true;
+		}
 	}
 
 	$result = \DataMachine\Core\Database\Chat\Chat::migrate_per_site_tables_to_network();

--- a/tests/chat-sessions-network-convergence-smoke.php
+++ b/tests/chat-sessions-network-convergence-smoke.php
@@ -7,6 +7,7 @@ namespace DataMachine\Core\Database {
 	abstract class BaseRepository {
 		public static function database_table_exists( string $table, $wpdb = null ): bool { unset( $wpdb ); return isset( $GLOBALS['chat_tables'][ $table ] ); }
 		public static function column_exists( string $table, string $column, $wpdb = null ): bool { unset( $wpdb ); return in_array( $column, $GLOBALS['chat_columns'][ $table ] ?? array(), true ); }
+		public static function is_sqlite(): bool { return false; }
 	}
 }
 
@@ -193,7 +194,6 @@ namespace {
 		);
 	}
 	$GLOBALS['chat_batch_reads'] = array();
-	$GLOBALS['chat_cas_prepares'] = array();
 	$GLOBALS['chat_collision_probe_reads'] = 0;
 	$GLOBALS['chat_force_collision_probe_exhaustion'] = false;
 	$GLOBALS['chat_concurrent_updates'] = array(
@@ -228,9 +228,6 @@ namespace {
 				$replacement = is_int( $arg ) ? (string) $arg : "'" . str_replace( "'", "''", (string) $arg ) . "'";
 				$prepared_query = preg_replace( '/%[isd]/', $replacement, $prepared_query, 1 );
 			}
-			if ( str_starts_with( $query, 'UPDATE %i SET ' ) && str_contains( $query, 'BINARY %i = BINARY %s' ) ) {
-				$GLOBALS['chat_cas_prepares'][] = array( 'template' => $query, 'query' => $prepared_query );
-			}
 			return $prepared_query;
 		}
 		private function unquote( string $value ): string { return str_replace( "''", "'", trim( $value, "'" ) ); }
@@ -261,6 +258,10 @@ namespace {
 			if ( preg_match( "/SELECT \\* FROM '([^']+)' WHERE session_id = ('(?:''|[^'])*')/", $query, $matches ) ) {
 				$session_id = $this->unquote( $matches[2] );
 				if ( isset( $GLOBALS['chat_tables'][ $matches[1] ][ $session_id ] ) ) {
+					if ( str_contains( $query, 'FOR UPDATE' ) && isset( $GLOBALS['chat_concurrent_updates'][ $session_id ] ) ) {
+						$GLOBALS['chat_tables'][ $matches[1] ][ $session_id ] = array_merge( $GLOBALS['chat_tables'][ $matches[1] ][ $session_id ], $GLOBALS['chat_concurrent_updates'][ $session_id ] );
+						unset( $GLOBALS['chat_concurrent_updates'][ $session_id ] );
+					}
 					return $GLOBALS['chat_tables'][ $matches[1] ][ $session_id ];
 				}
 				if ( $GLOBALS['chat_force_collision_probe_exhaustion'] && str_starts_with( $session_id, 'dm-' ) ) {
@@ -272,6 +273,8 @@ namespace {
 			return null;
 		}
 		public function get_var( string $query ) {
+			if ( 'SELECT @@autocommit' === $query ) { return 1; }
+			if ( "SHOW VARIABLES LIKE 'in_transaction'" === $query ) { return null; }
 			if ( preg_match( "/SHOW TABLES LIKE '([^']+)'/", $query, $matches ) ) {
 				return isset( $GLOBALS['chat_tables'][ $matches[1] ] ) ? $matches[1] : null;
 			}
@@ -313,10 +316,10 @@ namespace {
 			return empty( $changed ) ? 0 : 1;
 		}
 		public function query( string $query ): int|false {
-			if ( preg_match( "/^UPDATE '([^']+)' SET (.*) WHERE (.*)$/", $query, $matches ) && str_contains( $matches[3], 'BINARY ' ) ) {
+			if ( in_array( $query, array( 'START TRANSACTION', 'COMMIT', 'ROLLBACK' ), true ) ) { return 1; }
+			if ( preg_match( "/^UPDATE '([^']+)' SET (.*) WHERE 'session_id' = ('(?:''|[^'])*')$/", $query, $matches ) ) {
 				$table = $matches[1];
-				preg_match( "/BINARY 'session_id' = BINARY ('(?:''|[^'])*')/", $matches[3], $id_match );
-				$id = isset( $id_match[1] ) ? $this->unquote( $id_match[1] ) : '';
+				$id    = $this->unquote( $matches[3] );
 				$this->migration_update_queries[] = $query;
 				if ( 0 < ( $this->deadlocks_remaining[ $id ] ?? 0 ) ) {
 					--$this->deadlocks_remaining[ $id ];
@@ -326,23 +329,7 @@ namespace {
 				}
 				$this->last_error = '';
 				if ( ! isset( $GLOBALS['chat_tables'][ $table ][ $id ] ) ) { return 0; }
-				if ( isset( $GLOBALS['chat_concurrent_updates'][ $id ] ) ) {
-					$GLOBALS['chat_tables'][ $table ][ $id ] = array_merge( $GLOBALS['chat_tables'][ $table ][ $id ], $GLOBALS['chat_concurrent_updates'][ $id ] );
-					unset( $GLOBALS['chat_concurrent_updates'][ $id ] );
-				}
 				$row = $GLOBALS['chat_tables'][ $table ][ $id ];
-				preg_match_all( "/BINARY '([a-z_]+)' = BINARY ('(?:''|[^'])*')/", $matches[3], $binary_conditions, PREG_SET_ORDER );
-				foreach ( $binary_conditions as $condition ) {
-					if ( (string) ( $row[ $condition[1] ] ?? '' ) !== $this->unquote( $condition[2] ) ) { return 0; }
-				}
-				preg_match_all( "/(?:^| AND )'([a-z_]+)' = (-?[0-9]+)/", $matches[3], $numeric_conditions, PREG_SET_ORDER );
-				foreach ( $numeric_conditions as $condition ) {
-					if ( (int) ( $row[ $condition[1] ] ?? 0 ) !== (int) $condition[2] ) { return 0; }
-				}
-				preg_match_all( "/(?:^| AND )'([a-z_]+)' IS NULL/", $matches[3], $null_conditions, PREG_SET_ORDER );
-				foreach ( $null_conditions as $condition ) {
-					if ( null !== ( $row[ $condition[1] ] ?? null ) ) { return 0; }
-				}
 				if ( $this->force_update_zero ) { return 0; }
 				$data = array();
 				preg_match_all( "/'([a-z_]+)' = (NULL|-?[0-9]+|'(?:''|[^'])*')/", $matches[2], $assignments, PREG_SET_ORDER );
@@ -350,6 +337,9 @@ namespace {
 					$data[ $assignment[1] ] = 'NULL' === $assignment[2] ? null : ( "'" === $assignment[2][0] ? $this->unquote( $assignment[2] ) : (int) $assignment[2] );
 				}
 				$changed = array_diff_assoc( $data, $row );
+				if ( ! empty( $changed ) && array_key_exists( 'updated_at', $row ) && ! array_key_exists( 'updated_at', $data ) ) {
+					$data['updated_at'] = '2026-12-31 23:59:59';
+				}
 				$GLOBALS['chat_tables'][ $table ][ $id ] = array_merge( $row, $data );
 				return empty( $changed ) ? 0 : 1;
 			}
@@ -397,6 +387,7 @@ namespace {
 	function do_action( string $hook, ...$args ): void { $GLOBALS['chat_logs'][] = array( $hook, $args ); }
 
 	require_once dirname( __DIR__ ) . '/inc/Core/Database/LifecycleStateTransition.php';
+	require_once dirname( __DIR__ ) . '/inc/Core/Database/TransactionScope.php';
 	require_once dirname( __DIR__ ) . '/inc/Core/Database/Chat/Chat.php';
 	require_once dirname( __DIR__ ) . '/inc/setup/chat-sessions-network.php';
 
@@ -457,15 +448,22 @@ namespace {
 	$trailing_space_collisions = array_filter( $GLOBALS['chat_tables']['wp_datamachine_chat_sessions'], static fn( array $row ): bool => 'concurrent-trailing-space' === ( json_decode( (string) ( $row['metadata'] ?? '' ), true )['migration_source']['session_id'] ?? '' ) && 'concurrent-trailing-space' !== ( $row['session_id'] ?? '' ) );
 	$assert( 'Same title ' === ( $trailing_space_target['title'] ?? '' ), 'same-second trailing-space target mutation is detected by byte-exact content CAS and never overwritten' );
 	$assert( 1 === count( $trailing_space_collisions ), 'trailing-space divergent source is preserved through deterministic collision handling' );
-	$cas_templates = array_column( $GLOBALS['chat_cas_prepares'], 'template' );
-	$cas_queries   = array_column( $GLOBALS['chat_cas_prepares'], 'query' );
-	$assert( count( array_filter( $cas_templates, static fn( string $query ): bool => str_contains( $query, 'BINARY %i = BINARY %s' ) ) ) === count( $cas_templates ), 'all textual CAS predicates are explicitly byte-exact' );
-	$assert( 0 < count( array_filter( $cas_queries, static fn( string $query ): bool => str_contains( $query, 'BINARY \'messages\' = BINARY \'[{"role":"assistant","content":"Case"}]\'' ) ) ), 'prepared CAS renders a byte-exact messages predicate for case-sensitive observation' );
-	$assert( 0 < count( array_filter( $cas_queries, static fn( string $query ): bool => str_contains( $query, 'BINARY \'title\' = BINARY \'Same title\'' ) ) ), 'prepared CAS renders a byte-exact title predicate for trailing-space-sensitive observation' );
-	$assert( 0 < count( array_filter( $cas_templates, static fn( string $query ): bool => str_contains( $query, '%i = %d' ) && str_contains( $query, '%i IS NULL' ) ) ), 'CAS preparation retains numeric and null predicate handling' );
+	$assert( 0 < count( $GLOBALS['wpdb']->migration_update_queries ), 'migration performs focused updates when canonical enrichment is required' );
+	$assert( 0 === count( array_filter( $GLOBALS['wpdb']->migration_update_queries, static function ( string $query ): bool {
+		$where = strstr( $query, ' WHERE ' );
+		return str_contains( (string) $where, "'messages'" ) || str_contains( (string) $where, "'metadata'" );
+	} ) ), 'migration update predicates never compare transcript blobs' );
+	$assert( 0 === count( array_filter( $GLOBALS['wpdb']->migration_update_queries, static fn( string $query ): bool => 1 !== preg_match( "/ WHERE 'session_id' = '(?:''|[^'])*'$/", $query ) ) ), 'migration updates use only the locked primary key predicate' );
 	$row_count = count( $GLOBALS['chat_tables']['wp_datamachine_chat_sessions'] );
+	$batch_read_count = count( $GLOBALS['chat_batch_reads'] );
+	$update_count = count( $GLOBALS['wpdb']->migration_update_queries );
 	$assert( datamachine_converge_chat_sessions_to_network(), 'convergence rerun is idempotent' );
 	$assert( $row_count === count( $GLOBALS['chat_tables']['wp_datamachine_chat_sessions'] ), 'rerun does not duplicate canonical or collision rows' );
+	$assert( $batch_read_count === count( $GLOBALS['chat_batch_reads'] ) && $update_count === count( $GLOBALS['wpdb']->migration_update_queries ), 'verified migration marker skips repeated reads and rewrites' );
+	delete_site_option( 'datamachine_chat_sessions_network_migrated' );
+	$batch_read_count = count( $GLOBALS['chat_batch_reads'] );
+	$assert( datamachine_converge_chat_sessions_to_network(), 'forced parity verification remains idempotent' );
+	$assert( $batch_read_count < count( $GLOBALS['chat_batch_reads'] ) && $update_count === count( $GLOBALS['wpdb']->migration_update_queries ), 'unchanged canonical rows are verified without rewrite' );
 	$GLOBALS['wpdb']->force_update_zero = true;
 	$chat = new \DataMachine\Core\Database\Chat\Chat();
 	$read_at = $chat->mark_session_read_for_workspace(
@@ -479,22 +477,26 @@ namespace {
 
 	$update_target = new \ReflectionMethod( \DataMachine\Core\Database\Chat\Chat::class, 'update_migration_target' );
 	$observed      = $GLOBALS['chat_tables']['wp_datamachine_chat_sessions']['legacy-user'];
+	$canonical     = array_merge( $observed, array( 'title' => 'Migrated title' ) );
 	$query_offset  = count( $GLOBALS['wpdb']->migration_update_queries );
 	$GLOBALS['wpdb']->deadlocks_remaining['legacy-user'] = 2;
-	$updated = $update_target->invoke( null, 'wp_datamachine_chat_sessions', $observed, $observed );
+	$updated = $update_target->invoke( null, 'wp_datamachine_chat_sessions', $canonical, $observed );
 	$retry_queries = array_slice( $GLOBALS['wpdb']->migration_update_queries, $query_offset );
-	$assert( 0 === $updated && 3 === count( $retry_queries ), 'transient migration deadlocks retry until the exact CAS succeeds' );
-	$assert( 1 === count( array_unique( $retry_queries ) ), 'deadlock retries preserve the complete optimistic row-match predicate' );
+	$assert( 1 === $updated && 3 === count( $retry_queries ), 'transient migration deadlocks retry until the locked update succeeds' );
+	$assert( 1 === count( array_unique( $retry_queries ) ), 'deadlock retries preserve the focused primary-key update' );
 	$assert( 0 === $GLOBALS['wpdb']->leaked_errors && ! $GLOBALS['wpdb']->errors_suppressed, 'recovered deadlocks do not leak database output or alter caller suppression state' );
 
+	$observed = $GLOBALS['chat_tables']['wp_datamachine_chat_sessions']['legacy-user'];
+	$canonical = array_merge( $observed, array( 'title' => 'Never committed' ) );
 	$query_offset = count( $GLOBALS['wpdb']->migration_update_queries );
 	$GLOBALS['wpdb']->deadlocks_remaining['legacy-user'] = 5;
-	$updated = $update_target->invoke( null, 'wp_datamachine_chat_sessions', $observed, $observed );
+	$updated = $update_target->invoke( null, 'wp_datamachine_chat_sessions', $canonical, $observed );
 	$retry_queries = array_slice( $GLOBALS['wpdb']->migration_update_queries, $query_offset );
 	$assert( false === $updated && 5 === count( $retry_queries ), 'persistent migration deadlocks stop after the bounded attempt budget' );
 	$assert( 1 === count( array_unique( $retry_queries ) ) && str_contains( $GLOBALS['wpdb']->last_error, 'Deadlock found' ), 'exhaustion retains the exact CAS and database error for convergence reporting' );
 	$assert( 0 === $GLOBALS['wpdb']->leaked_errors && ! $GLOBALS['wpdb']->errors_suppressed, 'exhausted retries remain contained and restore caller suppression state' );
 
+	delete_site_option( 'datamachine_chat_sessions_network_migrated' );
 	$GLOBALS['chat_tables']['wp_7_datamachine_chat_sessions']['unmappable'] = array( 'session_id' => 'unmappable', 'user_id' => 1, 'messages' => '[]', 'metadata' => '{}', 'context' => 'chat' );
 	$GLOBALS['chat_home_urls'][7] = '';
 	$assert( ! datamachine_converge_chat_sessions_to_network(), 'unmappable source row fails parity' );
@@ -503,6 +505,7 @@ namespace {
 	$GLOBALS['chat_home_urls'][7] = 'https://events.example/';
 	$assert( datamachine_converge_chat_sessions_to_network(), 'safe source-site fallback retries successfully' );
 
+	delete_site_option( 'datamachine_chat_sessions_network_migrated' );
 	$GLOBALS['chat_tables']['wp_2_datamachine_chat_sessions']['probe-exhaustion'] = array(
 		'session_id' => 'probe-exhaustion', 'user_id' => 27, 'messages' => '[{"source":true}]', 'metadata' => '{}', 'context' => 'chat',
 		'created_at' => '2026-01-08 00:00:00', 'updated_at' => '2026-01-08 01:00:00',


### PR DESCRIPTION
## Summary
- make successful per-site-to-network chat migration terminal by honoring the existing network-wide verified completion marker
- retain recovery when convergence is interrupted or fails by leaving/clearing the marker so a later bounded setup pass can retry
- avoid blob-heavy convergence CAS updates during that one legitimate pass by locking the target row, rechecking the complete snapshot in PHP, and updating only changed columns by primary key

## Root cause
`AgentRegistry::reconcile()` runs on ordinary `init` and calls `ActivationServiceProvider::ensure_all_tables()`. Version-gated schema setup and activation also reach the same method. `datamachine_converge_chat_sessions_to_network()` persisted `datamachine_chat_sessions_network_migrated`, but explicitly treated it as evidence rather than a guard, so every call reconverged all immutable per-site sources into the shared network table. On multisite, concurrent requests repeated this network-wide work even after parity had already been verified.

This PR makes `verified: true` terminal before migration scans begin. Interrupted or failed convergence still deletes or never advances the marker, preserving the existing explicit recovery path: bounded 100-row source batches, finite collision probing, and bounded deadlock retries can run again on a later setup pass.

## Persistence and concurrency
For the legitimate migration/recovery pass, unchanged canonical rows with matching provenance return without an `UPDATE`.

Rows that need enrichment or promotion now use the existing `TransactionScope`:

1. `SELECT * FROM <network_table> WHERE session_id = %s FOR UPDATE`
2. compare every observed column byte-exactly in PHP while the row lock is held
3. abort and let convergence refetch if any concurrent target mutation is observed
4. `UPDATE <network_table> SET <changed canonical columns> WHERE session_id = %s`

The generated `WHERE` no longer contains `messages` or `metadata`. Race safety is not weakened to a timestamp-only CAS: the complete observed snapshot is checked under the row lock, including same-second, case-only, and trailing-space mutations. Canonical `updated_at` is pinned on real updates so MariaDB's `ON UPDATE` clause cannot change migration version precedence. Collision selection and provenance enrichment remain unchanged.

The #3311 guarantee remains in place around the whole transaction: deadlocks and lock-wait timeouts retry at most five times with bounded backoff, error suppression is restored, and terminal database errors remain available to convergence reporting.

## Tests
Passed:
- `php tests/chat-sessions-network-convergence-smoke.php`
- `php -l inc/Core/Database/Chat/Chat.php && php -l inc/setup/chat-sessions-network.php && php -l tests/chat-sessions-network-convergence-smoke.php`
- `vendor/bin/phpcs inc/Core/Database/Chat/Chat.php inc/setup/chat-sessions-network.php tests/chat-sessions-network-convergence-smoke.php`
- `composer lint`
- `composer validate --no-check-publish` (valid; existing package-version warning and host Composer deprecation notices only)
- `npm run build`
- `git diff --check`

The smoke harness specifically covers terminal marker short-circuiting, forced recovery verification without unchanged rewrites, primary-key-only update predicates, absence of transcript blobs from `WHERE`, exact concurrent-change detection, timestamp preservation, deterministic collisions, provenance, and transient/exhausted deadlock retries.

PHPStan is not installed in this worktree (`vendor/bin/phpstan` is absent). The repository has no PHPUnit configuration; the dedicated standalone migration smoke test is the executable regression harness for this path.

## Migration compatibility risks
- Existing successful installs with a durable `verified: true` marker will no longer rescan immutable legacy tables during ordinary bootstrap. Operators can delete that site option to request an explicit parity recovery pass.
- Installs without a verified marker retain current recovery behavior and only advance the marker after scoped parity succeeds.
- The locked update requires transactional row-lock support already used elsewhere in Data Machine; `TransactionScope` preserves enclosing transactions through savepoints and supports the repository's SQLite path.
- No schema columns, version strings, or changelog entries are changed.

Fixes #3326