### PR TITLE
fix(cli): enforce the worker time limit at the process level

### DIFF
--- a/inc/Cli/Commands/WorkerCommand.php
+++ b/inc/Cli/Commands/WorkerCommand.php
@@ -13,6 +13,7 @@ use DataMachine\Abilities\Job\RecoverStuckJobsAbility;
 use DataMachine\Cli\BaseCommand;
 use DataMachine\Cli\WorkerHealth;
 use DataMachine\Cli\WorkerLock;
+use DataMachine\Cli\WorkerProcessDeadline;
 use DataMachine\Core\AbilityResult;
 use DataMachine\Core\Database\Jobs\Jobs;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
@@ -35,7 +36,8 @@ class WorkerCommand extends BaseCommand {
 	 * ## OPTIONS
 	 *
 	 * [--time-limit=<seconds>]
-	 * : Maximum wall-clock seconds to run. 0 means no time limit.
+	 * : Maximum wall-clock seconds to run, enforced at the process level
+	 * so a hung pass or shutdown path still terminates the process. 0 means no time limit.
 	 * ---
 	 * default: 300
 	 * ---
@@ -149,6 +151,11 @@ class WorkerCommand extends BaseCommand {
 			'job_step_budget'         => isset( $assoc_args['job-step-budget'] ) ? max( 1, (int) $assoc_args['job-step-budget'] ) : 50,
 			'lane'                    => isset( $assoc_args['lane'] ) ? (string) $assoc_args['lane'] : '',
 		);
+
+		$time_limit = (int) $options['time_limit'];
+		if ( $time_limit > 0 ) {
+			WorkerProcessDeadline::arm( $time_limit );
+		}
 
 		$stats = self::runLoop( $options );
 

--- a/inc/Cli/WorkerProcessDeadline.php
+++ b/inc/Cli/WorkerProcessDeadline.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * CLI worker process deadline guard.
+ *
+ * @package DataMachine\Cli
+ */
+
+namespace DataMachine\Cli;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Terminate a worker process that exceeds its wall-clock budget.
+ *
+ * The worker loop already stops at its time limit, but operators schedule
+ * `worker run --once` under "skip if the previous run is still going"
+ * supervisors, which need a process-level bound: a drain pass, output step, or
+ * shutdown callback that never returns must not keep the process resident and
+ * burning CPU. This guard arms a SIGALRM watchdog for the full budget; when it
+ * fires the process emits a warning and exits with the conventional timeout
+ * status 124. If that exit is trapped by a hung shutdown path, a short
+ * follow-up alarm escalates to SIGKILL so the bound still holds.
+ *
+ * Hosts without pcntl simply keep the loop-level bounds.
+ */
+class WorkerProcessDeadline {
+
+	/** Follow-up grace in seconds before escalating to SIGKILL. */
+	private const HARD_KILL_GRACE_SECONDS = 30;
+
+	/** Exit status reported when the deadline fires. */
+	public const TIMEOUT_EXIT_CODE = 124;
+
+	/** Whether the watchdog is armed. */
+	private static bool $armed = false;
+
+	/** Whether the deadline fired and termination started. */
+	private static bool $terminating = false;
+
+	/** Armed budget in seconds. */
+	private static int $deadline_seconds = 0;
+
+	/** Grace in seconds before escalating to SIGKILL. */
+	private static int $grace_seconds = self::HARD_KILL_GRACE_SECONDS;
+
+	/** Previous SIGALRM handler. */
+	private static mixed $previous_handler = null;
+
+	/** Previous asynchronous-signal mode. */
+	private static bool $previous_async_signals = false;
+
+	/**
+	 * Arm the watchdog for a wall-clock budget.
+	 *
+	 * @param int $seconds       Deadline in seconds.
+	 * @param int $grace_seconds Grace in seconds before escalating to SIGKILL.
+	 * @return bool True when the watchdog is armed.
+	 */
+	public static function arm( int $seconds, int $grace_seconds = self::HARD_KILL_GRACE_SECONDS ): bool {
+		if ( self::$armed || $seconds <= 0 ) {
+			return false;
+		}
+
+		if ( ! function_exists( 'pcntl_alarm' ) || ! function_exists( 'pcntl_signal' ) || ! function_exists( 'pcntl_async_signals' ) ) {
+			return false;
+		}
+
+		$pending_alarm = pcntl_alarm( 0 );
+		if ( $pending_alarm > 0 ) {
+			pcntl_alarm( $pending_alarm );
+			return false;
+		}
+
+		self::$deadline_seconds       = $seconds;
+		self::$grace_seconds          = max( 1, $grace_seconds );
+		self::$previous_handler       = function_exists( 'pcntl_signal_get_handler' ) ? pcntl_signal_get_handler( SIGALRM ) : SIG_DFL;
+		self::$previous_async_signals = pcntl_async_signals();
+		self::$armed                  = true;
+
+		pcntl_async_signals( true );
+		pcntl_signal( SIGALRM, array( self::class, 'check' ) );
+		pcntl_alarm( $seconds );
+
+		return true;
+	}
+
+	/**
+	 * Alarm callback. The first fire terminates with the timeout status; a
+	 * later fire during a trapped exit escalates to SIGKILL.
+	 */
+	public static function check(): void {
+		if ( ! self::$armed ) {
+			return;
+		}
+
+		if ( ! self::$terminating ) {
+			self::$terminating = true;
+			pcntl_alarm( self::$grace_seconds );
+
+			$message = sprintf(
+				'Data Machine worker exceeded its %d second time limit; forcing process exit.',
+				self::$deadline_seconds
+			);
+
+			if ( class_exists( 'WP_CLI' ) ) {
+				\WP_CLI::warning( $message );
+			} else {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- STDERR is the process diagnostic stream, not a filesystem path; WP_Filesystem cannot write to it, and this runs from a signal handler where WP_CLI is unavailable.
+				fwrite( STDERR, 'Warning: ' . $message . PHP_EOL );
+			}
+
+			exit( self::TIMEOUT_EXIT_CODE ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Integer process exit status.
+		}
+
+		$pid = getmypid();
+		if ( function_exists( 'posix_kill' ) && false !== $pid ) {
+			posix_kill( $pid, SIGKILL );
+		}
+
+		exit( self::TIMEOUT_EXIT_CODE + 1 ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Integer process exit status.
+	}
+
+	/**
+	 * Disarm the watchdog and restore the caller's signal state.
+	 */
+	public static function disarm(): void {
+		if ( ! self::$armed ) {
+			return;
+		}
+
+		pcntl_alarm( 0 );
+		pcntl_signal( SIGALRM, self::$previous_handler ?? SIG_DFL );
+		pcntl_async_signals( self::$previous_async_signals );
+		self::$armed                  = false;
+		self::$terminating            = false;
+		self::$deadline_seconds       = 0;
+		self::$grace_seconds          = self::HARD_KILL_GRACE_SECONDS;
+		self::$previous_handler       = null;
+		self::$previous_async_signals = false;
+	}
+}

--- a/tests/worker-cli-smoke.php
+++ b/tests/worker-cli-smoke.php
@@ -56,6 +56,7 @@ assert_worker_contains( 'stop_on_pending_actions', $worker_src, 'worker can stop
 assert_worker_contains( 'max_passes', $worker_src, 'worker supports bounded pass counts' );
 assert_worker_contains( 'stop_before_timeout', $worker_src, 'worker exits before external supervisor timeouts' );
 assert_worker_contains( 'drain_time_limit', $worker_src, 'worker bounds each drain pass' );
+assert_worker_contains( 'WorkerProcessDeadline::arm( $time_limit )', $worker_src, 'worker enforces its time limit at the process level' );
 assert_worker_contains( '[--mode=<mode>]', $worker_src, 'worker exposes execution mode option' );
 assert_worker_contains( '[--job-step-budget=<number>]', $worker_src, 'worker exposes per-job step budget option' );
 assert_worker_contains( "'mode'                    => isset( \$assoc_args['mode'] )", $worker_src, 'worker passes mode option into run loop' );

--- a/tests/worker-process-exit-smoke.php
+++ b/tests/worker-process-exit-smoke.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Process-level exit coverage for the Data Machine worker deadline guard.
+ *
+ * Run with: php tests/worker-process-exit-smoke.php
+ *
+ * `worker run` already bounds its work loop, but `--once` and `--time-limit`
+ * are process-level promises (see issue #3431): after a terminal pass the
+ * process must exit, and the wall-clock budget must terminate a hung pass or
+ * shutdown path without an external kill. This smoke test arms the same
+ * WorkerProcessDeadline guard the CLI command arms, models both failure shapes
+ * in child processes, and asserts each child terminates within a bound.
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+	$worker_command_file = __DIR__ . '/../inc/Cli/Commands/WorkerCommand.php';
+	$deadline_file       = __DIR__ . '/../inc/Cli/WorkerProcessDeadline.php';
+	$worker_src          = file_get_contents( $worker_command_file ) ?: '';
+	$deadline_src        = file_get_contents( $deadline_file ) ?: '';
+
+	$assertions = 0;
+
+	$assert_true = static function ( bool $condition, string $message ): void {
+		global $assertions;
+		++$assertions;
+		if ( ! $condition ) {
+			fwrite( STDERR, "FAIL: {$message}\n" );
+			exit( 1 );
+		}
+	};
+
+	$assert_contains = static function ( string $needle, string $haystack, string $message ) use ( $assert_true ): void {
+		$assert_true( false !== strpos( $haystack, $needle ), $message );
+	};
+
+	$assert_contains( 'WorkerProcessDeadline::arm( $time_limit )', $worker_src, 'worker arms the process deadline for its time limit' );
+	$assert_contains( 'if ( $time_limit > 0 )', $worker_src, 'worker only arms the deadline when a time limit is configured' );
+	$assert_contains( 'pcntl_alarm', $deadline_src, 'deadline guard enforces its bound with a process alarm' );
+	$assert_contains( 'SIGKILL', $deadline_src, 'deadline guard escalates when its first exit is trapped' );
+
+	$mode = $argv[1] ?? '';
+	if ( ! in_array( $mode, array( 'once', 'time-limit', 'normal' ), true ) ) {
+		$run_child = static function ( string $child_mode, int $expected_exit, float $bound_seconds ) use ( $assert_true ): void {
+			$started_at = microtime( true );
+			$process    = proc_open(
+				array( PHP_BINARY, __FILE__, $child_mode ),
+				array(
+					1 => array( 'pipe', 'w' ),
+					2 => array( 'pipe', 'w' ),
+				),
+				$pipes
+			);
+			$assert_true( is_resource( $process ), "child process {$child_mode} started." );
+
+			$status = array( 'running' => true );
+			while ( $status['running'] ) {
+				$status = proc_get_status( $process );
+				if ( $status['running'] ) {
+					$assert_true( microtime( true ) - $started_at <= $bound_seconds, "child process {$child_mode} terminated within {$bound_seconds} seconds without an external kill." );
+					usleep( 50000 );
+				}
+			}
+
+			$assert_true( $expected_exit === $status['exitcode'], "child process {$child_mode} exited with status {$expected_exit}." );
+			stream_get_contents( $pipes[1] );
+			stream_get_contents( $pipes[2] );
+			fclose( $pipes[1] );
+			fclose( $pipes[2] );
+			proc_close( $process );
+		};
+
+		if ( ! function_exists( 'pcntl_alarm' ) ) {
+			echo "SKIP ({$assertions} assertions; pcntl unavailable, loop-level bounds unchanged)\n";
+			exit( 0 );
+		}
+
+		$run_child( 'once', 124, 8.0 );
+		$run_child( 'time-limit', 124, 8.0 );
+		$run_child( 'normal', 0, 8.0 );
+
+		echo "OK ({$assertions} assertions)\n";
+		exit( 0 );
+	}
+
+	define( 'ABSPATH', __DIR__ . '/../' );
+	require_once __DIR__ . '/../inc/Cli/WorkerProcessDeadline.php';
+
+	if ( 'once' === $mode ) {
+		// The observed #3431 failure: the terminal summary is printed, then the
+		// shutdown path never returns.
+		\DataMachine\Cli\WorkerProcessDeadline::arm( 1, 2 );
+		echo "passes 1 stop_reason once\n";
+		register_shutdown_function(
+			static function (): void {
+				$started_at = microtime( true );
+				while ( microtime( true ) - $started_at < 60 ) {
+					// Model the unreleased shutdown-path handle.
+				}
+			}
+		);
+		exit( 0 );
+	}
+
+	if ( 'time-limit' === $mode ) {
+		// A pass that ignores every cooperative bound and burns CPU.
+		\DataMachine\Cli\WorkerProcessDeadline::arm( 1, 2 );
+		echo "pass\n";
+		while ( true ) {
+			// Model a non-terminating work loop.
+		}
+	}
+
+	\DataMachine\Cli\WorkerProcessDeadline::arm( 30, 2 );
+	echo "ok\n";
+	exit( 0 );
+}


### PR DESCRIPTION
Closes #3431.

## Problem

`worker run --once --time-limit=60` prints its terminal summary at 48s and then never exits:

```
passes  duration_seconds  stop_reason  action_completions  pending_jobs
1       48                once         1                   420
```

Ten minutes later it is still resident and still burning CPU, with no progress — pending jobs unchanged at 420 across the whole window. It only stops when killed.

The loop-level bounds correctly stop the *work*. Nothing bounds the *process*, so a hung drain pass, output step, or shutdown callback keeps it alive indefinitely.

This is load-bearing, because the remedy Data Machine itself recommends for a starved scheduler is running this command on a cadence:

```json
"condition": "scheduler_dispatcher_starved",
"recommendation": { "code": "run_supported_worker",
                    "command": "wp datamachine worker run --once" }
```

A command that never returns cannot be scheduled. Under any "skip if the previous run is still going" supervisor it runs exactly once and never again, while the orphan accumulates CPU. On the affected host that left 427 pending jobs undrained, the oldest from 2026-05-10.

## Change

`WorkerProcessDeadline` arms a SIGALRM watchdog for the configured budget:

- On fire: warn and `exit(124)`, the conventional timeout status.
- If that exit is trapped by a hung shutdown path, a short follow-up alarm escalates to `SIGKILL`, so the bound holds even when the exit itself is blocked. This is the observed failure mode — the summary had already printed, so the hang was *after* the loop finished.
- Restores the caller's previous SIGALRM handler and async-signal mode on disarm.
- Refuses to arm over a pending alarm rather than clobbering another owner's.
- No-ops when `pcntl` is unavailable; existing loop-level bounds are unchanged.

Armed only when `--time-limit > 0`, preserving the documented `0 means no time limit`.

## Test

`tests/worker-process-exit-smoke.php` re-executes itself as child processes modelling both real failure shapes, and asserts each terminates **on its own** within 8s with status 124:

- `once` — prints the terminal summary, then a `register_shutdown_function` that spins for 60s. This is the observed #3431 hang: work finished, shutdown never returns.
- `time-limit` — a non-terminating work loop that ignores every cooperative bound.

I verified the behavioural assertions are meaningful rather than shape checks by running the identical hang with **no guard armed**:

```
$ timeout 12 php control_no_guard.php     # same shutdown-spin, no deadline
elapsed=12s rc=124                        # never self-terminated; killed externally
```

With the guard the equivalent child exits by itself in under 8 seconds. So the guard is demonstrably what produces the bound.

The suite skips cleanly with a reported reason on hosts without `pcntl`.

## Verification

```
worker-process-exit-smoke   OK (42 assertions)
worker-cli-smoke            OK (55 assertions)
worker-lock-smoke           OK (33 assertions)
job-liveness-cli-smoke      26 assertions, 0 failures
```

## Reviewer notes

Two things worth your judgement:

1. The new test mixes real behavioural coverage with a few source-text `assert_contains` checks (and adds one to `worker-cli-smoke.php`). The child-process assertions are the ones carrying the weight; the string checks are weaker and I am happy to drop them if you would rather not have shape assertions in the suite.
2. This bounds the process, which is what the issue asked for. It does **not** explain why the pass was spinning without progress in the first place. That underlying behaviour may deserve its own investigation — the guard turns an unbounded hang into a clean, observable `124`, which should make it far easier to catch.

## Provenance

Drafted by `homeboy agent-task fanout cook-batch` (OpenCode, glm-5.3). The cook exited without promoting, so I reviewed the diff, proved the behavioural boundary with the no-guard control above, ran the surrounding suites, and shipped it deliberately.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code; patch drafted by OpenCode (glm-5.3) under `homeboy agent-task cook-batch`
- **Used for:** I diagnosed and filed the underlying issue from a live host, cooked the fix, then reviewed the patch, verified the guard is what bounds the process, ran the gates, and wrote this description. Reviewed by me before opening.
