### PR TITLE
fix: allow null taxonomy reassignment output

### DIFF
--- a/inc/Abilities/Taxonomy/DeleteTaxonomyTermAbility.php
+++ b/inc/Abilities/Taxonomy/DeleteTaxonomyTermAbility.php
@@ -53,7 +53,12 @@ class DeleteTaxonomyTermAbility extends AbstractTaxonomyAbility {
 					'term_name'  => array( 'type' => 'string' ),
 					'taxonomy'   => array( 'type' => 'string' ),
 					'deleted'    => array( 'type' => 'boolean' ),
-					'reassigned' => array( 'type' => 'integer' ),
+					'reassigned' => array(
+						'anyOf' => array(
+							array( 'type' => 'integer' ),
+							array( 'type' => 'null' ),
+						),
+					),
 					'error'      => array( 'type' => 'string' ),
 				),
 			),

--- a/tests/Unit/Abilities/TaxonomyAbilityWpErrorTest.php
+++ b/tests/Unit/Abilities/TaxonomyAbilityWpErrorTest.php
@@ -74,6 +74,42 @@ class TaxonomyAbilityWpErrorTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Missing Term', $result['error'] );
 	}
 
+	public function test_registered_delete_taxonomy_term_accepts_null_reassignment(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		$term = wp_insert_term( 'Delete without reassignment', self::TEST_TAXONOMY );
+
+		$result = wp_get_ability( 'datamachine/delete-taxonomy-term' )->execute(
+			array(
+				'term'     => (string) $term['term_id'],
+				'taxonomy' => self::TEST_TAXONOMY,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+		$this->assertNull( $result['reassigned'] );
+	}
+
+	public function test_registered_delete_taxonomy_term_accepts_integer_reassignment(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		$source = wp_insert_term( 'Delete with reassignment', self::TEST_TAXONOMY );
+		$target = wp_insert_term( 'Reassignment target', self::TEST_TAXONOMY );
+
+		$result = wp_get_ability( 'datamachine/delete-taxonomy-term' )->execute(
+			array(
+				'term'     => (string) $source['term_id'],
+				'taxonomy' => self::TEST_TAXONOMY,
+				'reassign' => (int) $target['term_id'],
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( (int) $target['term_id'], $result['reassigned'] );
+	}
+
 	public function test_merge_term_meta_callback_failure_returns_wp_error(): void {
 		$result = ( new MergeTermMetaAbility() )->execute(
 			array(


### PR DESCRIPTION
## Summary

- align `datamachine/delete-taxonomy-term` output validation with its existing callback contract
- allow `reassigned` to be either an integer target ID or null when no reassignment occurred
- cover both registered-ability output shapes end to end

No deletion behavior, input schema, permissions, REST visibility, result fields, version, or changelog behavior changed.

## Verification

- authoritative WP Codebox focused suite: 8 passed, 0 failed (`745e0b38-ed30-4a0d-8f98-777ad387d690`)
- changed PHP syntax passes
- `git diff --check` passes

This canonical ability fix was exposed by the Taxonomy CLI convergence in #3380. The adapter must not bypass registered output validation.

Closes #3381
Blocks #3380
Refs #3332