### PR TITLE
refactor: drive source behavior from step metadata

### DIFF
--- a/docs/core-system/handler-registration-trait.md
+++ b/docs/core-system/handler-registration-trait.md
@@ -134,7 +134,7 @@ The preferred direct-style callback receives `(string $handler_slug, array $hand
 
 Existing filter-style callbacks are also supported. `ToolManager::resolveHandlerTools()` invokes callbacks with `($tools, $handler_slug, $handler_config, $engine_data)` when reflection detects four or more parameters, or a first parameter named `$tools` or `$all_tools`.
 
-Handler tool matching is exact by default: a registry entry with `'handler' => 'wordpress_publish'` is resolved only for adjacent steps whose handler slug is exactly `wordpress_publish`. Cross-cutting tools can use `'handler_types' => ['fetch', 'event_import']`; those are matched against `datamachine_handlers` metadata.
+Handler tool matching is exact by default: a registry entry with `'handler' => 'wordpress_publish'` is resolved only for adjacent steps whose handler slug is exactly `wordpress_publish`. Cross-cutting tools can use `'handler_categories' => ['source']`; those are matched against the handler's registered step-type metadata.
 
 `_handler_callable` entries are deferred registry entries. They are not directly executable tools and should not include normal tool parameters at the wrapper level. The callback returns the executable tool definitions.
 

--- a/docs/development/hooks/core-filters.md
+++ b/docs/development/hooks/core-filters.md
@@ -308,9 +308,11 @@ Matching modes:
 
 - `'handler' => 'slug'` — entry applies only when the adjacent step's handler
   slug equals `'slug'`.
-- `'handler_types' => ['fetch', 'event_import']` — entry applies to any
-  handler whose registered `type` is in the list. Used for cross-cutting
-  tools (e.g. `skip_item` exposed to every fetch-type handler).
+- `'handler_types' => ['fetch']` — entry applies when the handler's registered
+  type is in the list.
+- `'handler_categories' => ['source']` — entry applies when the handler's
+  registered step type declares that category. Used for cross-cutting tools
+  exposed to every source handler.
 
 The callback signature is `(string $handler_slug, array $handler_config, array $engine_data): array`.
 Returned array is `['tool_name' => $tool_definition]` (empty array to opt out).
@@ -318,7 +320,7 @@ Returned array is `['tool_name' => $tool_definition]` (empty array to opt out).
 **Preferred pattern**: use `HandlerRegistrationTrait::registerHandler()` — the
 trait wires the callback into this filter with the correct wrapper shape. Manual
 registration is only needed for cross-cutting tools that register against
-`handler_types`.
+handler types or categories.
 
 #### Resolved tool definition contract
 

--- a/docs/handlers/publish/handlers-overview.md
+++ b/docs/handlers/publish/handlers-overview.md
@@ -138,7 +138,7 @@ add_filter('datamachine_tools', function($tools) {
 });
 ```
 
-Handler tool entries are deferred registry entries, not directly executable tools. `ToolManager::resolveHandlerTools()` resolves entries whose `handler` exactly matches the adjacent step handler slug. Cross-cutting tools may use `handler_types`, for example `['fetch', 'event_import']`, which matches against `datamachine_handlers` metadata.
+Handler tool entries are deferred registry entries, not directly executable tools. `ToolManager::resolveHandlerTools()` resolves entries whose `handler` exactly matches the adjacent step handler slug. Cross-cutting tools may use `handler_categories`, for example `['source']`, which matches the handler's registered step-type metadata.
 
 Callback conventions supported by `ToolManager`:
 

--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -27,6 +27,7 @@ use DataMachine\Core\RunMetrics;
 use DataMachine\Core\StepExecutionResult;
 use DataMachine\Core\Steps\FlowStepConfig;
 use DataMachine\Core\Steps\Step;
+use DataMachine\Core\Steps\StepTypeMetadata;
 use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
 use DataMachine\Engine\StepNavigator;
 
@@ -760,7 +761,7 @@ class ExecuteStepAbility {
 				'reason'       => 'packet_claim_reconciliation_failed',
 			);
 		}
