### PR TITLE
refactor: route Jobs REST through registered abilities

### DIFF
--- a/inc/Api/Jobs.php
+++ b/inc/Api/Jobs.php
@@ -17,8 +17,6 @@
 namespace DataMachine\Api;
 
 use DataMachine\Abilities\PermissionHelper;
-use DataMachine\Abilities\Job\DeleteJobsAbility;
-use DataMachine\Abilities\Job\GetJobsAbility;
 use DataMachine\Core\AbilityResult;
 
 if ( ! defined( 'WPINC' ) ) {
@@ -228,7 +226,7 @@ class Jobs {
 			$input['metadata_scan_limit'] = (int) $request->get_param( 'metadata_scan_limit' );
 		}
 
-		$result = ( new GetJobsAbility() )->execute( $input );
+		$result = wp_get_ability( 'datamachine/get-jobs' )->execute( $input );
 
 		return AbilityResult::rest_collection_response( $result, 'jobs', array( 'top_extra' => array( 'filters_applied', 'metadata_query' ) ), 'get_jobs_failed', __( 'Failed to get jobs.', 'data-machine' ) );
 	}
@@ -241,7 +239,7 @@ class Jobs {
 	public static function handle_get_job_by_id( $request ) {
 		$job_id = (int) $request->get_param( 'id' );
 
-		$result = ( new GetJobsAbility() )->execute( array( 'job_id' => $job_id ) );
+		$result = wp_get_ability( 'datamachine/get-jobs' )->execute( array( 'job_id' => $job_id ) );
 
 		if ( is_wp_error( $result ) || empty( $result['jobs'] ) ) {
 			return is_wp_error( $result ) ? $result : new \WP_Error( 'job_not_found', __( 'Job not found.', 'data-machine' ), array( 'status' => 404 ) );
@@ -259,7 +257,7 @@ class Jobs {
 		$type              = $request->get_param( 'type' );
 		$cleanup_processed = (bool) $request->get_param( 'cleanup_processed' );
 
-		$result = ( new DeleteJobsAbility() )->execute(
+		$result = wp_get_ability( 'datamachine/delete-jobs' )->execute(
 			array(
 				'type'              => $type,
 				'cleanup_processed' => $cleanup_processed,

--- a/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
+++ b/tests/Unit/Abilities/Job/DirectJobOwnershipTest.php
@@ -272,6 +272,8 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 
 	public function test_jobs_rest_item_and_delete_errors_preserve_contracts(): void {
 		wp_set_current_user( $this->admin_id );
+		$this->assertNotNull( wp_get_ability( 'datamachine/get-jobs' ) );
+		$this->assertNotNull( wp_get_ability( 'datamachine/delete-jobs' ) );
 
 		$get_request = new \WP_REST_Request( 'GET', '/datamachine/v1/jobs/999999' );
 		$get_request->set_param( 'id', 999999 );
@@ -288,6 +290,27 @@ class DirectJobOwnershipTest extends WP_UnitTestCase {
 		$this->assertSame( 'delete_failed', $delete_response->get_error_code() );
 		$this->assertSame( 'type is required and must be "all" or "failed"', $delete_response->get_error_message() );
 		$this->assertSame( 500, $delete_response->get_error_data()['status'] );
+	}
+
+	public function test_jobs_rest_item_and_delete_success_contracts_are_unchanged(): void {
+		wp_set_current_user( $this->admin_id );
+		$created = $this->execute( 'jobs-rest-success' );
+		$job_id  = (int) $created['job_id'];
+
+		$get_request = new \WP_REST_Request( 'GET', "/datamachine/v1/jobs/{$job_id}" );
+		$get_request->set_param( 'id', $job_id );
+		$get_response = JobsApi::handle_get_job_by_id( $get_request );
+		$this->assertInstanceOf( \WP_REST_Response::class, $get_response );
+		$this->assertSame( $job_id, (int) $get_response->get_data()['data']['job_id'] );
+
+		$delete_request = new \WP_REST_Request( 'DELETE', '/datamachine/v1/jobs' );
+		$delete_request->set_param( 'type', 'all' );
+		$delete_request->set_param( 'cleanup_processed', false );
+		$delete_response = JobsApi::handle_clear( $delete_request );
+		$this->assertInstanceOf( \WP_REST_Response::class, $delete_response );
+		$this->assertTrue( $delete_response->get_data()['success'] );
+		$this->assertGreaterThanOrEqual( 1, $delete_response->get_data()['jobs_deleted'] );
+		$this->assertSame( 0, $delete_response->get_data()['processed_items_cleaned'] );
 	}
 
 	public function test_successful_rest_collection_contract_is_unchanged(): void {


### PR DESCRIPTION
## Summary

- remove concrete Jobs REST ability imports and instantiation
- execute `datamachine/get-jobs` and `datamachine/delete-jobs` through the canonical WordPress ability registry
- preserve all route parsing, principal scoping, collection extras, item errors, delete errors, and response mapping
- extend existing behavior coverage for registered slugs plus item/delete success contracts

## Production LOC

- Added: 3 production PHP lines
- Deleted: 5 production PHP lines
- Net: **-2 production PHP lines**

No helper, wrapper, resolver, compatibility path, ability change, repository change, REST contract change, version change, or changelog edit was added.

## Verification

- canonical ability registration suite: 2 passed, 0 failed (`0429e348-43fc-4197-8eaf-4e390b21b17d`)
- changed PHP syntax passes
- `git diff --check` passes
- local MySQL behavior execution cannot provision because this host lacks the Docker runtime provider; Homeboy surfaces the known downstream payload symptom tracked in Extra-Chill/homeboy#12776 and #12737
- authoritative PR MySQL shards are required for `DirectJobOwnershipTest`

The candidate was produced by Homeboy Cook. Live controller promotion remains blocked because the merged wp-coding-agents provider fix has not yet been installed on this host; the durable candidate was reviewed and applied to the issue-owned managed worktree.

Closes #3378
Refs #3332
Parent: #3113