### PR TITLE
fix: parse owned JSX in repository ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,10 +1,19 @@
 module.exports = [
 	{
 		name: 'data-machine/generated-admin-assets',
-		ignores: [ 'inc/Core/Admin/**/assets/build/**' ],
+		ignores: [
+			'**/node_modules/**',
+			'**/vendor/**',
+			'inc/Core/Admin/**/assets/build/**',
+		],
 	},
 	{
 		name: 'data-machine/admin-sources',
 		files: [ 'inc/Core/Admin/**/*.{js,jsx}' ],
+		languageOptions: {
+			parserOptions: {
+				ecmaFeatures: { jsx: true },
+			},
+		},
 	},
 ];


### PR DESCRIPTION
## Summary
- enable JSX parsing in Data Machine's owned admin JS/JSX scope
- explicitly exclude Composer and npm dependency trees while retaining the existing generated admin build exclusion
- keep WordPress rules and broad dependency/generated scope policy owned by Homeboy Extensions

## Root cause and ownership
PR #3284 added a repository flat config that declared the 141 owned admin JS/JSX sources, but the local config did not itself enable JSX parsing. Direct `npx eslint .` therefore failed with 98 parser errors. The narrow file matcher had removed the original traversal flood, but explicit vendor paths still received ESLint's empty fallback config when Composer dependencies were present.

Homeboy Extensions WordPress v3.36.0 owns provider defaults, repository config composition, JSX/TS discovery, and broad dependency-tree filtering. Data Machine only needs to declare its owned source scope, its generated build path, dependency roots that direct repository ESLint must never inspect, and the syntax required by those sources.

## Scope
Included by Data Machine config: `inc/Core/Admin/**/*.{js,jsx}` (141 tracked shipped sources).

Excluded by Data Machine config: `**/node_modules/**`, `**/vendor/**`, and `inc/Core/Admin/**/assets/build/**`.

The v3.36.0 provider additionally excludes vendor-prefix variants, all `build`/`dist` trees, minified files, and tests before composing this repository config.

## Verification
- `npx eslint . --max-warnings=0`
- `npm run build`
- exact v3.36.0-style provider composition: 141/141 sources reported, 0 omitted, 0 fatal parses, 0 ignored-source warnings, JSX enabled, provider `eqeqeq` retained, vendor/build probes ignored
- installed provider dependency-tree smoke: passed
- targeted `homeboy review lint --file inc/Core/Admin/shared/components/Pagination.jsx --placement local`: command passed

The host currently has WordPress extension v3.35.10 installed, so its older provider-only inventory still reports JSX as having no matching configuration. No installed extension state was changed; v3.36.0 behavior was verified against its exact published composition contract.

Fixes #3288