-		if ( in_array( $step_type, array( 'fetch', 'event_import', 'ai' ), true ) ) {
+		if ( 'ai' === $step_type || StepTypeMetadata::isSourceIngestion( $step_type ) ) {
 			$dataPackets     = self::filterReconciledPacketsForRouting( $dataPackets, $reconciled );
 			$payload['data'] = $dataPackets;
 		}
@@ -1141,7 +1142,7 @@ class ExecuteStepAbility {
 		}
 
 		// completed_no_items is an execution status, not a packet-count guess.
-		// Fetch/event_import legacy empty outputs classify this way, and explicit
+		// Source-step legacy empty outputs classify this way, and explicit
 		// result-shaped step returns can also choose it without emitting packets.
 		if ( 'completed_no_items' === ( $execution_result['status'] ?? '' ) ) {
 			if ( ! $this->recoveryGenerationStillOwned( $job_id, $recovery_generation, $recovery_claim_token ) ) {

--- a/inc/Abilities/Handler/TestHandlerAbility.php
+++ b/inc/Abilities/Handler/TestHandlerAbility.php
@@ -16,6 +16,7 @@ use DataMachine\Abilities\HandlerAbilities;
 use DataMachine\Abilities\PermissionHelper;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Steps\FlowStepConfig;
+use DataMachine\Core\Steps\StepTypeMetadata;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -416,13 +417,10 @@ class TestHandlerAbility {
 			);
 		}
 
-		// Find the first fetch or event_import step.
-		$fetch_step_types = array( 'fetch', 'event_import' );
-
 		foreach ( $flow_config as $step ) {
 			$step_type = $step['step_type'] ?? '';
 
-			if ( ! in_array( $step_type, $fetch_step_types, true ) ) {
+			if ( ! StepTypeMetadata::hasHandlerCategory( (string) $step_type, 'source' ) ) {
 				continue;
 			}
 
@@ -443,7 +441,7 @@ class TestHandlerAbility {
 
 		return array(
 			'success' => false,
-			'error'   => sprintf( 'Flow %d has no fetch or event_import step with a handler.', $flow_id ),
+			'error'   => sprintf( 'Flow %d has no source step with a handler.', $flow_id ),
 		);
 	}
 

--- a/inc/Abilities/Pipeline/PipelineHelpers.php
+++ b/inc/Abilities/Pipeline/PipelineHelpers.php
@@ -194,7 +194,7 @@ trait PipelineHelpers {
 		$valid_types         = array_keys( $step_type_abilities->getAllStepTypes() );
 
 		foreach ( $steps as $index => $step ) {
-			// Accept shorthand: "event_import" becomes step_type=event_import
+			// Accept shorthand step type slugs.
 			if ( is_string( $step ) ) {
 				$step = array( 'step_type' => $step );
 			}

--- a/inc/Api/Chat/Tools/CreatePipeline.php
+++ b/inc/Api/Chat/Tools/CreatePipeline.php
@@ -243,7 +243,7 @@ class CreatePipeline extends BaseTool {
 	private function normalizeSteps( array $steps ): array {
 		$normalized = array();
 		foreach ( $steps as $index => $step ) {
-			// Accept shorthand: "event_import" becomes step_type=event_import
+			// Accept shorthand step type slugs.
 			if ( is_string( $step ) ) {
 				$step = array( 'step_type' => $step );
 			}

--- a/inc/Cli/Commands/PipelinesCommand.php
+++ b/inc/Cli/Commands/PipelinesCommand.php
@@ -172,7 +172,7 @@ class PipelinesCommand extends BaseCommand {
 	 *
 	 *     # Create a pipeline with steps
 	 *     wp datamachine pipelines create --name="Event Pipeline" \
-	 *       --steps='[{"step_type":"event_import"},{"step_type":"ai_enrich"}]'
+	 *       --steps='[{"step_type":"fetch"},{"step_type":"ai"}]'
 	 *
 	 *     # Dry-run validation
 	 *     wp datamachine pipelines create --name="Test" --dry-run

--- a/inc/Cli/Commands/TestCommand.php
+++ b/inc/Cli/Commands/TestCommand.php
@@ -15,6 +15,7 @@ use WP_CLI;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Abilities\HandlerAbilities;
 use DataMachine\Abilities\Handler\TestHandlerAbility;
+use DataMachine\Core\Steps\StepTypeMetadata;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -141,13 +142,11 @@ class TestCommand extends BaseCommand {
 			return;
 		}
 
-		// Filter to fetch-type handlers (fetch + event_import).
-		$fetch_types = array( 'fetch', 'event_import' );
-		$items       = array();
+		$items = array();
 
 		foreach ( $handlers as $slug => $handler ) {
 			$handler_type = $handler['type'] ?? $handler['step_type'] ?? '';
-			if ( ! in_array( $handler_type, $fetch_types, true ) ) {
+			if ( ! StepTypeMetadata::hasHandlerCategory( (string) $handler_type, 'source' ) ) {
 				continue;
 			}
 

--- a/inc/Core/Similarity/SimilarityEngine.php
+++ b/inc/Core/Similarity/SimilarityEngine.php
@@ -7,7 +7,7 @@
  *
  * - DuplicateDetection (Core/WordPress) — publish-level fuzzy title match
  * - QueueValidator (Engine/AI/Tools) — Jaccard word-set similarity
- * - EventIdentifierGenerator (data-machine-events) — event title/venue matching
+ * - Domain-specific identifier generators for structured record matching
  *
  * All similarity math lives here. Consumers (QueueValidator, publish handlers,
  * DuplicateCheckAbility, extension strategies) call these pure functions.

--- a/inc/Core/StepExecutionResult.php
+++ b/inc/Core/StepExecutionResult.php
@@ -7,10 +7,16 @@
 
 namespace DataMachine\Core;
 
+use DataMachine\Core\Steps\StepTypeMetadata;
+
 defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( StepResult::class ) ) {
 	require_once __DIR__ . '/StepResult.php';
+}
+
+if ( ! class_exists( StepTypeMetadata::class ) ) {
+	require_once __DIR__ . '/Steps/StepTypeMetadata.php';
 }
 
 /**
@@ -85,7 +91,7 @@ class StepExecutionResult {
 		$packet_count = count( $data_packets );
 
 		if ( 0 === $packet_count ) {
-			if ( in_array( $step_type, array( 'fetch', 'event_import' ), true ) ) {
+			if ( StepTypeMetadata::allowsEmptyOutput( $step_type ) ) {
 				return self::buildResult( self::STATUS_COMPLETED_NO_ITEMS, array(), 'completed_no_items', JobStatus::COMPLETED_NO_ITEMS );
 			}
 

--- a/inc/Core/Steps/Fetch/FetchStep.php
+++ b/inc/Core/Steps/Fetch/FetchStep.php
@@ -163,12 +163,12 @@ class FetchStep extends Step {
 			$handler_settings,
 			(string) $handler,
 			array(
-				'flow_step_id' => $this->flow_step_config['flow_step_id'],
-				'pipeline_id'  => $this->flow_step_config['pipeline_id'],
-				'flow_id'      => $this->flow_step_config['flow_id'],
-				'job_id'       => $this->job_id,
-				'user_id'      => $owner_user_id,
-				'agent_id'     => $agent_id,
+				'flow_step_id'          => $this->flow_step_config['flow_step_id'],
+				'pipeline_id'           => $this->flow_step_config['pipeline_id'],
+				'flow_id'               => $this->flow_step_config['flow_id'],
+				'job_id'                => $this->job_id,
+				'user_id'               => $owner_user_id,
+				'agent_id'              => $agent_id,
 				'principal_less_system' => 0 === $owner_user_id && 0 === $agent_id,
 			)
 		);

--- a/inc/Core/Steps/Fetch/FetchStep.php
+++ b/inc/Core/Steps/Fetch/FetchStep.php
@@ -63,7 +63,11 @@ class FetchStep extends Step {
 			class_name: self::class,
 			position: 10,
 			usesHandler: true,
-			hasPipelineConfig: false
+			hasPipelineConfig: false,
+			sourceIngestion: true,
+			allowsEmptyOutput: true,
+			supportsItemDisposition: true,
+			handlerCategory: 'source'
 		);
 	}
 

--- a/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
+++ b/inc/Core/Steps/Fetch/Handlers/FetchHandler.php
@@ -403,7 +403,7 @@ abstract class FetchHandler {
 	 * Called after an item is marked as processed during dedup.
 	 *
 	 * Override in subclasses to add handler-specific side effects.
-	 * For example, EventImportHandler stores item context in engine data
+	 * For example, a specialized source handler may store item context in engine data
 	 * for the fetch disposition AI tools.
 	 *
 	 * @param ExecutionContext $context Execution context.
@@ -418,7 +418,7 @@ abstract class FetchHandler {
 	 *
 	 * Base handlers default to 1 to prevent unbounded fan-out for
 	 * AI-heavy pipelines (RSS, Reddit, etc.). Subclasses like
-	 * EventImportHandler override to 0 (unlimited) since structured
+	 * Specialized source handlers may override to 0 (unlimited) when structured
 	 * event scrapers produce clean data that is cheap to process.
 	 *
 	 * @return int Default max items. 0 = unlimited.
@@ -590,8 +590,7 @@ abstract class FetchHandler {
 	 * Initialize FetchHandler static functionality.
 	 *
 	 * Registers fetch disposition tools in the unified `datamachine_tools` registry
-	 * as a cross-cutting handler tool — ToolPolicyResolver resolves it for any
-	 * adjacent step whose handler type is `fetch` or `event_import`.
+	 * as a cross-cutting handler tool for adjacent source-category steps.
 	 *
 	 * @since 0.9.7
 	 */
@@ -602,7 +601,7 @@ abstract class FetchHandler {
 				$tools['__handler_tools_fetch_dispositions'] = ToolManager::handlerToolDeclaration(
 					array( self::class, 'resolveFetchDispositionTools' ),
 					array(
-						'handler_types'           => array( 'fetch', 'event_import' ),
+						'handler_categories'      => array( 'source' ),
 						'client_context_bindings' => array( 'job_id' ),
 					)
 				);
@@ -614,8 +613,8 @@ abstract class FetchHandler {
 	/**
 	 * Resolve fetch disposition tools for a specific fetch-type handler.
 	 *
-	 * Invoked lazily by ToolManager::resolveHandlerTools() when ANY adjacent
-	 * step handler's registered type is `fetch` or `event_import`. The tool
+	 * Invoked lazily by ToolManager::resolveHandlerTools() when an adjacent
+	 * step handler belongs to the source category. The tool
 	 * is re-shaped per-handler so the description can reference the concrete
 	 * source in pipeline prompts.
 	 *

--- a/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
+++ b/inc/Core/Steps/Fetch/Tools/FetchItemDispositionTool.php
@@ -18,6 +18,7 @@ namespace DataMachine\Core\Steps\Fetch\Tools;
 use DataMachine\Core\RunMetrics;
 use DataMachine\Core\EngineData;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachine\Core\Steps\StepTypeMetadata;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -415,10 +416,10 @@ class FetchItemDispositionTool {
 	}
 
 	/**
-	 * Resolve the source fetch/event_import step ID from engine flow config.
+	 * Resolve the item-disposition source step ID from engine flow config.
 	 *
 	 * @param object $engine Engine data wrapper.
-	 * @return string|null Fetch step ID, or null when unavailable.
+	 * @return string|null Source step ID, or null when unavailable.
 	 */
 	private function resolveFetchFlowStepId( object $engine ): ?string {
 		$flow_config = $engine->get( 'flow_config' );
@@ -431,7 +432,7 @@ class FetchItemDispositionTool {
 				continue;
 			}
 
-			if ( in_array( $config['step_type'] ?? '', array( 'fetch', 'event_import' ), true ) ) {
+			if ( StepTypeMetadata::supportsItemDisposition( (string) ( $config['step_type'] ?? '' ) ) ) {
 				return (string) $step_id;
 			}
 		}

--- a/inc/Core/Steps/Step.php
+++ b/inc/Core/Steps/Step.php
@@ -19,6 +19,10 @@ if ( ! defined('ABSPATH') ) {
 	exit;
 }
 
+if ( ! class_exists( StepTypeMetadata::class ) ) {
+	require_once __DIR__ . '/StepTypeMetadata.php';
+}
+
 abstract class Step {
 
 
@@ -121,7 +125,7 @@ abstract class Step {
 	 * @return array Explicit step execution result.
 	 */
 	protected function failedStepResult( string $reason ): array {
-		$status = in_array( $this->step_type, array( 'fetch', 'event_import' ), true ) && empty( $this->dataPackets ) ? 'completed_no_items' : 'failed';
+		$status = StepTypeMetadata::allowsEmptyOutput( $this->step_type ) && empty( $this->dataPackets ) ? 'completed_no_items' : 'failed';
 
 		return StepExecutionResult::fromStepOutput(
 			array(

--- a/inc/Core/Steps/StepTypeMetadata.php
+++ b/inc/Core/Steps/StepTypeMetadata.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Registered step type metadata queries.
+ *
+ * @package DataMachine\Core\Steps
+ */
+
+namespace DataMachine\Core\Steps;
+
+defined( 'ABSPATH' ) || exit;
+
+class StepTypeMetadata {
+
+	/**
+	 * Determine whether a step owns source-ingestion lifecycle behavior.
+	 *
+	 * @param string $step_type Step type slug.
+	 * @return bool
+	 */
+	public static function isSourceIngestion( string $step_type ): bool {
+		$step_types = apply_filters( 'datamachine_step_types', array() );
+
+		return true === ( $step_types[ $step_type ]['source_ingestion'] ?? false );
+	}
+
+	/**
+	 * Determine whether empty output completes successfully for a step type.
+	 *
+	 * @param string $step_type Step type slug.
+	 * @return bool
+	 */
+	public static function allowsEmptyOutput( string $step_type ): bool {
+		$step_types = apply_filters( 'datamachine_step_types', array() );
+
+		return true === ( $step_types[ $step_type ]['allows_empty_output'] ?? false );
+	}
+
+	/**
+	 * Determine whether a step supports item-disposition tools.
+	 *
+	 * @param string $step_type Step type slug.
+	 * @return bool
+	 */
+	public static function supportsItemDisposition( string $step_type ): bool {
+		$step_types = apply_filters( 'datamachine_step_types', array() );
+
+		return true === ( $step_types[ $step_type ]['supports_item_disposition'] ?? false );
+	}
+
+	/**
+	 * Determine whether a step type belongs to a handler category.
+	 *
+	 * @param string $step_type Step type slug.
+	 * @param string $category Handler category.
+	 * @return bool
+	 */
+	public static function hasHandlerCategory( string $step_type, string $category ): bool {
+		$step_types = apply_filters( 'datamachine_step_types', array() );
+
+		return $category === ( $step_types[ $step_type ]['handler_category'] ?? null );
+	}
+}

--- a/inc/Core/Steps/StepTypeMetadata.php
+++ b/inc/Core/Steps/StepTypeMetadata.php
@@ -57,6 +57,6 @@ class StepTypeMetadata {
 	public static function hasHandlerCategory( string $step_type, string $category ): bool {
 		$step_types = apply_filters( 'datamachine_step_types', array() );
 
-		return $category === ( $step_types[ $step_type ]['handler_category'] ?? null );
+		return ( $step_types[ $step_type ]['handler_category'] ?? null ) === $category;
 	}
 }

--- a/inc/Core/Steps/StepTypeRegistrationTrait.php
+++ b/inc/Core/Steps/StepTypeRegistrationTrait.php
@@ -43,6 +43,10 @@ trait StepTypeRegistrationTrait {
 	 * @param bool       $hasPipelineConfig Whether step has pipeline-level configuration
 	 * @param bool       $consumeAllPackets Whether step consumes all packets at once
 	 * @param array|null $stepSettings Optional UI settings for pipeline step configuration
+	 * @param bool       $sourceIngestion Whether step owns source-ingestion lifecycle behavior
+	 * @param bool       $allowsEmptyOutput Whether empty output completes successfully
+	 * @param bool        $supportsItemDisposition Whether source items support disposition tools
+	 * @param string|null $handlerCategory Optional handler discovery category
 	 */
 	protected static function registerStepType(
 		string $slug,
@@ -55,7 +59,11 @@ trait StepTypeRegistrationTrait {
 		bool $hasPipelineConfig = false,
 		bool $consumeAllPackets = false,
 		?array $stepSettings = null,
-		bool $showSettingsDisplay = true
+		bool $showSettingsDisplay = true,
+		bool $sourceIngestion = false,
+		bool $allowsEmptyOutput = false,
+		bool $supportsItemDisposition = false,
+		?string $handlerCategory = null
 	): void {
 		// Prevent duplicate registration when step class is instantiated multiple times
 		if ( isset( self::$registered_step_types[ $slug ] ) ) {
@@ -75,18 +83,26 @@ trait StepTypeRegistrationTrait {
 				$multiHandler,
 				$hasPipelineConfig,
 				$consumeAllPackets,
-				$showSettingsDisplay
+				$showSettingsDisplay,
+				$sourceIngestion,
+				$allowsEmptyOutput,
+				$supportsItemDisposition,
+				$handlerCategory
 			) {
 				$steps[ $slug ] = array(
-					'label'                 => $label,
-					'description'           => $description,
-					'class'                 => $class_name,
-					'position'              => $position,
-					'uses_handler'          => $usesHandler,
-					'multi_handler'         => $multiHandler,
-					'has_pipeline_config'   => $hasPipelineConfig,
-					'consume_all_packets'   => $consumeAllPackets,
-					'show_settings_display' => $showSettingsDisplay,
+					'label'                     => $label,
+					'description'               => $description,
+					'class'                     => $class_name,
+					'position'                  => $position,
+					'uses_handler'              => $usesHandler,
+					'multi_handler'             => $multiHandler,
+					'has_pipeline_config'       => $hasPipelineConfig,
+					'consume_all_packets'       => $consumeAllPackets,
+					'show_settings_display'     => $showSettingsDisplay,
+					'source_ingestion'           => $sourceIngestion,
+					'allows_empty_output'        => $allowsEmptyOutput,
+					'supports_item_disposition' => $supportsItemDisposition,
+					'handler_category'           => $handlerCategory,
 				);
 				return $steps;
 			}

--- a/inc/Core/Steps/StepTypeRegistrationTrait.php
+++ b/inc/Core/Steps/StepTypeRegistrationTrait.php
@@ -99,10 +99,10 @@ trait StepTypeRegistrationTrait {
 					'has_pipeline_config'       => $hasPipelineConfig,
 					'consume_all_packets'       => $consumeAllPackets,
 					'show_settings_display'     => $showSettingsDisplay,
-					'source_ingestion'           => $sourceIngestion,
-					'allows_empty_output'        => $allowsEmptyOutput,
+					'source_ingestion'          => $sourceIngestion,
+					'allows_empty_output'       => $allowsEmptyOutput,
 					'supports_item_disposition' => $supportsItemDisposition,
-					'handler_category'           => $handlerCategory,
+					'handler_category'          => $handlerCategory,
 				);
 				return $steps;
 			}

--- a/inc/Engine/AI/Directives/AgentModeDirective.php
+++ b/inc/Engine/AI/Directives/AgentModeDirective.php
@@ -57,7 +57,7 @@ You are in the Data Machine admin pipeline editor. You have tools to configure a
 
 HANDLERS are the core intelligence. Fetch handlers extract and structure source data. Update/publish handlers apply changes with schema defaults for unconfigured fields. Each handler has a settings schema — only use documented fields.
 
-PIPELINES define workflow structure: step types in sequence (e.g., event_import → ai → upsert). The pipeline system_prompt defines AI behavior shared by all flows.
+PIPELINES define workflow structure: step types in sequence (e.g., source → ai → destination). The pipeline system_prompt defines AI behavior shared by all flows.
 
 FLOWS are configured pipeline instances. Handler-backed steps use handler_slugs + handler_configs; handler-free steps use flow_step_settings when they have settings. When creating flows, match handler configurations from existing flows on the same pipeline.
 

--- a/inc/Engine/AI/Tools/ToolManager.php
+++ b/inc/Engine/AI/Tools/ToolManager.php
@@ -17,6 +17,7 @@ namespace DataMachine\Engine\AI\Tools;
 
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\PluginSettings;
+use DataMachine\Core\Steps\StepTypeMetadata;
 use DataMachine\Engine\AI\ToolSchemaNormalizer;
 use DataMachine\Engine\AI\Tools\Sources\AbilityToolSource;
 
@@ -220,7 +221,7 @@ class ToolManager {
 	 * first-class shape new handler registrations should use.
 	 *
 	 * @param callable $handler_callable Callback that returns tools for a handler.
-	 * @param array    $args             Declaration args: handler, handler_types, modes,
+	 * @param array    $args             Declaration args: handler, handler_types, handler_categories, modes,
 	 *                                   access_level, ability, client_context_bindings.
 	 * @return array<string,mixed> Handler-tool declaration.
 	 */
@@ -251,6 +252,9 @@ class ToolManager {
 		if ( isset( $definition['handler_types'] ) && is_string( $definition['handler_types'] ) ) {
 			$definition['handler_types'] = array( $definition['handler_types'] );
 		}
+		if ( isset( $definition['handler_categories'] ) && is_string( $definition['handler_categories'] ) ) {
+			$definition['handler_categories'] = array( $definition['handler_categories'] );
+		}
 
 		return $definition;
 	}
@@ -264,9 +268,10 @@ class ToolManager {
 	 *
 	 * - **Exact slug**: `['handler' => 'wordpress_publish']` — the entry only
 	 *   applies when the adjacent step's handler_slug equals `'wordpress_publish'`.
-	 * - **Type match**: `['handler_types' => ['fetch', 'event_import']]` — the
-	 *   entry applies to any handler whose registered type is in the list
-	 *   (used by cross-cutting tools like `skip_item`).
+	 * - **Type match**: `['handler_types' => ['fetch']]` — the entry applies to
+	 *   any handler whose registered type is in the list.
+	 * - **Category match**: `['handler_categories' => ['source']]` — the entry
+	 *   applies when the handler's step type declares that category.
 	 *
 	 * Callbacks receive `(handler_slug, handler_config, engine_data)` and
 	 * return an `['tool_name' => $tool_definition]` array (empty to opt out).
@@ -297,7 +302,7 @@ class ToolManager {
 
 		$raw_tools        = $this->get_raw_tools();
 		$resolved         = array();
-		$handlers_by_slug = null; // Lazy-loaded only when handler_types matching is needed.
+		$handlers_by_slug = null; // Lazy-loaded only when handler metadata matching is needed.
 
 		foreach ( $raw_tools as $definition ) {
 			if ( ! is_array( $definition ) ) {
@@ -324,6 +329,21 @@ class ToolManager {
 				$handler_type = $handler_meta['type'] ?? '';
 				if ( $handler_type && in_array( $handler_type, $definition['handler_types'], true ) ) {
 					$matches = true;
+				}
+			}
+
+			// Handler-category match (cross-cutting tools across step types).
+			if ( ! $matches && ! empty( $definition['handler_categories'] ) && is_array( $definition['handler_categories'] ) ) {
+				if ( null === $handlers_by_slug ) {
+					$handlers_by_slug = apply_filters( 'datamachine_handlers', array() );
+				}
+				$handler_meta = $handlers_by_slug[ $handler_slug ] ?? null;
+				$handler_type = $handler_meta['type'] ?? '';
+				foreach ( $definition['handler_categories'] as $handler_category ) {
+					if ( $handler_type && is_string( $handler_category ) && StepTypeMetadata::hasHandlerCategory( $handler_type, $handler_category ) ) {
+						$matches = true;
+						break;
+					}
 				}
 			}
 

--- a/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
+++ b/inc/Engine/Actions/Handlers/StepLifecycleHandler.php
@@ -18,6 +18,7 @@ use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Core\JobStatus;
 use DataMachine\Core\PacketEngineData;
 use DataMachine\Core\RunMetrics;
+use DataMachine\Core\Steps\StepTypeMetadata;
 
 /**
  * Keeps source-ingestion processed-item behavior behind lifecycle hooks.
@@ -1192,6 +1193,6 @@ class StepLifecycleHandler {
 	 * @return bool
 	 */
 	private static function isSourceIngestionStep( string $step_type ): bool {
-		return in_array( $step_type, array( 'fetch', 'event_import' ), true );
+		return StepTypeMetadata::isSourceIngestion( $step_type );
 	}
 }

--- a/tests/Unit/AI/Tools/HandlerToolResolutionTest.php
+++ b/tests/Unit/AI/Tools/HandlerToolResolutionTest.php
@@ -6,7 +6,7 @@
  * `chubes_ai_tools` filter:
  *
  *  - Exact slug matching (`'handler' => 'wp_publish'`)
- *  - Cross-cutting type matching (`'handler_types' => ['fetch', 'event_import']`)
+ *  - Cross-cutting type and category matching
  *  - Per-scope caching
  *  - Pipeline gather flow through ToolPolicyResolver
  *
@@ -46,7 +46,7 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 	private static function capture_filter_ids(): array {
 		global $wp_filter;
 		$ids = array();
-		foreach ( array( 'datamachine_handlers', 'datamachine_tools' ) as $hook ) {
+		foreach ( array( 'datamachine_handlers', 'datamachine_step_types', 'datamachine_tools' ) as $hook ) {
 			$ids[ $hook ] = array();
 			if ( ! isset( $wp_filter[ $hook ] ) ) {
 				continue;
@@ -340,6 +340,37 @@ class HandlerToolResolutionTest extends WP_UnitTestCase {
 		$this->assertSame( 'Skip item from rss_feed', $resolved['skip_item_test']['description'] );
 		$this->assertSame( 'rss_feed', $resolved['skip_item_test']['handler'] );
 		$this->assertSame( 'rss_feed', $resolved['skip_item_test']['_resolved_slug'] );
+	}
+
+	public function test_resolves_cross_cutting_tool_via_handler_category(): void {
+		add_filter(
+			'datamachine_handlers',
+			static function ( array $handlers ): array {
+				$handlers['external_feed'] = array( 'type' => 'external_source' );
+				return $handlers;
+			}
+		);
+		add_filter(
+			'datamachine_step_types',
+			static function ( array $step_types ): array {
+				$step_types['external_source'] = array( 'handler_category' => 'source' );
+				return $step_types;
+			}
+		);
+		add_filter(
+			'datamachine_tools',
+			static function ( array $tools ): array {
+				$tools['__handler_tools_source_test'] = array(
+					'_handler_callable'  => static fn() => array( 'source_test' => array( 'description' => 'Source tool' ) ),
+					'handler_categories' => array( 'source' ),
+				);
+				return $tools;
+			}
+		);
+
+		$resolved = $this->tool_manager->resolveHandlerTools( 'external_feed', array(), array(), 'category-scope' );
+
+		$this->assertArrayHasKey( 'source_test', $resolved );
 	}
 
 	public function test_handler_types_skips_non_matching_handler_type(): void {

--- a/tests/Unit/Abilities/Engine/ExecuteStepMixedClaimRoutingTest.php
+++ b/tests/Unit/Abilities/Engine/ExecuteStepMixedClaimRoutingTest.php
@@ -36,8 +36,12 @@ class ExecuteStepMixedClaimRoutingTest extends WP_UnitTestCase {
 
 		$this->step_types_filter = static function ( array $types ): array {
 			$types['fetch'] = array(
-				'class'        => MixedClaimFetchStep::class,
-				'uses_handler' => false,
+				'class'                     => MixedClaimFetchStep::class,
+				'uses_handler'              => false,
+				'source_ingestion'          => true,
+				'allows_empty_output'       => true,
+				'supports_item_disposition' => true,
+				'handler_category'          => 'source',
 			);
 			$types['ai'] = array(
 				'class'        => MixedClaimAIStep::class,

--- a/tests/Unit/Abilities/Engine/PipelineBatchDeferralRoutingTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchDeferralRoutingTest.php
@@ -24,6 +24,7 @@ class PipelineBatchDeferralRoutingTest extends WP_UnitTestCase {
 	public function set_up(): void {
 		parent::set_up();
 		datamachine_test_prepare_site();
+		add_filter( 'datamachine_step_types', array( $this, 'registerSourceStepCapabilities' ) );
 
 		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
@@ -43,11 +44,23 @@ class PipelineBatchDeferralRoutingTest extends WP_UnitTestCase {
 	}
 
 	public function tear_down(): void {
+		remove_filter( 'datamachine_step_types', array( $this, 'registerSourceStepCapabilities' ) );
 		if ( function_exists( 'as_unschedule_all_actions' ) ) {
 			as_unschedule_all_actions( PipelineBatchScheduler::BATCH_HOOK );
 		}
 		wp_set_current_user( 0 );
 		parent::tear_down();
+	}
+
+	public function registerSourceStepCapabilities( array $step_types ): array {
+		$step_types['event_import'] = array(
+			'source_ingestion'          => true,
+			'allows_empty_output'       => true,
+			'supports_item_disposition' => true,
+			'handler_category'          => 'source',
+		);
+
+		return $step_types;
 	}
 
 	public function test_execute_step_fanout_excludes_exhausted_identity_and_routes_siblings(): void {

--- a/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineBatchSchedulerTest.php
@@ -31,6 +31,7 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 	public function set_up(): void {
 		parent::set_up();
 		datamachine_test_prepare_site();
+		add_filter( 'datamachine_step_types', array( $this, 'registerSourceStepCapabilities' ) );
 
 		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
@@ -51,11 +52,23 @@ class PipelineBatchSchedulerTest extends WP_UnitTestCase {
 	}
 
 	public function tear_down(): void {
+		remove_filter( 'datamachine_step_types', array( $this, 'registerSourceStepCapabilities' ) );
 		if ( function_exists( 'as_unschedule_all_actions' ) ) {
 			as_unschedule_all_actions( PipelineBatchScheduler::BATCH_HOOK );
 		}
 		wp_set_current_user( 0 );
 		parent::tear_down();
+	}
+
+	public function registerSourceStepCapabilities( array $step_types ): array {
+		$step_types['event_import'] = array(
+			'source_ingestion'          => true,
+			'allows_empty_output'       => true,
+			'supports_item_disposition' => true,
+			'handler_category'          => 'source',
+		);
+
+		return $step_types;
 	}
 
 	/**

--- a/tests/Unit/Core/StepTypeMetadataTest.php
+++ b/tests/Unit/Core/StepTypeMetadataTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Step type metadata tests.
+ *
+ * @package DataMachine\Tests\Unit\Core
+ */
+
+namespace DataMachine\Tests\Unit\Core;
+
+use DataMachine\Core\Steps\StepTypeMetadata;
+use WP_UnitTestCase;
+
+class StepTypeMetadataTest extends WP_UnitTestCase {
+
+	public function test_fetch_declares_source_step_contract(): void {
+		$step_types = apply_filters( 'datamachine_step_types', array() );
+		$fetch      = $step_types['fetch'];
+
+		$this->assertTrue( $fetch['source_ingestion'] );
+		$this->assertTrue( $fetch['allows_empty_output'] );
+		$this->assertTrue( $fetch['supports_item_disposition'] );
+		$this->assertSame( 'source', $fetch['handler_category'] );
+	}
+
+	public function test_queries_extension_registered_metadata_without_known_slugs(): void {
+		$register_external_source =
+			static function ( array $step_types ): array {
+				$step_types['external_source'] = array(
+					'source_ingestion'          => true,
+					'allows_empty_output'       => true,
+					'supports_item_disposition' => true,
+					'handler_category'          => 'source',
+				);
+				return $step_types;
+			};
+		add_filter(
+			'datamachine_step_types',
+			$register_external_source
+		);
+
+		$this->assertTrue( StepTypeMetadata::isSourceIngestion( 'external_source' ) );
+		$this->assertTrue( StepTypeMetadata::allowsEmptyOutput( 'external_source' ) );
+		$this->assertTrue( StepTypeMetadata::supportsItemDisposition( 'external_source' ) );
+		$this->assertTrue( StepTypeMetadata::hasHandlerCategory( 'external_source', 'source' ) );
+		$this->assertFalse( StepTypeMetadata::isSourceIngestion( 'unknown' ) );
+
+		remove_filter( 'datamachine_step_types', $register_external_source );
+	}
+}

--- a/tests/step-base-explicit-result-smoke.php
+++ b/tests/step-base-explicit-result-smoke.php
@@ -31,6 +31,22 @@ if ( ! function_exists( 'datamachine_get_engine_data' ) ) {
 	}
 }
 
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value ) {
+		if ( 'datamachine_step_types' === $hook ) {
+			$value['fetch'] = array( 'allows_empty_output' => true );
+		}
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data, int $options = 0 ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Pure-PHP smoke test fallback outside WordPress.
+		return json_encode( $data, $options );
+	}
+}
+
 require_once __DIR__ . '/../inc/Core/DataPacket.php';
 require_once __DIR__ . '/../inc/Core/EngineData.php';
 require_once __DIR__ . '/../inc/Core/JobStatus.php';

--- a/tests/step-execution-result-contract-smoke.php
+++ b/tests/step-execution-result-contract-smoke.php
@@ -25,6 +25,15 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 	}
 }
 
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value ) {
+		if ( 'datamachine_step_types' === $hook ) {
+			$value['fetch'] = array( 'allows_empty_output' => true );
+		}
+		return $value;
+	}
+}
+
 require_once __DIR__ . '/../inc/Core/JobStatus.php';
 require_once __DIR__ . '/../inc/Core/StepResult.php';
 require_once __DIR__ . '/../inc/Core/RunResult.php';


### PR DESCRIPTION
## Summary
- replace generic `event_import` branches with bounded step registration metadata for source lifecycle, empty-output success, item disposition, and handler category
- register built-in `fetch` with the same contract and add generic source-category matching for adjacent handler tools
- remove downstream-specific production literals and examples while preserving existing fetch behavior

## Metadata contract
- `source_ingestion` controls source claim lifecycle and reconciled packet routing
- `allows_empty_output` controls `completed_no_items` classification
- `supports_item_disposition` identifies the source step for disposition tools
- `handler_category: source` powers handler testing/discovery, CLI listing, and adjacent disposition-tool visibility

## Compatibility and merge order
Merge Extra-Chill/data-machine-events#717 first so `EventImportStep` owns equivalent metadata before these core special cases disappear. Merge this core PR second.

## Verification
- canonical Homeboy changed-scope lint passed with zero PHPCS/PHPStan findings
- focused source/result/adjacency/handler smokes passed: 25 + 5 + 13 + 47 assertions/checks
- all changed PHP files pass syntax checks and `git diff --check`
- production `inc/` search contains no `event_import`, `data-machine-events`, `Ticketmaster`, or `EventImport` literals
- managed Homeboy PHPUnit was attempted; changed-scope topology expanded to the entire 302-test inventory despite the filter, and the hot-host supervisor terminated unrelated real-WordPress smoke execution with exit 143 before structured focused results were produced

Fixes #3329
Parent: #3113
Events consumer PR: https://github.com/Extra-Chill/data-machine-events/pull/717