### PR TITLE
fix: complete identity reservation retries

### DIFF
--- a/inc/Abilities/Content/UpsertPostAbility.php
+++ b/inc/Abilities/Content/UpsertPostAbility.php
@@ -414,7 +414,9 @@ class UpsertPostAbility {
 				);
 			}
 
-			return self::callback_result( self::execute_resolved_write( $write_context, (int) $existing_id ) );
+			if ( ! self::has_usable_identity_meta( $identity_meta ) ) {
+				return self::callback_result( self::execute_resolved_write( $write_context, (int) $existing_id ) );
+			}
 		}
 
 		if ( self::has_usable_identity_meta( $identity_meta ) ) {
@@ -422,7 +424,8 @@ class UpsertPostAbility {
 				$write_context,
 				$identity_meta,
 				$slug,
-				$parent_id
+				$parent_id,
+				$post_id
 			);
 		}
 
@@ -446,22 +449,24 @@ class UpsertPostAbility {
 	/**
 	 * Execute an identity-backed write while holding its advisory fence.
 	 *
-	 * @param array $context       Normalized write context.
-	 * @param array $identity_meta Identity meta input.
-	 * @param string $slug         Slug fallback.
-	 * @param int   $parent_id     Slug parent scope.
+	 * @param array  $context          Normalized write context.
+	 * @param array  $identity_meta    Identity meta input.
+	 * @param string $slug             Slug fallback.
+	 * @param int    $parent_id        Slug parent scope.
+	 * @param int    $explicit_post_id Explicit post candidate.
 	 * @return array|\WP_Error
 	 */
 	private static function execute_identity_backed(
 		array $context,
 		array $identity_meta,
 		string $slug,
-		int $parent_id
+		int $parent_id,
+		int $explicit_post_id = 0
 	): array|\WP_Error {
 		$post_type = $context['post_type'];
 
 		$slug_fallback_id = 0;
-		if ( '' !== $slug ) {
+		if ( $explicit_post_id <= 0 && '' !== $slug ) {
 			$slug_fallback_id = self::resolve_existing_post( 0, $slug, $parent_id, array(), $post_type );
 			if ( is_wp_error( $slug_fallback_id ) ) {
 				return self::callback_result( array(
@@ -509,7 +514,7 @@ class UpsertPostAbility {
 			$reservation = $reservations->reserve_and_resolve(
 				$post_type,
 				$identity_meta,
-				0,
+				$explicit_post_id,
 				(int) $slug_fallback_id,
 				$shell
 			);

--- a/tests/Integration/Abilities/Content/PostIdentityExplicitRetryProcessTest.php
+++ b/tests/Integration/Abilities/Content/PostIdentityExplicitRetryProcessTest.php
@@ -1,0 +1,321 @@
+<?php
+/**
+ * Process-death integration coverage for explicit identity retries.
+ *
+ * @package DataMachine\Tests\Integration\Abilities\Content
+ */
+
+namespace DataMachine\Tests\Integration\Abilities\Content;
+
+use DataMachine\Abilities\Content\UpsertPostAbility;
+use DataMachine\Core\Database\BaseRepository;
+use DataMachine\Core\Database\PostIdentityReservations\PostIdentityReservations;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group integration
+ * @group mysql
+ */
+class PostIdentityExplicitRetryProcessTest extends TestCase {
+
+	private const CHILD_TIMEOUT_SECONDS = 10.0;
+
+	/** @var array<int,true> */
+	private array $children = array();
+
+	public function test_process_death_retry_completes_durable_identity_checkpoint(): void {
+		if ( BaseRepository::is_sqlite() ) {
+			$this->markTestSkipped( 'Process-death coverage requires MySQL/InnoDB.' );
+		}
+		if ( ! function_exists( 'pcntl_fork' ) || ! function_exists( 'pcntl_waitpid' ) || ! function_exists( 'posix_kill' ) ) {
+			$this->markTestSkipped( 'PCNTL and POSIX process control are required.' );
+		}
+
+		global $wpdb;
+		$this->assertSame( '0', (string) $wpdb->get_var( 'SELECT @@session.in_transaction' ), 'Plain integration tests must not hold a parent transaction.' );
+		PostIdentityReservations::create_table();
+		$repository = new PostIdentityReservations();
+		$schema     = $repository->validate_schema();
+		if ( is_wp_error( $schema ) ) {
+			$this->markTestSkipped( 'A valid InnoDB reservation schema is required: ' . $schema->get_error_message() );
+		}
+
+		$parent_wpdb = $wpdb;
+		$value       = 'process-retry-' . wp_generate_uuid4();
+		$identity    = PostIdentityReservations::normalize_identity(
+			'post',
+			array(
+				'key'   => '_source',
+				'value' => $value,
+			)
+		);
+		$table       = $repository->get_table_name();
+		$result_file = tempnam( sys_get_temp_dir(), 'dm-identity-death-' );
+		$retry_file  = tempnam( sys_get_temp_dir(), 'dm-identity-retry-' );
+		$post_id     = 0;
+		$inspect     = null;
+
+		if ( false === $result_file || false === $retry_file ) {
+			$this->remove_temporary_files( array( $result_file, $retry_file ) );
+			$this->markTestSkipped( 'Temporary process result files are unavailable.' );
+		}
+
+		try {
+			$writer_pid = $this->fork_child();
+			if ( 0 === $writer_pid ) {
+				$this->run_checkpoint_writer( $parent_wpdb->prefix, $identity, $value, $result_file );
+			}
+			$writer_status = $this->wait_for_child( $writer_pid );
+			$checkpoint    = json_decode( (string) file_get_contents( $result_file ), true );
+			$post_id       = (int) ( $checkpoint['post_id'] ?? 0 );
+
+			$this->assertArrayNotHasKey( 'error', $checkpoint );
+			$this->assertTrue( pcntl_wifsignaled( $writer_status ), 'Checkpoint writer must die by signal.' );
+			$this->assertSame( SIGKILL, pcntl_wtermsig( $writer_status ) );
+
+			$inspect               = $this->new_wpdb( $parent_wpdb->prefix );
+			$GLOBALS['wpdb']       = $inspect;
+			$checkpoint_repository = new PostIdentityReservations();
+			$checkpoint_row        = $checkpoint_repository->get_reservation( $identity['identity_hash'] );
+			$this->assertSame( 'linked', $checkpoint_row['state'] );
+			$this->assertSame( $post_id, (int) $checkpoint_row['post_id'] );
+			$this->assertSame( 'process_interrupted', $checkpoint_row['last_error_code'] );
+
+			$retry_pid = $this->fork_child();
+			if ( 0 === $retry_pid ) {
+				$this->run_retry( $parent_wpdb->prefix, $post_id, $value, $retry_file );
+			}
+			$retry_status = $this->wait_for_child( $retry_pid );
+			$result       = json_decode( (string) file_get_contents( $retry_file ), true );
+
+			$this->assertTrue( pcntl_wifexited( $retry_status ) );
+			$this->assertSame( 0, pcntl_wexitstatus( $retry_status ) );
+			$this->assertArrayNotHasKey( 'error', $result );
+			$this->assertTrue( $result['success'] );
+			$this->assertSame( $post_id, (int) $result['post_id'] );
+
+			$row = ( new PostIdentityReservations() )->get_reservation( $identity['identity_hash'] );
+			$this->assertSame( 'complete', $row['state'] );
+			$this->assertSame( $post_id, (int) $row['post_id'] );
+			$this->assertNull( $row['last_error_code'] );
+			$this->assertNull( $row['last_error_message'] );
+			$this->assertNotEmpty( $row['completed_at'] );
+
+			$claimants = $inspect->get_col(
+				$inspect->prepare(
+					'SELECT DISTINCT post_id FROM %i WHERE meta_key = %s AND meta_value = %s ORDER BY post_id',
+					$inspect->postmeta,
+					'_source',
+					$value
+				)
+			);
+			$this->assertSame( array( (string) $post_id ), array_map( 'strval', $claimants ) );
+			$this->assertSame( 1, (int) $inspect->get_var( $inspect->prepare( 'SELECT COUNT(*) FROM %i WHERE identity_hash = %s', $table, $identity['identity_hash'] ) ) );
+
+			$lock_repository = new PostIdentityReservations();
+			$this->assertTrue( $lock_repository->acquire_lock( $identity['identity_hash'] ) );
+			$this->assertTrue( $lock_repository->release_lock( $identity['identity_hash'] ) );
+		} finally {
+			$this->terminate_children();
+			$cleanup         = $inspect instanceof \wpdb ? $inspect : $this->new_wpdb( $parent_wpdb->prefix );
+			$GLOBALS['wpdb'] = $cleanup;
+			if ( $post_id <= 0 ) {
+				$post_id = (int) $cleanup->get_var( $cleanup->prepare( 'SELECT post_id FROM %i WHERE identity_hash = %s', $table, $identity['identity_hash'] ) );
+			}
+			$cleanup->delete( $table, array( 'identity_hash' => $identity['identity_hash'] ), array( '%s' ) );
+			$this->delete_post_tree( $cleanup, $post_id );
+			$cleanup->close();
+			$GLOBALS['wpdb'] = $parent_wpdb;
+			$this->remove_temporary_files( array( $result_file, $retry_file ) );
+		}
+	}
+
+	private function run_checkpoint_writer( string $prefix, array $identity, string $value, string $result_file ): void {
+		$post_id = 0;
+		try {
+			$child_wpdb      = $this->new_wpdb( $prefix );
+			$GLOBALS['wpdb'] = $child_wpdb;
+			$repository      = new PostIdentityReservations();
+			$locked          = $repository->acquire_lock( $identity['identity_hash'] );
+			if ( is_wp_error( $locked ) ) {
+				throw new \RuntimeException( $locked->get_error_message() );
+			}
+			$reserved = $repository->reserve_and_resolve(
+				'post',
+				array(
+					'key'   => '_source',
+					'value' => $value,
+				),
+				0,
+				0,
+				$this->shell()
+			);
+			if ( is_wp_error( $reserved ) ) {
+				throw new \RuntimeException( $reserved->get_error_message() );
+			}
+			$post_id = (int) $reserved['post_id'];
+			update_post_meta( $post_id, '_source', $value );
+			$repository->record_error( $identity['identity_hash'], 'process_interrupted', 'Writer died after identity metadata.' );
+			file_put_contents( $result_file, wp_json_encode( array( 'post_id' => $post_id ) ), LOCK_EX );
+			posix_kill( getmypid(), SIGKILL );
+		} catch ( \Throwable $throwable ) {
+			file_put_contents(
+				$result_file,
+				wp_json_encode(
+					array(
+						'error'   => $throwable->getMessage(),
+						'post_id' => $post_id,
+					)
+				),
+				LOCK_EX
+			);
+			exit( 1 );
+		}
+		exit( 2 );
+	}
+
+	private function run_retry( string $prefix, int $post_id, string $value, string $retry_file ): void {
+		try {
+			$child_wpdb      = $this->new_wpdb( $prefix );
+			$GLOBALS['wpdb'] = $child_wpdb;
+			$result          = UpsertPostAbility::execute(
+				array(
+					'post_type'     => 'post',
+					'post_id'       => $post_id,
+					'title'         => 'Recovered after process death',
+					'content'       => '<!-- wp:paragraph --><p>Recovered body</p><!-- /wp:paragraph -->',
+					'identity_meta' => array(
+						'key'   => '_source',
+						'value' => $value,
+					),
+				)
+			);
+			if ( is_wp_error( $result ) ) {
+				throw new \RuntimeException( $result->get_error_message() );
+			}
+			file_put_contents( $retry_file, wp_json_encode( $result ), LOCK_EX );
+			exit( 0 );
+		} catch ( \Throwable $throwable ) {
+			file_put_contents( $retry_file, wp_json_encode( array( 'error' => $throwable->getMessage() ) ), LOCK_EX );
+			exit( 1 );
+		}
+	}
+
+	private function fork_child(): int {
+		$pid = pcntl_fork();
+		if ( -1 === $pid ) {
+			$this->fail( 'Unable to fork integration child process.' );
+		}
+		if ( $pid > 0 ) {
+			$this->children[ $pid ] = true;
+		}
+		return $pid;
+	}
+
+	private function wait_for_child( int $pid ): int {
+		$deadline = microtime( true ) + self::CHILD_TIMEOUT_SECONDS;
+		do {
+			$waited = pcntl_waitpid( $pid, $status, WNOHANG );
+			if ( $pid === $waited ) {
+				unset( $this->children[ $pid ] );
+				return $status;
+			}
+			usleep( 10000 );
+		} while ( microtime( true ) < $deadline );
+
+		posix_kill( $pid, SIGTERM );
+		$deadline = microtime( true ) + 1.0;
+		do {
+			$waited = pcntl_waitpid( $pid, $status, WNOHANG );
+			if ( $pid === $waited ) {
+				unset( $this->children[ $pid ] );
+				return $status;
+			}
+			usleep( 10000 );
+		} while ( microtime( true ) < $deadline );
+
+		posix_kill( $pid, SIGKILL );
+		pcntl_waitpid( $pid, $status );
+		unset( $this->children[ $pid ] );
+		return $status;
+	}
+
+	private function terminate_children(): void {
+		foreach ( array_keys( $this->children ) as $pid ) {
+			posix_kill( $pid, SIGTERM );
+		}
+		$deadline = microtime( true ) + 1.0;
+		do {
+			foreach ( array_keys( $this->children ) as $pid ) {
+				$waited = pcntl_waitpid( $pid, $status, WNOHANG );
+				if ( $pid === $waited ) {
+					unset( $this->children[ $pid ] );
+				}
+			}
+			if ( empty( $this->children ) ) {
+				return;
+			}
+			usleep( 10000 );
+		} while ( microtime( true ) < $deadline );
+
+		foreach ( array_keys( $this->children ) as $pid ) {
+			posix_kill( $pid, SIGKILL );
+			pcntl_waitpid( $pid, $status );
+			unset( $this->children[ $pid ] );
+		}
+	}
+
+	private function delete_post_tree( \wpdb $database, int $post_id ): void {
+		if ( $post_id <= 0 ) {
+			return;
+		}
+		$ids   = array( $post_id );
+		$queue = array( $post_id );
+		while ( ! empty( $queue ) ) {
+			$parent   = array_shift( $queue );
+			$children = array_map( 'intval', $database->get_col( $database->prepare( 'SELECT ID FROM %i WHERE post_parent = %d', $database->posts, $parent ) ) );
+			foreach ( $children as $child ) {
+				if ( ! in_array( $child, $ids, true ) ) {
+					$ids[]   = $child;
+					$queue[] = $child;
+				}
+			}
+		}
+		foreach ( array_reverse( $ids ) as $id ) {
+			$comment_ids = array_map( 'intval', $database->get_col( $database->prepare( 'SELECT comment_ID FROM %i WHERE comment_post_ID = %d', $database->comments, $id ) ) );
+			foreach ( $comment_ids as $comment_id ) {
+				$database->delete( $database->commentmeta, array( 'comment_id' => $comment_id ), array( '%d' ) );
+			}
+			$database->delete( $database->comments, array( 'comment_post_ID' => $id ), array( '%d' ) );
+			$database->delete( $database->term_relationships, array( 'object_id' => $id ), array( '%d' ) );
+			$database->delete( $database->postmeta, array( 'post_id' => $id ), array( '%d' ) );
+			$database->delete( $database->posts, array( 'ID' => $id ), array( '%d' ) );
+			clean_post_cache( $id );
+		}
+	}
+
+	private function new_wpdb( string $prefix ): \wpdb {
+		$database = new \wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+		$database->set_prefix( $prefix );
+		return $database;
+	}
+
+	private function remove_temporary_files( array $files ): void {
+		foreach ( $files as $file ) {
+			if ( is_string( $file ) && file_exists( $file ) ) {
+				unlink( $file );
+			}
+		}
+	}
+
+	private function shell(): array {
+		return array(
+			'post_author'    => get_current_user_id(),
+			'comment_status' => get_default_comment_status( 'post' ),
+			'ping_status'    => get_default_comment_status( 'post', 'pingback' ),
+			'post_date'      => current_time( 'mysql' ),
+			'post_date_gmt'  => current_time( 'mysql', true ),
+			'guid'           => 'urn:uuid:' . wp_generate_uuid4(),
+		);
+	}
+}

--- a/tests/Unit/Abilities/Content/UpsertPostAbilityTest.php
+++ b/tests/Unit/Abilities/Content/UpsertPostAbilityTest.php
@@ -98,6 +98,33 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( 'complete', $this->repository->get_reservation( $identity['identity_hash'] )['state'] );
 	}
 
+	public function test_explicit_retry_completes_matching_link_and_clears_stale_diagnostic(): void {
+		$reserved = $this->repository->reserve_and_resolve(
+			'post',
+			array(
+				'key'   => '_source',
+				'value' => 'explicit-retry',
+			),
+			0,
+			0,
+			$this->shell()
+		);
+		update_post_meta( $reserved['post_id'], '_source', 'explicit-retry' );
+		$this->repository->record_error( $reserved['identity']['identity_hash'], 'interrupted_population', 'Interrupted after metadata write.' );
+
+		$input            = $this->input( 'explicit-retry', 'Recovered' );
+		$input['post_id'] = $reserved['post_id'];
+		$result           = UpsertPostAbility::execute( $input );
+		$row              = $this->repository->get_reservation( $reserved['identity']['identity_hash'] );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $reserved['post_id'], $result['post_id'] );
+		$this->assertSame( 'complete', $row['state'] );
+		$this->assertNull( $row['last_error_code'] );
+		$this->assertNull( $row['last_error_message'] );
+		$this->assertNotEmpty( $row['completed_at'] );
+	}
+
 	public function test_linked_shell_retry_reconciles_full_post_behavior(): void {
 		$reserved = $this->repository->reserve_and_resolve(
 			'post',
@@ -236,7 +263,7 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( 0, $count );
 	}
 
-	public function test_explicit_post_bypasses_identity_reservation_and_metadata(): void {
+	public function test_first_explicit_identity_adopts_explicit_post_over_other_candidates(): void {
 		$explicit_id = self::factory()->post->create( array( 'post_type' => 'post' ) );
 		$identity_id = self::factory()->post->create( array( 'post_type' => 'post' ) );
 		$slug_id     = self::factory()->post->create( array( 'post_type' => 'post', 'post_name' => 'priority-slug' ) );
@@ -251,13 +278,44 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( $explicit_id, $result['post_id'] );
 		$this->assertSame( 'Explicit wins', get_post( $explicit_id )->post_title );
-		$this->assertSame( '', get_post_meta( $explicit_id, '_source', true ) );
+		$this->assertSame( 'priority-explicit', get_post_meta( $explicit_id, '_source', true ) );
 		$this->assertSame( 'priority-explicit', get_post_meta( $identity_id, '_source', true ) );
 		$this->assertSame( $identity_title, get_post( $identity_id )->post_title );
 		$this->assertNotSame( 'Explicit wins', get_post( $slug_id )->post_title );
 
 		$identity = PostIdentityReservations::normalize_identity( 'post', $input['identity_meta'] );
-		$this->assertNull( $this->repository->get_reservation( $identity['identity_hash'] ) );
+		$row      = $this->repository->get_reservation( $identity['identity_hash'] );
+		$this->assertSame( 'complete', $row['state'] );
+		$this->assertSame( $explicit_id, (int) $row['post_id'] );
+	}
+
+	public function test_explicit_identity_suppresses_slug_fallback_lookup(): void {
+		$explicit_id = self::factory()->post->create( array( 'post_type' => 'post' ) );
+		self::factory()->post->create(
+			array(
+				'post_type' => 'post',
+				'post_name' => 'observable-fallback',
+			)
+		);
+		$slug_queries = 0;
+		$observer     = static function ( \WP_Query $query ) use ( &$slug_queries ): void {
+			if ( 'observable-fallback' === $query->get( 'name' ) ) {
+				++$slug_queries;
+			}
+		};
+		add_action( 'pre_get_posts', $observer );
+		try {
+			$input            = $this->input( 'observable-explicit', 'Explicit without fallback' );
+			$input['post_id'] = $explicit_id;
+			$input['slug']    = 'observable-fallback';
+			$result           = UpsertPostAbility::execute( $input );
+		} finally {
+			remove_action( 'pre_get_posts', $observer );
+		}
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( $explicit_id, $result['post_id'] );
+		$this->assertSame( 0, $slug_queries );
 	}
 
 	public function test_wrong_type_explicit_post_fails_before_reservation(): void {
@@ -298,21 +356,75 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( 'identity-miss', get_post_meta( $slug_id, '_source', true ) );
 	}
 
-	public function test_explicit_post_bypasses_an_existing_link_without_rebinding_it(): void {
-		$first       = UpsertPostAbility::execute( $this->input( 'linked-conflict', 'First' ) );
-		$other_id    = self::factory()->post->create( array( 'post_type' => 'post' ) );
-		$retry_input = $this->input( 'linked-conflict', 'Other' );
+	public function test_conflicting_explicit_post_fails_without_rebinding_existing_link(): void {
+		$first                  = UpsertPostAbility::execute( $this->input( 'linked-conflict', 'First' ) );
+		$other_id               = self::factory()->post->create( array( 'post_type' => 'post' ) );
+		$retry_input            = $this->input( 'linked-conflict', 'Other' );
 		$retry_input['post_id'] = $other_id;
+		$identity               = PostIdentityReservations::normalize_identity( 'post', $retry_input['identity_meta'] );
+		$before                 = $this->repository->get_reservation( $identity['identity_hash'] );
 
 		$result = UpsertPostAbility::execute( $retry_input );
 
-		$this->assertTrue( $result['success'] );
-		$this->assertSame( $other_id, $result['post_id'] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'identity_explicit_conflict', $result->get_error_code() );
+		$this->assertSame( $first['post_id'], $result->get_error_data()['linked_post_id'] );
+		$this->assertSame( $other_id, $result->get_error_data()['explicit_post_id'] );
 		$this->assertSame( '', get_post_meta( $other_id, '_source', true ) );
-		$identity = PostIdentityReservations::normalize_identity( 'post', $retry_input['identity_meta'] );
-		$row      = $this->repository->get_reservation( $identity['identity_hash'] );
+		$row = $this->repository->get_reservation( $identity['identity_hash'] );
 		$this->assertSame( $first['post_id'], (int) $row['post_id'] );
+		$this->assertSame( $before['state'], $row['state'] );
+		$this->assertSame( $before['completed_at'], $row['completed_at'] );
 		$this->assertSame( 'linked-conflict', get_post_meta( $first['post_id'], '_source', true ) );
+		$this->assertIdentityLockIsFree( 'linked-conflict' );
+	}
+
+	public function test_unusable_identity_meta_keeps_direct_explicit_post_behavior(): void {
+		$identity = static fn( $key, $value ): array => array(
+			'key'   => $key,
+			'value' => $value,
+		);
+		$cases    = array(
+			'omitted'               => null,
+			'empty-array'           => array(),
+			'partial-key'           => array( 'key' => '_source' ),
+			'partial-value'         => array( 'value' => 'partial' ),
+			'empty-key'             => $identity( '', 'empty-key' ),
+			'empty-value'           => $identity( '_source', '' ),
+			'false-key'             => $identity( false, 'false-key' ),
+			'false-value'           => $identity( '_source', false ),
+			'integer-zero-value'    => $identity( '_source', 0 ),
+			'string-zero-value'     => $identity( '_source', '0' ),
+			'non-array-string'      => 'not-an-array',
+			'non-array-false'       => false,
+			'non-array-null'        => null,
+			'sanitized-empty-key'   => $identity( '!!!', 'sanitized-empty' ),
+			'sanitized-empty-value' => $identity( '_source', '<>' ),
+		);
+
+		foreach ( $cases as $label => $identity_meta ) {
+			$post_id = self::factory()->post->create( array( 'post_type' => 'post' ) );
+			$input   = array(
+				'post_type' => 'post',
+				'post_id'   => $post_id,
+				'title'     => 'Direct explicit ' . $label,
+				'content'   => '<!-- wp:paragraph --><p>Direct body</p><!-- /wp:paragraph -->',
+			);
+			if ( 'omitted' !== $label ) {
+				$input['identity_meta'] = $identity_meta;
+			}
+
+			$result = UpsertPostAbility::execute( $input );
+
+			$this->assertTrue( $result['success'], $label );
+			$this->assertSame( 'updated', $result['action'], $label );
+			$this->assertSame( $post_id, $result['post_id'], $label );
+			$this->assertSame( 'Direct explicit ' . $label, get_post( $post_id )->post_title, $label );
+			$this->assertSame( '', get_post_meta( $post_id, '_source', true ), $label );
+		}
+
+		global $wpdb;
+		$this->assertSame( 0, (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $this->repository->get_table_name() ) ) );
 	}
 
 	public function test_identity_meta_round_trips_backslashes_and_quotes(): void {
@@ -526,6 +638,17 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 		update_post_meta( $post_id, UpsertPostAbility::META_CONTENT_HASH, hash( 'sha256', $content ) );
 
 		return $post_id;
+	}
+
+	private function shell(): array {
+		return array(
+			'post_author'    => get_current_user_id(),
+			'comment_status' => get_default_comment_status( 'post' ),
+			'ping_status'    => get_default_comment_status( 'post', 'pingback' ),
+			'post_date'      => current_time( 'mysql' ),
+			'post_date_gmt'  => current_time( 'mysql', true ),
+			'guid'           => 'urn:uuid:' . wp_generate_uuid4(),
+		);
 	}
 
 	private function status_input( int $post_id, string $post_status ): array {

--- a/tests/Unit/Core/Database/PostIdentityReservations/PostIdentityReservationsTest.php
+++ b/tests/Unit/Core/Database/PostIdentityReservations/PostIdentityReservationsTest.php
@@ -417,6 +417,51 @@ class PostIdentityReservationsTest extends WP_UnitTestCase {
 		$this->assertFalse( $result['allocated'] );
 	}
 
+	public function test_first_explicit_candidate_is_adopted_without_legacy_lookup(): void {
+		$explicit_id = self::factory()->post->create( array( 'post_type' => 'post' ) );
+		$legacy_id   = self::factory()->post->create( array( 'post_type' => 'post' ) );
+		update_post_meta( $legacy_id, '_source', 'explicit-adoption' );
+
+		$result = $this->repository->reserve_and_resolve(
+			'post',
+			array(
+				'key'   => '_source',
+				'value' => 'explicit-adoption',
+			),
+			$explicit_id,
+			0,
+			$this->shell()
+		);
+
+		$this->assertSame( $explicit_id, $result['post_id'] );
+		$this->assertTrue( $result['adopted'] );
+		$this->assertFalse( $result['allocated'] );
+		$row = $this->repository->get_reservation( $result['identity']['identity_hash'] );
+		$this->assertSame( $explicit_id, (int) $row['post_id'] );
+		$this->assertSame( 'linked', $row['state'] );
+	}
+
+	public function test_conflicting_explicit_candidate_retains_original_link(): void {
+		$identity = array(
+			'key'   => '_source',
+			'value' => 'explicit-conflict',
+		);
+		$first    = $this->repository->reserve_and_resolve( 'post', $identity, 0, 0, $this->shell() );
+		$other_id = self::factory()->post->create( array( 'post_type' => 'post' ) );
+		$before   = $this->repository->get_reservation( $first['identity']['identity_hash'] );
+
+		$result = $this->repository->reserve_and_resolve( 'post', $identity, $other_id, 0, $this->shell() );
+		$row    = $this->repository->get_reservation( $first['identity']['identity_hash'] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'identity_explicit_conflict', $result->get_error_code() );
+		$this->assertSame( $first['post_id'], $result->get_error_data()['linked_post_id'] );
+		$this->assertSame( $other_id, $result->get_error_data()['explicit_post_id'] );
+		$this->assertSame( $first['post_id'], (int) $row['post_id'] );
+		$this->assertSame( $before['state'], $row['state'] );
+		$this->assertSame( $before['completed_at'], $row['completed_at'] );
+	}
+
 	public function test_duplicate_legacy_claimants_are_visible_conflict(): void {
 		$ids = array(
 			self::factory()->post->create( array( 'post_type' => 'post' ) ),


### PR DESCRIPTION
## Summary
- route explicit `post_id` retries with usable `identity_meta` through the existing reservation fence
- complete matching linked reservations and clear stale interruption diagnostics
- preserve identity-less explicit updates and reject conflicting explicit posts without relinking
- prove abrupt-process recovery with a MySQL/PCNTL integration test using fresh connections and real advisory locks

## Verification
- `php tests/phpunit-file-isolation-smoke.php` (16 clusters)
- `php tests/ability-boundary-helpers-smoke.php` (5 checks)
- changed-file PHP syntax
- `git diff --check`
- focused MySQL test is CI-gated; local WP Codebox recipe discovered tests but executed zero because its recipe payload was unparseable

Closes #3407
Blocks: Extra-Chill/data-machine-events#528, Extra-Chill/extrachill-users#373