### PR TITLE
test: remove downstream Agents API scans

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -794,12 +794,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/agents-api.git",
-                "reference": "c930b9afeb2019e83a60f62a80104b90833dd81d"
+                "reference": "5f893293851cac8cad8a862ed2f096ffda6f23da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/c930b9afeb2019e83a60f62a80104b90833dd81d",
-                "reference": "c930b9afeb2019e83a60f62a80104b90833dd81d",
+                "url": "https://api.github.com/repos/Automattic/agents-api/zipball/5f893293851cac8cad8a862ed2f096ffda6f23da",
+                "reference": "5f893293851cac8cad8a862ed2f096ffda6f23da",
                 "shasum": ""
             },
             "require": {
@@ -820,14 +820,22 @@
             "autoload": {
                 "files": [
                     "agents-api.php"
+                ],
+                "classmap": [
+                    "src/Registry/class-wp-agent.php",
+                    "src/Packages/"
                 ]
             },
             "scripts": {
                 "phpstan": [
                     "phpstan analyse --no-progress --memory-limit=2G"
                 ],
+                "phpstan-consumer": [
+                    "phpstan analyse --no-progress --memory-limit=1G -c tests/fixtures/phpstan-consumer.neon"
+                ],
                 "smoke": [
                     "php tests/composer-autoload-smoke.php",
+                    "@phpstan-consumer",
                     "php tests/bootstrap-version-skew-smoke.php",
                     "php tests/bootstrap-smoke.php",
                     "php tests/message-envelope-smoke.php",
@@ -964,7 +972,7 @@
                 "issues": "https://github.com/Automattic/agents-api/issues",
                 "source": "https://github.com/Automattic/agents-api"
             },
-            "time": "2026-08-23T00:35:11+00:00"
+            "time": "2026-08-25T03:29:11+00:00"
         }
     ],
     "packages-dev": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,0 @@
-parameters:
-	# Guarded global classes are not Composer-discoverable until agents-api#524 ships consumer config.
-	scanFiles:
-		- %currentWorkingDirectory%/vendor/wordpress/agents-api/src/Packages/class-wp-agent-package.php
-		- %currentWorkingDirectory%/vendor/wordpress/agents-api/src/Packages/class-wp-agent-package-capability-report.php
-		- %currentWorkingDirectory%/vendor/wordpress/agents-api/src/Packages/class-wp-agent-package-artifact-status.php


### PR DESCRIPTION
## Summary
- update the locked `wordpress/agents-api` dependency to upstream commit `5f893293`
- delete Data Machine's temporary PHPStan source-path scan configuration
- rely exclusively on Agents API's package-owned Composer classmap for public package types

## Verification
- forced level-7 lint scope includes `AgentBundler` and `AgentPackageProjection`: passed with `phpstan_component_config: null`
- full managed WordPress suite: 1,496 passed, 32 skipped, 0 failed
- Composer validation: passed
- Composer production dependency audit: no advisories
- Homeboy PR architecture audit: no introduced findings
- Homeboy production build: passed, including PHP syntax and package structure validation
- `git diff --check`: passed

## Merge compatibility
Open WordPress.org candidate PR #3361 changes only `composer.lock`'s top-level content hash. This PR changes the Agents API package record; the hunks are independent.

Depends on Automattic/agents-api#525.
Closes #3410