### PR TITLE
style: align direct operation recovery assignments

### DIFF
--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -535,9 +535,9 @@ class Jobs extends BaseRepository {
 			$result['reason'] = 'action_receipt_missing';
 			return $result;
 		}
-		$engine   = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
 		unset( $engine['job_status_reason'] );
-		$engine['direct_operation_recovery'] = array(
+		$engine['direct_operation_recovery']   = array(
 			'schema'                        => 'datamachine.direct-operation-recovery.v1',
 			'state'                         => 'requeued',
 			'trigger'                       => sanitize_key( $trigger ),

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -535,7 +535,7 @@ class Jobs extends BaseRepository {
 			$result['reason'] = 'action_receipt_missing';
 			return $result;
 		}
-		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
+		$engine   = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
 		unset( $engine['job_status_reason'] );
 		$engine['direct_operation_recovery'] = array(
 			'schema'                        => 'datamachine.direct-operation-recovery.v1',
@@ -547,9 +547,9 @@ class Jobs extends BaseRepository {
 			'operation_generation'          => $new_generation,
 			'recovered_at'                  => gmdate( 'c' ),
 		);
-		$run_lifecycle                       = is_array( $engine[ RunLifecycleStore::META_KEY ] ?? null ) ? $engine[ RunLifecycleStore::META_KEY ] : array();
-		$run_lifecycle['status']             = JobStatus::PENDING;
-		$run_lifecycle['updated_at']         = current_time( 'mysql', true );
+		$run_lifecycle                         = is_array( $engine[ RunLifecycleStore::META_KEY ] ?? null ) ? $engine[ RunLifecycleStore::META_KEY ] : array();
+		$run_lifecycle['status']               = JobStatus::PENDING;
+		$run_lifecycle['updated_at']           = current_time( 'mysql', true );
 		$engine[ RunLifecycleStore::META_KEY ] = $run_lifecycle;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching


### PR DESCRIPTION
## Summary

- apply the PHPCBF-equivalent alignment for four direct-operation recovery assignments
- clear the only blocking findings from #3364's repaired CI rerun
- make no behavioral changes

## Verification

- `php -l inc/Core/Database/Jobs/Jobs.php`
- direct PHPCS on `Jobs.php`
- `git diff --check`
- Homeboy changed-file lint: pass, including PHPStan level 7

Closes #3365