### PR TITLE
Accept partial-content HTTP GET responses

### DIFF
--- a/inc/Core/HttpClient.php
+++ b/inc/Core/HttpClient.php
@@ -20,7 +20,7 @@ class HttpClient {
 	private const VALID_METHODS = array( 'GET', 'POST', 'PUT', 'DELETE', 'PATCH' );
 
 	private const SUCCESS_CODES = array(
-		'GET'    => array( 200, 202 ),
+		'GET'    => array( 200, 202, 206 ),
 		'POST'   => array( 200, 201, 202 ),
 		'PUT'    => array( 200, 201, 204 ),
 		'PATCH'  => array( 200, 204 ),

--- a/inc/Core/HttpClient.php
+++ b/inc/Core/HttpClient.php
@@ -79,7 +79,7 @@ class HttpClient {
 		}
 
 		$options = self::resolveAuthRefOptions( $options, $context );
-		if ( is_wp_error( $options ) ) {
+		if ( $options instanceof \WP_Error ) {
 			return array(
 				'success' => false,
 				'error'   => $options->get_error_message(),
@@ -103,7 +103,7 @@ class HttpClient {
 			}
 		}
 
-		if ( is_wp_error( $response ) ) {
+		if ( $response instanceof \WP_Error ) {
 			return self::handleWpError( $response, $method, $url, $context, $args );
 		}
 
@@ -297,7 +297,7 @@ class HttpClient {
 				'runtime' => true,
 			)
 		);
-		if ( is_wp_error( $resolved ) ) {
+		if ( $resolved instanceof \WP_Error ) {
 			$error_code = $resolved->get_error_code();
 			return new \WP_Error(
 				'' !== $error_code ? $error_code : 'http_auth_ref_unresolved',
@@ -359,6 +359,8 @@ class HttpClient {
 
 	/**
 	 * Handle WP_Error response
+	 *
+	 * @return array{success: false, error: string}
 	 */
 	private static function handleWpError( \WP_Error $response, string $method, string $url, string $context, array $args = array() ): array {
 		$error_message = sprintf(
@@ -408,6 +410,8 @@ class HttpClient {
 
 	/**
 	 * Handle non-success HTTP status code
+	 *
+	 * @return array{success: false, error: string, data: string, status_code: int, headers: mixed, response: array}
 	 */
 	private static function handleHttpError( array $response, int $status_code, string $body, string $method, string $url, string $context, bool $log_response_body_preview ): array {
 		$error_message = sprintf(

--- a/tests/http-client-proxy-auth-smoke.php
+++ b/tests/http-client-proxy-auth-smoke.php
@@ -59,6 +59,37 @@ if ( ! function_exists( 'apply_filters' ) ) {
 	}
 }
 
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, mixed ...$args ): void {
+		unset( $hook, $args );
+	}
+}
+
+if ( ! function_exists( 'wp_remote_get' ) ) {
+	function wp_remote_get( string $url, array $args ): array {
+		$GLOBALS['datamachine_http_client_request'] = compact( 'url', 'args' );
+		return $GLOBALS['datamachine_http_client_response'];
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_response_code' ) ) {
+	function wp_remote_retrieve_response_code( array $response ): int {
+		return (int) ( $response['response']['code'] ?? 0 );
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
+	function wp_remote_retrieve_body( array $response ): string {
+		return (string) ( $response['body'] ?? '' );
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_headers' ) ) {
+	function wp_remote_retrieve_headers( array $response ): array {
+		return (array) ( $response['headers'] ?? array() );
+	}
+}
+
 if ( ! function_exists( 'get_site_option' ) ) {
 	function get_site_option( string $name, mixed $default = false ): mixed {
 		return $GLOBALS['datamachine_http_client_options'][ $name ] ?? $default;
@@ -187,6 +218,20 @@ $bounded_args = http_client_private( 'buildRequestArgs', 'GET', array( 'limit_re
 http_client_smoke_assert( 'response byte limit is forwarded to WordPress HTTP', 1048576 === ( $bounded_args['limit_response_size'] ?? null ) );
 $unbounded_args = http_client_private( 'buildRequestArgs', 'GET', array( 'limit_response_size' => 0 ) );
 http_client_smoke_assert( 'invalid response byte limit is omitted', ! isset( $unbounded_args['limit_response_size'] ) );
+
+$GLOBALS['datamachine_http_client_response'] = array(
+	'response' => array( 'code' => 206 ),
+	'headers'  => array( 'content-range' => 'bytes 900-999/1000' ),
+	'body'     => 'bounded tail',
+);
+$partial_response = HttpClient::get(
+	'https://example.test/log.txt',
+	array( 'headers' => array( 'Range' => 'bytes=-100' ) )
+);
+http_client_smoke_assert(
+	'partial content is a successful bounded GET response',
+	true === ( $partial_response['success'] ?? false ) && 206 === ( $partial_response['status_code'] ?? 0 ) && 'bounded tail' === ( $partial_response['data'] ?? '' )
+);
 
 echo "\n[2] Auth ref options\n";
 


### PR DESCRIPTION
## Summary

- treat HTTP 206 as a successful GET response
- cover byte-range requests through the shared HTTP client request path

## Why

Bounded readers need HTTP range requests to retrieve tails without downloading complete remote resources. WordPress returns the expected 206 response, but the shared client currently classifies it as an error.

## Verification

- `php tests/http-client-proxy-auth-smoke.php`
- `php -l inc/Core/HttpClient.php`
- `php -l tests/http-client-proxy-auth-smoke.php`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol in OpenCode identified the shared status-code gap, implemented the minimal client change and behavioral coverage, and ran the verification commands. Chris Huber directed the integration and reviewed the scope.