### PR TITLE
Fix composable file mode under WP-CLI

### DIFF
--- a/inc/Engine/AI/ComposableFileGenerator.php
+++ b/inc/Engine/AI/ComposableFileGenerator.php
@@ -248,7 +248,8 @@ class ComposableFileGenerator {
 
 		$payload = $content . "\n";
 		$written = file_put_contents( $temp_path, $payload, LOCK_EX ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-		@chmod( $temp_path, FS_CHMOD_FILE ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod,WordPress.PHP.NoSilencedErrors.Discouraged
+		$file_mode = defined( 'FS_CHMOD_FILE' ) ? FS_CHMOD_FILE : 0644;
+		@chmod( $temp_path, $file_mode ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod,WordPress.PHP.NoSilencedErrors.Discouraged
 		if ( strlen( $payload ) !== $written || ! @rename( $temp_path, $filepath ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename,WordPress.PHP.NoSilencedErrors.Discouraged
 			@unlink( $temp_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink,WordPress.PHP.NoSilencedErrors.Discouraged
 			return false;

--- a/inc/Engine/AI/ComposableFileGenerator.php
+++ b/inc/Engine/AI/ComposableFileGenerator.php
@@ -246,8 +246,8 @@ class ComposableFileGenerator {
 			return false;
 		}
 
-		$payload = $content . "\n";
-		$written = file_put_contents( $temp_path, $payload, LOCK_EX ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		$payload   = $content . "\n";
+		$written   = file_put_contents( $temp_path, $payload, LOCK_EX ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		$file_mode = defined( 'FS_CHMOD_FILE' ) ? FS_CHMOD_FILE : 0644;
 		@chmod( $temp_path, $file_mode ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod,WordPress.PHP.NoSilencedErrors.Discouraged
 		if ( strlen( $payload ) !== $written || ! @rename( $temp_path, $filepath ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename,WordPress.PHP.NoSilencedErrors.Discouraged

--- a/tests/composable-file-atomic-write-smoke.php
+++ b/tests/composable-file-atomic-write-smoke.php
@@ -15,34 +15,73 @@ namespace DataMachine\Core\FilesRepository {
 	}
 
 	class FilesystemHelper {
+		public static array $group_writable_paths = array();
+
 		public static function make_group_writable( string $filepath ): bool {
+			self::$group_writable_paths[] = $filepath;
 			return is_file( $filepath );
 		}
 	}
 }
 
 namespace {
+	$mode = $argv[1] ?? '';
+	if ( ! in_array( $mode, array( 'defined', 'undefined' ), true ) ) {
+		$run = static function ( string $mode ): array {
+			$process = proc_open( array( PHP_BINARY, __FILE__, $mode ), array( 1 => array( 'pipe', 'w' ), 2 => array( 'pipe', 'w' ) ), $pipes );
+			if ( ! is_resource( $process ) ) {
+				return array( 1, '', 'Failed to start child process.' );
+			}
+
+			$output = stream_get_contents( $pipes[1] );
+			$error  = stream_get_contents( $pipes[2] );
+			fclose( $pipes[1] );
+			fclose( $pipes[2] );
+
+			return array( proc_close( $process ), $output, $error );
+		};
+
+		foreach ( array( 'defined', 'undefined' ) as $child_mode ) {
+			list( $status, $output, $error ) = $run( $child_mode );
+			if ( 0 !== $status ) {
+				fwrite( STDERR, "FAIL: {$child_mode} FS_CHMOD_FILE child failed.\n{$output}{$error}" );
+				exit( 1 );
+			}
+		}
+
+		echo "OK (atomic replacement and FS_CHMOD_FILE fallback)\n";
+		exit( 0 );
+	}
+
 	define( 'ABSPATH', __DIR__ );
-	define( 'FS_CHMOD_FILE', 0644 );
+	if ( 'defined' === $mode ) {
+		define( 'FS_CHMOD_FILE', 0640 );
+	} elseif ( defined( 'FS_CHMOD_FILE' ) ) {
+		fwrite( STDERR, "FAIL: FS_CHMOD_FILE must be undefined for this child.\n" );
+		exit( 1 );
+	}
 	require_once dirname( __DIR__ ) . '/inc/Engine/AI/ComposableFileGenerator.php';
 
 	$directory = sys_get_temp_dir() . '/dm-compose-atomic-' . bin2hex( random_bytes( 5 ) );
 	$filepath  = $directory . '/AGENTS.md';
+	$expected_mode = 'defined' === $mode ? 0640 : 0644;
 	mkdir( $directory, 0700 );
 	file_put_contents( $filepath, str_repeat( 'old', 10000 ) );
 
 	$method = new \ReflectionMethod( \DataMachine\Engine\AI\ComposableFileGenerator::class, 'write_file' );
 	$result = $method->invoke( null, $filepath, $directory, str_repeat( 'new', 10000 ) );
 	$actual = file_get_contents( $filepath );
-	$temps  = glob( $directory . '/.AGENTS.md.tmp-*' );
+	clearstatcache( true, $filepath );
+	$permissions = fileperms( $filepath ) & 0777;
+	$temps       = glob( $directory . '/.AGENTS.md.tmp-*' );
 
 	@unlink( $filepath );
 	@rmdir( $directory );
 
-	if ( true !== $result || str_repeat( 'new', 10000 ) . "\n" !== $actual || array() !== $temps ) {
-		fwrite( STDERR, "FAIL: composable file was not atomically replaced and cleaned up.\n" );
+	if ( true !== $result || str_repeat( 'new', 10000 ) . "\n" !== $actual || $expected_mode !== $permissions || array() !== $temps || array( $filepath ) !== \DataMachine\Core\FilesRepository\FilesystemHelper::$group_writable_paths ) {
+		fwrite( STDERR, "FAIL: composable file write did not preserve atomic replacement, cleanup, mode, and group-writable normalization.\n" );
 		exit( 1 );
 	}
 
-	echo "OK (atomic same-directory replacement)\n";
+	echo "OK ({$mode} FS_CHMOD_FILE mode)\n";
 }


### PR DESCRIPTION
## Summary

- use WordPress's `FS_CHMOD_FILE` when defined and a safe `0644` default otherwise
- exercise defined and undefined constant environments in isolated PHP processes
- preserve atomic replacement, temporary-file cleanup, and group-writable normalization coverage

Closes #3429.

## Verification

- `php tests/composable-file-atomic-write-smoke.php`
- `php -l inc/Engine/AI/ComposableFileGenerator.php`
- `php -l tests/composable-file-atomic-write-smoke.php`
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode traced the live WP-CLI fatal, implemented the fallback and process-isolated regression coverage, reviewed an asynchronously produced candidate diff, and ran verification under Chris Huber's direction.