### PR TITLE
refactor: accept map-only ability tool projections

### DIFF
--- a/inc/Engine/AI/Tools/Global/InternalLinkAudit.php
+++ b/inc/Engine/AI/Tools/Global/InternalLinkAudit.php
@@ -33,7 +33,6 @@ class InternalLinkAudit extends BaseTool {
 			array_merge(
 				$this->getToolDefinition(),
 				array(
-					'ability'                    => 'datamachine/audit-internal-links',
 					'ability_map'                => array(
 						'audit'     => 'datamachine/audit-internal-links',
 						'orphans'   => 'datamachine/get-orphaned-posts',

--- a/inc/Engine/AI/Tools/ability-tool-projections.php
+++ b/inc/Engine/AI/Tools/ability-tool-projections.php
@@ -11,8 +11,8 @@ if ( ! function_exists( 'datamachine_register_ability_tool' ) ) {
 	/**
 	 * Register an ability as a model-facing tool projection.
 	 *
-	 * The declaration must include an `ability` slug. AbilityToolSource uses that
-	 * slug as both permission metadata and the explicit direct-execution marker.
+	 * The declaration must include an `ability` slug or non-empty `ability_map`.
+	 * AbilityToolSource uses the primary slug for projection metadata.
 	 * Optional keys such as `modes`, `description`, `parameters`,
 	 * `requires_opt_in`, `action_policy`, and `runtime` are passed through.
 	 *
@@ -21,7 +21,7 @@ if ( ! function_exists( 'datamachine_register_ability_tool' ) ) {
 	 * @return bool Whether the projection was registered.
 	 */
 	function datamachine_register_ability_tool( string $tool_name, array $declaration ): bool {
-		if ( '' === $tool_name || empty( $declaration['ability'] ) || ! is_string( $declaration['ability'] ) ) {
+		if ( '' === $tool_name || ( ( empty( $declaration['ability'] ) || ! is_string( $declaration['ability'] ) ) && ( empty( $declaration['ability_map'] ) || ! is_array( $declaration['ability_map'] ) ) ) ) {
 			return false;
 		}
 

--- a/tests/ability-tool-source-smoke.php
+++ b/tests/ability-tool-source-smoke.php
@@ -307,6 +307,23 @@ $helper_registered = datamachine_register_ability_tool(
 		'modes'   => array( 'chat' ),
 	)
 );
+$helper_map_registered = datamachine_register_ability_tool(
+	'helper_map_demo',
+	array(
+		'ability_map'            => array( 'summarize' => 'demo/summarize' ),
+		'modes'                  => array( 'chat' ),
+		'strip_action_parameter' => true,
+		'parameters'             => array(
+			'type'       => 'object',
+			'properties' => array(
+				'action'  => array( 'type' => 'string' ),
+				'message' => array( 'type' => 'string' ),
+			),
+			'required'   => array( 'action', 'message' ),
+		),
+	)
+);
+$empty_map_registered = datamachine_register_ability_tool( 'empty_map_demo', array( 'ability_map' => array() ) );
 
 add_filter(
 	'datamachine_ability_tool_projections',
@@ -367,8 +384,12 @@ echo "\n[1] ability metadata becomes a model-facing tool declaration:\n";
 $source = new AbilityToolSource( new AbilityToolSourceSmokeManager() );
 $tools  = $source( array( 'chat' ), array( 'allow_only' => array( 'summarize_demo' ) ) );
 assert_ability_tool_source_equals( true, $helper_registered, 'helper registers a valid ability tool projection', $failures, $passes );
+assert_ability_tool_source_equals( true, $helper_map_registered, 'helper registers a non-empty ability map projection', $failures, $passes );
+assert_ability_tool_source_equals( false, $empty_map_registered, 'helper rejects an empty ability map projection', $failures, $passes );
 assert_ability_tool_source_equals( true, isset( $tools['summarize_demo'] ), 'chat mode exposes selected ability tool when opted in', $failures, $passes );
 assert_ability_tool_source_equals( true, isset( $tools['helper_demo'] ), 'helper projection feeds ability tool source', $failures, $passes );
+assert_ability_tool_source_equals( true, isset( $tools['helper_map_demo'] ), 'map-only helper projection feeds ability tool source', $failures, $passes );
+assert_ability_tool_source_equals( false, isset( $tools['helper_map_demo']['execution_ability'] ), 'map-only projection omits the scalar execution marker', $failures, $passes );
 assert_ability_tool_source_equals( 'demo/summarize', $tools['summarize_demo']['ability'] ?? '', 'generated tool links ability slug', $failures, $passes );
 assert_ability_tool_source_equals( 'demo/summarize', $tools['summarize_demo']['execution_ability'] ?? '', 'generated tool declares explicit direct-execution ability marker', $failures, $passes );
 assert_ability_tool_source_equals( 'Summarize Demo', $tools['summarize_demo']['label'] ?? '', 'generated tool carries ability label', $failures, $passes );
@@ -483,6 +504,38 @@ assert_ability_tool_source_equals( true, $result['success'] ?? false, 'generated
 assert_ability_tool_source_equals( 1, $ability->execute_count, 'ability execute callback ran once', $failures, $passes );
 assert_ability_tool_source_equals( 'hello', $result['result']['received']['message'] ?? '', 'AI parameter reached ability input', $failures, $passes );
 assert_ability_tool_source_equals( 123, $result['result']['received']['job_id'] ?? 0, 'payload context reached ability input through existing binding path', $failures, $passes );
+
+$mapped_result = ToolExecutor::executeTool(
+	'helper_map_demo',
+	array(
+		'action'  => 'summarize',
+		'message' => 'mapped hello',
+	),
+	array( 'helper_map_demo' => $tools['helper_map_demo'] ),
+	array()
+);
+assert_ability_tool_source_equals( true, $mapped_result['success'] ?? false, 'map-only helper projection executes successfully', $failures, $passes );
+assert_ability_tool_source_equals( 'mapped hello', $mapped_result['result']['received']['message'] ?? '', 'map-only projection forwards declared input', $failures, $passes );
+assert_ability_tool_source_equals( false, array_key_exists( 'action', $mapped_result['result']['received'] ?? array() ), 'map-only projection strips the routing action', $failures, $passes );
+
+$missing_action = ToolExecutor::executeTool(
+	'helper_map_demo',
+	array( 'message' => 'missing action' ),
+	array( 'helper_map_demo' => $tools['helper_map_demo'] ),
+	array()
+);
+assert_ability_tool_source_equals( 'missing_required_parameters', $missing_action['metadata']['error_type'] ?? '', 'map-only projection rejects a missing action', $failures, $passes );
+
+$unknown_action = ToolExecutor::executeTool(
+	'helper_map_demo',
+	array(
+		'action'  => 'unknown',
+		'message' => 'unknown action',
+	),
+	array( 'helper_map_demo' => $tools['helper_map_demo'] ),
+	array()
+);
+assert_ability_tool_source_equals( 'missing_execution_ability', $unknown_action['metadata']['error_type'] ?? '', 'map-only projection rejects an unknown action', $failures, $passes );
 
 echo "\n[5] required-tool evidence reports ability projection rejection reasons:\n";
 $resolver_evidence = ( new ToolPolicyResolver( new AbilityToolSourceSmokeManager() ) )->resolveWithEvidence(


### PR DESCRIPTION
## Summary
- allow `datamachine_register_ability_tool()` to accept the existing non-empty `ability_map` contract without a redundant scalar `ability`
- prove map-only declaration, execution, action stripping, and missing/unknown-action behavior through executable projection coverage
- retain `manage_logs` and `manage_queue` after auditing showed their curated contracts are not safely expressible by the current adapter

## Before/after contracts
Before, the registrar rejected every declaration without a scalar `ability`, even though `AbilityToolAdapter` already supports `ability_map`. Map projections therefore had to duplicate their first mapped slug as scalar metadata.

After, callers may provide either the existing scalar `ability` or a non-empty `ability_map`. The first valid mapped slug remains the projection metadata source through `AbilityToolAdapter::primaryAbilitySlug()`. Existing scalar projections, declaration normalization, modes, policies, runtime metadata, success/error envelopes, and action routing are unchanged.

## Abilities mapped
The existing `internal_link_audit` projection now relies only on its map:
- `audit` -> `datamachine/audit-internal-links`
- `orphans` -> `datamachine/get-orphaned-posts`
- `backlinks` -> `datamachine/get-backlinks`
- `broken` -> `datamachine/check-broken-links`

## Scope retained
- `manage_logs` remains bounded because it coerces non-positive `agent_id` values to the all-logs scope, ignores the presentation-only `context`, reshapes clear success payloads, and preserves bespoke error text. The existing adapter only strips `action` and would change those contracts.
- `manage_queue` remains bounded because it builds an action-specific input allowlist and preserves the current nested `data` result envelope plus classified errors. A direct map projection would forward unrelated/undeclared inputs and flatten the result payload.
- No mapping DSL, callback hook, or generic result/input projection framework was added merely to delete these wrappers.

## Production LOC
- Production PHP: 3 additions, 4 deletions, net -1 LOC.
- Tests: 53 additions for executable map-only coverage.

## Verification
- `php tests/ability-tool-source-smoke.php` (48 assertions passed)
- `php tests/tool-executor-ability-native-smoke.php` (47 assertions passed)
- `php tests/global-ability-projections-smoke.php` (25 assertions passed)
- canonical WordPress/MySQL gate via Homeboy (1467 passed, 28 skipped, 0 failed)
- changed-file canonical lint via Homeboy (PHPCS and PHPStan passed)
- targeted WordPress PHPCS, PHP syntax, and `git diff --check` passed
- whole-tree lint remains red on 173 pre-existing findings outside this patch; no changed file has a finding

Refs #3341
Parent: #3332