### PR TITLE
fix: allow engine data writes without MySQL packet limits

### DIFF
--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -2174,7 +2174,7 @@ class Jobs extends BaseRepository {
 		}
 
 		$max_allowed_packet             = (int) $this->wpdb->get_var( 'SELECT @@SESSION.max_allowed_packet' );
-		$budget                         = (int) floor( $max_allowed_packet * 0.8 );
+		$budget                         = 0 < $max_allowed_packet ? (int) floor( $max_allowed_packet * 0.8 ) : PHP_INT_MAX;
 		$this->engine_data_query_budget = max( 0, (int) apply_filters( 'datamachine_engine_data_query_budget', $budget, $max_allowed_packet ) );
 		return $this->engine_data_query_budget;
 	}

--- a/tests/Unit/Core/Database/EngineDataPersistenceTest.php
+++ b/tests/Unit/Core/Database/EngineDataPersistenceTest.php
@@ -64,6 +64,24 @@ class EngineDataPersistenceTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'do-not-log', (string) wp_json_encode( $rejections ) );
 	}
 
+	public function test_missing_mysql_packet_limit_does_not_reject_engine_data_writes(): void {
+		remove_filter( 'datamachine_engine_data_query_budget', $this->budget_filter );
+		$packet_query = static function ( string $query ): string {
+			return str_contains( $query, '@@SESSION.max_allowed_packet' ) ? 'SELECT 0' : $query;
+		};
+		add_filter( 'query', $packet_query );
+
+		try {
+			$jobs   = new Jobs();
+			$job_id = $jobs->create_job( array( 'source' => 'pipeline', 'label' => 'Non-MySQL engine data budget test' ) );
+			$this->assertIsInt( $job_id );
+			$this->assertTrue( $jobs->store_engine_data( $job_id, array( 'payload' => str_repeat( 'x', 5000 ) ) ) );
+		} finally {
+			remove_filter( 'query', $packet_query );
+			add_filter( 'datamachine_engine_data_query_budget', $this->budget_filter );
+		}
+	}
+
 	public function test_mutation_stops_after_deterministic_oversize_rejection(): void {
 		$jobs   = new Jobs();
 		$job_id = $jobs->create_job( array( 'source' => 'pipeline', 'label' => 'Mutation budget test' ) );

--- a/tests/drain-claim-ownership-smoke.php
+++ b/tests/drain-claim-ownership-smoke.php
@@ -7,7 +7,7 @@
  * @package DataMachine\Tests
  */
 
-$drain_file = __DIR__ . '/../inc/Cli/Commands/DrainCommand.php';
+$drain_file = __DIR__ . '/../inc/Core/ActionScheduler/ScopedDrainService.php';
 $drain_src  = file_get_contents( $drain_file ) ?: '';
 
 $assertions = 0;
@@ -36,7 +36,7 @@ assert_contains( 'runActionSchedulerTimeoutCleanup( $store )', $drain_src, 'drai
 assert_contains( 'stake_claim( $claim_size, null, $hooks ?? array(), self::GROUP )', $drain_src, 'drain stakes a group-scoped Action Scheduler claim' );
 assert_contains( '$claim->get_actions()', $drain_src, 'drain processes actions from the claim' );
 assert_contains( 'find_actions_by_claim_id( $claim->get_id() )', $drain_src, 'drain rechecks claim ownership before processing each action' );
-assert_contains( '$runner->process_action( $action_id, \'Data Machine CLI drain\' )', $drain_src, 'drain executes only claim-owned action IDs' );
+assert_contains( '$runner->process_action( $action_id, $execution_context )', $drain_src, 'drain executes only claim-owned action IDs' );
 assert_contains( 'flushRuntimeCache()', $drain_src, 'drain flushes runtime cache between actions' );
 assert_contains( 'isMemorySoftLimitReached()', $drain_src, 'drain checks memory soft limit while processing actions' );
 assert_contains( "'memory_limit'", $drain_src, 'drain reports memory-limit stop reason from batch processing' );
@@ -49,7 +49,7 @@ $ensure_pos  = strpos( $drain_src, 'GroupRegistrar::ensureDataMachineGroup()' );
 $cleanup_pos = strpos( $drain_src, 'runActionSchedulerTimeoutCleanup( $store )' );
 $stake_pos   = strpos( $drain_src, 'stake_claim( $claim_size, null, $hooks ?? array(), self::GROUP )' );
 $verify_pos  = strpos( $drain_src, 'find_actions_by_claim_id( $claim->get_id() )' );
-$process_pos = strpos( $drain_src, '$runner->process_action( $action_id, \'Data Machine CLI drain\' )' );
+$process_pos = strpos( $drain_src, '$runner->process_action( $action_id, $execution_context )' );
 $flush_pos   = strpos( $drain_src, 'flushRuntimeCache()' );
 $memory_pos  = strpos( $drain_src, 'isMemorySoftLimitReached()' );
 $release_pos = strpos( $drain_src, '$store->release_claim( $claim )' );


### PR DESCRIPTION
## Summary
- treat an unavailable MySQL `max_allowed_packet` value as no packet-specific ceiling instead of a zero-byte budget
- add regression coverage for non-MySQL engine-data writes
- repair the stale drain ownership smoke so it inspects the shared drain service that owns the behavior

## Reproduction
The exact `wp-site-generator` bundle from failing run `27094708135` was replayed through current WP Codebox with current Data Machine, Agents API, and Data Machine Code. The upstream activation-order failure no longer appeared. The bounded SQLite run instead failed before its first AI step because `Jobs::engine_data_query_budget()` cast the unsupported `@@SESSION.max_allowed_packet` result to `0` and rejected the normal workflow snapshot:

```text
engine_data_persist_failed
error: engine_data_query_oversize
new_bytes: 4863
estimated_query_bytes: 13822
```

No live GitHub mutation occurred; the scenario used deterministic OpenAI and GitHub HTTP responses.

## Root cause
The packet guard assumed every database exposed MySQL's session packet variable. On SQLite, the missing value became a zero-byte budget, so every non-empty engine-data write was rejected before SQL execution.

## Exact E2E evidence
- Before: artifact `runtime-mt5bthvq-pbzjx6` rejected engine data with `engine_data_query_oversize` before scheduling the AI step.
- After: artifact `runtime-mt5c0zhb-je5312` records `Stored engine_data successfully`, creates the direct step action, and advances into the execution lifecycle.
- The next independent SQLite lifecycle blocker is tracked separately in #3340; this PR does not work around it.
- Focused gates: `drain-claim-ownership-smoke` 29 assertions, `transaction-scope-smoke` 0 failures, `agent-bundle-runner-contract-smoke` 66 assertions, `tool-policy-resolver-adjacency-smoke` 13 assertions.
- Canonical Homeboy test invocation was attempted as run `baf9f7c9-a15c-47aa-9712-735e65771213`, but the current runner emitted `PHPUNIT_ZERO_TESTS cause=recipe_run_no_executions`; no tests failed because none executed.

## Preserved policy
Required adjacent-handler policy is unchanged and was not weakened. Existing resolver, recorder, output projection, and required-output assertions remain intact.

Refs #2578
Fixes #3338
Parent #3113