### PR TITLE
fix: restore canonical ability tool execution

### DIFF
--- a/inc/Engine/AI/Tools/AbilityToolAdapter.php
+++ b/inc/Engine/AI/Tools/AbilityToolAdapter.php
@@ -158,20 +158,7 @@ final class AbilityToolAdapter {
 			return self::missingAbilityResult( $tool_name, $ability_slug );
 		}
 
-		$input      = self::buildAbilityInput( $parameters, $tool_definition );
-		$permission = $ability->check_permissions( $input );
-		if ( is_wp_error( $permission ) ) {
-			return WP_Agent_Tool_Result::error( $tool_name, $permission->get_error_message(), array( 'ability' => $ability_slug ) );
-		}
-
-		if ( true !== $permission ) {
-			return WP_Agent_Tool_Result::error(
-				$tool_name,
-				sprintf( "Tool '%s' is not permitted by ability '%s'.", $tool_name, $ability_slug ),
-				array( 'ability' => $ability_slug )
-			);
-		}
-
+		$input  = self::buildAbilityInput( $parameters, $tool_definition );
 		$result = $ability->execute( $input );
 		if ( is_wp_error( $result ) ) {
 			return WP_Agent_Tool_Result::error(

--- a/tests/Unit/Engine/AI/Tools/AbilityToolAdapterTest.php
+++ b/tests/Unit/Engine/AI/Tools/AbilityToolAdapterTest.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Tests for canonical ability execution through AbilityToolAdapter.
+ *
+ * @package DataMachine\Tests\Unit\Engine\AI\Tools
+ */
+
+namespace DataMachine\Tests\Unit\Engine\AI\Tools;
+
+use DataMachine\Engine\AI\Tools\AbilityToolAdapter;
+use WP_Ability;
+use WP_Error;
+use WP_UnitTestCase;
+
+class Instrumented_Ability extends WP_Ability {
+
+	/** @var string[] */
+	public static array $events = array();
+
+	public static int $execute_calls = 0;
+
+	public function normalize_input( $input = null ) {
+		self::$events[] = 'normalize';
+		$input          = parent::normalize_input( $input );
+
+		if ( is_array( $input ) && isset( $input['message'] ) && is_string( $input['message'] ) ) {
+			$input['message'] = strtoupper( $input['message'] );
+		}
+
+		return $input;
+	}
+
+	public function validate_input( $input = null ) {
+		self::$events[] = 'validate';
+		return parent::validate_input( $input );
+	}
+
+	public function check_permissions( $input = null ) {
+		self::$events[] = 'permissions';
+		return parent::check_permissions( $input );
+	}
+
+	public function execute( $input = null ) {
+		++self::$execute_calls;
+		return parent::execute( $input );
+	}
+}
+
+class AbilityToolAdapterTest extends WP_UnitTestCase {
+
+	private const ABILITY_SLUG = 'datamachine/adapter-contract-test';
+
+	private int $permission_calls = 0;
+
+	private int $callback_calls = 0;
+
+	private mixed $permission_input = null;
+
+	private mixed $callback_input = null;
+
+	public function set_up(): void {
+		parent::set_up();
+		datamachine_test_prepare_site();
+
+		$this->unregisterAbility();
+		Instrumented_Ability::$events        = array();
+		Instrumented_Ability::$execute_calls = 0;
+	}
+
+	public function tear_down(): void {
+		$this->unregisterAbility();
+		parent::tear_down();
+	}
+
+	public function test_execute_uses_core_order_once_and_preserves_success_envelope(): void {
+		$this->registerAbility(
+			function ( $input ): bool {
+				++$this->permission_calls;
+				$this->permission_input = $input;
+				return true;
+			},
+			function ( $input ): array {
+				++$this->callback_calls;
+				$this->callback_input = $input;
+				Instrumented_Ability::$events[] = 'execute_callback';
+				return array(
+					'visible'  => 'success',
+					'_internal' => 'hidden',
+				);
+			}
+		);
+
+		$result = AbilityToolAdapter::execute(
+			'adapter_contract_tool',
+			array(
+				'action'  => 'run',
+				'message' => 'normalized by core',
+			),
+			array(
+				'ability_map'                => array( 'run' => self::ABILITY_SLUG ),
+				'strip_action_parameter'     => true,
+				'strip_internal_result_keys' => true,
+			)
+		);
+
+		$this->assertSame( 1, Instrumented_Ability::$execute_calls );
+		$this->assertSame( 1, $this->permission_calls );
+		$this->assertSame( 1, $this->callback_calls );
+		$this->assertSame( array( 'normalize', 'validate', 'permissions', 'execute_callback' ), Instrumented_Ability::$events );
+		$this->assertSame( array( 'message' => 'NORMALIZED BY CORE' ), $this->permission_input );
+		$this->assertSame( $this->permission_input, $this->callback_input );
+		$this->assertSame(
+			array(
+				'success'   => true,
+				'tool_name' => 'adapter_contract_tool',
+				'metadata'  => array( 'ability' => self::ABILITY_SLUG ),
+				'result'    => array( 'visible' => 'success' ),
+			),
+			$result
+		);
+	}
+
+	public function test_invalid_input_stops_before_permissions(): void {
+		$this->registerAbility(
+			function (): bool {
+				++$this->permission_calls;
+				return true;
+			},
+			function (): array {
+				++$this->callback_calls;
+				return array( 'visible' => 'unexpected' );
+			}
+		);
+
+		$result = AbilityToolAdapter::execute(
+			'adapter_contract_tool',
+			array( 'message' => 42 ),
+			array( 'execution_ability' => self::ABILITY_SLUG )
+		);
+
+		$this->assertSame( array( 'normalize', 'validate' ), Instrumented_Ability::$events );
+		$this->assertSame( 1, Instrumented_Ability::$execute_calls );
+		$this->assertSame( 0, $this->permission_calls );
+		$this->assertSame( 0, $this->callback_calls );
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'ability_invalid_input', $result['metadata']['wp_error_code'] );
+	}
+
+	public function test_permission_error_uses_core_generic_denial_without_leaking_details(): void {
+		$this->registerAbility(
+			function (): WP_Error {
+				++$this->permission_calls;
+				return new WP_Error( 'secret_denial', 'Sensitive permission details.' );
+			},
+			function (): array {
+				++$this->callback_calls;
+				return array( 'visible' => 'unexpected' );
+			}
+		);
+
+		$this->setExpectedIncorrectUsage( 'WP_Ability::execute' );
+		$result = AbilityToolAdapter::execute(
+			'adapter_contract_tool',
+			array( 'message' => 'denied' ),
+			array( 'execution_ability' => self::ABILITY_SLUG )
+		);
+
+		$this->assertSame( array( 'normalize', 'validate', 'permissions' ), Instrumented_Ability::$events );
+		$this->assertSame( 1, Instrumented_Ability::$execute_calls );
+		$this->assertSame( 1, $this->permission_calls );
+		$this->assertSame( 0, $this->callback_calls );
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'ability_invalid_permissions', $result['metadata']['wp_error_code'] );
+		$this->assertStringNotContainsString( 'Sensitive permission details.', $result['error'] );
+	}
+
+	private function registerAbility( callable $permission_callback, callable $execute_callback ): void {
+		$ability = \WP_Abilities_Registry::get_instance()->register(
+			self::ABILITY_SLUG,
+			array(
+				'label'               => 'Adapter contract test',
+				'description'         => 'Exercises the canonical ability execution boundary.',
+				'category'            => 'datamachine-system',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'message' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'permission_callback' => $permission_callback,
+				'execute_callback'    => $execute_callback,
+				'ability_class'       => Instrumented_Ability::class,
+			)
+		);
+
+		$this->assertInstanceOf( Instrumented_Ability::class, $ability );
+	}
+
+	private function unregisterAbility(): void {
+		$registry = \WP_Abilities_Registry::get_instance();
+		if ( $registry->is_registered( self::ABILITY_SLUG ) ) {
+			$registry->unregister( self::ABILITY_SLUG );
+		}
+	}
+}

