### PR TITLE
test: make canonical test gate fail closed

### DIFF
--- a/.github/workflows/homeboy-test.yml
+++ b/.github/workflows/homeboy-test.yml
@@ -22,6 +22,9 @@ jobs:
       # alone decides whether the full-suite candidate regresses from main.
       commands: 'review test'
       expected-commands: 'review test'
+      # PR CI is the authoritative complete MySQL suite. Repository defaults
+      # remain Docker-free SQLite for local and release-preflight parity.
+      args: '--setting database_type=mysql --setting wp_codebox_phpunit_config=/wordpress/wp-content/plugins/data-machine/phpunit.xml.dist'
       scope: full
       differential-gating: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
       baseline-commands: ${{ github.event_name == 'pull_request' && 'review test' || 'none' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,7 @@ jobs:
         uses: Extra-Chill/homeboy-action@v2
         with:
           commands: release
+          args: '--setting database_type=mysql --setting wp_codebox_phpunit_config=/wordpress/wp-content/plugins/data-machine/phpunit.xml.dist'
           release-dry-run: 'true'
 
       - name: Decide whether to release
@@ -144,6 +145,7 @@ jobs:
         id: release
         with:
           commands: release
+          args: '--setting database_type=mysql --setting wp_codebox_phpunit_config=/wordpress/wp-content/plugins/data-machine/phpunit.xml.dist'
           release-dry-run: ${{ inputs.dry-run || 'false' }}
           app-token: ${{ steps.app-token.outputs.token || '' }}
 

--- a/homeboy.json
+++ b/homeboy.json
@@ -17,14 +17,13 @@
     "wordpress": {
       "php": "8.2",
       "node": "20",
-      "database_type": "mysql",
-      "mysql_host": "localhost",
-      "mysql_database": "wptests",
-      "mysql_user": "root",
-      "mysql_password": "",
+      "database_type": "sqlite",
       "release_latest_branch": "release-latest",
       "settings": {
-        "runtime_wordpress_version": "7.0"
+        "runtime_wordpress_version": "7.0",
+        "phpunit_no_tests": "fail",
+        "wp_codebox_phpunit_bootstrap_mode": "managed",
+        "wp_codebox_phpunit_config": "/wordpress/wp-content/plugins/data-machine/phpunit.sqlite.xml.dist"
       }
     }
   },

--- a/phpunit.sqlite.xml.dist
+++ b/phpunit.sqlite.xml.dist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true">
+	<!--
+		Local and release-preflight suite for environments without Docker/MySQL.
+		GitHub CI overrides this with phpunit.xml.dist and runs every excluded
+		persistence/concurrency class against MySQL.
+	-->
+	<testsuites>
+		<testsuite name="Data Machine SQLite">
+			<directory suffix="Test.php">tests</directory>
+			<file>tests/test-sample.php</file>
+			<exclude>tests/Unit/AI/Tools/ImageGenerationToolCallTest.php</exclude>
+			<exclude>tests/Unit/AI/Tools/ToolExecutorValidationTest.php</exclude>
+			<exclude>tests/Unit/Abilities/Content/UpsertPostAbilityTest.php</exclude>
+			<exclude>tests/Unit/Abilities/Engine/DrainJobAbilityTest.php</exclude>
+			<exclude>tests/Unit/Abilities/Engine/ExecuteStepMixedClaimRoutingTest.php</exclude>
+			<exclude>tests/Unit/Abilities/Engine/PipelineBatchDeferralRoutingTest.php</exclude>
+			<exclude>tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php</exclude>
+			<exclude>tests/Unit/Abilities/Engine/PipelineExecutionContractTest.php</exclude>
+			<exclude>tests/Unit/Abilities/Engine/RunFlowAbilityLifecycleTest.php</exclude>
+			<exclude>tests/Unit/Abilities/ImageGenerationPromptRefinementTest.php</exclude>
+			<exclude>tests/Unit/Abilities/Job/DelegatedOperationTest.php</exclude>
+			<exclude>tests/Unit/Abilities/Job/DirectJobOwnershipTest.php</exclude>
+			<exclude>tests/Unit/Abilities/Job/GetRunArtifactsAbilityTest.php</exclude>
+			<exclude>tests/Unit/Abilities/Media/ImageGenerationAbilitiesTest.php</exclude>
+			<exclude>tests/Unit/Core/Agents/AgentBundlerImportTest.php</exclude>
+			<exclude>tests/Unit/Core/Content/SourceDerivedBlockAttributeRepairTest.php</exclude>
+			<exclude>tests/Unit/Core/Database/JobLifecycleTransitionTest.php</exclude>
+			<exclude>tests/Unit/Core/Database/ProcessedItemsTest.php</exclude>
+			<exclude>tests/Unit/Core/ExecutionContextSourceEligibilityTest.php</exclude>
+			<exclude>tests/Unit/Core/Identity/AgentIdentityStoreAdapterTest.php</exclude>
+			<exclude>tests/Unit/Core/ItemClaimLifecycleTest.php</exclude>
+			<exclude>tests/Unit/Core/OptionLeaseStoreTest.php</exclude>
+			<exclude>tests/Unit/Core/Steps/WebhookGate/WebhookGateStepTest.php</exclude>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true">
+	<testsuites>
+		<testsuite name="Data Machine">
+			<directory suffix="Test.php">tests</directory>
+			<file>tests/test-sample.php</file>
+		</testsuite>
+	</testsuites>
+</phpunit>


### PR DESCRIPTION
## Summary
- declare managed PHPUnit as Data Machine's canonical test surface and fail when discovery returns zero tests
- add explicit complete MySQL and broad SQLite PHPUnit suite configurations
- use Docker-free SQLite by default for local/release-preflight execution while PR and GitHub release workflows override to the complete MySQL suite
- remove obsolete localhost MySQL credentials from repository configuration

## Suite ownership

`phpunit.xml.dist` is the complete suite. GitHub PR and release workflows run it against MySQL, including every persistence and concurrency class.

`phpunit.sqlite.xml.dist` is the Docker-free broad local suite. It excludes 23 classes whose current behavior depends on MySQL transactions, locks, concurrent sessions, JSON/storage semantics, or related persistence contracts. Those classes are not suppressed: they remain mandatory in the complete MySQL suite.

Standalone `tests/*-smoke.php` scripts remain explicit diagnostic/operator targets and are not silently mixed into the canonical PHPUnit gate.

## Verification
- `homeboy review test data-machine --path . --placement local --skip-lint` executed 1,494 SQLite tests: 1,466 passed, 28 skipped, 0 failed
- an unconfigured Docker-backed run failed closed with 0 tests instead of reporting success
- the unpartitioned SQLite run executed 1,891 tests and identified 188 failures concentrated in the 23 explicitly MySQL-owned classes
- `jq empty homeboy.json`
- both PHPUnit XML files parse successfully
- `git diff --check`

GitHub CI on this PR is the authoritative proof that the complete MySQL suite still discovers, shards, and passes every configured test.

Fixes #3198
Fixes #3207
Fixes #3209