### PR TITLE
Restore clean full-tree lint gate

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -9,60 +9,69 @@
       "metadata": {
         "findings_count": 0
       }
+    },
+    "lint:115f25907f28371418122a6879a5e3b487458182b6a658ba4e6fcf7f4c741bf5": {
+      "context_id": "data-machine",
+      "created_at": "2026-08-24T04:02:42Z",
+      "item_count": 0,
+      "known_fingerprints": [],
+      "metadata": {
+        "findings_count": 0
+      }
     }
   },
   "changelog_target": "docs/CHANGELOG.md",
-  "remote_path": "wp-content/plugins/data-machine",
   "extensions": {
     "wordpress": {
-      "php": "8.2",
-      "node": "20",
       "database_type": "sqlite",
+      "node": "20",
+      "php": "8.2",
       "release_latest_branch": "release-latest",
       "settings": {
-        "runtime_wordpress_version": "7.0",
         "phpunit_no_tests": "fail",
+        "runtime_wordpress_version": "7.0",
         "wp_codebox_phpunit_bootstrap_mode": "managed",
         "wp_codebox_phpunit_config": "/wordpress/wp-content/plugins/data-machine/phpunit.sqlite.xml.dist"
       }
     }
   },
   "id": "data-machine",
+  "remote_path": "wp-content/plugins/data-machine",
   "transforms": {
     "drop_wp_ability_dead_guards": {
       "description": "Drop dead class_exists('WP_Ability') and class_exists('WP_Abilities_Registry') guards. Plugin header requires WP 7.0 where both classes ship in core, so every guard on these symbols is unreachable. Ref: https://github.com/Extra-Chill/data-machine/issues/XXXX",
       "rules": [
         {
-          "id": "simple_guard",
+          "context": "file",
           "description": "Remove standalone if ( ! class_exists( 'WP_Ability' ) ) { return; } blocks.",
+          "files": "inc/Abilities/**/*.php",
           "find": "(?s)\n\t\tif \\( ! class_exists\\( ?'WP_Ability' ?\\) \\) \\{\n\t\t\treturn;\n\t\t\\}\n",
-          "replace": "",
-          "files": "inc/Abilities/**/*.php",
-          "context": "file"
+          "id": "simple_guard",
+          "replace": ""
         },
         {
-          "id": "combined_guard_registered",
+          "context": "file",
           "description": "Drop the WP_Ability half of 'if ( ! class_exists( WP_Ability ) || self::$registered ) { return; }' guards.",
-          "find": "(?s)if \\( ! class_exists\\( 'WP_Ability' \\) \\|\\| self::\\$registered \\) \\{\n\t+return;\n\t+\\}",
-          "replace": "if ( self::$$registered ) {\n\t\t\treturn;\n\t\t}",
           "files": "inc/Abilities/**/*.php",
-          "context": "file"
-        },
-        {
-          "id": "ternary_registry_guard",
-          "description": "Replace '(class_exists(WP_Abilities_Registry) ? WP_Abilities_Registry::get_instance() : null)' with a direct call — the ternary is unreachable.",
-          "find": "class_exists\\( 'WP_Abilities_Registry' \\) \\? \\\\WP_Abilities_Registry::get_instance\\(\\) : null",
-          "replace": "\\\\WP_Abilities_Registry::get_instance()",
-          "files": "inc/**/*.php",
-          "context": "line"
-        },
-        {
-          "id": "combined_guard_registered_engine",
-          "description": "Same as combined_guard_registered but catches the one hit in inc/Engine/ (ResolvePendingActionAbility).",
           "find": "(?s)if \\( ! class_exists\\( 'WP_Ability' \\) \\|\\| self::\\$registered \\) \\{\n\t+return;\n\t+\\}",
-          "replace": "if ( self::$$registered ) {\n\t\t\treturn;\n\t\t}",
+          "id": "combined_guard_registered",
+          "replace": "if ( self::$$registered ) {\n\t\t\treturn;\n\t\t}"
+        },
+        {
+          "context": "line",
+          "description": "Replace '(class_exists(WP_Abilities_Registry) ? WP_Abilities_Registry::get_instance() : null)' with a direct call — the ternary is unreachable.",
+          "files": "inc/**/*.php",
+          "find": "class_exists\\( 'WP_Abilities_Registry' \\) \\? \\\\WP_Abilities_Registry::get_instance\\(\\) : null",
+          "id": "ternary_registry_guard",
+          "replace": "\\\\WP_Abilities_Registry::get_instance()"
+        },
+        {
+          "context": "file",
+          "description": "Same as combined_guard_registered but catches the one hit in inc/Engine/ (ResolvePendingActionAbility).",
           "files": "inc/Engine/**/*.php",
-          "context": "file"
+          "find": "(?s)if \\( ! class_exists\\( 'WP_Ability' \\) \\|\\| self::\\$registered \\) \\{\n\t+return;\n\t+\\}",
+          "id": "combined_guard_registered_engine",
+          "replace": "if ( self::$$registered ) {\n\t\t\treturn;\n\t\t}"
         }
       ]
     }

--- a/inc/Abilities/AgentMemoryAbilities.php
+++ b/inc/Abilities/AgentMemoryAbilities.php
@@ -317,7 +317,7 @@ class AgentMemoryAbilities {
 	 * @return array Result.
 	 */
 	public static function getMemory( array $input ): array|\WP_Error {
-		$memory  = self::resolveMemory( $input );
+		$memory = self::resolveMemory( $input );
 		if ( is_wp_error( $memory ) ) {
 			return $memory;
 		}
@@ -490,7 +490,7 @@ class AgentMemoryAbilities {
 	 * @return array Search results.
 	 */
 	public static function searchMemory( array $input ): array|\WP_Error {
-		$memory  = self::resolveMemory( $input );
+		$memory = self::resolveMemory( $input );
 		if ( is_wp_error( $memory ) ) {
 			return $memory;
 		}
@@ -534,9 +534,9 @@ class AgentMemoryAbilities {
 	 * @return AgentMemory|\WP_Error
 	 */
 	private static function resolveMemory( array $input ): AgentMemory|\WP_Error {
-		$user_id  = (int) ( $input['user_id'] ?? 0 );
-		$agent_id = (int) ( $input['agent_id'] ?? 0 );
-		$filename = $input['file'] ?? 'MEMORY.md';
+		$user_id   = (int) ( $input['user_id'] ?? 0 );
+		$agent_id  = (int) ( $input['agent_id'] ?? 0 );
+		$filename  = $input['file'] ?? 'MEMORY.md';
 		$principal = PermissionHelper::get_execution_principal();
 
 		if ( null !== $principal ) {

--- a/inc/Abilities/Chat/AgentsChatHandler.php
+++ b/inc/Abilities/Chat/AgentsChatHandler.php
@@ -109,7 +109,7 @@ class AgentsChatHandler {
 		$agent_id = $identity ? $identity->agent_id : 0;
 
 		$calling_user_id = $this->resolveCallingUserId( $input );
-		$user_id = $this->resolveRuntimeUserId( $identity, (string) ( $input['agent'] ?? '' ), $input );
+		$user_id         = $this->resolveRuntimeUserId( $identity, (string) ( $input['agent'] ?? '' ), $input );
 		if ( $user_id <= 0 ) {
 			return new WP_Error( 'no_user', __( 'No user context available.', 'data-machine' ), array( 'status' => 400 ) );
 		}
@@ -154,7 +154,7 @@ class AgentsChatHandler {
 				'modes'                 => $modes,
 				'agent_id'              => $agent_id,
 				'agent_slug'            => $identity ? $identity->agent_slug : '',
-				'calling_user_id'        => $calling_user_id,
+				'calling_user_id'       => $calling_user_id,
 				'attachments'           => $input['attachments'] ?? array(),
 				'client_context'        => $client_context,
 				'tool_policy'           => is_array( $input['tool_policy'] ?? null ) ? $input['tool_policy'] : null,

--- a/inc/Abilities/Content/InsertContentAbility.php
+++ b/inc/Abilities/Content/InsertContentAbility.php
@@ -183,7 +183,7 @@ class InsertContentAbility {
 	/** Execute only from the pending-action dispatcher with a one-time receipt. */
 	public static function apply_pending_action( array $input, array $payload, array $receipt ): array|\WP_Error {
 		$input['preview'] = false;
-		$receipt_input = $input;
+		$receipt_input    = $input;
 		unset( $receipt_input['preview'] );
 		$authorized = ContentActionHandlers::consume_receipt( 'insert_content', $receipt_input, $payload, $receipt );
 		if ( is_wp_error( $authorized ) ) {

--- a/inc/Abilities/Email/EmailAbilities.php
+++ b/inc/Abilities/Email/EmailAbilities.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
 class EmailAbilities {
 
 	private static bool $registered = false;
-	private ?array $activeMailbox = null;
+	private ?array $activeMailbox   = null;
 
 	public function __construct() {
 		if ( self::$registered ) {
@@ -103,11 +103,11 @@ class EmailAbilities {
 						'required'   => array( 'uid' ),
 						'properties' => array(
 							'auth_ref' => self::authRefProperty(),
-							'uid'    => array(
+							'uid'      => array(
 								'type'        => 'integer',
 								'description' => __( 'Message UID to delete', 'data-machine' ),
 							),
-							'folder' => array(
+							'folder'   => array(
 								'type'    => 'string',
 								'default' => 'INBOX',
 							),
@@ -138,7 +138,7 @@ class EmailAbilities {
 						'type'       => 'object',
 						'required'   => array( 'uid', 'destination' ),
 						'properties' => array(
-							'auth_ref'     => self::authRefProperty(),
+							'auth_ref'    => self::authRefProperty(),
 							'uid'         => array(
 								'type'        => 'integer',
 								'description' => __( 'Message UID to move', 'data-machine' ),
@@ -179,20 +179,20 @@ class EmailAbilities {
 						'required'   => array( 'uid', 'flag' ),
 						'properties' => array(
 							'auth_ref' => self::authRefProperty(),
-							'uid'    => array(
+							'uid'      => array(
 								'type'        => 'integer',
 								'description' => __( 'Message UID', 'data-machine' ),
 							),
-							'flag'   => array(
+							'flag'     => array(
 								'type'        => 'string',
 								'description' => __( 'IMAP flag: Seen, Flagged, Answered, Deleted, Draft', 'data-machine' ),
 							),
-							'action' => array(
+							'action'   => array(
 								'type'        => 'string',
 								'default'     => 'set',
 								'description' => __( 'set or clear the flag', 'data-machine' ),
 							),
-							'folder' => array(
+							'folder'   => array(
 								'type'    => 'string',
 								'default' => 'INBOX',
 							),
@@ -223,7 +223,7 @@ class EmailAbilities {
 						'type'       => 'object',
 						'required'   => array( 'search', 'destination' ),
 						'properties' => array(
-							'auth_ref'     => self::authRefProperty(),
+							'auth_ref'    => self::authRefProperty(),
 							'search'      => array(
 								'type'        => 'string',
 								'description' => __( 'IMAP search criteria (e.g., FROM "github.com")', 'data-machine' ),
@@ -271,24 +271,24 @@ class EmailAbilities {
 						'required'   => array( 'search', 'flag' ),
 						'properties' => array(
 							'auth_ref' => self::authRefProperty(),
-							'search' => array(
+							'search'   => array(
 								'type'        => 'string',
 								'description' => __( 'IMAP search criteria', 'data-machine' ),
 							),
-							'flag'   => array(
+							'flag'     => array(
 								'type'        => 'string',
 								'description' => __( 'Flag: Seen, Flagged, Answered, Deleted, Draft', 'data-machine' ),
 							),
-							'action' => array(
+							'action'   => array(
 								'type'        => 'string',
 								'default'     => 'set',
 								'description' => __( 'set or clear', 'data-machine' ),
 							),
-							'folder' => array(
+							'folder'   => array(
 								'type'    => 'string',
 								'default' => 'INBOX',
 							),
-							'max'    => array(
+							'max'      => array(
 								'type'    => 'integer',
 								'default' => 500,
 							),
@@ -322,15 +322,15 @@ class EmailAbilities {
 						'required'   => array( 'search' ),
 						'properties' => array(
 							'auth_ref' => self::authRefProperty(),
-							'search' => array(
+							'search'   => array(
 								'type'        => 'string',
 								'description' => __( 'IMAP search criteria', 'data-machine' ),
 							),
-							'folder' => array(
+							'folder'   => array(
 								'type'    => 'string',
 								'default' => 'INBOX',
 							),
-							'max'    => array(
+							'max'      => array(
 								'type'        => 'integer',
 								'default'     => 100,
 								'description' => __( 'Maximum messages to delete (safety limit, lower default)', 'data-machine' ),
@@ -365,11 +365,11 @@ class EmailAbilities {
 						'required'   => array( 'uid' ),
 						'properties' => array(
 							'auth_ref' => self::authRefProperty(),
-							'uid'    => array(
+							'uid'      => array(
 								'type'        => 'integer',
 								'description' => __( 'Message UID to unsubscribe from', 'data-machine' ),
 							),
-							'folder' => array(
+							'folder'   => array(
 								'type'    => 'string',
 								'default' => 'INBOX',
 							),
@@ -402,15 +402,15 @@ class EmailAbilities {
 						'required'   => array( 'search' ),
 						'properties' => array(
 							'auth_ref' => self::authRefProperty(),
-							'search' => array(
+							'search'   => array(
 								'type'        => 'string',
 								'description' => __( 'IMAP search criteria', 'data-machine' ),
 							),
-							'folder' => array(
+							'folder'   => array(
 								'type'    => 'string',
 								'default' => 'INBOX',
 							),
-							'max'    => array(
+							'max'      => array(
 								'type'        => 'integer',
 								'default'     => 20,
 								'description' => __( 'Max unique senders to unsubscribe from (deduped by sender)', 'data-machine' ),

--- a/inc/Abilities/Engine/ScheduleNextStepAbility.php
+++ b/inc/Abilities/Engine/ScheduleNextStepAbility.php
@@ -268,13 +268,13 @@ class ScheduleNextStepAbility {
 		}
 
 		$action_args = $this->actionArgs( $job_id, $flow_step_id );
-		$action = new \ActionScheduler_Action(
+		$action      = new \ActionScheduler_Action(
 			'datamachine_execute_step',
 			$action_args,
 			new \ActionScheduler_SimpleSchedule( as_get_datetime_object( time() ) ),
 			'data-machine'
 		);
-		$action_id = $this->saveAtomicAction( $store, $action );
+		$action_id   = $this->saveAtomicAction( $store, $action );
 		if ( $action_id <= 0
 			|| $action_id <= (int) $previous_max_id
 			|| \ActionScheduler_Store::STATUS_PENDING !== $store->get_status( $action_id )

--- a/inc/Abilities/Fetch/FetchEmailAbility.php
+++ b/inc/Abilities/Fetch/FetchEmailAbility.php
@@ -487,7 +487,7 @@ class FetchEmailAbility {
 	 */
 	private function fetchBody( $connection, int $uid, bool $peek ): string {
 		$fetch_flags = FT_UID | ( $peek ? FT_PEEK : 0 );
-		$structure = imap_fetchstructure( $connection, $uid, FT_UID );
+		$structure   = imap_fetchstructure( $connection, $uid, FT_UID );
 		if ( ! $structure ) {
 			return '';
 		}

--- a/inc/Abilities/Publish/SendEmailAbility.php
+++ b/inc/Abilities/Publish/SendEmailAbility.php
@@ -516,20 +516,20 @@ class SendEmailAbility {
 		if ( ! is_array( $grant ) || empty( $grant['signature'] ) ) {
 			return new \WP_Error( 'email_queue_grant_invalid', 'Queued mailbox authorization is invalid.', array( 'status' => 403 ) );
 		}
-		$user_id  = absint( $grant['user_id'] ?? 0 );
-		$agent_id = absint( $grant['agent_id'] ?? 0 );
+		$user_id   = absint( $grant['user_id'] ?? 0 );
+		$agent_id  = absint( $grant['agent_id'] ?? 0 );
 		$issued_at = absint( $grant['issued_at'] ?? 0 );
 		$nonce     = (string) ( $grant['nonce'] ?? '' );
 		$payload   = $this->mailboxGrantPayload( $config, $user_id, $agent_id, $issued_at, $nonce );
-		$expected = hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) );
+		$expected  = hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) );
 		if ( ! hash_equals( $expected, (string) $grant['signature'] ) ) {
 			return new \WP_Error( 'email_queue_grant_invalid', 'Queued mailbox authorization is invalid.', array( 'status' => 403 ) );
 		}
 		return array(
-			'user_id'      => $user_id,
-			'agent_id'     => $agent_id,
-			'token_id'     => absint( $grant['token_id'] ?? 0 ),
-			'issuer_type'  => (string) ( $grant['issuer_type'] ?? '' ),
+			'user_id'       => $user_id,
+			'agent_id'      => $agent_id,
+			'token_id'      => absint( $grant['token_id'] ?? 0 ),
+			'issuer_type'   => (string) ( $grant['issuer_type'] ?? '' ),
 			'legacy_sender' => ! empty( $grant['legacy_sender'] ),
 		);
 	}
@@ -539,6 +539,7 @@ class SendEmailAbility {
 		unset( $payload['_attempt'], $payload['_mailbox_grant'] );
 		$payload = $this->canonicalizeGrantValue( $payload );
 		return implode( '|', array(
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Canonical internal data is hashed for an HMAC and never unserialized.
 			hash( 'sha256', serialize( $payload ) ),
 			(string) $user_id,
 			(string) $agent_id,

--- a/inc/Api/Chat/ChatOrchestrator.php
+++ b/inc/Api/Chat/ChatOrchestrator.php
@@ -82,7 +82,7 @@ class ChatOrchestrator {
 		if ( ! $workspace instanceof WP_Agent_Workspace_Scope ) {
 			return new WP_Error( 'invalid_transcript_workspace', __( 'A canonical transcript workspace is required.', 'data-machine' ), array( 'status' => 400 ) );
 		}
-		$transcript_owner     = ChatTranscriptOwner::resolve_for_request( $options, $user_id );
+		$transcript_owner = ChatTranscriptOwner::resolve_for_request( $options, $user_id );
 		if ( is_wp_error( $transcript_owner ) ) {
 			return $transcript_owner;
 		}
@@ -425,7 +425,7 @@ class ChatOrchestrator {
 			);
 		}
 
-		$metadata = $session['metadata'] ?? array();
+		$metadata        = $session['metadata'] ?? array();
 		$calling_user_id = null !== $calling_user_id
 			? max( 0, $calling_user_id )
 			: ( array_key_exists( 'calling_user_id', $metadata ) ? max( 0, (int) $metadata['calling_user_id'] ) : $user_id );
@@ -913,15 +913,15 @@ class ChatOrchestrator {
 			$client_context = $options['client_context'] ?? array();
 			$all_tools      = $resolver->resolve(
 				array(
-					'modes'          => $modes,
-					'agent_id'       => $agent_id,
-					'agent_slug'     => $agent_slug,
-					'user_id'        => $user_id,
+					'modes'           => $modes,
+					'agent_id'        => $agent_id,
+					'agent_slug'      => $agent_slug,
+					'user_id'         => $user_id,
 					'calling_user_id' => $calling_user_id,
-					'interactive'    => true,
-					'client_context' => is_array( $client_context ) ? $client_context : array(),
-					'tool_policy'    => is_array( $options['tool_policy'] ?? null ) ? $options['tool_policy'] : null,
-					'allow_only'     => is_array( $options['allow_only'] ?? null ) ? $options['allow_only'] : array(),
+					'interactive'     => true,
+					'client_context'  => is_array( $client_context ) ? $client_context : array(),
+					'tool_policy'     => is_array( $options['tool_policy'] ?? null ) ? $options['tool_policy'] : null,
+					'allow_only'      => is_array( $options['allow_only'] ?? null ) ? $options['allow_only'] : array(),
 				)
 			);
 

--- a/inc/Api/Email.php
+++ b/inc/Api/Email.php
@@ -477,9 +477,9 @@ class Email {
 		}
 
 		$result = $ability->execute( array(
-			'auth_ref'        => self::mailbox_ref( $request ),
-			'folder'          => $request->get_param( 'folder' ) ?? 'INBOX',
-			'uid'             => (int) $request->get_param( 'uid' ),
+			'auth_ref' => self::mailbox_ref( $request ),
+			'folder'   => $request->get_param( 'folder' ) ?? 'INBOX',
+			'uid'      => (int) $request->get_param( 'uid' ),
 		) );
 
 		return self::to_response( $result );
@@ -513,8 +513,8 @@ class Email {
 
 		$result = $ability->execute( array(
 			'auth_ref' => self::mailbox_ref( $request ),
-			'uid'    => (int) $request->get_param( 'uid' ),
-			'folder' => $request->get_param( 'folder' ) ?? 'INBOX',
+			'uid'      => (int) $request->get_param( 'uid' ),
+			'folder'   => $request->get_param( 'folder' ) ?? 'INBOX',
 		) );
 
 		return self::to_response( $result );
@@ -527,7 +527,7 @@ class Email {
 		}
 
 		$result = $ability->execute( array(
-			'auth_ref'     => self::mailbox_ref( $request ),
+			'auth_ref'    => self::mailbox_ref( $request ),
 			'uid'         => (int) $request->get_param( 'uid' ),
 			'destination' => $request->get_param( 'destination' ),
 			'folder'      => $request->get_param( 'folder' ) ?? 'INBOX',
@@ -544,10 +544,10 @@ class Email {
 
 		$result = $ability->execute( array(
 			'auth_ref' => self::mailbox_ref( $request ),
-			'uid'    => (int) $request->get_param( 'uid' ),
-			'flag'   => $request->get_param( 'flag' ),
-			'action' => $request->get_param( 'action' ) ?? 'set',
-			'folder' => $request->get_param( 'folder' ) ?? 'INBOX',
+			'uid'      => (int) $request->get_param( 'uid' ),
+			'flag'     => $request->get_param( 'flag' ),
+			'action'   => $request->get_param( 'action' ) ?? 'set',
+			'folder'   => $request->get_param( 'folder' ) ?? 'INBOX',
 		) );
 
 		return self::to_response( $result );
@@ -560,7 +560,7 @@ class Email {
 		}
 
 		$result = $ability->execute( array(
-			'auth_ref'     => self::mailbox_ref( $request ),
+			'auth_ref'    => self::mailbox_ref( $request ),
 			'search'      => $request->get_param( 'search' ),
 			'destination' => $request->get_param( 'destination' ),
 			'folder'      => $request->get_param( 'folder' ) ?? 'INBOX',
@@ -578,11 +578,11 @@ class Email {
 
 		$result = $ability->execute( array(
 			'auth_ref' => self::mailbox_ref( $request ),
-			'search' => $request->get_param( 'search' ),
-			'flag'   => $request->get_param( 'flag' ),
-			'action' => $request->get_param( 'action' ) ?? 'set',
-			'folder' => $request->get_param( 'folder' ) ?? 'INBOX',
-			'max'    => (int) ( $request->get_param( 'max' ) ?? 500 ),
+			'search'   => $request->get_param( 'search' ),
+			'flag'     => $request->get_param( 'flag' ),
+			'action'   => $request->get_param( 'action' ) ?? 'set',
+			'folder'   => $request->get_param( 'folder' ) ?? 'INBOX',
+			'max'      => (int) ( $request->get_param( 'max' ) ?? 500 ),
 		) );
 
 		return self::to_response( $result );
@@ -596,9 +596,9 @@ class Email {
 
 		$result = $ability->execute( array(
 			'auth_ref' => self::mailbox_ref( $request ),
-			'search' => $request->get_param( 'search' ),
-			'folder' => $request->get_param( 'folder' ) ?? 'INBOX',
-			'max'    => (int) ( $request->get_param( 'max' ) ?? 100 ),
+			'search'   => $request->get_param( 'search' ),
+			'folder'   => $request->get_param( 'folder' ) ?? 'INBOX',
+			'max'      => (int) ( $request->get_param( 'max' ) ?? 100 ),
 		) );
 
 		return self::to_response( $result );
@@ -612,8 +612,8 @@ class Email {
 
 		$result = $ability->execute( array(
 			'auth_ref' => self::mailbox_ref( $request ),
-			'uid'    => (int) $request->get_param( 'uid' ),
-			'folder' => $request->get_param( 'folder' ) ?? 'INBOX',
+			'uid'      => (int) $request->get_param( 'uid' ),
+			'folder'   => $request->get_param( 'folder' ) ?? 'INBOX',
 		) );
 
 		return self::to_response( $result );
@@ -627,9 +627,9 @@ class Email {
 
 		$result = $ability->execute( array(
 			'auth_ref' => self::mailbox_ref( $request ),
-			'search' => $request->get_param( 'search' ),
-			'folder' => $request->get_param( 'folder' ) ?? 'INBOX',
-			'max'    => (int) ( $request->get_param( 'max' ) ?? 20 ),
+			'search'   => $request->get_param( 'search' ),
+			'folder'   => $request->get_param( 'folder' ) ?? 'INBOX',
+			'max'      => (int) ( $request->get_param( 'max' ) ?? 20 ),
 		) );
 
 		return self::to_response( $result );
@@ -655,13 +655,13 @@ class Email {
 		return rest_ensure_response( $result );
 	}
 
-	private static function mailbox_ref( \WP_REST_Request $request, bool $default = true ): string {
+	private static function mailbox_ref( \WP_REST_Request $request, bool $use_default = true ): string {
 		$ref = trim( (string) $request->get_param( 'auth_ref' ) );
 		if ( '' === $ref ) {
 			$mailbox = trim( (string) $request->get_param( 'mailbox' ) );
 			$ref     = '' !== $mailbox ? 'email_imap:' . $mailbox : '';
 		}
-		return '' !== $ref ? $ref : ( $default ? 'email_imap:default' : '' );
+		return '' !== $ref ? $ref : ( $use_default ? 'email_imap:default' : '' );
 	}
 
 	private static function mailbox_args(): array {

--- a/inc/Api/Execute.php
+++ b/inc/Api/Execute.php
@@ -40,32 +40,32 @@ class Execute {
 					return PermissionHelper::can( 'manage_flows' );
 				},
 				'args'                => array(
-					'flow_id'      => array(
+					'flow_id'       => array(
 						'type'        => 'integer',
 						'required'    => false,
 						'description' => 'Database flow ID to execute',
 					),
-					'workflow'     => array(
+					'workflow'      => array(
 						'type'        => 'object',
 						'required'    => false,
 						'description' => 'Ephemeral workflow structure',
 					),
-					'count'        => array(
+					'count'         => array(
 						'type'        => 'integer',
 						'required'    => false,
 						'description' => 'Number of times to run (1-10, database flow only)',
 					),
-					'timestamp'    => array(
+					'timestamp'     => array(
 						'type'        => 'integer',
 						'required'    => false,
 						'description' => 'Unix timestamp for delayed execution',
 					),
-					'initial_data' => array(
+					'initial_data'  => array(
 						'type'        => 'object',
 						'required'    => false,
 						'description' => 'Initial engine data to merge before workflow execution',
 					),
-					'dry_run'      => array(
+					'dry_run'       => array(
 						'type'        => 'boolean',
 						'required'    => false,
 						'default'     => false,
@@ -232,10 +232,10 @@ class Execute {
 	 * Handle ephemeral workflow execution via datamachine/execute-workflow.
 	 */
 	private static function handle_ephemeral_execution( $request ) {
-		$workflow     = $request->get_param( 'workflow' );
-		$timestamp    = $request->get_param( 'timestamp' );
-		$initial_data = $request->get_param( 'initial_data' );
-		$dry_run      = $request->get_param( 'dry_run' );
+		$workflow      = $request->get_param( 'workflow' );
+		$timestamp     = $request->get_param( 'timestamp' );
+		$initial_data  = $request->get_param( 'initial_data' );
+		$dry_run       = $request->get_param( 'dry_run' );
 		$operation_key = $request->get_param( 'operation_key' );
 
 		$ability = wp_get_ability( 'datamachine/execute-workflow' );
@@ -268,8 +268,8 @@ class Execute {
 		}
 
 		if ( ! ( $result['success'] ?? false ) ) {
-			$status = 400;
-			$error  = $result['error'] ?? __( 'Execution failed', 'data-machine' );
+			$status     = 400;
+			$error      = $result['error'] ?? __( 'Execution failed', 'data-machine' );
 			$error_data = array( 'status' => $status );
 
 			if ( false !== strpos( $error, 'not found' ) ) {
@@ -277,7 +277,7 @@ class Execute {
 			} elseif ( false !== strpos( $error, 'Failed to create' ) || false !== strpos( $error, 'not available' ) ) {
 				$status = 500;
 			} elseif ( ! empty( $result['retryable'] ) ) {
-				$status = 409;
+				$status                      = 409;
 				$error_data['retryable']     = true;
 				$error_data['enqueue_state'] = (string) ( $result['enqueue_state'] ?? 'enqueuing' );
 			}

--- a/inc/Cli/Commands/EmailCommand.php
+++ b/inc/Cli/Commands/EmailCommand.php
@@ -431,9 +431,9 @@ class EmailCommand extends BaseCommand {
 		}
 
 		$result = $ability->execute( array(
-			'auth_ref'        => $this->mailboxRef( $assoc_args ),
-			'folder'          => $assoc_args['folder'] ?? 'INBOX',
-			'uid'             => $uid,
+			'auth_ref' => $this->mailboxRef( $assoc_args ),
+			'folder'   => $assoc_args['folder'] ?? 'INBOX',
+			'uid'      => $uid,
 		) );
 
 		if ( is_wp_error( $result ) ) {
@@ -593,8 +593,8 @@ class EmailCommand extends BaseCommand {
 
 		$result = $ability->execute( array(
 			'auth_ref' => $this->mailboxRef( $assoc_args ),
-			'uid'    => $uid,
-			'folder' => $assoc_args['folder'] ?? 'INBOX',
+			'uid'      => $uid,
+			'folder'   => $assoc_args['folder'] ?? 'INBOX',
 		) );
 
 		if ( is_wp_error( $result ) ) {
@@ -652,7 +652,7 @@ class EmailCommand extends BaseCommand {
 		}
 
 		$result = $ability->execute( array(
-			'auth_ref'     => $this->mailboxRef( $assoc_args ),
+			'auth_ref'    => $this->mailboxRef( $assoc_args ),
 			'uid'         => $uid,
 			'destination' => $destination,
 			'folder'      => $assoc_args['folder'] ?? 'INBOX',
@@ -723,10 +723,10 @@ class EmailCommand extends BaseCommand {
 
 		$result = $ability->execute( array(
 			'auth_ref' => $this->mailboxRef( $assoc_args ),
-			'uid'    => $uid,
-			'flag'   => $flag,
-			'action' => $assoc_args['action'] ?? 'set',
-			'folder' => $assoc_args['folder'] ?? 'INBOX',
+			'uid'      => $uid,
+			'flag'     => $flag,
+			'action'   => $assoc_args['action'] ?? 'set',
+			'folder'   => $assoc_args['folder'] ?? 'INBOX',
 		) );
 
 		if ( is_wp_error( $result ) ) {
@@ -798,7 +798,7 @@ class EmailCommand extends BaseCommand {
 		}
 
 		$result = $ability->execute( array(
-			'auth_ref'     => $this->mailboxRef( $assoc_args ),
+			'auth_ref'    => $this->mailboxRef( $assoc_args ),
 			'search'      => $search,
 			'destination' => $destination,
 			'folder'      => $assoc_args['folder'] ?? 'INBOX',
@@ -885,11 +885,11 @@ class EmailCommand extends BaseCommand {
 
 		$result = $ability->execute( array(
 			'auth_ref' => $this->mailboxRef( $assoc_args ),
-			'search' => $search,
-			'flag'   => $flag,
-			'action' => $action,
-			'folder' => $assoc_args['folder'] ?? 'INBOX',
-			'max'    => (int) ( $assoc_args['max'] ?? 500 ),
+			'search'   => $search,
+			'flag'     => $flag,
+			'action'   => $action,
+			'folder'   => $assoc_args['folder'] ?? 'INBOX',
+			'max'      => (int) ( $assoc_args['max'] ?? 500 ),
 		) );
 
 		if ( is_wp_error( $result ) ) {
@@ -956,9 +956,9 @@ class EmailCommand extends BaseCommand {
 
 		$result = $ability->execute( array(
 			'auth_ref' => $this->mailboxRef( $assoc_args ),
-			'search' => $search,
-			'folder' => $assoc_args['folder'] ?? 'INBOX',
-			'max'    => (int) ( $assoc_args['max'] ?? 100 ),
+			'search'   => $search,
+			'folder'   => $assoc_args['folder'] ?? 'INBOX',
+			'max'      => (int) ( $assoc_args['max'] ?? 100 ),
 		) );
 
 		if ( is_wp_error( $result ) ) {
@@ -1014,8 +1014,8 @@ class EmailCommand extends BaseCommand {
 
 		$result = $ability->execute( array(
 			'auth_ref' => $this->mailboxRef( $assoc_args ),
-			'uid'    => $uid,
-			'folder' => $assoc_args['folder'] ?? 'INBOX',
+			'uid'      => $uid,
+			'folder'   => $assoc_args['folder'] ?? 'INBOX',
 		) );
 
 		if ( is_wp_error( $result ) ) {
@@ -1086,9 +1086,9 @@ class EmailCommand extends BaseCommand {
 
 		$result = $ability->execute( array(
 			'auth_ref' => $this->mailboxRef( $assoc_args ),
-			'search' => $search,
-			'folder' => $assoc_args['folder'] ?? 'INBOX',
-			'max'    => (int) ( $assoc_args['max'] ?? 20 ),
+			'search'   => $search,
+			'folder'   => $assoc_args['folder'] ?? 'INBOX',
+			'max'      => (int) ( $assoc_args['max'] ?? 20 ),
 		) );
 
 		if ( is_wp_error( $result ) ) {
@@ -1169,11 +1169,11 @@ class EmailCommand extends BaseCommand {
 		return $providers['email_imap'] ?? null;
 	}
 
-	private function mailboxRef( array $assoc_args, bool $default = true ): string {
+	private function mailboxRef( array $assoc_args, bool $use_default = true ): string {
 		$ref = trim( (string) ( $assoc_args['auth-ref'] ?? '' ) );
 		if ( '' === $ref && ! empty( $assoc_args['mailbox'] ) ) {
 			$ref = 'email_imap:' . trim( (string) $assoc_args['mailbox'] );
 		}
-		return '' !== $ref ? $ref : ( $default ? 'email_imap:default' : '' );
+		return '' !== $ref ? $ref : ( $use_default ? 'email_imap:default' : '' );
 	}
 }

--- a/inc/Cli/Commands/PendingActionsCommand.php
+++ b/inc/Cli/Commands/PendingActionsCommand.php
@@ -34,7 +34,12 @@ class PendingActionsCommand extends BaseCommand {
 		if ( '' === $action_id ) {
 			WP_CLI::error( 'action_id is required.' );
 		}
-		$result = \DataMachine\Engine\AI\Actions\ResolvePendingActionAbility::execute( array( 'action_id' => $action_id, 'decision' => $decision, 'resolver' => 'cli:' . get_current_user_id(), 'context' => array( 'resolution_transport' => 'cli' ) ) );
+		$result = \DataMachine\Engine\AI\Actions\ResolvePendingActionAbility::execute( array(
+			'action_id' => $action_id,
+			'decision'  => $decision,
+			'resolver'  => 'cli:' . get_current_user_id(),
+			'context'   => array( 'resolution_transport' => 'cli' ),
+		) );
 		if ( empty( $result['success'] ) ) {
 			WP_CLI::error( (string) ( $result['error'] ?? 'Pending action could not be resolved.' ) );
 		}

--- a/inc/Cli/JobLivenessClassifier.php
+++ b/inc/Cli/JobLivenessClassifier.php
@@ -67,22 +67,22 @@ class JobLivenessClassifier {
 		$oldest_progress_age = self::minutesSince( $oldest_in_progress, $now );
 		$owner_actions       = array_merge( $pending, $fresh_progress );
 
-		$job_id          = (int) ( $job['job_id'] ?? 0 );
-		$active_children = (int) ( $child_counts['active'] ?? 0 );
-		$total_children  = (int) ( $child_counts['total'] ?? 0 );
-		$batch_total     = (int) ( $engine_data['batch_total'] ?? 0 );
-		$throttle        = is_array( $engine_data['ai_concurrency_throttle'] ?? null ) ? $engine_data['ai_concurrency_throttle'] : array();
+		$job_id             = (int) ( $job['job_id'] ?? 0 );
+		$active_children    = (int) ( $child_counts['active'] ?? 0 );
+		$total_children     = (int) ( $child_counts['total'] ?? 0 );
+		$batch_total        = (int) ( $engine_data['batch_total'] ?? 0 );
+		$throttle           = is_array( $engine_data['ai_concurrency_throttle'] ?? null ) ? $engine_data['ai_concurrency_throttle'] : array();
 		$contention_actions = array_values(
 			array_filter(
 				$owner_actions,
 				static fn( array $action ): bool => 'datamachine_resume_ai_step' === (string) ( $action['hook'] ?? '' )
 			)
 		);
-		$contention_owned = ! empty( $throttle )
+		$contention_owned   = ! empty( $throttle )
 			&& 'deferred' === ( $throttle['state'] ?? 'deferred' )
 			&& ! empty( $contention_actions );
-		$first_deferred  = strtotime( (string) ( $throttle['first_deferred_at'] ?? '' ) );
-		$defer_age       = false === $first_deferred ? (int) ( $throttle['defer_age_seconds'] ?? 0 ) : max( 0, $now - $first_deferred );
+		$first_deferred     = strtotime( (string) ( $throttle['first_deferred_at'] ?? '' ) );
+		$defer_age          = false === $first_deferred ? (int) ( $throttle['defer_age_seconds'] ?? 0 ) : max( 0, $now - $first_deferred );
 
 		if ( ! empty( $fresh_progress ) ) {
 			$classification = 'active_processing';

--- a/inc/Cli/WorkerHealth.php
+++ b/inc/Cli/WorkerHealth.php
@@ -29,13 +29,13 @@ class WorkerHealth {
 			);
 		}
 
-		$due_count               = max( 0, (int) ( $evidence['due_count'] ?? 0 ) );
-		$deferred                = max( 0, (int) ( $evidence['concurrency_deferred_actions'] ?? 0 ) );
-		$stale_due_sample_age    = isset( $evidence['stale_due_sample_age_seconds'] ) ? max( 0, (int) $evidence['stale_due_sample_age_seconds'] ) : null;
-		$queue_trigger_state     = (string) ( $evidence['queue_trigger_state'] ?? 'unknown' );
-		$heartbeat_state         = (string) ( $evidence['worker_heartbeat_state'] ?? 'absent' );
-		$worker_claimed          = 'fresh' === $heartbeat_state;
-		$dispatcher_starved      = $due_count > 0
+		$due_count            = max( 0, (int) ( $evidence['due_count'] ?? 0 ) );
+		$deferred             = max( 0, (int) ( $evidence['concurrency_deferred_actions'] ?? 0 ) );
+		$stale_due_sample_age = isset( $evidence['stale_due_sample_age_seconds'] ) ? max( 0, (int) $evidence['stale_due_sample_age_seconds'] ) : null;
+		$queue_trigger_state  = (string) ( $evidence['queue_trigger_state'] ?? 'unknown' );
+		$heartbeat_state      = (string) ( $evidence['worker_heartbeat_state'] ?? 'absent' );
+		$worker_claimed       = 'fresh' === $heartbeat_state;
+		$dispatcher_starved   = $due_count > 0
 			&& ! $worker_claimed
 			&& null !== $stale_due_sample_age
 			&& $stale_due_sample_age > $stale_threshold_seconds

--- a/inc/Core/ActionScheduler/LogPersistencePolicy.php
+++ b/inc/Core/ActionScheduler/LogPersistencePolicy.php
@@ -44,6 +44,7 @@ class LogPersistencePolicy {
 	 * @param array|bool|null $policy  Persistence policy, if configured.
 	 * @return mixed
 	 */
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- The filter contract supplies four arguments to this callback.
 	public static function filterPersistentTableQuery( $query, string $table_suffix, string $table, $policy ) {
 		if ( self::TABLE_SUFFIX !== $table_suffix || ! is_string( $query ) || '' === $query ) {
 			return $query;

--- a/inc/Core/Bootstrap/DependencyChecker.php
+++ b/inc/Core/Bootstrap/DependencyChecker.php
@@ -15,18 +15,18 @@ defined( 'ABSPATH' ) || exit;
  */
 class DependencyChecker {
 
-	public const CHECK_ACTION_SCHEDULER    = 'action_scheduler';
-	public const CHECK_FILESYSTEM_WRITES   = 'filesystem_writes';
-	public const CHECK_IMAP                = 'imap';
-	public const CHECK_ZIP_ARCHIVE         = 'zip_archive';
+	public const CHECK_ACTION_SCHEDULER  = 'action_scheduler';
+	public const CHECK_FILESYSTEM_WRITES = 'filesystem_writes';
+	public const CHECK_IMAP              = 'imap';
+	public const CHECK_ZIP_ARCHIVE       = 'zip_archive';
 
 	/** @return array<string,string> */
 	private static function checks(): array {
 		return array(
-			self::CHECK_ACTION_SCHEDULER    => 'Action Scheduler is available.',
-			self::CHECK_FILESYSTEM_WRITES   => 'The Data Machine directory is writable.',
-			self::CHECK_IMAP                => 'The PHP IMAP extension is available.',
-			self::CHECK_ZIP_ARCHIVE         => 'The PHP Zip extension is available.',
+			self::CHECK_ACTION_SCHEDULER  => 'Action Scheduler is available.',
+			self::CHECK_FILESYSTEM_WRITES => 'The Data Machine directory is writable.',
+			self::CHECK_IMAP              => 'The PHP IMAP extension is available.',
+			self::CHECK_ZIP_ARCHIVE       => 'The PHP Zip extension is available.',
 		);
 	}
 

--- a/inc/Core/Database/Jobs/Jobs.php
+++ b/inc/Core/Database/Jobs/Jobs.php
@@ -537,7 +537,7 @@ class Jobs extends BaseRepository {
 		}
 		$engine = is_array( $job['engine_data'] ?? null ) ? $job['engine_data'] : array();
 		unset( $engine['job_status_reason'] );
-		$engine['direct_operation_recovery'] = array(
+		$engine['direct_operation_recovery']   = array(
 			'schema'                        => 'datamachine.direct-operation-recovery.v1',
 			'state'                         => 'requeued',
 			'trigger'                       => sanitize_key( $trigger ),
@@ -547,9 +547,9 @@ class Jobs extends BaseRepository {
 			'operation_generation'          => $new_generation,
 			'recovered_at'                  => gmdate( 'c' ),
 		);
-		$run_lifecycle                       = is_array( $engine[ RunLifecycleStore::META_KEY ] ?? null ) ? $engine[ RunLifecycleStore::META_KEY ] : array();
-		$run_lifecycle['status']             = JobStatus::PENDING;
-		$run_lifecycle['updated_at']         = current_time( 'mysql', true );
+		$run_lifecycle                         = is_array( $engine[ RunLifecycleStore::META_KEY ] ?? null ) ? $engine[ RunLifecycleStore::META_KEY ] : array();
+		$run_lifecycle['status']               = JobStatus::PENDING;
+		$run_lifecycle['updated_at']           = current_time( 'mysql', true );
 		$engine[ RunLifecycleStore::META_KEY ] = $run_lifecycle;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching

--- a/inc/Core/Database/TransactionScope.php
+++ b/inc/Core/Database/TransactionScope.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 final class TransactionScope {
 
 	private static int $savepoint_sequence = 0;
-	private bool $active = true;
+	private bool $active                   = true;
 
 	private function __construct(
 		private $wpdb,

--- a/inc/Core/FilesRepository/DirectoryManager.php
+++ b/inc/Core/FilesRepository/DirectoryManager.php
@@ -28,8 +28,8 @@ class DirectoryManager {
 	 *
 	 * @var bool
 	 */
-	private static bool $agent_files_ensured     = false;
-	private static ?int $default_agent_user_id   = null;
+	private static bool $agent_files_ensured   = false;
+	private static ?int $default_agent_user_id = null;
 
 	/**
 	 * Ensure default memory files exist across layers (SOUL.md + MEMORY.md in agent, USER.md in user).
@@ -226,7 +226,7 @@ class DirectoryManager {
 	 * @return string Full principal memory directory path.
 	 */
 	public function get_principal_directory( int $user_id, int $agent_id ): string {
-		$user_id = absint( $user_id );
+		$user_id  = absint( $user_id );
 		$agent_id = absint( $agent_id );
 		if ( 0 === $user_id || 0 === $agent_id ) {
 			throw new \InvalidArgumentException( 'Principal memory requires a positive user ID and agent ID.' );

--- a/inc/Core/FilesRepository/FileCleanup.php
+++ b/inc/Core/FilesRepository/FileCleanup.php
@@ -309,7 +309,7 @@ class FileCleanup {
 				'warning',
 				'FileCleanup: Artifact is not readable by the cleanup runtime user.',
 				array(
-					'file_path'      => $file_path,
+					'file_path'       => $file_path,
 					'retention_scope' => $retention_scope,
 				)
 			);

--- a/inc/Core/HttpClient.php
+++ b/inc/Core/HttpClient.php
@@ -57,10 +57,10 @@ class HttpClient {
 			);
 		}
 
-		$method       = strtoupper( $method );
-		$context      = $options['context'] ?? 'HTTP Request';
+		$method                    = strtoupper( $method );
+		$context                   = $options['context'] ?? 'HTTP Request';
 		$log_response_body_preview = $options['log_response_body_preview'] ?? true;
-		$proxy_filter = null;
+		$proxy_filter              = null;
 
 		if ( ! in_array( $method, self::VALID_METHODS, true ) ) {
 			do_action(

--- a/inc/Core/Steps/WebhookGate/WebhookGateStep.php
+++ b/inc/Core/Steps/WebhookGate/WebhookGateStep.php
@@ -94,7 +94,7 @@ class WebhookGateStep extends Step {
 		add_action(
 			'datamachine_webhook_gate_timeout',
 			function ( $job_id, $token ) {
-				$job_id = (int) $job_id;
+				$job_id  = (int) $job_id;
 				$db_jobs = new \DataMachine\Core\Database\Jobs\Jobs();
 				$result  = $db_jobs->timeout_webhook_gate( $job_id, (string) $token );
 
@@ -298,7 +298,7 @@ class WebhookGateStep extends Step {
 				$webhook_body = array();
 			}
 
-			$webhook_packet    = new DataPacket(
+			$webhook_packet = new DataPacket(
 				array(
 					'title' => 'Webhook Payload',
 					'body'  => $webhook_body,
@@ -311,7 +311,7 @@ class WebhookGateStep extends Step {
 				),
 				'webhook_payload'
 			);
-			$data_packets      = $webhook_packet->addTo( array() );
+			$data_packets   = $webhook_packet->addTo( array() );
 			if ( ! is_string( wp_json_encode( $data_packets ) ) ) {
 				return new \WP_Error(
 					'webhook_payload_persistence_failed',

--- a/inc/Engine/AI/Actions/PendingActionHelper.php
+++ b/inc/Engine/AI/Actions/PendingActionHelper.php
@@ -93,8 +93,8 @@ class PendingActionHelper {
 		$grants = apply_filters( 'datamachine_pending_action_resolver_grants', $grants, $args );
 		$grants = is_array( $grants ) ? array_values( array_filter( $grants, 'is_array' ) ) : array();
 
-		$datamachine_metadata    = isset( $metadata['datamachine'] ) && is_array( $metadata['datamachine'] ) ? $metadata['datamachine'] : array();
-		$metadata['datamachine'] = array_merge(
+		$datamachine_metadata                     = isset( $metadata['datamachine'] ) && is_array( $metadata['datamachine'] ) ? $metadata['datamachine'] : array();
+		$metadata['datamachine']                  = array_merge(
 			$datamachine_metadata,
 			array(
 				'agent_id'        => $agent_id,
@@ -104,7 +104,7 @@ class PendingActionHelper {
 				'resolve_with'    => 'resolve_pending_action',
 			)
 		);
-		$authorization = isset( $args['authorization'] ) && is_array( $args['authorization'] ) ? $args['authorization'] : array();
+		$authorization                            = isset( $args['authorization'] ) && is_array( $args['authorization'] ) ? $args['authorization'] : array();
 		$metadata['datamachine']['authorization'] = array(
 			'operation' => (string) ( $authorization['operation'] ?? $kind ),
 			'target'    => $authorization['target'] ?? $apply_input,

--- a/inc/Engine/Agents/PersistedAgentGraphProjector.php
+++ b/inc/Engine/Agents/PersistedAgentGraphProjector.php
@@ -140,7 +140,7 @@ final class PersistedAgentGraphProjector {
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation exception data is returned to callers, never rendered here.
 			throw new BundleValidationException( sprintf( 'Graph %s source is missing or escapes its root: %s', $label, $relative ) );
 		}
-		$contents = file_get_contents( $real );
+		$contents = file_get_contents( $real ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- This is a verified local file path, not a remote URL.
 		if ( ! is_string( $contents ) ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Validation exception data is returned to callers, never rendered here.
 			throw new BundleValidationException( sprintf( 'Graph %s source is unreadable: %s', $label, $relative ) );

--- a/inc/Engine/Bundle/AgentBundleDirectory.php
+++ b/inc/Engine/Bundle/AgentBundleDirectory.php
@@ -559,7 +559,10 @@ final class AgentBundleDirectory {
 					$stored = BundleSchema::SUBAGENTS_DIR . '/' . $child['slug'] . '/' . $kind . '/' . $path;
 					self::ensure_directory( dirname( $directory . '/' . $stored ) );
 					self::write_file( $directory . '/' . $stored, $contents );
-					$entries[] = array( 'path' => $path, 'sha256' => hash( 'sha256', $contents ) );
+					$entries[] = array(
+						'path'   => $path,
+						'sha256' => hash( 'sha256', $contents ),
+					);
 				}
 				$manifest['subagents'][ $index ][ $kind ] = $entries;
 			}
@@ -567,7 +570,10 @@ final class AgentBundleDirectory {
 	}
 
 	private static function write_agent_artifacts( string $directory, array &$manifest ): void {
-		foreach ( array( 'skills' => BundleSchema::SKILLS_DIR, 'references' => BundleSchema::REFERENCES_DIR ) as $kind => $root ) {
+		foreach ( array(
+			'skills'     => BundleSchema::SKILLS_DIR,
+			'references' => BundleSchema::REFERENCES_DIR,
+		) as $kind => $root ) {
 			if ( ! array_key_exists( $kind, $manifest['agent'] ?? array() ) ) {
 				continue;
 			}
@@ -579,7 +585,10 @@ final class AgentBundleDirectory {
 				}
 				self::ensure_directory( dirname( $directory . '/' . $root . '/' . $path ) );
 				self::write_file( $directory . '/' . $root . '/' . $path, $contents );
-				$entries[] = array( 'path' => $path, 'sha256' => hash( 'sha256', $contents ) );
+				$entries[] = array(
+					'path'   => $path,
+					'sha256' => hash( 'sha256', $contents ),
+				);
 			}
 			$manifest['agent'][ $kind ] = $entries;
 		}
@@ -600,7 +609,7 @@ final class AgentBundleDirectory {
 					if ( ! is_array( $entry ) || ! is_string( $entry['path'] ?? null ) || ! preg_match( '/^[a-f0-9]{64}$/', (string) ( $entry['sha256'] ?? '' ) ) ) {
 						throw new BundleValidationException( sprintf( 'Subagent %s artifact metadata is invalid.', esc_html( $kind ) ) );
 					}
-					$path = self::normalize_relative_path( $entry['path'], 'subagent ' . $kind );
+					$path      = self::normalize_relative_path( $entry['path'], 'subagent ' . $kind );
 					$candidate = $directory . '/' . BundleSchema::SUBAGENTS_DIR . '/' . $child['slug'] . '/' . $kind . '/' . $path;
 					$file_real = realpath( $candidate );
 					if ( false === $file_real || ! is_file( $file_real ) || ! str_starts_with( $file_real, $bundle_real . DIRECTORY_SEPARATOR ) ) {
@@ -622,7 +631,10 @@ final class AgentBundleDirectory {
 		if ( false === $bundle_real ) {
 			throw new BundleValidationException( 'Bundle directory cannot be resolved.' );
 		}
-		foreach ( array( 'skills' => BundleSchema::SKILLS_DIR, 'references' => BundleSchema::REFERENCES_DIR ) as $kind => $root ) {
+		foreach ( array(
+			'skills'     => BundleSchema::SKILLS_DIR,
+			'references' => BundleSchema::REFERENCES_DIR,
+		) as $kind => $root ) {
 			if ( ! array_key_exists( $kind, $manifest['agent'] ?? array() ) ) {
 				continue;
 			}
@@ -634,7 +646,7 @@ final class AgentBundleDirectory {
 				if ( ! is_array( $entry ) || ! is_string( $entry['path'] ?? null ) || ! preg_match( '/^[a-f0-9]{64}$/', (string) ( $entry['sha256'] ?? '' ) ) ) {
 					throw new BundleValidationException( sprintf( 'Agent %s artifact metadata is invalid.', esc_html( $kind ) ) );
 				}
-				$path = self::normalize_relative_path( $entry['path'], 'agent ' . $kind );
+				$path      = self::normalize_relative_path( $entry['path'], 'agent ' . $kind );
 				$candidate = $directory . '/' . $root . '/' . $path;
 				$file_real = realpath( $candidate );
 				if ( false === $file_real || ! is_file( $file_real ) || ! str_starts_with( $file_real, $bundle_real . DIRECTORY_SEPARATOR ) ) {

--- a/inc/Engine/Bundle/AgentBundleManifest.php
+++ b/inc/Engine/Bundle/AgentBundleManifest.php
@@ -42,8 +42,8 @@ final class AgentBundleManifest {
 		$this->subagents       = AgentSubagentGraph::normalize( $subagents, (string) $this->agent['slug'] );
 		if ( ! empty( $this->subagents ) ) {
 			$this->agent['subagents'] = AgentSubagentGraph::coordinator_edges( $this->agent['subagents'] ?? array(), $this->subagents, (string) $this->agent['slug'] );
-			$this->capabilities[] = AgentSubagentGraph::CAPABILITY;
-			$this->capabilities   = array_values( array_unique( $this->capabilities ) );
+			$this->capabilities[]     = AgentSubagentGraph::CAPABILITY;
+			$this->capabilities       = array_values( array_unique( $this->capabilities ) );
 			sort( $this->capabilities, SORT_STRING );
 		}
 	}

--- a/inc/Engine/Filters/OAuth.php
+++ b/inc/Engine/Filters/OAuth.php
@@ -82,7 +82,7 @@ function datamachine_register_oauth_system() {
 
 			if ( $auth_instance instanceof \DataMachine\Core\OAuth\BaseOAuth2Provider && $auth_instance->supports_agent_scoped_oauth_callback() ) {
 				$is_implicit_initial_request = 'token' === $auth_instance->get_oauth_response_type() && empty( $_POST['datamachine_implicit_flow'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- This only permits rendering a token/state relay page.
-				$agent_callback             = $is_implicit_initial_request || false !== datamachine_oauth_agent_callback_payload( $auth_instance, $request_params );
+				$agent_callback              = $is_implicit_initial_request || false !== datamachine_oauth_agent_callback_payload( $auth_instance, $request_params );
 				if ( ! $can_handle && $agent_callback ) {
 					$can_handle = $is_implicit_initial_request || datamachine_oauth_can_handle_agent_scoped_callback( $auth_instance, $request_params );
 				}


### PR DESCRIPTION
## Summary
- apply the exact Homeboy PHPCBF-safe formatting fixes for all 162 auto-fixable findings
- resolve or narrowly justify the six manual findings without changing runtime behavior
- refresh the lint baseline only after a clean full-tree PHPCS, PHPStan, and ESLint run

## Findings
- Before: 168 PHPCS findings across 27 files (162 auto-fixable, 6 manual); PHPStan and ESLint passed
- After: 0 PHPCS findings; PHPStan and ESLint pass

## Verification
- changed-file Homeboy lint: 0 findings
- full-tree Homeboy lint: 0 findings
- canonical SQLite suite: 1,502 total, 1,473 passed, 29 skipped, 0 failed
- package/build gate: passed; production ZIP and PHP syntax/structure validation succeeded
- focused behavior smokes: Action Scheduler persistence policy (8), graph projector path integrity (4), send-email template/queue behavior (121)
- `git diff --check`: passed
- local MySQL recipe failed closed before execution with an unparseable recipe payload; the PR's authoritative `homeboy-test.yml` runs the complete suite as four MySQL shards

Fixes #3360
Refs #2424

Blocked work: #3355, #3358, #3361
