### PR TITLE
refactor: retire redundant step-result projection

### DIFF
--- a/inc/Core/RunMetrics.php
+++ b/inc/Core/RunMetrics.php
@@ -53,8 +53,6 @@ class RunMetrics {
 
 	private const STEP_RESULTS_KEY = 'step_results';
 
-	private const STEP_RESULT_ENVELOPES_KEY = 'step_result';
-
 	private const RUN_RESULT_KEY = 'run_result';
 
 	public static function recordStepResult( int $job_id, string $flow_step_id, array $result ): bool {
@@ -81,13 +79,6 @@ class RunMetrics {
 				);
 
 				$engine[ self::STEP_RESULTS_KEY ] = $step_results;
-				if ( is_array( $clean_result['step_result'] ?? null ) ) {
-					$step_result_envelopes                     = is_array( $engine[ self::STEP_RESULT_ENVELOPES_KEY ] ?? null ) ? $engine[ self::STEP_RESULT_ENVELOPES_KEY ] : array();
-					$step_result_envelope                      = $clean_result['step_result'];
-					$step_result_envelope['flow_step_id']    ??= $flow_step_id;
-					$step_result_envelopes[ $flow_step_id ]    = $step_result_envelope;
-					$engine[ self::STEP_RESULT_ENVELOPES_KEY ] = $step_result_envelopes;
-				}
 
 				$metrics = self::normalize( $engine[ self::KEY ] ?? array() );
 				if ( isset( $clean_result['packet_count'] ) && 'fetch' === ( $clean_result['step_type'] ?? '' ) ) {
@@ -671,7 +662,7 @@ class RunMetrics {
 
 	private static function jobForEnvelope( int $job_id, array $engine, ?string $status_override = null ): ?array {
 		global $wpdb;
-		if ( $job_id <= 0 || ! is_object( $wpdb ) ) {
+		if ( $job_id <= 0 || ! ( $wpdb instanceof \wpdb ) ) {
 			return null;
 		}
 
@@ -714,7 +705,7 @@ class RunMetrics {
 		}
 
 		global $wpdb;
-		if ( ! is_object( $wpdb ) ) {
+		if ( ! ( $wpdb instanceof \wpdb ) ) {
 			return $empty;
 		}
 

--- a/tests/Unit/Abilities/Engine/PipelineExecutionContractTest.php
+++ b/tests/Unit/Abilities/Engine/PipelineExecutionContractTest.php
@@ -257,10 +257,7 @@ class PipelineExecutionContractTest extends WP_UnitTestCase
         $this->assertSame('flow_ai', $this->_latestScheduledStep()['flow_step_id'] ?? '');
 
 		$engine_after_fetch = datamachine_get_engine_data($job_id);
-		$this->assertSame(
-			'datamachine.step_result.v1',
-			$engine_after_fetch['step_result']['flow_fetch']['schema_version'] ?? ''
-		);
+		$this->assertArrayNotHasKey( 'step_result', $engine_after_fetch );
 		$this->assertSame(
 			'datamachine.step_result.v1',
 			$engine_after_fetch['step_results']['flow_fetch']['step_result']['schema_version'] ?? ''
@@ -317,11 +314,8 @@ class PipelineExecutionContractTest extends WP_UnitTestCase
             $engine_after_ai['token_usage'] ?? array()
         );
         $this->assertSame('preserved', $engine_after_ai['fake_handler_written_key'] ?? '');
-		$this->assertSame(
-			'datamachine.step_result.v1',
-			$engine_after_ai['step_result']['flow_ai']['schema_version'] ?? ''
-		);
-		$this->assertNotEmpty($engine_after_ai['step_result']['flow_ai']['packet_refs'] ?? array());
+		$this->assertArrayNotHasKey( 'step_result', $engine_after_ai );
+		$this->assertNotEmpty($engine_after_ai['step_results']['flow_ai']['step_result']['packet_refs'] ?? array());
 
         $publish_result = $executor->execute(
             array(

--- a/tests/Unit/Core/RunResultStepProjectionCompatibilityTest.php
+++ b/tests/Unit/Core/RunResultStepProjectionCompatibilityTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Persisted step-result projection compatibility tests.
+ *
+ * @package DataMachine\Tests\Unit\Core
+ */
+
+namespace DataMachine\Tests\Unit\Core;
+
+use DataMachine\Core\RunResult;
+use DataMachine\Core\StepResult;
+use WP_UnitTestCase;
+
+class RunResultStepProjectionCompatibilityTest extends WP_UnitTestCase {
+
+	public function test_nested_step_envelope_is_canonical(): void {
+		$nested = $this->envelope( 'nested', 'succeeded' );
+		$result = $this->project(
+			array(
+				'step_results' => array(
+					'fetch' => $this->step_row( 'fetch', $nested ),
+				),
+			)
+		);
+
+		$this->assertSame( $nested, $result['step_results'][0] );
+	}
+
+	public function test_top_level_step_envelope_remains_a_historical_fallback(): void {
+		$fallback = $this->envelope( 'fallback', 'succeeded' );
+		$result   = $this->project(
+			array(
+				'step_results' => array(
+					'fetch' => $this->step_row( 'fetch' ),
+				),
+				'step_result'  => array(
+					'fetch' => $fallback,
+				),
+			)
+		);
+
+		$this->assertSame( $fallback, $result['step_results'][0] );
+	}
+
+	public function test_identical_dual_projection_preserves_output(): void {
+		$envelope = $this->envelope( 'identical', 'succeeded' );
+		$nested   = $this->project(
+			array(
+				'step_results' => array(
+					'fetch' => $this->step_row( 'fetch', $envelope ),
+				),
+			)
+		);
+		$dual     = $this->project(
+			array(
+				'step_results' => array(
+					'fetch' => $this->step_row( 'fetch', $envelope ),
+				),
+				'step_result'  => array(
+					'fetch' => $envelope,
+				),
+			)
+		);
+
+		$this->assertSame( $nested['step_results'], $dual['step_results'] );
+		$this->assertSame( $nested['packet_refs'], $dual['packet_refs'] );
+		$this->assertSame( $nested['replay'], $dual['replay'] );
+	}
+
+	public function test_nested_step_envelope_wins_when_dual_projections_diverge(): void {
+		$nested = $this->envelope( 'nested-wins', 'succeeded' );
+		$top    = $this->envelope( 'top-loses', 'failed' );
+		$result = $this->project(
+			array(
+				'step_results' => array(
+					'fetch' => $this->step_row( 'fetch', $nested ),
+				),
+				'step_result'  => array(
+					'fetch' => $top,
+				),
+			)
+		);
+
+		$this->assertSame( $nested, $result['step_results'][0] );
+		$this->assertSame( 'nested-wins', $result['step_results'][0]['diagnostics']['source'] );
+	}
+
+	public function test_legacy_metrics_row_without_envelope_is_synthesized(): void {
+		$result = $this->project(
+			array(
+				'step_results' => array(
+					'fetch' => array(
+						'flow_step_id' => 'fetch',
+						'step_type'    => 'fetch',
+						'result'       => 'completed',
+						'packet_count' => 2,
+					),
+				),
+			)
+		);
+
+		$this->assertSame( StepResult::SCHEMA_VERSION, $result['step_results'][0]['schema_version'] );
+		$this->assertSame( 2, $result['step_results'][0]['outputs']['packet_count'] );
+	}
+
+	private function project( array $engine ): array {
+		$step_results = array_values( is_array( $engine['step_results'] ?? null ) ? $engine['step_results'] : array() );
+
+		return RunResult::fromJobSummary(
+			array(
+				'job_id'      => 0,
+				'status'      => 'completed',
+				'engine_data' => $engine,
+			),
+			array(
+				'job_id'       => 0,
+				'status'       => 'completed',
+				'step_results' => $step_results,
+			)
+		);
+	}
+
+	private function step_row( string $flow_step_id, ?array $envelope = null ): array {
+		$row = array(
+			'flow_step_id' => $flow_step_id,
+			'step_type'    => 'fetch',
+			'result'       => 'completed',
+			'packet_count' => 1,
+		);
+		if ( null !== $envelope ) {
+			$row['step_result'] = $envelope;
+		}
+
+		return $row;
+	}
+
+	private function envelope( string $source, string $status ): array {
+		return array(
+			'schema_version' => StepResult::SCHEMA_VERSION,
+			'flow_step_id'   => 'fetch',
+			'status'         => $status,
+			'outputs'        => array( 'packet_count' => 1 ),
+			'artifact_refs'  => array(),
+			'packet_refs'    => array(
+				array(
+					'index'        => 0,
+					'content_hash' => "sha256:{$source}",
+				),
+			),
+			'diagnostics'    => array( 'source' => $source ),
+			'replay'         => array( 'content_hashes' => array() ),
+		);
+	}
+}

--- a/tests/step-result-persistence-cas-smoke.php
+++ b/tests/step-result-persistence-cas-smoke.php
@@ -131,6 +131,12 @@ namespace {
 		'existing' => array(
 			'value' => 'preserved',
 		),
+		'step_result' => array(
+			'legacy_step' => array(
+				'schema_version' => 'datamachine.step_result.v1',
+				'status'         => 'succeeded',
+			),
+		),
 	);
 	Jobs::$inject_conflict      = true;
 
@@ -187,6 +193,8 @@ namespace {
 	datamachine_step_result_persistence_assert( 'preserved' === ( $snapshot['existing']['value'] ?? null ), 'pre-existing engine_data remains intact' );
 	datamachine_step_result_persistence_assert( 'datamachine.step_result.v1' === ( $snapshot['step_results']['fetch_sources']['step_result']['schema_version'] ?? null ), 'canonical StepResult envelope is persisted' );
 	datamachine_step_result_persistence_assert( 'kept' === ( $snapshot['step_results']['fetch_sources']['step_result']['outputs']['nested']['value'] ?? null ), 'nested envelope data survives sanitization' );
+	datamachine_step_result_persistence_assert( ! isset( $snapshot['step_result']['fetch_sources'] ), 'new writes do not create the redundant top-level StepResult projection' );
+	datamachine_step_result_persistence_assert( 'succeeded' === ( $snapshot['step_result']['legacy_step']['status'] ?? null ), 'historical top-level StepResult data remains untouched' );
 	datamachine_step_result_persistence_assert( 2 === ( $snapshot['run_metrics']['counts']['fetch_packets'] ?? 0 ), 'fetch packet count is recorded in run metrics' );
 
 	$metrics = RunMetrics::fromJob(


### PR DESCRIPTION
## Summary

- stop dual-writing canonical `datamachine.step_result.v1` envelopes to top-level `engine_data.step_result`
- retain canonical nested writes at `engine_data.step_results[flow_step_id].step_result`
- retain the existing top-level fallback reader for historical compatibility
- preserve pre-existing top-level data untouched during CAS mutations
- lock nested-first precedence, historical fallback, identical/divergent behavior, legacy synthesis, and replay parity

## Live evidence

Read-only audit across all 11 live network job tables:

- total rows: 994,819
- dual copies: 8,178
- nested-only: 0
- top-level-only: 0
- semantic divergences: 0
- orphan top-level envelopes: 0
- jobs requiring historical fallback: 0
- malformed non-empty engine data: 0

All 8,178 dual copies differ only because the top-level writer adds `flow_step_id`. No live data was mutated.

## Production LOC

- `RunMetrics.php`: 2 additions / 11 deletions
- Net: **-9 production PHP lines**

The two additions tighten existing `$wpdb` type guards so changed-scope PHPStan remains authoritative.

## Verification

- persisted-shape matrix: 5 passed, 0 failed (`817cba1d-a395-4ec7-abb9-cd1b894ec50d`)
- CAS persistence smoke passes, including no new top-level write and historical-key preservation
- step execution contract: 25 assertions passed
- run metrics, outcome metrics, status presentation, engine ledger, bundle runner, and runtime-tool delegated result smokes pass
- changed-scope PHPCS passes
- changed-scope PHPStan level 7 passes
- changed-scope audit passes with zero introduced findings
- PHP syntax and `git diff --check` pass
- `PipelineExecutionContractTest` requires authoritative PR MySQL shards

One unrelated stale standalone smoke lacks a `wp_json_encode()` bootstrap and is tracked separately in #3387; production WordPress tests are unaffected.

Closes #3386
Parent: #3113