### PR TITLE
fix: propagate subagent export profile

### DIFF
--- a/inc/Core/Agents/AgentBundler.php
+++ b/inc/Core/Agents/AgentBundler.php
@@ -139,6 +139,7 @@ class AgentBundler {
 		$agent_id        = (int) $agent['agent_id'];
 		$export_manifest = self::resolve_export_manifest( $agent_id, $context );
 		$handler_auth    = (string) $export_manifest['handler_auth'];
+		$profile         = (string) ( $context['profile'] ?? 'share' );
 
 		$pipelines                 = $this->pipelines_repo->get_all_pipelines( null, $agent_id );
 		$flows                     = $this->flows_repo->get_all_flows( null, $agent_id );
@@ -243,7 +244,7 @@ class AgentBundler {
 			\DataMachine\Engine\Bundle\BundleSchema::PROMPTS_DIR => SystemTaskPromptRegistry::bundle_prompt_files(),
 		);
 		$extension_paths   = array_map( static fn( array $artifact ) => (string) ( $artifact['source_path'] ?? '' ), $extension_artifacts );
-		$subagents         = $this->export_subagents( is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array() );
+		$subagents         = $this->export_subagents( is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array(), $profile );
 		$root_subagent     = is_array( $agent['agent_config']['datamachine_subagent'] ?? null ) ? $agent['agent_config']['datamachine_subagent'] : array();
 		$coordinator_edges = AgentSubagentGraph::coordinator_edges(
 			is_array( $agent['agent_config'] ?? null ) ? ( $agent['agent_config']['subagents'] ?? array() ) : array(),
@@ -263,7 +264,7 @@ class AgentBundler {
 				'description'  => '',
 				'agent_config' => AgentBundleAgentConfig::export_payload(
 					is_array( $agent['agent_config'] ?? null ) ? $agent['agent_config'] : array(),
-					(string) ( $context['profile'] ?? 'share' )
+					$profile
 				),
 				'subagents'    => $coordinator_edges,
 				'tool_policy'  => is_array( $root_subagent['tool_policy'] ?? null ) ? $root_subagent['tool_policy'] : array(),
@@ -309,8 +310,12 @@ class AgentBundler {
 		return ! empty( $context['reproducible'] ) ? self::REPRODUCIBLE_EXPORTED_AT : gmdate( 'c' );
 	}
 
-	/** @return array<int,array<string,mixed>> */
-	private function export_subagents( array $coordinator_config ): array {
+	/**
+	 * @param array<string,mixed> $coordinator_config Coordinator agent config.
+	 * @param string              $profile            Export projection profile.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function export_subagents( array $coordinator_config, string $profile ): array {
 		$edges = AgentSubagentGraph::edges_from_config( $coordinator_config['subagents'] ?? array() );
 		$nodes = array();
 		while ( ! empty( $edges ) ) {
@@ -329,7 +334,7 @@ class AgentBundler {
 				'slug'         => (string) $child['agent_slug'],
 				'label'        => (string) $child['agent_name'],
 				'description'  => (string) ( $config['description'] ?? '' ),
-				'agent_config' => AgentBundleAgentConfig::export_payload( $config ),
+				'agent_config' => AgentBundleAgentConfig::export_payload( $config, $profile ),
 				'memory'       => $memory,
 				'tool_policy'  => is_array( $subagent['tool_policy'] ?? null ) ? $subagent['tool_policy'] : array(),
 				'skill_policy' => is_array( $subagent['skill_policy'] ?? null ) ? $subagent['skill_policy'] : array(),

--- a/tests/Unit/Core/Agents/AgentBundlerImportTest.php
+++ b/tests/Unit/Core/Agents/AgentBundlerImportTest.php
@@ -1271,6 +1271,33 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		};
 		add_filter( 'datamachine_agent_config_artifact_projection_policies', $this->agent_config_projection_filter, 10, 1 );
 
+		$grandchild_config = array(
+			'default_model'      => 'gpt-5.5-mini',
+			'plugin_runtime'     => array( 'endpoint' => 'https://grandchild-runtime.example.test' ),
+			'backup_private'     => array( 'token' => 'grandchild-secret' ),
+			'datamachine_bundle' => array( 'source_revision' => 'grandchild-source-revision' ),
+		);
+		$grandchild_id = $this->agents_repo->create_if_missing( 'backup-grandchild', 'Backup Grandchild', $this->owner_id, $grandchild_config, 7 );
+		$this->assertIsInt( $grandchild_id );
+
+		$child_config = array(
+			'default_model'      => 'gpt-5.5-mini',
+			'plugin_runtime'     => array( 'endpoint' => 'https://child-runtime.example.test' ),
+			'backup_private'     => array( 'token' => 'child-secret' ),
+			'datamachine_bundle' => array( 'source_revision' => 'child-source-revision' ),
+			'subagents'          => array( 'backup-grandchild' ),
+		);
+		$child_id = $this->agents_repo->create_if_missing( 'backup-child', 'Backup Child', $this->owner_id, $child_config, 7 );
+		$this->assertIsInt( $child_id );
+		$coordinator_id = $this->agents_repo->create_if_missing(
+			'profile-coordinator',
+			'Profile Coordinator',
+			$this->owner_id,
+			array( 'subagents' => array( 'backup-child' ) ),
+			7
+		);
+		$this->assertIsInt( $coordinator_id );
+
 		$source_config = array(
 			'default_provider'        => 'openai',
 			'default_model'           => 'gpt-5.5',
@@ -1294,7 +1321,7 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 
 		$exports = array();
 		foreach ( array( 'share', 'backup', 'fork' ) as $profile ) {
-			$result = $this->bundler->export_directory_object( 'backup-source', array( 'profile' => $profile ) );
+			$result = $this->bundler->export_directory_object( 'backup-source', array( 'profile' => $profile, 'reproducible' => true ) );
 			$this->assertTrue( (bool) $result['success'], "{$profile} export succeeds." );
 			$this->assertInstanceOf( AgentBundleDirectory::class, $result['directory'] ?? null );
 			$exports[ $profile ] = AgentBundleArrayAdapter::to_array_bundle( $result['directory'] );
@@ -1313,6 +1340,37 @@ class AgentBundlerImportTest extends WP_UnitTestCase {
 		$this->assertSame( 'https://runtime.example.test', $backup_config['example']['runtime_endpoints']['events']['url'] ?? null );
 		$this->assertSame( 'runtime:events', $backup_config['example']['auth_refs']['events'] ?? null );
 		$this->assertArrayNotHasKey( 'backup_private', $backup_config, 'Backup honors explicit backup egress exclusion.' );
+
+		$nested_exports = array();
+		foreach ( array( 'share', 'backup', 'fork' ) as $profile ) {
+			$result = $this->bundler->export_directory_object( 'profile-coordinator', array( 'profile' => $profile, 'reproducible' => true ) );
+			$this->assertTrue( (bool) $result['success'], "{$profile} nested export succeeds." );
+			$nested_exports[ $profile ] = AgentBundleArrayAdapter::to_array_bundle( $result['directory'] );
+		}
+		$share_subagents    = array_column( $nested_exports['share']['subagents'], null, 'slug' );
+		$backup_subagents   = array_column( $nested_exports['backup']['subagents'], null, 'slug' );
+		$fork_subagents     = array_column( $nested_exports['fork']['subagents'], null, 'slug' );
+		$subagent_endpoints = array(
+			'backup-child'      => 'https://child-runtime.example.test',
+			'backup-grandchild' => 'https://grandchild-runtime.example.test',
+		);
+		foreach ( $subagent_endpoints as $subagent_slug => $expected_endpoint ) {
+			$share_child      = $share_subagents[ $subagent_slug ]['agent_config'] ?? array();
+			$backup_child     = $backup_subagents[ $subagent_slug ]['agent_config'] ?? array();
+			$fork_child       = $fork_subagents[ $subagent_slug ]['agent_config'] ?? array();
+
+			$this->assertArrayNotHasKey( 'plugin_runtime', $share_child, "Share applies tracking exclusions to {$subagent_slug}." );
+			$this->assertArrayNotHasKey( 'plugin_runtime', $fork_child, "Fork applies tracking exclusions to {$subagent_slug}." );
+			$this->assertSame( $expected_endpoint, $backup_child['plugin_runtime']['endpoint'] ?? null );
+			$this->assertArrayNotHasKey( 'backup_private', $backup_child, "Backup applies egress exclusions to {$subagent_slug}." );
+			$this->assertArrayNotHasKey( 'datamachine_bundle', $share_child );
+			$this->assertArrayNotHasKey( 'datamachine_bundle', $backup_child );
+			$this->assertArrayNotHasKey( 'datamachine_bundle', $fork_child );
+		}
+
+		$repeat = $this->bundler->export_directory_object( 'profile-coordinator', array( 'profile' => 'backup', 'reproducible' => true ) );
+		$this->assertTrue( (bool) $repeat['success'] );
+		$this->assertSame( $nested_exports['backup'], AgentBundleArrayAdapter::to_array_bundle( $repeat['directory'] ) );
 
 		$restore = $this->bundler->import( $exports['backup'], 'backup-restored', $this->owner_id );
 		$this->assertTrue( (bool) $restore['success'], 'Backup imports into a fresh agent.' );


### PR DESCRIPTION
## Summary
- resolve the root export profile once and pass it explicitly through nested subagent graph export
- apply the same `share`, `fork`, or `backup` projection to every child and grandchild config
- isolate nested-profile fixtures from the existing backup-restore fixture and assert deterministic repeated backup export

## Behavior
- `share` and `fork` continue using tracked config projection for every graph node
- `backup` preserves tracking-excluded restorable config for every graph node
- backup-private fields and runtime bundle metadata remain excluded
- nested export no longer throws an argument-count error under PHP 8

## Verification
- full managed WordPress suite: 1,496 passed, 29 skipped, 0 failed
- focused subagent graph, directory round-trip, and export projection smokes passed
- Homeboy PR architecture audit: no introduced findings
- Homeboy production build: passed, including PHP syntax and package structure validation
- PHPCS: passed
- `git diff --check`: passed

## Full-CI coverage
`AgentBundlerImportTest` is intentionally excluded from the local SQLite suite. Full PR CI exercises the added child/grandchild profile assertions, including `share`, `fork`, `backup`, redaction/exclusion behavior, graph depth, deterministic output, and the existing fresh backup restore.

## Static analysis
This fixes the concrete missing-argument PHPStan finding. The remaining 13 existing whole-file `AgentBundler` findings are tracked in #3403.

Closes #3392