### PR TITLE
refactor: route processed items through registered ability

### DIFF
--- a/inc/Api/ProcessedItems.php
+++ b/inc/Api/ProcessedItems.php
@@ -3,7 +3,7 @@
  * Processed Items REST API Endpoint
  *
  * Provides REST API access to clear processed items tracking for deduplication.
- * Delegates to ProcessedItemsAbilities for core logic.
+ * Delegates to the registered clear-processed-items ability.
  * Requires WordPress manage_options capability for all operations.
  *
  * Endpoints:
@@ -15,22 +15,12 @@
 namespace DataMachine\Api;
 
 use DataMachine\Abilities\PermissionHelper;
-use DataMachine\Abilities\ProcessedItemsAbilities;
 
 if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
 class ProcessedItems {
-
-	private static ?ProcessedItemsAbilities $abilities = null;
-
-	private static function getAbilities(): ProcessedItemsAbilities {
-		if ( null === self::$abilities ) {
-			self::$abilities = new ProcessedItemsAbilities();
-		}
-		return self::$abilities;
-	}
 
 	/**
 	 * Register REST API routes
@@ -94,7 +84,12 @@ class ProcessedItems {
 		$clear_type = $request->get_param( 'clear_type' );
 		$target_id  = (int) $request->get_param( 'target_id' );
 
-		$result = self::getAbilities()->executeClearProcessedItems(
+		$ability = wp_get_ability( 'datamachine/clear-processed-items' );
+		if ( ! $ability ) {
+			return new \WP_Error( 'ability_not_found', __( 'Ability not found', 'data-machine' ), array( 'status' => 500 ) );
+		}
+
+		$result = $ability->execute(
 			array(
 				'clear_type' => $clear_type,
 				'target_id'  => $target_id,

--- a/tests/Unit/Api/ProcessedItemsEndpointTest.php
+++ b/tests/Unit/Api/ProcessedItemsEndpointTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Processed items REST endpoint tests.
+ *
+ * @package DataMachine\Tests\Unit\Api
+ */
+
+namespace DataMachine\Tests\Unit\Api;
+
+use DataMachine\Api\ProcessedItems;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_UnitTestCase;
+
+class ProcessedItemsEndpointTest extends WP_UnitTestCase {
+
+	private const ABILITY = 'datamachine/clear-processed-items';
+
+	public function set_up(): void {
+		parent::set_up();
+		datamachine_register_capabilities();
+		$this->unregister_ability();
+	}
+
+	public function tear_down(): void {
+		$this->unregister_ability();
+		$this->restore_ability();
+		parent::tear_down();
+	}
+
+	public function test_handle_clear_invokes_registered_ability_with_exact_input_and_projects_success(): void {
+		$received = null;
+		$this->register_ability(
+			static function () {
+				return true;
+			},
+			static function ( array $input ) use ( &$received ): array {
+				$received = $input;
+				return array(
+					'success'       => true,
+					'message'       => 'Cleared by ability',
+					'deleted_count' => 3,
+				);
+			}
+		);
+
+		$request = new WP_REST_Request( 'DELETE', '/datamachine/v1/processed-items' );
+		$request->set_param( 'clear_type', 'flow' );
+		$request->set_param( 'target_id', '42' );
+
+		$response = ProcessedItems::handle_clear( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( array( 'clear_type' => 'flow', 'target_id' => 42 ), $received );
+		$this->assertSame(
+			array(
+				'success'       => true,
+				'data'          => null,
+				'message'       => 'Cleared by ability',
+				'items_deleted' => 3,
+			),
+			$response->get_data()
+		);
+	}
+
+	public function test_handle_clear_passes_through_ability_wp_error(): void {
+		$error = new WP_Error( 'clear_failed', 'Native clear failure', array( 'status' => 409 ) );
+		$this->register_ability( static function () { return true; }, static function () use ( $error ) { return $error; } );
+
+		$request = new WP_REST_Request( 'DELETE', '/datamachine/v1/processed-items' );
+		$request->set_param( 'clear_type', 'pipeline' );
+		$request->set_param( 'target_id', 7 );
+
+		$result = ProcessedItems::handle_clear( $request );
+
+		$this->assertSame( $error, $result );
+	}
+
+	public function test_handle_clear_returns_safe_error_when_ability_is_missing(): void {
+		$request = new WP_REST_Request( 'DELETE', '/datamachine/v1/processed-items' );
+		$request->set_param( 'clear_type', 'flow' );
+		$request->set_param( 'target_id', 1 );
+
+		$result = ProcessedItems::handle_clear( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'ability_not_found', $result->get_error_code() );
+		$this->assertSame( 'Ability not found', $result->get_error_message() );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+	}
+
+	public function test_permission_behavior_is_unchanged(): void {
+		wp_set_current_user( 0 );
+
+		$result = ProcessedItems::check_permission( new WP_REST_Request( 'DELETE', '/datamachine/v1/processed-items' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	public function test_permission_allows_flow_managers(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$this->assertTrue( ProcessedItems::check_permission( new WP_REST_Request( 'DELETE', '/datamachine/v1/processed-items' ) ) );
+	}
+
+	private function register_ability( callable $permission_callback, callable $execute_callback ): void {
+		\WP_Abilities_Registry::get_instance()->register(
+			self::ABILITY,
+			array(
+				'label'               => 'Processed items endpoint test',
+				'description'         => 'Test ability',
+				'category'            => 'datamachine-system',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'required'   => array( 'clear_type', 'target_id' ),
+					'properties' => array(
+						'clear_type' => array( 'type' => 'string' ),
+						'target_id'  => array( 'type' => 'integer' ),
+					),
+				),
+				'output_schema'       => array( 'type' => 'object' ),
+				'permission_callback' => $permission_callback,
+				'execute_callback'    => $execute_callback,
+			)
+		);
+	}
+
+	private function unregister_ability(): void {
+		$registry = \WP_Abilities_Registry::get_instance();
+		if ( $registry->is_registered( self::ABILITY ) ) {
+			$registry->unregister( self::ABILITY );
+		}
+	}
+
+	private function restore_ability(): void {
+		$abilities = new \DataMachine\Abilities\ProcessedItemsAbilities();
+		$method    = new \ReflectionMethod( $abilities, 'registerClearProcessedItems' );
+		$method->invoke( $abilities );
+	}
+}


### PR DESCRIPTION
## Summary

- remove the processed-items REST controller's private ability singleton and direct implementation invocation
- execute `datamachine/clear-processed-items` through the registered WordPress ability boundary
- preserve the route, permission checks, native `WP_Error` behavior, and exact success response including literal `data: null`
- add focused endpoint contract coverage for invocation, response mapping, errors, missing registration, and permissions

Production code is net-negative by 5 lines. No CLI, model-tool, ability schema, bootstrap, projection, version, or changelog contract changes.

## Verification

- `php -l inc/Api/ProcessedItems.php` passes
- `php -l tests/Unit/Api/ProcessedItemsEndpointTest.php` passes
- `git diff --check` passes
- PHPUnit and PHPCS could not be accepted as valid local evidence: current Composer autoload exits 0 before either tool starts, producing no version, discovery, or test output. Tracked in #3369; PR CI remains required.
- Homeboy produced the original durable candidate, but DMC promotion failed because the installed provider invokes `worktree list` without its required repo positional. Already tracked in Extra-Chill/wp-coding-agents#401.

Closes #3368
Refs #3332
Parent: #3113