### PR TITLE
fix: preserve Jobs delete REST compatibility

### DIFF
--- a/inc/Api/Jobs.php
+++ b/inc/Api/Jobs.php
@@ -171,7 +171,6 @@ class Jobs {
 	 * Check if user has permission to manage jobs
 	 */
 	public static function check_permission( $request ) {
-		$request;
 		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
@@ -256,6 +255,9 @@ class Jobs {
 	public static function handle_clear( $request ) {
 		$type              = $request->get_param( 'type' );
 		$cleanup_processed = (bool) $request->get_param( 'cleanup_processed' );
+		if ( ! in_array( $type, array( 'all', 'failed' ), true ) ) {
+			return new \WP_Error( 'delete_failed', 'type is required and must be "all" or "failed"', array( 'status' => 500 ) );
+		}
 
 		$result = wp_get_ability( 'datamachine/delete-jobs' )->execute(
 			array(

--- a/inc/Api/Jobs.php
+++ b/inc/Api/Jobs.php
@@ -171,6 +171,7 @@ class Jobs {
 	 * Check if user has permission to manage jobs
 	 */
 	public static function check_permission( $request ) {
+		unset( $request );
 		if ( ! PermissionHelper::can( 'manage_flows' ) ) {
 			return new \WP_Error(
 				'rest_forbidden',

--- a/tests/Unit/Api/JobsEndpointCompatibilityTest.php
+++ b/tests/Unit/Api/JobsEndpointCompatibilityTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Jobs REST compatibility tests.
+ *
+ * @package DataMachine\Tests\Unit\Api
+ */
+
+namespace DataMachine\Tests\Unit\Api;
+
+use DataMachine\Api\Jobs;
+use WP_Error;
+use WP_REST_Request;
+use WP_UnitTestCase;
+
+class JobsEndpointCompatibilityTest extends WP_UnitTestCase {
+
+	public function test_invalid_delete_type_preserves_legacy_controller_error(): void {
+		$request = new WP_REST_Request( 'DELETE', '/datamachine/v1/jobs' );
+		$request->set_param( 'type', 'invalid' );
+
+		$result = Jobs::handle_clear( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'delete_failed', $result->get_error_code() );
+		$this->assertSame( 'type is required and must be "all" or "failed"', $result->get_error_message() );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+	}
+}


### PR DESCRIPTION
## Summary

- preserve the established direct-controller `delete_failed` response for invalid Jobs delete types
- keep valid delete requests on the registered `datamachine/delete-jobs` path
- retain the canonical ability schema and validation unchanged
- remove a no-op request expression exposed by changed-file PHPStan

## Verification

- focused WP Codebox compatibility test: 1 passed, 0 failed (`9ca5ff51-e0de-4042-9dde-41d238ec884b`)
- changed-scope PHPCS passes with one existing unused callback-parameter advisory
- changed-scope PHPStan level 7 passes
- PHP syntax and `git diff --check` pass

Full PR CI on #3383 exposed this inherited regression in shard 4. This transport-specific mapping restores the contract without reverting registered ability convergence.

Closes #3384
Blocks #3383
Refs #3378 #3332