--- a/tests/tool-executor-ability-native-smoke.php
+++ b/tests/tool-executor-ability-native-smoke.php
@@ -14,14 +14,28 @@ namespace {
 
 	if ( ! class_exists( 'WP_Error' ) ) {
 		class WP_Error {
+			private string $code;
+
 			private string $message;
 
-			public function __construct( string $code = '', string $message = '' ) {
+			private mixed $data;
+
+			public function __construct( string $code = '', string $message = '', $data = null ) {
+				$this->code    = $code;
 				$this->message = '' !== $message ? $message : $code;
+				$this->data    = $data;
 			}
 
 			public function get_error_message(): string {
 				return $this->message;
+			}
+
+			public function get_error_code(): string {
+				return $this->code;
+			}
+
+			public function get_error_data() {
+				return $this->data;
 			}
 		}
 	}
@@ -55,6 +69,8 @@ namespace {
 	}
 
 	class Ability_Native_Smoke_Ability {
+		private string $name = '';
+
 		/** @var callable */
 		private $permission_callback;
 
@@ -63,6 +79,8 @@ namespace {
 
 		public int $execute_count = 0;
 
+		public int $permission_count = 0;
+
 		public mixed $last_input = null;
 
 		public function __construct( callable $permission_callback, callable $execute_callback ) {
@@ -70,11 +88,23 @@ namespace {
 			$this->execute_callback    = $execute_callback;
 		}
 
+		public function set_name( string $name ): void {
+			$this->name = $name;
+		}
+
 		public function check_permissions( $input = null ) {
+			++$this->permission_count;
 			return call_user_func( $this->permission_callback, $input );
 		}
 
 		public function execute( $input = null ) {
+			if ( true !== $this->check_permissions( $input ) ) {
+				return new WP_Error(
+					'ability_invalid_permissions',
+					sprintf( 'Ability "%s" does not have necessary permission.', $this->name )
+				);
+			}
+
 			++$this->execute_count;
 			$this->last_input = $input;
 			return call_user_func( $this->execute_callback, $input );
@@ -100,6 +130,7 @@ namespace {
 		}
 
 		public function register_for_smoke( string $slug, Ability_Native_Smoke_Ability $ability ): void {
+			$ability->set_name( $slug );
 			$this->abilities[ $slug ] = $ability;
 		}
 
@@ -604,6 +635,7 @@ namespace DataMachine\Tests\ToolExecutorAbilityNativeSmoke {
 		)
 	);
 	assert_smoke( 'permission-denied ability fails', false === ( $result['success'] ?? true ) );
+	assert_smoke( 'permission callback ran exactly once', 1 === $denied->permission_count );
 	assert_smoke( 'permission-denied ability execute callback did not run', 0 === ability_execute_count( $denied ) );
 	assert_smoke( 'permission-denied error names the ability slug', false !== strpos( $result['error'] ?? '', 'datamachine/denied-ability' ) );
 


### PR DESCRIPTION
## Summary
- remove the adapter-level permission precheck so registered abilities execute through WordPress core's canonical `WP_Ability::execute()` boundary exactly once
- preserve projected input, action mapping, model-facing tool names, payload filtering, ability metadata, and `WP_Agent_Tool_Result` envelopes
- add real-core and smoke coverage for execution order, single permission evaluation, generic denial handling, and unchanged success behavior

## Root cause
`AbilityToolAdapter::execute()` called `check_permissions()` directly before calling `WP_Ability::execute()`. Core already normalizes and validates input, checks permissions, executes the callback, and validates output. The adapter therefore evaluated permissions twice against different input shapes and exposed callback-specific permission errors that core intentionally replaces with `ability_invalid_permissions`.

## Core contract
The adapter now only builds the projected ability input and calls the registered ability's canonical `execute()` method. Core remains the sole owner of normalization, validation, authorization, callback execution, output validation, and permission-error redaction.

## Preserved tool behavior
The model-facing tool name, success payload, action-to-ability routing, action stripping, internal result-key filtering, ability metadata, and existing success/error envelope remain unchanged. Final core `WP_Error` values continue to map into the existing tool-result metadata fields.

## Verification
- `homeboy review test data-machine --path /var/lib/datamachine/workspace/data-machine@fix-3327-ability-tool-permissions --placement local --skip-lint -- --filter AbilityToolAdapterTest` (3 passed)
- `php tests/tool-executor-ability-native-smoke.php` (47 assertions passed)
- `vendor/bin/phpcs --standard=WordPress inc/Engine/AI/Tools/AbilityToolAdapter.php tests/Unit/Engine/AI/Tools/AbilityToolAdapterTest.php tests/tool-executor-ability-native-smoke.php`
- `php -l` on all changed PHP files
- `git diff --check`

Fixes #3327
Parent: #3113