### PR TITLE
test: isolate explicit identity fallback query

### DIFF
--- a/tests/Unit/Abilities/Content/UpsertPostAbilityTest.php
+++ b/tests/Unit/Abilities/Content/UpsertPostAbilityTest.php
@@ -299,7 +299,15 @@ class UpsertPostAbilityTest extends WP_UnitTestCase {
 		);
 		$slug_queries = 0;
 		$observer     = static function ( \WP_Query $query ) use ( &$slug_queries ): void {
-			if ( 'observable-fallback' === $query->get( 'name' ) ) {
+			if (
+				'observable-fallback' === $query->get( 'name' )
+				&& 'post' === $query->get( 'post_type' )
+				&& 'any' === $query->get( 'post_status' )
+				&& 0 === $query->get( 'post_parent' )
+				&& 1 === $query->get( 'posts_per_page' )
+				&& 'ids' === $query->get( 'fields' )
+				&& true === $query->get( 'no_found_rows' )
+			) {
 				++$slug_queries;
 			}
 		};


### PR DESCRIPTION
## Summary
- narrow explicit-identity fallback instrumentation to Data Machine's complete resolver query signature
- stop counting WordPress core's same-slug trashed-post collision query as a fallback lookup
- preserve the invariant that complete explicit identity never executes slug fallback resolution

## Root Cause
This was test-isolation instrumentation, not production logic. `UpsertPostAbility` correctly skips its slug fallback when an explicit `post_id` accompanies usable `identity_meta`. During the subsequent write, however, WordPress core's `wp_add_trashed_suffix_to_post_name_for_trashed_posts()` performs its own `WP_Query` with the requested `name` and `post_status=trash`. The test observer matched only `name`, so MySQL counted that core collision check as Data Machine's fallback. The observer now matches the fallback resolver's complete contract: post type, any status, parent scope, one ID result, and no found rows.

## MySQL Evidence
Before: workflow 32868274703, shard-1 ran 522 PHPUnit tests with 520 passed, 1 failed, and 1 skipped. `test_explicit_identity_suppresses_slug_fallback_lookup` observed 1 query instead of 0.

Ordering reproduction: the retained shard plan runs `PostIdentityExplicitRetryProcessTest.php`, three unit files, and then the complete `UpsertPostAbilityTest.php` file before the remaining shard-1 files. This proved the failure in the exact process/integration and class ordering where it surfaced rather than an isolated SQLite-only invocation.

After: workflow 32877947780 passed all four authoritative MySQL shards. Each shard passed all 39 selected test files with 0 failed IDs and 0 skips, for 156 selected files total. Shard-1 passed the same ordering, including `PostIdentityExplicitRetryProcessTest.php` and the complete `UpsertPostAbilityTest.php`. Aggregate MySQL, lint, audit, refactor, and prefix-policy checks all passed.

## Invariant
Complete explicit identity still suppresses Data Machine's slug fallback lookup. The assertion remains exactly zero and has not been weakened, skipped, database-branched, retried, or relaxed; only unrelated WordPress core queries are excluded by matching the fallback resolver's full query shape.

## Verification
- MySQL workflow 32877947780: four shards passed, 39 selected files per shard, 156 total, 0 failed IDs, 0 skips
- `php tests/phpunit-file-isolation-smoke.php` (16 clusters passed)
- `php tests/ability-boundary-helpers-smoke.php` (5 checks passed)
- `homeboy review lint --changed-since origin/main` (1 changed file, no findings)
- `homeboy review audit --changed-since origin/main` (0 introduced findings)
- hosted candidate lint, audit, and refactor gates passed
- `php -l tests/Unit/Abilities/Content/UpsertPostAbilityTest.php`
- `git diff --check`
- Local managed MySQL and SQLite WP Codebox execution was attempted but blocked by the existing `recipe_run_payload_unparseable` zero-test failure; direct host PHPUnit cannot bootstrap `WP_UnitTestCase`. Authoritative hosted MySQL verification passed.
- No production code changed; no production build required.

Fixes #3418

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode investigated the retained CI shard plan and failure artifacts, traced the false positive to WordPress core's trashed-slug collision query, implemented the focused fixture correction, and ran the listed gates under Chris Huber's direction.