### PR TITLE
test: expect missing ability registry notice

### DIFF
--- a/tests/Unit/Api/ProcessedItemsEndpointTest.php
+++ b/tests/Unit/Api/ProcessedItemsEndpointTest.php
@@ -82,6 +82,7 @@ class ProcessedItemsEndpointTest extends WP_UnitTestCase {
 		$request->set_param( 'clear_type', 'flow' );
 		$request->set_param( 'target_id', 1 );
 
+		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
 		$result = ProcessedItems::handle_clear( $request );
 
 		$this->assertInstanceOf( WP_Error::class, $result );


### PR DESCRIPTION
## Summary

Declare WordPress's intentional incorrect-usage notice in the processed-items missing-ability test while preserving all `ability_not_found` assertions.

## Verification

- Authoritative WP Codebox focused suite: 5 passed, 0 failed (`04f8d720-3458-494a-b74b-5232b1056801`)
- PHP syntax passes
- `git diff --check` passes

Closes #3371