### PR TITLE
test: remove leaking CLI permission state

### DIFF
--- a/tests/Unit/Abilities/PostQueryAbilitiesTest.php
+++ b/tests/Unit/Abilities/PostQueryAbilitiesTest.php
@@ -452,6 +452,12 @@ class PostQueryAbilitiesTest extends WP_UnitTestCase {
 		$this->assertEquals( $pipeline_id, $post['pipeline_id'] );
 	}
 
+	/**
+	 * Keep the immutable WP_CLI constant from leaking into later test files.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
 	public function test_permission_callback_with_cli(): void {
 		if ( ! defined( 'WP_CLI' ) ) {
 			define( 'WP_CLI', true );

--- a/tests/Unit/Abilities/PostQueryAbilitiesTest.php
+++ b/tests/Unit/Abilities/PostQueryAbilitiesTest.php
@@ -452,24 +452,6 @@ class PostQueryAbilitiesTest extends WP_UnitTestCase {
 		$this->assertEquals( $pipeline_id, $post['pipeline_id'] );
 	}
 
-	/**
-	 * Keep the immutable WP_CLI constant from leaking into later test files.
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_permission_callback_with_cli(): void {
-		if ( ! defined( 'WP_CLI' ) ) {
-			define( 'WP_CLI', true );
-		}
-		$ability = wp_get_ability( 'datamachine/query-posts' );
-
-		$this->assertNotNull( $ability );
-
-		$result = $ability->execute( array( 'filter_by' => 'handler', 'filter_value' => 'test' ) );
-		$this->assertNotInstanceOf( \WP_Error::class, $result );
-	}
-
 	public function test_permission_callback_without_permissions(): void {
 		wp_set_current_user( 0 );
 		add_filter( 'datamachine_cli_bypass_permissions', '__return_false' );


### PR DESCRIPTION
## Summary
- delete the invalid query-post CLI permission test that permanently defined `WP_CLI=true` in the shared PHPUnit process
- retain executable anonymous-denial coverage for the query-post and scaffold abilities
- leave production authorization and the CLI bypass implementation unchanged

## Root cause
`PostQueryAbilitiesTest::test_permission_callback_with_cli` defined the immutable, process-wide `WP_CLI` constant as `true`. PHPUnit then continued with other test files in the same shard process. `PermissionHelper::can()` intentionally authorizes CLI requests, so a later anonymous scaffold ability call bypassed logged-out denial and returned a successful result array. Shard redistribution changed whether this file preceded `AgentIdentityStoreAdapterTest`, explaining why the failure moved between shards after updating main.

The deleted test did not prove the CLI path: `PostQueryAbilitiesTest::set_up()` authenticates an administrator before every method, so the ability succeeded through normal user capabilities regardless of `WP_CLI`. The following anonymous query-post test explicitly disables the CLI bypass and therefore also could not detect the leaked constant. No existing injectable request-context seam exists, and this PR does not invent production infrastructure to retain a flawed test.

## Authorization
Anonymous authorization is unchanged in production. `ScaffoldAbilities` still gates public execution through `PermissionHelper::can( 'chat' )`, and `AgentIdentityStoreAdapterTest::test_bootstrap_materializes_without_authenticated_user_while_public_ability_remains_denied` still requires `ability_invalid_permissions`. `PostQueryAbilitiesTest::test_permission_callback_without_permissions` also remains intact.

## Reproduction
Before: run `PostQueryAbilitiesTest::test_permission_callback_with_cli` before `AgentIdentityStoreAdapterTest::test_bootstrap_materializes_without_authenticated_user_while_public_ability_remains_denied` in one PHPUnit process. The first test leaves `WP_CLI=true`; the scaffold ability executes and returns an array instead of `WP_Error`.

After: no PHPUnit test defines `WP_CLI`, so later anonymous ability checks evaluate the actual logged-out context deterministically regardless of shard order.

## Verification
- `php -l tests/Unit/Abilities/PostQueryAbilitiesTest.php`
- `git diff --check`
- Canonical SQLite focused run of the superseded child-process approach correctly exposed WP Codebox incompatibility (`Test was run in child process and ended unexpectedly`); that approach was replaced in commit `9089a9401`
- Canonical complete four-shard MySQL and changed-file lint rerun by this PR's checks

Fixes #3349
Refs #3346