### PR TITLE
fix: schedule network-safe transcript retention

### DIFF
--- a/inc/Cli/Commands/RetentionCommand.php
+++ b/inc/Cli/Commands/RetentionCommand.php
@@ -113,7 +113,7 @@ class RetentionCommand extends BaseCommand {
 	 * @param array $assoc_args Associative arguments.
 	 */
 	public function optimize( array $args, array $assoc_args ): void {
-		$raw = (string) ( $assoc_args['tables'] ?? '' );
+		$raw      = (string) ( $assoc_args['tables'] ?? '' );
 		$selected = array_values( array_filter( array_map( 'trim', explode( ',', $raw ) ) ) );
 		if ( empty( $selected ) ) {
 			WP_CLI::error( 'Provide --tables with one or more owned table names.' );
@@ -502,7 +502,7 @@ class RetentionCommand extends BaseCommand {
 	private function get_table_sizes(): array {
 		global $wpdb;
 
-		$tables = array(
+		$tables      = array(
 			'Completed jobs'  => $wpdb->prefix . 'datamachine_jobs',
 			'Failed jobs'     => $wpdb->prefix . 'datamachine_jobs',
 			'Pipeline logs'   => $wpdb->prefix . 'datamachine_logs',
@@ -514,9 +514,9 @@ class RetentionCommand extends BaseCommand {
 		$table_data  = array();
 		foreach ( $allocations as $table => $data ) {
 			$table_data[ $table ] = array(
-				'rows'    => $data['rows'],
-				'size_mb' => null === $data['live_bytes'] ? 'N/A' : number_format( $data['live_bytes'] / 1024 / 1024, 1 ),
-				'free_mb' => null === $data['allocated_free_bytes'] ? 'N/A' : number_format( $data['allocated_free_bytes'] / 1024 / 1024, 1 ),
+				'rows'          => $data['rows'],
+				'size_mb'       => null === $data['live_bytes'] ? 'N/A' : number_format( $data['live_bytes'] / 1024 / 1024, 1 ),
+				'free_mb'       => null === $data['allocated_free_bytes'] ? 'N/A' : number_format( $data['allocated_free_bytes'] / 1024 / 1024, 1 ),
 				'reclaim_ratio' => null === $data['reclaim_ratio'] ? 'N/A' : number_format( 100 * $data['reclaim_ratio'], 1 ) . '%',
 			);
 		}

--- a/inc/Cli/Commands/RetentionCommand.php
+++ b/inc/Cli/Commands/RetentionCommand.php
@@ -204,6 +204,7 @@ class RetentionCommand extends BaseCommand {
 
 		$this->report_action_scheduler_detail( $assoc_args );
 		$this->report_engine_data_detail();
+		$this->report_chat_session_detail( $assoc_args );
 
 		if ( ! $dry_run ) {
 			$total = array_sum( array_column( $results, 'eligible' ) );
@@ -329,6 +330,32 @@ class RetentionCommand extends BaseCommand {
 	}
 
 	/**
+	 * Report independent eligibility for the shared chat table's two policies.
+	 *
+	 * @param array $assoc_args Associative arguments (for --format).
+	 */
+	private function report_chat_session_detail( array $assoc_args ): void {
+		$breakdown = RetentionCleanup::countChatSessionBreakdown();
+		$rows      = array(
+			array(
+				'type'      => 'Human chat sessions',
+				'threshold' => $breakdown['session_retention_days'] . ' days',
+				'eligible'  => $breakdown['sessions'],
+			),
+			array(
+				'type'      => 'Pipeline transcripts',
+				'threshold' => $breakdown['transcript_retention_days'] > 0 ? $breakdown['transcript_retention_days'] . ' days' : 'disabled',
+				'eligible'  => $breakdown['transcripts'],
+			),
+		);
+
+		WP_CLI::log( '' );
+		WP_CLI::log( WP_CLI::colorize( '%BChat retention - independent eligibility%n' ) );
+		WP_CLI::log( '' );
+		$this->format_items( $rows, array( 'type', 'threshold', 'eligible' ), $assoc_args );
+	}
+
+	/**
 	 * Format a fractional-day window for human-readable CLI output.
 	 *
 	 * @param float $days Window in days (may be fractional, e.g. 0.25).
@@ -451,6 +478,10 @@ class RetentionCommand extends BaseCommand {
 			'Chat sessions'        => array(
 				'retention' => \DataMachine\Core\PluginSettings::get( 'chat_retention_days', 90 ) . ' days',
 				'filter'    => 'setting: chat_retention_days',
+			),
+			'Pipeline transcripts' => array(
+				'retention' => RetentionCleanup::transcriptRetentionDays() > 0 ? RetentionCleanup::transcriptRetentionDays() . ' days' : 'disabled',
+				'filter'    => 'option: datamachine_pipeline_transcript_retention_days',
 			),
 			'File cleanup'         => array(
 				'retention' => \DataMachine\Core\PluginSettings::get( 'file_retention_days', 7 ) . ' days',

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -2278,12 +2278,18 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 		$table_name  = self::get_prefixed_table_name();
 		$cutoff_date = gmdate( 'Y-m-d H:i:s', time() - ( $retention_days * DAY_IN_SECONDS ) );
 
+		// Pipeline transcripts have their own retention window and must never be
+		// deleted by the human-session policy.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$deleted = $wpdb->query(
 			$wpdb->prepare(
-				'DELETE FROM %i WHERE updated_at < %s',
+				'DELETE FROM %i
+				WHERE updated_at < %s
+				AND NOT (mode = %s AND metadata LIKE %s)',
 				$table_name,
-				$cutoff_date
+				$cutoff_date,
+				'pipeline',
+				'%"source":"pipeline_transcript"%'
 			)
 		);
 

--- a/inc/Core/Database/Chat/Chat.php
+++ b/inc/Core/Database/Chat/Chat.php
@@ -373,7 +373,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 					}
 
 					if ( empty( $changes ) ) {
-						$updated = $scope->commit() ? 0 : false;
+						$updated  = $scope->commit() ? 0 : false;
 						$db_error = false === $updated ? (string) $wpdb->last_error : '';
 					} else {
 						$set       = array();
@@ -403,7 +403,7 @@ class Chat extends BaseRepository implements ConversationStoreInterface {
 						} elseif ( ! $scope->commit() ) {
 							$db_error = (string) $wpdb->last_error;
 							$scope->rollback();
-							$updated  = false;
+							$updated = false;
 						}
 					}
 				}

--- a/inc/Engine/AI/System/SystemAgentServiceProvider.php
+++ b/inc/Engine/AI/System/SystemAgentServiceProvider.php
@@ -261,6 +261,7 @@ class SystemAgentServiceProvider {
 					'enabled_setting' => 'retention_chat_sessions_enabled',
 					'default_enabled' => true,
 					'label'           => 'Daily chat-session cleanup',
+					'network_only'    => true,
 				)
 			),
 			RetentionCleanup::TASK_JOB_ARTIFACTS   => array_merge(
@@ -316,7 +317,7 @@ class SystemAgentServiceProvider {
 
 			$dispatch_schedule = static function () use ( $schedule_id, $task_type ): void {
 				$def = RecurringScheduleRegistry::get( $schedule_id );
-				if ( null === $def ) {
+				if ( null === $def || ! self::isScheduleOwnedByCurrentSite( $def ) ) {
 					return;
 				}
 
@@ -420,7 +421,8 @@ class SystemAgentServiceProvider {
 
 		foreach ( RecurringScheduleRegistry::all() as $schedule ) {
 			$hook    = RecurringScheduleRegistry::hookFor( $schedule );
-			$enabled = RecurringScheduleRegistry::isEnabled( $schedule );
+			$enabled = self::isScheduleOwnedByCurrentSite( $schedule )
+				&& RecurringScheduleRegistry::isEnabled( $schedule );
 
 			$options = array();
 			if ( ! empty( $schedule['cron_expression'] ) ) {
@@ -460,6 +462,22 @@ class SystemAgentServiceProvider {
 				);
 			}
 		}
+	}
+
+	/**
+	 * Determine whether the current site owns a recurring schedule.
+	 *
+	 * Network-table maintenance is scheduled only from the network's main site.
+	 * Reconciliation on subsites receives disabled state so legacy duplicate
+	 * chains are unscheduled, while the dispatch guard makes fetched stale
+	 * actions harmless before that reconciliation occurs.
+	 */
+	private static function isScheduleOwnedByCurrentSite( array $schedule ): bool {
+		if ( empty( $schedule['network_only'] ) || ! function_exists( 'is_multisite' ) || ! is_multisite() ) {
+			return true;
+		}
+
+		return function_exists( 'is_main_site' ) && is_main_site();
 	}
 
 	/**

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -282,12 +282,12 @@ class RetentionCleanup {
 		global $wpdb;
 
 		return array(
-			'datamachine_jobs'              => $wpdb->prefix . 'datamachine_jobs',
-			'datamachine_logs'              => $wpdb->prefix . 'datamachine_logs',
-			'datamachine_processed_items'   => $wpdb->prefix . 'datamachine_processed_items',
-			'actionscheduler_actions'       => $wpdb->prefix . 'actionscheduler_actions',
-			'actionscheduler_logs'          => $wpdb->prefix . 'actionscheduler_logs',
-			'actionscheduler_claims'        => $wpdb->prefix . 'actionscheduler_claims',
+			'datamachine_jobs'            => $wpdb->prefix . 'datamachine_jobs',
+			'datamachine_logs'            => $wpdb->prefix . 'datamachine_logs',
+			'datamachine_processed_items' => $wpdb->prefix . 'datamachine_processed_items',
+			'actionscheduler_actions'     => $wpdb->prefix . 'actionscheduler_actions',
+			'actionscheduler_logs'        => $wpdb->prefix . 'actionscheduler_logs',
+			'actionscheduler_claims'      => $wpdb->prefix . 'actionscheduler_claims',
 		);
 	}
 
@@ -311,15 +311,15 @@ class RetentionCleanup {
 
 		foreach ( $tables as $suffix => $table ) {
 			$report[ $table ] = array(
-				'table'                 => $table,
-				'logical_name'          => $suffix,
-				'rows'                  => 0,
-				'live_bytes'            => null,
-				'allocated_free_bytes'  => null,
-				'allocation_bytes'      => null,
+				'table'                => $table,
+				'logical_name'         => $suffix,
+				'rows'                 => 0,
+				'live_bytes'           => null,
+				'allocated_free_bytes' => null,
+				'allocation_bytes'     => null,
 				'reclaim_ratio'        => null,
 				'engine'               => null,
-				'available'             => false,
+				'available'            => false,
 			);
 		}
 
@@ -334,14 +334,14 @@ class RetentionCleanup {
 
 		$names        = array_keys( $report );
 		$placeholders = implode( ',', array_fill( 0, count( $names ), '%s' ) );
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 		$results = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT TABLE_NAME, ENGINE, TABLE_ROWS, DATA_LENGTH, INDEX_LENGTH, DATA_FREE FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ({$placeholders})",
 				...$names
 			)
 		);
-		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 
 		if ( ! is_array( $results ) ) {
 			return $report;
@@ -354,13 +354,14 @@ class RetentionCleanup {
 			}
 			$live = (int) ( $result->DATA_LENGTH ?? 0 ) + (int) ( $result->INDEX_LENGTH ?? 0 );
 			$free = max( 0, (int) ( $result->DATA_FREE ?? 0 ) );
+
 			$report[ $table ]['rows']                 = (int) ( $result->TABLE_ROWS ?? 0 );
 			$report[ $table ]['live_bytes']           = $live;
 			$report[ $table ]['allocated_free_bytes'] = $free;
 			$report[ $table ]['allocation_bytes']     = $live + $free;
 			$report[ $table ]['reclaim_ratio']        = $live + $free > 0 ? $free / ( $live + $free ) : 0.0;
-			$report[ $table ]['engine']                = (string) ( $result->ENGINE ?? '' );
-			$report[ $table ]['available']             = true;
+			$report[ $table ]['engine']               = (string) ( $result->ENGINE ?? '' );
+			$report[ $table ]['available']            = true;
 		}
 
 		return $report;
@@ -373,8 +374,8 @@ class RetentionCleanup {
 	 * @return array{optimized: array<int, string>, rejected: array<string, string>}
 	 */
 	public static function optimizeOwnedTables( array $selected ): array {
-		$owned    = self::ownedTableNames();
-		$allowed  = array_combine( array_values( $owned ), array_values( $owned ) );
+		$owned   = self::ownedTableNames();
+		$allowed = array_combine( array_values( $owned ), array_values( $owned ) );
 		foreach ( $owned as $suffix => $table ) {
 			$allowed[ $suffix ] = $table;
 		}
@@ -386,7 +387,10 @@ class RetentionCleanup {
 			foreach ( $selected as $table ) {
 				$rejected[ (string) $table ] = 'SQLite does not support InnoDB table allocation';
 			}
-			return array( 'optimized' => $optimized, 'rejected' => $rejected );
+			return array(
+				'optimized' => $optimized,
+				'rejected'  => $rejected,
+			);
 		}
 
 		global $wpdb;
@@ -407,7 +411,10 @@ class RetentionCleanup {
 			}
 		}
 
-		return array( 'optimized' => $optimized, 'rejected' => $rejected );
+		return array(
+			'optimized' => $optimized,
+			'rejected'  => $rejected,
+		);
 	}
 
 	/**
@@ -420,24 +427,27 @@ class RetentionCleanup {
 		$ratio    = self::tableFreeRatioThreshold();
 		$warnings = array();
 		foreach ( self::ownedTableAllocations() as $table => $data ) {
-			$free = $data['allocated_free_bytes'];
+			$free  = $data['allocated_free_bytes'];
 			$share = $data['reclaim_ratio'];
 			if ( null === $free || null === $share || ( $free < $absolute && $share < $ratio ) ) {
 				continue;
 			}
 			$warnings[] = array(
-				'table'              => $table,
-				'live_bytes'         => $data['live_bytes'],
-				'reclaimable_bytes'  => $free,
-				'reclaim_ratio'      => $share,
-				'command'            => 'wp datamachine retention optimize --tables=' . $table . ' --yes',
+				'table'             => $table,
+				'live_bytes'        => $data['live_bytes'],
+				'reclaimable_bytes' => $free,
+				'reclaim_ratio'     => $share,
+				'command'           => 'wp datamachine retention optimize --tables=' . $table . ' --yes',
 			);
 		}
 
 		return array(
 			'status'     => empty( $warnings ) ? 'ok' : 'warning',
 			'warnings'   => $warnings,
-			'thresholds' => array( 'free_bytes' => $absolute, 'free_ratio' => $ratio ),
+			'thresholds' => array(
+				'free_bytes' => $absolute,
+				'free_ratio' => $ratio,
+			),
 		);
 	}
 
@@ -1378,7 +1388,7 @@ class RetentionCleanup {
 
 		$threshold = self::actionSchedulerOptimizeThreshold();
 		$optimized = array();
-		$owned    = array_values( self::ownedTableNames() );
+		$owned     = array_values( self::ownedTableNames() );
 
 		foreach ( $tables_affected as $table => $affected ) {
 			if ( ! in_array( $table, $owned, true ) || (int) $affected < $threshold ) {
@@ -1515,19 +1525,20 @@ class RetentionCleanup {
 	 */
 	public static function countChatSessionBreakdown(): array {
 		$chat_db = ConversationStoreFactory::get();
+
 		$retention_days            = self::chatRetentionDays();
 		$transcript_retention_days = self::transcriptRetentionDays();
 
 		if ( $chat_db instanceof Chat && ! Chat::table_exists() ) {
 			return array(
-				'sessions'                 => 0,
-				'transcripts'              => 0,
-				'session_retention_days'   => $retention_days,
+				'sessions'                  => 0,
+				'transcripts'               => 0,
+				'session_retention_days'    => $retention_days,
 				'transcript_retention_days' => $transcript_retention_days,
 			);
 		}
 
-		$transcript_count          = method_exists( $chat_db, 'count_old_pipeline_transcripts' ) ? $chat_db->count_old_pipeline_transcripts( $transcript_retention_days ) : 0;
+		$transcript_count = method_exists( $chat_db, 'count_old_pipeline_transcripts' ) ? $chat_db->count_old_pipeline_transcripts( $transcript_retention_days ) : 0;
 
 		return array(
 			'sessions'                  => $chat_db->count_old_sessions( $retention_days, true ),

--- a/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
+++ b/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php
@@ -1504,19 +1504,37 @@ class RetentionCleanup {
 	}
 
 	public static function countChatSessions(): int {
+		$breakdown = self::countChatSessionBreakdown();
+		return $breakdown['sessions'] + $breakdown['transcripts'];
+	}
+
+	/**
+	 * Count human sessions and pipeline transcripts against independent TTLs.
+	 *
+	 * @return array{sessions:int,transcripts:int,session_retention_days:int,transcript_retention_days:int}
+	 */
+	public static function countChatSessionBreakdown(): array {
 		$chat_db = ConversationStoreFactory::get();
-
-		if ( $chat_db instanceof Chat && ! Chat::table_exists() ) {
-			return 0;
-		}
-
 		$retention_days            = self::chatRetentionDays();
 		$transcript_retention_days = self::transcriptRetentionDays();
+
+		if ( $chat_db instanceof Chat && ! Chat::table_exists() ) {
+			return array(
+				'sessions'                 => 0,
+				'transcripts'              => 0,
+				'session_retention_days'   => $retention_days,
+				'transcript_retention_days' => $transcript_retention_days,
+			);
+		}
+
 		$transcript_count          = method_exists( $chat_db, 'count_old_pipeline_transcripts' ) ? $chat_db->count_old_pipeline_transcripts( $transcript_retention_days ) : 0;
 
-		$session_count = $chat_db->count_old_sessions( $retention_days, $transcript_retention_days > 0 );
-
-		return $transcript_count + $session_count;
+		return array(
+			'sessions'                  => $chat_db->count_old_sessions( $retention_days, true ),
+			'transcripts'               => $transcript_count,
+			'session_retention_days'    => $retention_days,
+			'transcript_retention_days' => $transcript_retention_days,
+		);
 	}
 
 	public static function cleanupChatSessions(): array {

--- a/inc/Engine/Tasks/RecurringScheduleRegistry.php
+++ b/inc/Engine/Tasks/RecurringScheduleRegistry.php
@@ -21,6 +21,7 @@
  *             'first_run_arg'      => 'tomorrow midnight',
  *             'label'              => 'Daily at midnight UTC',
  *             'per_agent'          => true, // Fan out one job per active agent.
+ *             'network_only'       => false, // Main site owns one network-wide recurrence.
  *         );
  *         return $schedules;
  *     } );
@@ -81,6 +82,7 @@ class RecurringScheduleRegistry {
 					'first_run_arg'      => null,
 					'label'              => null,
 					'per_agent'          => false,
+					'network_only'       => false,
 				),
 				$def
 			);

--- a/tests/transcript-retention-smoke.php
+++ b/tests/transcript-retention-smoke.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Focused smoke coverage for network-safe transcript retention (#3328).
+ *
+ * Run with: php tests/transcript-retention-smoke.php
+ */
+
+$root     = dirname( __DIR__ );
+$provider = file_get_contents( $root . '/inc/Engine/AI/System/SystemAgentServiceProvider.php' ) ?: '';
+$registry = file_get_contents( $root . '/inc/Engine/Tasks/RecurringScheduleRegistry.php' ) ?: '';
+$cleanup  = file_get_contents( $root . '/inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php' ) ?: '';
+$task     = file_get_contents( $root . '/inc/Engine/AI/System/Tasks/Retention/RetentionChatSessionsTask.php' ) ?: '';
+$chat     = file_get_contents( $root . '/inc/Core/Database/Chat/Chat.php' ) ?: '';
+$cli      = file_get_contents( $root . '/inc/Cli/Commands/RetentionCommand.php' ) ?: '';
+
+$failures = 0;
+$assert   = static function ( bool $condition, string $message ) use ( &$failures ): void {
+	if ( $condition ) {
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	++$failures;
+	echo "FAIL: {$message}\n";
+};
+
+$assert(
+	(bool) preg_match( "/TASK_CHAT_SESSIONS[\\s\\S]*?'network_only'\\s*=>\\s*true/", $provider ),
+	'chat retention recurrence is declared network-only'
+);
+$assert(
+	str_contains( $registry, "'network_only'       => false" ),
+	'recurring registry normalizes network ownership'
+);
+$assert(
+	str_contains( $provider, 'self::isScheduleOwnedByCurrentSite( $schedule )' )
+		&& str_contains( $provider, 'self::isScheduleOwnedByCurrentSite( $def )' ),
+	'reconciliation disables subsite chains and dispatch rejects stale subsite ticks'
+);
+$assert(
+	str_contains( $provider, "is_main_site()" ),
+	'multisite ownership resolves to the network main site'
+);
+$assert(
+	str_contains( $task, 'RetentionCleanup::cleanupChatSessions()' )
+		&& str_contains( $cleanup, 'cleanup_pipeline_transcripts( $transcript_retention_days )' ),
+	'recurring retention task reaches pipeline transcript cleanup'
+);
+$assert(
+	str_contains( $cleanup, "PluginSettings::get( 'chat_retention_days', 90 )" )
+		&& str_contains( $cleanup, "get_option( 'datamachine_pipeline_transcript_retention_days', 30 )" ),
+	'human and pipeline retention keep independent 90-day and 30-day defaults'
+);
+$assert(
+	(bool) preg_match( "/DELETE FROM %i[\\s\\S]*?NOT \\(mode = %s AND metadata LIKE %s\\)/", $chat ),
+	'human-session deletion excludes pipeline transcript rows'
+);
+$assert(
+	str_contains( $cleanup, 'countChatSessionBreakdown()' )
+		&& str_contains( $cli, 'Human chat sessions' )
+		&& str_contains( $cli, 'Pipeline transcripts' ),
+	'dry-run and status surfaces distinguish both eligibility thresholds'
+);
+
+if ( $failures > 0 ) {
+	echo "transcript-retention-smoke failed: {$failures} assertion(s).\n";
+	exit( 1 );
+}
+
+echo "All transcript retention smoke assertions passed.\n";


### PR DESCRIPTION
## Summary

- make the existing unified chat-retention recurrence main-site-owned when chat storage is network-scoped
- guard stale subsite ticks and reconcile their duplicate recurring chains to disabled state
- preserve independent 90-day human-session and 30-day pipeline-transcript deletion policies
- report human and transcript eligibility separately in retention status and dry-run output

## Root cause

The retired `datamachine_cleanup_chat_sessions` hook was not the active scheduler and should not be restored. The unified `retention_chat_sessions` system task is registered, its `datamachine_recurring_retention_chat_sessions` Action Scheduler action fires, and completed task jobs exist on both the main site and Festival Wire.

The active defect was ownership: every subsite scheduled and dispatched the same cleanup against `wp_datamachine_chat_sessions`, even though that table uses `base_prefix` and is shared network-wide. Production inspection also caught legacy convergence attempting to reinsert an old Wire transcript after cleanup; that separate migration lifecycle issue is #3326 / #3330 and is already in the PR base, not this diff.

## Scheduler ownership and multisite safety

`network_only` is normalized by `RecurringScheduleRegistry` and set only on the chat-retention schedule. On multisite, `SystemAgentServiceProvider` enables that recurrence only on `is_main_site()`:

- main-site reconciliation retains one daily chain
- subsite reconciliation disables and unschedules old duplicate chains
- the dispatch callback applies the same ownership check, so a fetched stale subsite action cannot enqueue cleanup before reconciliation removes it
- single-site behavior is unchanged

This continues to use `RecurringScheduler`, `TaskScheduler`, `RetentionChatSessionsTask`, and `RetentionCleanup`; no second scheduler or deprecated action was introduced.

## Retention behavior

- pipeline transcripts continue to use `datamachine_pipeline_transcript_retention_days`, default 30 days
- human sessions continue to use `chat_retention_days`, default 90 days
- human-session deletion now explicitly excludes `mode=pipeline` / `metadata.source=pipeline_transcript`, so changing or disabling one TTL cannot silently apply the other TTL
- `wp datamachine retention show` lists the transcript policy explicitly
- `wp datamachine retention run --dry-run` adds a human/transcript eligibility breakdown while retaining one scheduled cleanup task

No production transcript rows were deleted and the Festival Wire persistence option was not changed.

## Tests

Passed:

- `php tests/transcript-retention-smoke.php`
- `php tests/recurring-schedule-reconciliation-logging-smoke.php`
- `php tests/recurring-scheduler-idempotency-smoke.php`
- `php tests/retention-action-scheduler-batching-smoke.php`
- `php tests/retention-reporting-smoke.php`
- `php tests/chat-sessions-network-convergence-smoke.php`
- `vendor/bin/phpcs inc/Engine/Tasks/RecurringScheduleRegistry.php inc/Engine/AI/System/SystemAgentServiceProvider.php inc/Core/Database/Chat/Chat.php inc/Engine/AI/System/Tasks/Retention/RetentionCleanup.php inc/Cli/Commands/RetentionCommand.php tests/transcript-retention-smoke.php`
- `composer validate --no-check-publish` (valid; existing package-version warning and system Composer PHP deprecations only)
- `npm run build`
- `git diff --check`

## Operational follow-up

After a future release/deploy, verify that the main site retains one pending `datamachine_recurring_retention_chat_sessions` chain, subsite chains reconcile away, and the next main-site run reduces the separately reported transcript eligibility count. No manual cleanup is part of this PR.

Fixes #3328