### PR TITLE
Contain abandoned composable-memory operations

### DIFF
--- a/inc/Abilities/File/ScaffoldAbilities.php
+++ b/inc/Abilities/File/ScaffoldAbilities.php
@@ -160,7 +160,7 @@ class ScaffoldAbilities {
 		if ( ! empty( $result['success'] ) ) {
 			return $result;
 		}
-		return new \WP_Error( $result['error_code'] ?? 'scaffold_failed', $result['error'] ?? 'Scaffold failed.', array_merge( array( 'status' => 500 ), $result ) );
+		return new \WP_Error( $result['error_code'] ?? 'scaffold_failed', $result['error'] ?? $result['message'] ?? 'Scaffold failed.', array_merge( array( 'status' => 500 ), $result ) );
 	}
 
 	// =========================================================================
@@ -186,12 +186,12 @@ class ScaffoldAbilities {
 		// Composable files delegate to ComposableFileGenerator.
 		if ( ! empty( $meta['composable'] ) ) {
 			$result = ComposableFileGenerator::regenerate( $filename, $input );
-			return array(
-				'success'  => $result['success'],
-				'message'  => $result['message'],
-				'filename' => $filename,
-				'filepath' => $result['filepath'] ?? '',
-				'created'  => $result['success'],
+			return array_merge(
+				$result,
+				array(
+					'filename' => $filename,
+					'created'  => $result['success'],
+				)
 			);
 		}
 

--- a/inc/Abilities/File/ScaffoldAbilities.php
+++ b/inc/Abilities/File/ScaffoldAbilities.php
@@ -401,7 +401,7 @@ class ScaffoldAbilities {
 		 */
 		$content = apply_filters( 'datamachine_scaffold_content', '', $filename, $context );
 
-		return is_string( $content ) ? trim( $content ) : '';
+		return trim( $content );
 	}
 
 	/**

--- a/inc/Cli/CallerLivenessMonitor.php
+++ b/inc/Cli/CallerLivenessMonitor.php
@@ -15,19 +15,19 @@ defined( 'ABSPATH' ) || exit;
 class CallerLivenessMonitor {
 
 	/** Whether monitoring is active. */
-	private static bool $active                        = false;
+	private static bool $active = false;
 	/** Original parent process ID. */
-	private static int $parent_pid                    = 0;
+	private static int $parent_pid = 0;
 	/** Previous alarm handler. */
-	private static $previous_handler                  = null;
+	private static mixed $previous_handler = null;
 	/** Previous asynchronous-signal mode. */
-	private static bool $previous_async_signals        = false;
+	private static bool $previous_async_signals = false;
 	/** Previous termination handlers keyed by signal. */
 	private static array $previous_termination_handlers = array();
 	/** Original process group. */
-	private static int $previous_process_group        = 0;
+	private static int $previous_process_group = 0;
 	/** Whether start() isolated the process group. */
-	private static bool $changed_process_group         = false;
+	private static bool $changed_process_group = false;
 
 	/**
 	 * Start monitoring when the host provides asynchronous POSIX signals.

--- a/inc/Cli/CallerLivenessMonitor.php
+++ b/inc/Cli/CallerLivenessMonitor.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * CLI caller-liveness guard.
+ *
+ * @package DataMachine\Cli
+ */
+
+namespace DataMachine\Cli;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Stops a long-running CLI operation when its direct caller disappears.
+ */
+class CallerLivenessMonitor {
+
+	/** Whether monitoring is active. */
+	private static bool $active                        = false;
+	/** Original parent process ID. */
+	private static int $parent_pid                    = 0;
+	/** Previous alarm handler. */
+	private static $previous_handler                  = null;
+	/** Previous asynchronous-signal mode. */
+	private static bool $previous_async_signals        = false;
+	/** Previous termination handlers keyed by signal. */
+	private static array $previous_termination_handlers = array();
+	/** Original process group. */
+	private static int $previous_process_group        = 0;
+	/** Whether start() isolated the process group. */
+	private static bool $changed_process_group         = false;
+
+	/**
+	 * Start monitoring when the host provides asynchronous POSIX signals.
+	 */
+	public static function start(): bool {
+		if ( self::$active || ! function_exists( 'posix_getppid' ) || ! function_exists( 'pcntl_alarm' ) || ! function_exists( 'pcntl_signal' ) || ! function_exists( 'pcntl_async_signals' ) ) {
+			return false;
+		}
+		$pending_alarm = pcntl_alarm( 0 );
+		if ( $pending_alarm > 0 ) {
+			pcntl_alarm( $pending_alarm );
+			return false;
+		}
+
+		$parent_pid = posix_getppid();
+		if ( $parent_pid <= 1 ) {
+			return false;
+		}
+
+		self::$parent_pid             = $parent_pid;
+		self::$previous_handler       = function_exists( 'pcntl_signal_get_handler' ) ? pcntl_signal_get_handler( SIGALRM ) : SIG_DFL;
+		self::$previous_async_signals = pcntl_async_signals();
+		self::$active                 = true;
+
+		if ( function_exists( 'posix_getpgrp' ) && function_exists( 'posix_setpgid' ) ) {
+			self::$previous_process_group = posix_getpgrp();
+			if ( getmypid() !== self::$previous_process_group ) {
+				self::$changed_process_group = posix_setpgid( 0, 0 );
+			}
+		}
+
+		pcntl_async_signals( true );
+		pcntl_signal( SIGALRM, array( self::class, 'check' ) );
+		foreach ( array( SIGTERM, SIGINT, SIGHUP ) as $signal ) {
+			self::$previous_termination_handlers[ $signal ] = function_exists( 'pcntl_signal_get_handler' ) ? pcntl_signal_get_handler( $signal ) : SIG_DFL;
+			pcntl_signal( $signal, array( self::class, 'terminate' ) );
+		}
+		pcntl_alarm( 1 );
+		return true;
+	}
+
+	/**
+	 * Alarm callback. A changed parent means the invoking process exited.
+	 */
+	public static function check(): void {
+		if ( ! self::$active ) {
+			return;
+		}
+
+		if ( posix_getppid() !== self::$parent_pid ) {
+			self::terminate( SIGTERM );
+		}
+
+		pcntl_alarm( 1 );
+	}
+
+	/**
+	 * Terminate this operation's process group, including callback descendants.
+	 *
+	 * @param int $signal Termination signal.
+	 */
+	public static function terminate( int $signal ): void {
+		pcntl_alarm( 0 );
+		foreach ( array( SIGTERM, SIGINT, SIGHUP ) as $handled_signal ) {
+			pcntl_signal( $handled_signal, SIG_DFL );
+		}
+
+		$owns_process_group = function_exists( 'posix_getpgrp' ) && posix_getpgrp() === getmypid();
+		if ( $owns_process_group && function_exists( 'posix_kill' ) ) {
+			posix_kill( 0, $signal );
+		}
+
+		exit( 128 + $signal ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Integer process exit status.
+	}
+
+	/**
+	 * Restore the caller's signal and process-group state.
+	 */
+	public static function stop(): void {
+		if ( ! self::$active ) {
+			return;
+		}
+
+		pcntl_alarm( 0 );
+		pcntl_signal( SIGALRM, self::$previous_handler ?? SIG_DFL );
+		foreach ( self::$previous_termination_handlers as $signal => $handler ) {
+			pcntl_signal( $signal, $handler );
+		}
+		if ( self::$changed_process_group && self::$previous_process_group > 0 ) {
+			posix_setpgid( 0, self::$previous_process_group );
+		}
+		pcntl_async_signals( self::$previous_async_signals );
+		self::$active                        = false;
+		self::$parent_pid                    = 0;
+		self::$previous_handler              = null;
+		self::$previous_async_signals        = false;
+		self::$previous_termination_handlers = array();
+		self::$previous_process_group        = 0;
+		self::$changed_process_group         = false;
+	}
+}

--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -668,11 +668,11 @@ class MemoryCommand extends BaseCommand {
 		$result = $daily->read( $parts['year'], $parts['month'], $parts['day'] );
 
 		if ( ! $result['success'] ) {
-			WP_CLI::error( $result['message'] );
+			WP_CLI::error( $result['message'] ?? 'Daily memory file could not be read.' );
 			return;
 		}
 
-		WP_CLI::log( $result['content'] );
+		WP_CLI::log( $result['content'] ?? '' );
 	}
 
 	/**
@@ -890,12 +890,13 @@ class MemoryCommand extends BaseCommand {
 		$now   = time();
 
 		foreach ( $files as $file ) {
-			$mtime    = filemtime( $file );
+			$mtime    = (int) filemtime( $file );
+			$size     = (int) filesize( $file );
 			$age_days = floor( ( $now - $mtime ) / 86400 );
 
 			$items[] = array(
 				'file'     => basename( $file ),
-				'size'     => size_format( filesize( $file ) ),
+				'size'     => size_format( $size ),
 				'modified' => wp_date( 'Y-m-d H:i:s', $mtime ),
 				'age'      => $age_days . 'd',
 			);
@@ -931,7 +932,7 @@ class MemoryCommand extends BaseCommand {
 		$stale     = 0;
 
 		foreach ( $files as $file ) {
-			$mtime    = filemtime( $file );
+			$mtime    = (int) filemtime( $file );
 			$age_days = floor( ( $now - $mtime ) / 86400 );
 			$is_stale = $mtime < $threshold;
 
@@ -1241,7 +1242,7 @@ class MemoryCommand extends BaseCommand {
 				$result = ComposableFileGenerator::regenerate_all( $context );
 
 				foreach ( $result['results'] as $file_result ) {
-					$status = ! empty( $file_result['success'] ) ? 'OK' : 'FAIL';
+					$status  = ! empty( $file_result['success'] ) ? 'OK' : 'FAIL';
 					$message = $file_result['message'];
 					if ( isset( $file_result['blocker'] ) ) {
 						$message .= ' Blocker: ' . wp_json_encode( $file_result['blocker'], JSON_UNESCAPED_SLASHES );
@@ -1640,7 +1641,7 @@ class MemoryCommand extends BaseCommand {
 				'relative_files' => $relative_files,
 			);
 
-			WP_CLI::line( wp_json_encode( $output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			WP_CLI::line( (string) wp_json_encode( $output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 		} else {
 			$items = array();
 			foreach ( $core_files as $entry ) {

--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -23,6 +23,7 @@ use DataMachine\Core\FilesRepository\DailyMemory;
 use DataMachine\Core\FilesRepository\DirectoryManager;
 use DataMachine\Core\FilesRepository\FilesystemHelper;
 use DataMachine\Cli\UserResolver;
+use DataMachine\Cli\CallerLivenessMonitor;
 use DataMachine\Engine\AI\MemoryFileRegistry;
 use DataMachine\Engine\AI\SectionRegistry;
 use DataMachine\Engine\AI\ComposableFileGenerator;
@@ -1214,30 +1215,84 @@ class MemoryCommand extends BaseCommand {
 		// Build context from CLI flags.
 		$context = $this->build_compose_context( $assoc_args );
 
-		if ( ! empty( $filename ) ) {
-			// Regenerate a single file.
-			$result = ComposableFileGenerator::regenerate( $filename, $context );
+		$monitoring = CallerLivenessMonitor::start();
+		try {
+			if ( ! empty( $filename ) ) {
+				// Regenerate a single file.
+				$result = ComposableFileGenerator::regenerate( $filename, $context );
 
-			if ( ! $result['success'] ) {
-				WP_CLI::error( $result['message'] );
-				return;
-			}
+				if ( ! $result['success'] ) {
+					$message = $result['message'];
+					if ( isset( $result['blocker'] ) ) {
+						$message .= ' Blocker: ' . wp_json_encode( $result['blocker'], JSON_UNESCAPED_SLASHES );
+					}
+					if ( $monitoring ) {
+						WP_CLI::error( $message, false );
+						CallerLivenessMonitor::terminate( SIGTERM );
+					}
+					WP_CLI::error( $message );
+				}
 
-			if ( ! $quiet ) {
-				WP_CLI::success( $result['message'] );
-			}
-		} else {
-			// Regenerate all composable files.
-			$result = ComposableFileGenerator::regenerate_all( $context );
+				if ( ! $quiet ) {
+					WP_CLI::success( $result['message'] );
+				}
+			} else {
+				// Regenerate all composable files.
+				$result = ComposableFileGenerator::regenerate_all( $context );
 
-			if ( ! $quiet ) {
 				foreach ( $result['results'] as $file_result ) {
 					$status = ! empty( $file_result['success'] ) ? 'OK' : 'FAIL';
-					WP_CLI::log( sprintf( '  [%s] %s — %s', $status, $file_result['filename'], $file_result['message'] ) );
+					$message = $file_result['message'];
+					if ( isset( $file_result['blocker'] ) ) {
+						$message .= ' Blocker: ' . wp_json_encode( $file_result['blocker'], JSON_UNESCAPED_SLASHES );
+					}
+					if ( ! $quiet || empty( $file_result['success'] ) ) {
+						WP_CLI::log( sprintf( '  [%s] %s — %s', $status, $file_result['filename'], $message ) );
+					}
 				}
-				WP_CLI::success( $result['message'] );
+				if ( ! $result['success'] ) {
+					if ( $monitoring ) {
+						WP_CLI::error( $result['message'], false );
+						CallerLivenessMonitor::terminate( SIGTERM );
+					}
+					WP_CLI::error( $result['message'] );
+				}
+				if ( ! $quiet ) {
+					WP_CLI::success( $result['message'] );
+				}
+			}
+		} finally {
+			if ( $monitoring ) {
+				CallerLivenessMonitor::stop();
 			}
 		}
+	}
+
+	/**
+	 * Inspect bounded composable-file lock owner diagnostics.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<filename>]
+	 * : Optional composable filename. Defaults to all composable files.
+	 *
+	 * [--format=<format>]
+	 * : Output format (table or json).
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 * @subcommand compose-status
+	 */
+	public function compose_status( array $args, array $assoc_args ): void {
+		$filename = (string) ( $args[0] ?? '' );
+		$context  = $this->build_compose_context( $assoc_args );
+		$files    = '' === $filename ? array_keys( MemoryFileRegistry::get_composable() ) : array( $filename );
+		$items    = array_map(
+			static fn( string $file ): array => ComposableFileGenerator::lock_status( $file, $context ),
+			$files
+		);
+
+		$this->format_items( $items, array( 'filename', 'lock_status', 'owner_operation', 'owner_pid', 'owner_run_id', 'lock_age_seconds', 'owner_alive', 'recovery_command' ), $assoc_args );
 	}
 
 	/**

--- a/inc/Engine/AI/ComposableFileGenerator.php
+++ b/inc/Engine/AI/ComposableFileGenerator.php
@@ -67,98 +67,135 @@ class ComposableFileGenerator {
 			);
 		}
 
-		// A root convention path is shared by every site in a multisite install.
-		// Persist each site's rendered ownership snapshot before aggregating so a
-		// request-local plugin set cannot erase another site's valid sections.
-		if ( ! empty( $meta['convention_path'] ) && is_multisite() ) {
-			$content = MultisiteSectionAggregator::compose( $filename, $context );
-		} else {
-			$content = SectionRegistry::generate( $filename, $context );
+		$target = self::resolve_target( $filename, $meta, $context );
+		if ( ! $target['success'] ) {
+			return $target;
 		}
 
-		if ( '' === trim( $content ) ) {
+		$directory = $target['directory'];
+		$filepath  = $target['filepath'];
+		$dm        = new DirectoryManager();
+		if ( ! $dm->ensure_directory_exists( $directory ) ) {
 			return array(
 				'success' => false,
-				'message' => sprintf( 'All sections returned empty content for "%s".', $filename ),
+				'message' => sprintf( 'Could not create composition directory for "%s".', $filename ),
 			);
 		}
 
-		// Resolve write target.
-		// Files with a convention_path write ONLY to that path (e.g. AGENTS.md → site root).
-		// Files without one write to their layer directory as before.
-		$stale_layer_path = '';
-		if ( ! empty( $meta['convention_path'] ) ) {
-			$filepath  = rtrim( ABSPATH, '/' ) . '/' . $meta['convention_path'];
-			$directory = dirname( $filepath );
+		$acquisition = ComposableFileLock::acquire( $filename, $filepath );
+		if ( ! $acquisition['acquired'] || ! $acquisition['lock'] instanceof ComposableFileLock ) {
+			return array(
+				'success'    => false,
+				'error_code' => 'composition_locked',
+				'message'    => sprintf( 'Composition lock unavailable for "%s" after 2 seconds.', $filename ),
+				'blocker'    => $acquisition['diagnostic'],
+			);
+		}
 
-			// Pre-v0.67.0 versions wrote to the layer dir; the convention_path
-			// flag only controls writes now. If a stale layer-dir copy exists
-			// from before the migration, remove it so consumers reading the
-			// layer dir don't get pointed at a frozen snapshot. Resolving the
-			// directory must not fail the regenerate — cleanup is best-effort.
-			$layer_dir = ScaffoldAbilities::resolve_directory( $meta['layer'], $context );
-			if ( $layer_dir ) {
-				$candidate = trailingslashit( $layer_dir ) . $filename;
-				if ( $candidate !== $filepath && file_exists( $candidate ) ) {
-					$stale_layer_path = $candidate;
-				}
+		$lock = $acquisition['lock'];
+		try {
+			// A root convention path is shared by every site in a multisite install.
+			// Persist each site's rendered ownership snapshot before aggregating so a
+			// request-local plugin set cannot erase another site's valid sections.
+			if ( ! empty( $meta['convention_path'] ) && is_multisite() ) {
+				$content = MultisiteSectionAggregator::compose( $filename, $context );
+			} else {
+				$content = SectionRegistry::generate( $filename, $context );
 			}
-		} else {
-			$directory = ScaffoldAbilities::resolve_directory( $meta['layer'], $context );
 
-			if ( ! $directory ) {
+			if ( '' === trim( $content ) ) {
 				return array(
 					'success' => false,
-					'message' => sprintf( 'Could not resolve directory for layer "%s".', $meta['layer'] ),
+					'message' => sprintf( 'All sections returned empty content for "%s".', $filename ),
 				);
 			}
 
-			$filepath = trailingslashit( $directory ) . $filename;
-		}
+			$stale_layer_path = '';
+			if ( ! empty( $meta['convention_path'] ) ) {
+				// Pre-v0.67.0 versions wrote to the layer dir; resolving that
+				// directory must not make best-effort cleanup fail composition.
+				$layer_dir = ScaffoldAbilities::resolve_directory( $meta['layer'], $context );
+				if ( $layer_dir ) {
+					$candidate = trailingslashit( $layer_dir ) . $filename;
+					if ( $candidate !== $filepath && file_exists( $candidate ) ) {
+						$stale_layer_path = $candidate;
+					}
+				}
+			}
 
-		$written = self::write_file( $filepath, $directory, $content );
+			$written = self::write_file( $filepath, $directory, $content );
 
-		if ( ! $written ) {
+			if ( ! $written ) {
+				return array(
+					'success' => false,
+					'message' => sprintf( 'Failed to write %s to disk.', $filename ),
+				);
+			}
+
+			// Best-effort cleanup only targets the dead layer-directory copy.
+			$stale_removed = '';
+			if ( '' !== $stale_layer_path ) {
+				$fs = FilesystemHelper::get();
+				if ( $fs && $fs->delete( $stale_layer_path ) ) {
+					$stale_removed = $stale_layer_path;
+				}
+			}
+
+			/**
+			 * Fires after a composable file has been regenerated.
+			 *
+			 * @since 0.67.0 Convention-path files now write only to the convention path.
+			 * @since 0.66.0
+			 *
+			 * @param string $filename Composable filename.
+			 * @param string $filepath Full path where the file was written.
+			 * @param array  $context  Generation context.
+			 */
+			do_action( 'datamachine_composable_regenerated', $filename, $filepath, $context );
+
+			$message = sprintf( 'Regenerated %s at %s (%d sections).', $filename, $filepath, count( SectionRegistry::get_sections( $filename ) ) );
+			if ( '' !== $stale_removed ) {
+				$message .= sprintf( ' Removed stale layer-dir copy at %s.', $stale_removed );
+			}
+
 			return array(
-				'success' => false,
-				'message' => sprintf( 'Failed to write %s to disk.', $filename ),
+				'success'       => true,
+				'message'       => $message,
+				'filepath'      => $filepath,
+				'stale_removed' => $stale_removed,
+			);
+		} finally {
+			$lock->release();
+		}
+	}
+
+	/**
+	 * Return bounded composition-lock diagnostics without acquiring the lock.
+	 *
+	 * @param string $filename Composable filename.
+	 * @param array  $context  Generation context.
+	 * @return array<string,int|string|bool>
+	 */
+	public static function lock_status( string $filename, array $context = array() ): array {
+		$meta = MemoryFileRegistry::get( $filename );
+		if ( ! $meta || empty( $meta['composable'] ) ) {
+			return array(
+				'type'        => 'composable_file_lock',
+				'lock_status' => 'unregistered',
+				'filename'    => $filename,
 			);
 		}
 
-		// Best-effort cleanup of pre-v0.67.0 layer-dir copy. We only remove the
-		// file when it's at the dead layer-dir path, never the convention_path
-		// itself (those paths are guaranteed different by the check above).
-		$stale_removed = '';
-		if ( '' !== $stale_layer_path ) {
-			$fs = FilesystemHelper::get();
-			if ( $fs && $fs->delete( $stale_layer_path ) ) {
-				$stale_removed = $stale_layer_path;
-			}
+		$target = self::resolve_target( $filename, $meta, $context );
+		if ( ! $target['success'] ) {
+			return array(
+				'type'        => 'composable_file_lock',
+				'lock_status' => 'unavailable',
+				'filename'    => $filename,
+			);
 		}
 
-		/**
-		 * Fires after a composable file has been regenerated.
-		 *
-		 * @since 0.67.0 Convention-path files now write only to the convention path.
-		 * @since 0.66.0
-		 *
-		 * @param string $filename Composable filename.
-		 * @param string $filepath Full path where the file was written.
-		 * @param array  $context  Generation context.
-		 */
-		do_action( 'datamachine_composable_regenerated', $filename, $filepath, $context );
-
-		$message = sprintf( 'Regenerated %s at %s (%d sections).', $filename, $filepath, count( SectionRegistry::get_sections( $filename ) ) );
-		if ( '' !== $stale_removed ) {
-			$message .= sprintf( ' Removed stale layer-dir copy at %s.', $stale_removed );
-		}
-
-		return array(
-			'success'       => true,
-			'message'       => $message,
-			'filepath'      => $filepath,
-			'stale_removed' => $stale_removed,
-		);
+		return ComposableFileLock::snapshot( $filename, $target['filepath'] );
 	}
 
 	/**
@@ -184,7 +221,7 @@ class ComposableFileGenerator {
 		}
 
 		return array(
-			'success' => true,
+			'success' => $regenerated === count( $composable ),
 			'message' => sprintf( 'Regenerated %d of %d composable file(s).', $regenerated, count( $composable ) ),
 			'results' => $results,
 		);
@@ -204,16 +241,53 @@ class ComposableFileGenerator {
 			return false;
 		}
 
-		$fs = FilesystemHelper::get();
-		if ( ! $fs ) {
+		$temp_path = tempnam( $directory, '.' . basename( $filepath ) . '.tmp-' );
+		if ( false === $temp_path ) {
 			return false;
 		}
 
-		$result = $fs->put_contents( $filepath, $content . "\n", FS_CHMOD_FILE );
-		if ( $result ) {
-			FilesystemHelper::make_group_writable( $filepath );
+		$payload = $content . "\n";
+		$written = file_put_contents( $temp_path, $payload, LOCK_EX ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		@chmod( $temp_path, FS_CHMOD_FILE ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod,WordPress.PHP.NoSilencedErrors.Discouraged
+		if ( strlen( $payload ) !== $written || ! @rename( $temp_path, $filepath ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename,WordPress.PHP.NoSilencedErrors.Discouraged
+			@unlink( $temp_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink,WordPress.PHP.NoSilencedErrors.Discouraged
+			return false;
 		}
 
-		return (bool) $result;
+		FilesystemHelper::make_group_writable( $filepath );
+		return true;
+	}
+
+	/**
+	 * Resolve a composable file's canonical write target.
+	 *
+	 * @param string $filename Composable filename.
+	 * @param array  $meta     Registry metadata.
+	 * @param array  $context  Generation context.
+	 * @return array{success:bool,directory?:string,filepath?:string,message?:string}
+	 */
+	private static function resolve_target( string $filename, array $meta, array $context ): array {
+		if ( ! empty( $meta['convention_path'] ) ) {
+			$filepath = rtrim( ABSPATH, '/' ) . '/' . $meta['convention_path'];
+			return array(
+				'success'   => true,
+				'directory' => dirname( $filepath ),
+				'filepath'  => $filepath,
+			);
+		}
+
+		$directory = ScaffoldAbilities::resolve_directory( $meta['layer'], $context );
+		if ( ! $directory ) {
+			return array(
+				'success' => false,
+				'message' => sprintf( 'Could not resolve directory for layer "%s".', $meta['layer'] ),
+			);
+		}
+
+		return array(
+			'success'   => true,
+			'directory' => $directory,
+			'filepath'  => trailingslashit( $directory ) . $filename,
+		);
 	}
 }

--- a/inc/Engine/AI/ComposableFileGenerator.php
+++ b/inc/Engine/AI/ComposableFileGenerator.php
@@ -41,7 +41,7 @@ class ComposableFileGenerator {
 	 *     @type string $agent_slug Agent slug.
 	 *     @type int    $agent_id   Agent ID.
 	 * }
-	 * @return array{success: bool, message: string, filepath?: string, stale_removed?: string}
+	 * @return array{success:true,message:string,filepath:string,stale_removed:string}|array{success:false,message:string,error_code?:string,blocker?:array<string,int|string|bool>}
 	 */
 	public static function regenerate( string $filename, array $context = array() ): array {
 		$meta = MemoryFileRegistry::get( $filename );
@@ -221,7 +221,7 @@ class ComposableFileGenerator {
 		}
 
 		return array(
-			'success' => $regenerated === count( $composable ),
+			'success' => count( $composable ) === $regenerated,
 			'message' => sprintf( 'Regenerated %d of %d composable file(s).', $regenerated, count( $composable ) ),
 			'results' => $results,
 		);
@@ -264,7 +264,7 @@ class ComposableFileGenerator {
 	 * @param string $filename Composable filename.
 	 * @param array  $meta     Registry metadata.
 	 * @param array  $context  Generation context.
-	 * @return array{success:bool,directory?:string,filepath?:string,message?:string}
+	 * @return array{success:true,directory:string,filepath:string}|array{success:false,message:string}
 	 */
 	private static function resolve_target( string $filename, array $meta, array $context ): array {
 		if ( ! empty( $meta['convention_path'] ) ) {

--- a/inc/Engine/AI/ComposableFileLock.php
+++ b/inc/Engine/AI/ComposableFileLock.php
@@ -32,8 +32,9 @@ class ComposableFileLock {
 	 * @param resource $handle Locked file handle.
 	 */
 	private function __construct( $handle ) {
+		$pid             = getmypid();
 		$this->handle    = $handle;
-		$this->owner_pid = getmypid();
+		$this->owner_pid = false === $pid ? 0 : $pid;
 	}
 
 	/**

--- a/inc/Engine/AI/ComposableFileLock.php
+++ b/inc/Engine/AI/ComposableFileLock.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Bounded per-file lock for composable memory generation.
+ *
+ * @package DataMachine\Engine\AI
+ */
+
+namespace DataMachine\Engine\AI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Serializes composition without making unrelated requests wait on the lock.
+ */
+class ComposableFileLock {
+
+	private const METADATA_LIMIT = 8192;
+
+	/**
+	 * Owned lock-file handle.
+	 *
+	 * @var resource|null
+	 */
+	private $handle;
+
+	/** Acquiring process ID, used to fence forked destructors. */
+	private int $owner_pid;
+
+	/**
+	 * Create an owned lock instance.
+	 *
+	 * @param resource $handle Locked file handle.
+	 */
+	private function __construct( $handle ) {
+		$this->handle    = $handle;
+		$this->owner_pid = getmypid();
+	}
+
+	/**
+	 * Acquire a per-target lock within a bounded wait.
+	 *
+	 * @param string $filename          Composable filename.
+	 * @param string $filepath          Canonical output path.
+	 * @param int    $wait_milliseconds Maximum acquisition wait.
+	 * @return array{acquired:bool,lock:?self,diagnostic:array<string,int|string|bool>}
+	 */
+	public static function acquire( string $filename, string $filepath, int $wait_milliseconds = 2000 ): array {
+		$lock_path = self::path_for( $filepath );
+		$handle    = @fopen( $lock_path, 'c+' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen,WordPress.PHP.NoSilencedErrors.Discouraged
+		if ( false === $handle ) {
+			return array(
+				'acquired'   => false,
+				'lock'       => null,
+				'diagnostic' => self::diagnostic( 'unavailable', $filename, $filepath, $lock_path, array() ),
+			);
+		}
+
+		$deadline = microtime( true ) + ( max( 0, $wait_milliseconds ) / 1000 );
+		do {
+			if ( flock( $handle, LOCK_EX | LOCK_NB ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+				$metadata = array(
+					'type'       => 'composable_file_lock',
+					'operation'  => 'memory compose ' . $filename,
+					'filename'   => $filename,
+					'filepath'   => $filepath,
+					'pid'        => getmypid(),
+					'run_id'     => bin2hex( random_bytes( 8 ) ),
+					'started_at' => time(),
+				);
+				self::write_metadata( $handle, $metadata );
+
+				return array(
+					'acquired'   => true,
+					'lock'       => new self( $handle ),
+					'diagnostic' => self::diagnostic( 'held', $filename, $filepath, $lock_path, $metadata ),
+				);
+			}
+			$remaining_microseconds = (int) ( ( $deadline - microtime( true ) ) * 1000000 );
+			if ( $remaining_microseconds <= 0 ) {
+				break;
+			}
+			usleep( min( 50000, $remaining_microseconds ) );
+		} while ( microtime( true ) < $deadline );
+
+		$metadata = self::read_metadata( $handle );
+		fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+
+		return array(
+			'acquired'   => false,
+			'lock'       => null,
+			'diagnostic' => self::diagnostic( 'blocked', $filename, $filepath, $lock_path, $metadata ),
+		);
+	}
+
+	/**
+	 * Return an immediate, read-only lock snapshot.
+	 *
+	 * @param string $filename Composable filename.
+	 * @param string $filepath Canonical output path.
+	 * @return array<string,int|string|bool>
+	 */
+	public static function snapshot( string $filename, string $filepath ): array {
+		$lock_path = self::path_for( $filepath );
+		$handle    = @fopen( $lock_path, 'c+' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen,WordPress.PHP.NoSilencedErrors.Discouraged
+		if ( false === $handle ) {
+			return self::diagnostic( 'unavailable', $filename, $filepath, $lock_path, array() );
+		}
+
+		$metadata = self::read_metadata( $handle );
+		if ( flock( $handle, LOCK_EX | LOCK_NB ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+			$status = empty( $metadata ) ? 'unlocked' : 'stale';
+			flock( $handle, LOCK_UN ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+		} else {
+			$status = 'held';
+		}
+		fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+
+		return self::diagnostic( $status, $filename, $filepath, $lock_path, $metadata );
+	}
+
+	/**
+	 * Release this process's owned lock.
+	 */
+	public function release(): void {
+		if ( ! is_resource( $this->handle ) || getmypid() !== $this->owner_pid ) {
+			return;
+		}
+
+		self::write_metadata( $this->handle, array() );
+		flock( $this->handle, LOCK_UN ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+		fclose( $this->handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		$this->handle = null;
+	}
+
+	/**
+	 * Release the lock if the owner unwinds unexpectedly.
+	 */
+	public function __destruct() {
+		$this->release();
+	}
+
+	/**
+	 * Resolve the lock file adjacent to its target.
+	 *
+	 * @param string $filepath Canonical output path.
+	 */
+	private static function path_for( string $filepath ): string {
+		return dirname( $filepath ) . '/.' . basename( $filepath ) . '.compose.lock';
+	}
+
+	/**
+	 * Read bounded owner metadata.
+	 *
+	 * @param resource $handle Lock-file handle.
+	 */
+	private static function read_metadata( $handle ): array {
+		rewind( $handle );
+		$raw     = stream_get_contents( $handle, self::METADATA_LIMIT );
+		$decoded = json_decode( is_string( $raw ) ? $raw : '', true );
+		return is_array( $decoded ) ? $decoded : array();
+	}
+
+	/**
+	 * Replace owner metadata while holding the kernel lock.
+	 *
+	 * @param resource            $handle   Lock-file handle.
+	 * @param array<string,mixed> $metadata Owner metadata.
+	 */
+	private static function write_metadata( $handle, array $metadata ): void {
+		$encoded = empty( $metadata ) ? '' : (string) wp_json_encode( $metadata, JSON_UNESCAPED_SLASHES );
+		rewind( $handle );
+		ftruncate( $handle, 0 );
+		if ( '' !== $encoded ) {
+			fwrite( $handle, $encoded ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+		}
+		fflush( $handle );
+	}
+
+	/**
+	 * Normalize untrusted lock-file metadata into bounded typed output.
+	 *
+	 * @param string              $status    Observed lock state.
+	 * @param string              $filename  Composable filename.
+	 * @param string              $filepath  Canonical output path.
+	 * @param string              $lock_path Lock-file path.
+	 * @param array<string,mixed> $metadata  Stored owner metadata.
+	 * @return array<string,int|string|bool>
+	 */
+	private static function diagnostic( string $status, string $filename, string $filepath, string $lock_path, array $metadata ): array {
+		$started_at = max( 0, (int) ( $metadata['started_at'] ?? 0 ) );
+		$pid        = max( 0, (int) ( $metadata['pid'] ?? 0 ) );
+
+		return array(
+			'type'             => 'composable_file_lock',
+			'lock_status'      => $status,
+			'filename'         => $filename,
+			'filepath'         => $filepath,
+			'lock_path'        => $lock_path,
+			'owner_operation'  => substr( (string) ( $metadata['operation'] ?? '' ), 0, 160 ),
+			'owner_pid'        => $pid,
+			'owner_run_id'     => substr( (string) ( $metadata['run_id'] ?? '' ), 0, 64 ),
+			'lock_started_at'  => $started_at,
+			'lock_age_seconds' => $started_at > 0 ? max( 0, time() - $started_at ) : 0,
+			'owner_alive'      => self::pid_is_alive( $pid ),
+			'recovery_command' => in_array( $status, array( 'held', 'blocked' ), true ) && $pid > 0
+				? 'kill -TERM -- ' . $pid
+				: 'wp datamachine memory compose ' . escapeshellarg( $filename ),
+		);
+	}
+
+	/**
+	 * Check whether an owner PID currently exists.
+	 *
+	 * @param int $pid Owner process ID.
+	 */
+	private static function pid_is_alive( int $pid ): bool {
+		return $pid > 0 && function_exists( 'posix_kill' ) && @posix_kill( $pid, 0 ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+	}
+}

--- a/tests/composable-caller-containment-smoke.php
+++ b/tests/composable-caller-containment-smoke.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Process-level coverage for abandoned composable-memory callers.
+ *
+ * Run with: php tests/composable-caller-containment-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! function_exists( 'pcntl_fork' ) || ! function_exists( 'pcntl_waitpid' ) || ! function_exists( 'posix_kill' ) || ! function_exists( 'pcntl_alarm' ) ) {
+	echo "SKIP: PCNTL and POSIX process control are required.\n";
+	exit( 0 );
+}
+
+define( 'ABSPATH', __DIR__ );
+require_once dirname( __DIR__ ) . '/inc/Cli/CallerLivenessMonitor.php';
+
+use DataMachine\Cli\CallerLivenessMonitor;
+
+$state_file = tempnam( sys_get_temp_dir(), 'dm-compose-caller-' );
+if ( false === $state_file ) {
+	fwrite( STDERR, "FAIL: unable to create process state file.\n" );
+	exit( 1 );
+}
+
+$caller_pid = pcntl_fork();
+if ( 0 === $caller_pid ) {
+	$compose_pid = pcntl_fork();
+	if ( 0 === $compose_pid ) {
+		if ( ! CallerLivenessMonitor::start() ) {
+			exit( 2 );
+		}
+		$worker_pid = pcntl_fork();
+		if ( 0 === $worker_pid ) {
+			while ( true ) {
+				usleep( 100000 );
+			}
+		}
+		file_put_contents( $state_file, json_encode( array( getmypid(), $worker_pid ) ), LOCK_EX );
+		while ( true ) {
+			usleep( 100000 );
+		}
+	}
+
+	while ( true ) {
+		usleep( 100000 );
+	}
+}
+
+$deadline    = microtime( true ) + 3.0;
+$compose_pid = 0;
+$worker_pid  = 0;
+do {
+	$pids        = json_decode( (string) file_get_contents( $state_file ), true );
+	$compose_pid = (int) ( $pids[0] ?? 0 );
+	$worker_pid  = (int) ( $pids[1] ?? 0 );
+	if ( $compose_pid > 0 && $worker_pid > 0 ) {
+		break;
+	}
+	usleep( 10000 );
+} while ( microtime( true ) < $deadline );
+
+if ( $compose_pid <= 0 || $worker_pid <= 0 ) {
+	posix_kill( $caller_pid, SIGKILL );
+	pcntl_waitpid( $caller_pid, $status );
+	@unlink( $state_file );
+	fwrite( STDERR, "FAIL: monitored compose descendant did not start.\n" );
+	exit( 1 );
+}
+
+posix_kill( $caller_pid, SIGKILL );
+pcntl_waitpid( $caller_pid, $status );
+
+$deadline = microtime( true ) + 4.0;
+do {
+	if ( ! @posix_kill( $compose_pid, 0 ) && ! @posix_kill( $worker_pid, 0 ) ) {
+		@unlink( $state_file );
+		echo "OK (compose process group terminated after caller death)\n";
+		exit( 0 );
+	}
+	usleep( 20000 );
+} while ( microtime( true ) < $deadline );
+
+posix_kill( $compose_pid, SIGKILL );
+posix_kill( $worker_pid, SIGKILL );
+@unlink( $state_file );
+fwrite( STDERR, "FAIL: compose descendant survived caller death.\n" );
+exit( 1 );

--- a/tests/composable-file-atomic-write-smoke.php
+++ b/tests/composable-file-atomic-write-smoke.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Pure-PHP coverage for atomic composable-file replacement.
+ *
+ * Run with: php tests/composable-file-atomic-write-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Core\FilesRepository {
+	class DirectoryManager {
+		public function ensure_directory_exists( string $directory ): bool {
+			return is_dir( $directory );
+		}
+	}
+
+	class FilesystemHelper {
+		public static function make_group_writable( string $filepath ): bool {
+			return is_file( $filepath );
+		}
+	}
+}
+
+namespace {
+	define( 'ABSPATH', __DIR__ );
+	define( 'FS_CHMOD_FILE', 0644 );
+	require_once dirname( __DIR__ ) . '/inc/Engine/AI/ComposableFileGenerator.php';
+
+	$directory = sys_get_temp_dir() . '/dm-compose-atomic-' . bin2hex( random_bytes( 5 ) );
+	$filepath  = $directory . '/AGENTS.md';
+	mkdir( $directory, 0700 );
+	file_put_contents( $filepath, str_repeat( 'old', 10000 ) );
+
+	$method = new \ReflectionMethod( \DataMachine\Engine\AI\ComposableFileGenerator::class, 'write_file' );
+	$result = $method->invoke( null, $filepath, $directory, str_repeat( 'new', 10000 ) );
+	$actual = file_get_contents( $filepath );
+	$temps  = glob( $directory . '/.AGENTS.md.tmp-*' );
+
+	@unlink( $filepath );
+	@rmdir( $directory );
+
+	if ( true !== $result || str_repeat( 'new', 10000 ) . "\n" !== $actual || array() !== $temps ) {
+		fwrite( STDERR, "FAIL: composable file was not atomically replaced and cleaned up.\n" );
+		exit( 1 );
+	}
+
+	echo "OK (atomic same-directory replacement)\n";
+}

--- a/tests/composable-file-lock-process-smoke.php
+++ b/tests/composable-file-lock-process-smoke.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Process-level coverage for composable-file lock ownership and recovery.
+ *
+ * Run with: php tests/composable-file-lock-process-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+if ( ! function_exists( 'pcntl_fork' ) || ! function_exists( 'pcntl_waitpid' ) || ! function_exists( 'posix_kill' ) ) {
+	echo "SKIP: PCNTL and POSIX process control are required.\n";
+	exit( 0 );
+}
+
+define( 'ABSPATH', __DIR__ );
+
+/**
+ * Minimal WordPress JSON helper for this standalone smoke test.
+ */
+function wp_json_encode( mixed $value, int $flags = 0 ): string|false {
+	return json_encode( $value, $flags );
+}
+
+require_once dirname( __DIR__ ) . '/inc/Engine/AI/ComposableFileLock.php';
+
+use DataMachine\Engine\AI\ComposableFileLock;
+
+$directory   = sys_get_temp_dir() . '/dm-compose-lock-' . bin2hex( random_bytes( 5 ) );
+$filepath    = $directory . '/AGENTS.md';
+$result_file = $directory . '/result.json';
+mkdir( $directory, 0700 );
+
+$fail = static function ( string $message ) use ( $directory, $filepath, $result_file ): void {
+	@unlink( $result_file );
+	@unlink( $directory . '/.' . basename( $filepath ) . '.compose.lock' );
+	@rmdir( $directory );
+	fwrite( STDERR, "FAIL: {$message}\n" );
+	exit( 1 );
+};
+
+$first = ComposableFileLock::acquire( 'AGENTS.md', $filepath, 100 );
+if ( ! $first['acquired'] || ! $first['lock'] instanceof ComposableFileLock ) {
+	$fail( 'first owner did not acquire the lock.' );
+}
+
+$contender_pid = pcntl_fork();
+if ( 0 === $contender_pid ) {
+	$contender = ComposableFileLock::acquire( 'AGENTS.md', $filepath, 100 );
+	file_put_contents( $result_file, json_encode( $contender['diagnostic'] ), LOCK_EX );
+	exit( $contender['acquired'] ? 2 : 0 );
+}
+pcntl_waitpid( $contender_pid, $status );
+$blocked = json_decode( (string) file_get_contents( $result_file ), true );
+if ( ! pcntl_wifexited( $status ) || 0 !== pcntl_wexitstatus( $status ) || 'blocked' !== ( $blocked['lock_status'] ?? '' ) || getmypid() !== ( $blocked['owner_pid'] ?? 0 ) ) {
+	$fail( 'contender did not return bounded typed owner diagnostics.' );
+}
+
+$after_fork = ComposableFileLock::acquire( 'AGENTS.md', $filepath, 0 );
+if ( $after_fork['acquired'] ) {
+	$fail( 'forked contender destructor released the parent owner lock.' );
+}
+$first['lock']->release();
+
+$owner_pid = pcntl_fork();
+if ( 0 === $owner_pid ) {
+	$owned = ComposableFileLock::acquire( 'AGENTS.md', $filepath, 100 );
+	file_put_contents( $result_file, $owned['acquired'] ? 'ready' : 'failed', LOCK_EX );
+	while ( true ) {
+		usleep( 100000 );
+	}
+}
+
+$deadline = microtime( true ) + 2.0;
+do {
+	if ( 'ready' === (string) file_get_contents( $result_file ) ) {
+		break;
+	}
+	usleep( 10000 );
+} while ( microtime( true ) < $deadline );
+
+posix_kill( $owner_pid, SIGKILL );
+pcntl_waitpid( $owner_pid, $status );
+$stale = ComposableFileLock::snapshot( 'AGENTS.md', $filepath );
+if ( 'stale' !== $stale['lock_status'] || $owner_pid !== $stale['owner_pid'] || $stale['owner_alive'] ) {
+	$fail( 'killed owner did not leave non-blocking stale diagnostics.' );
+}
+
+$replacement = ComposableFileLock::acquire( 'AGENTS.md', $filepath, 100 );
+if ( ! $replacement['acquired'] || ! $replacement['lock'] instanceof ComposableFileLock ) {
+	$fail( 'stale owner metadata prevented lock takeover.' );
+}
+$replacement['lock']->release();
+
+@unlink( $result_file );
+@unlink( $directory . '/.' . basename( $filepath ) . '.compose.lock' );
+@rmdir( $directory );
+echo "OK (live blocker and stale-owner recovery)\n";


### PR DESCRIPTION
## Summary

- terminate compose descendants when the invoking CLI caller disappears or composition is cancelled
- serialize each composable target with a bounded kernel lock and typed owner diagnostics
- expose `datamachine memory compose-status` for normal lock inspection and recovery
- preserve typed blockers through scaffold and compose-all paths
- replace composable files atomically after validating the complete write

Fixes #3409.

## Verification

- `php tests/composable-caller-containment-smoke.php`
- `php tests/composable-file-lock-process-smoke.php`
- `php tests/composable-file-atomic-write-smoke.php`
- `php tests/phpunit-file-isolation-smoke.php`
- focused WordPress PHPCS checks on changed production files
- PHPCompatibilityWP for PHP 8.2+
- PHP syntax checks and `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode implemented and tested the process-containment and composition-lock repair in an isolated worktree. Chris Huber directed the parallel workflow, reviewed the diff and evidence, and remains responsible for the change.
