### PR TITLE
fix: preserve refreshed OAuth account fields

### DIFF
--- a/inc/Core/OAuth/BaseOAuth2Provider.php
+++ b/inc/Core/OAuth/BaseOAuth2Provider.php
@@ -201,8 +201,11 @@ abstract class BaseOAuth2Provider extends BaseAuthProvider {
 			}
 
 			if ( ! is_wp_error( $refreshed ) && ! empty( $refreshed['access_token'] ) ) {
-				$account['access_token']      = $refreshed['access_token'];
-				$account['token_expires_at']  = $refreshed['expires_at'] ?? $account['token_expires_at'];
+				$account = array_merge( $this->get_account(), $refreshed );
+				unset( $account['expires_at'] );
+				if ( isset( $refreshed['expires_at'] ) ) {
+					$account['token_expires_at'] = $refreshed['expires_at'];
+				}
 				$account['last_refreshed_at'] = time();
 				$this->save_account( $account );
 
@@ -251,6 +254,10 @@ abstract class BaseOAuth2Provider extends BaseAuthProvider {
 	 *
 	 * Expected return format on success:
 	 *   ['access_token' => '...', 'expires_at' => <unix_timestamp>]
+	 *
+	 * Additional provider-specific account fields may be returned. They are
+	 * merged into the latest persisted account before the common token fields
+	 * are saved.
 	 *
 	 * @since 0.31.1
 	 * @param string $current_token The current access token to refresh.
@@ -454,8 +461,11 @@ abstract class BaseOAuth2Provider extends BaseAuthProvider {
 		}
 
 		if ( ! is_wp_error( $refreshed ) && ! empty( $refreshed['access_token'] ) ) {
-			$account['access_token']      = $refreshed['access_token'];
-			$account['token_expires_at']  = $refreshed['expires_at'] ?? $account['token_expires_at'];
+			$account = array_merge( $this->get_account(), $refreshed );
+			unset( $account['expires_at'] );
+			if ( isset( $refreshed['expires_at'] ) ) {
+				$account['token_expires_at'] = $refreshed['expires_at'];
+			}
 			$account['last_refreshed_at'] = time();
 			$this->save_account( $account );
 

--- a/tests/Unit/Core/OAuth/BaseOAuth2ProviderTest.php
+++ b/tests/Unit/Core/OAuth/BaseOAuth2ProviderTest.php
@@ -43,6 +43,12 @@ class TestOAuth2Provider extends BaseOAuth2Provider {
 	 */
 	public int $refreshed_expires_in = 5184000; // 60 days
 
+	/**
+	 * Provider-specific fields persisted or returned during refresh.
+	 */
+	public array $persisted_refresh_fields = array();
+	public array $returned_refresh_fields  = array();
+
 	public function get_config_fields(): array {
 		return array(
 			'client_id'     => array(
@@ -81,10 +87,14 @@ class TestOAuth2Provider extends BaseOAuth2Provider {
 			return new \WP_Error( 'test_refresh_failed', 'Simulated refresh failure' );
 		}
 
-		return array(
+		if ( ! empty( $this->persisted_refresh_fields ) ) {
+			$this->update_account( $this->persisted_refresh_fields );
+		}
+
+		return array_merge( array(
 			'access_token' => $this->refreshed_token,
 			'expires_at'   => time() + $this->refreshed_expires_in,
-		);
+		), $this->returned_refresh_fields );
 	}
 }
 
@@ -291,6 +301,23 @@ class BaseOAuth2ProviderTest extends WP_UnitTestCase {
 		$this->assertGreaterThan( time() + 5000000, $account['token_expires_at'] );
 	}
 
+	public function test_refresh_preserves_provider_specific_account_fields(): void {
+		$this->provider->persisted_refresh_fields = array( 'provider_credential' => 'rotated_value' );
+		$this->provider->returned_refresh_fields  = array( 'provider_scope' => 'updated_scope' );
+		$this->provider->save_account( array(
+			'access_token'       => 'tok_old',
+			'token_expires_at'   => time() - 100,
+			'provider_credential' => 'stale_value',
+		) );
+
+		$this->provider->get_valid_access_token();
+
+		$account = $this->provider->get_account();
+		$this->assertSame( 'rotated_value', $account['provider_credential'] );
+		$this->assertSame( 'updated_scope', $account['provider_scope'] );
+		$this->assertArrayNotHasKey( 'expires_at', $account );
+	}
+
 	public function test_refresh_does_not_trigger_outside_buffer(): void {
 		// Token expires in 10 days — outside the 7-day buffer.
 		$this->provider->save_account( array(
@@ -434,9 +461,12 @@ class BaseOAuth2ProviderTest extends WP_UnitTestCase {
 	public function test_schedule_proactive_refresh_attempts_recovery_when_past(): void {
 		// Token expires in 2 days — refresh time would be (2d - 7d) = -5d, which is in the past.
 		// With recovery, the provider should attempt an immediate refresh.
+		$this->provider->persisted_refresh_fields = array( 'provider_credential' => 'rotated_value' );
+		$this->provider->returned_refresh_fields  = array( 'provider_scope' => 'updated_scope' );
 		$this->provider->save_account( array(
-			'access_token'    => 'tok_123',
-			'token_expires_at' => time() + ( 2 * DAY_IN_SECONDS ),
+			'access_token'       => 'tok_123',
+			'token_expires_at'   => time() + ( 2 * DAY_IN_SECONDS ),
+			'provider_credential' => 'stale_value',
 		) );
 
 		$result = $this->provider->schedule_proactive_refresh();
@@ -448,6 +478,8 @@ class BaseOAuth2ProviderTest extends WP_UnitTestCase {
 		// New token should be saved.
 		$account = $this->provider->get_account();
 		$this->assertSame( 'refreshed_tok_999', $account['access_token'] );
+		$this->assertSame( 'rotated_value', $account['provider_credential'] );
+		$this->assertSame( 'updated_scope', $account['provider_scope'] );
 
 		// A cron event should now be scheduled for the new token.
 		$next = wp_next_scheduled( $this->provider->get_cron_hook_name() );


### PR DESCRIPTION
## Summary
- Reload the latest persisted OAuth account after a provider refresh callback, then merge provider-returned fields before the base class writes common token metadata.
- Apply the same canonical persistence sequence to on-demand and proactive recovery refreshes.
- Add regression coverage for provider fields persisted during the callback and returned through the refresh result.

## Root Cause
`get_valid_access_token()` and `attempt_recovery_refresh()` loaded the account before calling `do_refresh_token()`. A provider could persist a changed provider-specific field during that callback, but the base class then updated access token/expiry on its stale pre-refresh array and saved the entire stale account. That final stale write immediately overwrote the provider's refreshed field.

## Persistence Behavior
Before: read account A, provider refresh persists account B, base mutates stale A with common access token/expiry fields, then saves stale A over B.

After: read account A, provider refresh persists and/or returns account changes, base re-reads canonical account B, merges returned fields, translates `expires_at` to `token_expires_at`, stamps `last_refreshed_at`, and performs one final base save of the canonical account. The contract remains provider-agnostic because arbitrary provider-owned account keys are merged without naming or special-casing any provider.

## Verification
- `homeboy review test --placement auto -- --filter BaseOAuth2ProviderTest` after initial skip-bootstrap state: failed with 0 tests because `vendor/autoload.php` was absent; no PHPUnit test executed (run `ed96933f-ce10-42b3-b0ee-a290db51d248`).
- `composer install --no-interaction --prefer-dist`: passed; hydrated locked dependencies in the assigned worktree.
- `homeboy review test --placement auto -- --filter BaseOAuth2ProviderTest`: passed, 54 tests, 54 passed, 0 failed, 0 skipped (final run `f7629583-1773-41b7-8378-178e82054dd5`).
- `homeboy review test --placement auto -- --filter OAuth`: passed, 169 tests, 169 passed, 0 failed, 0 skipped (run `c9b587df-458f-45cd-b765-11fdc152535b`).
- `vendor/bin/phpcs inc/Core/OAuth/BaseOAuth2Provider.php tests/Unit/Core/OAuth/BaseOAuth2ProviderTest.php`: passed with no findings.
- `php -l inc/Core/OAuth/BaseOAuth2Provider.php && php -l tests/Unit/Core/OAuth/BaseOAuth2ProviderTest.php`: passed.
- `git diff --check`: passed.

This unblocks Extra-Chill/data-machine-socials#210 by preventing rotated provider credentials from being restored to stale values after refresh.

Closes #3350.