### PR TITLE
Store multiple named HTTP Basic credentials per install

### DIFF
--- a/inc/Core/OAuth/HttpBasicAuthProvider.php
+++ b/inc/Core/OAuth/HttpBasicAuthProvider.php
@@ -83,12 +83,13 @@ final class HttpBasicAuthProvider extends BaseAuthProvider {
 		}
 
 		$accounts             = $this->stored_accounts( $context, false );
-		$accounts[ $account ] = $this->encrypt_account(
+		$accounts[ $account ] = $this->map_account_secrets(
 			array(
 				'username'  => (string) ( $data['username'] ?? '' ),
 				'password'  => (string) ( $data['password'] ?? '' ),
 				'proxy_url' => trim( (string) ( $data['proxy_url'] ?? '' ) ),
-			)
+			),
+			true
 		);
 
 		return parent::save_config( array( 'accounts' => $accounts ), $context );
@@ -184,7 +185,7 @@ final class HttpBasicAuthProvider extends BaseAuthProvider {
 				'proxy_url' => trim( (string) ( $config['proxy_url'] ?? '' ) ),
 			);
 
-			return array( $legacy_account => $decrypt ? $legacy : $this->encrypt_account( $legacy ) );
+			return array( $legacy_account => $decrypt ? $legacy : $this->map_account_secrets( $legacy, true ) );
 		}
 
 		$accounts = array();
@@ -192,43 +193,34 @@ final class HttpBasicAuthProvider extends BaseAuthProvider {
 			if ( ! is_array( $credential ) ) {
 				continue;
 			}
-			$accounts[ (string) $name ] = $decrypt ? $this->decrypt_account( $credential ) : $credential;
+			$accounts[ (string) $name ] = $decrypt ? $this->map_account_secrets( $credential, false ) : $credential;
 		}
 
 		return $accounts;
 	}
 
 	/**
-	 * Encrypt the secret fields of a single account entry.
+	 * Map the secret fields of a single account entry through the base encrypt or decrypt pass.
 	 *
-	 * @param array $credential Plaintext account entry.
+	 * The base helpers only walk top-level string keys, so an account nested under `accounts`
+	 * has to be handed to them one field at a time; doing that in one place keeps the two
+	 * directions from drifting apart.
+	 *
+	 * @param array $credential Account entry.
+	 * @param bool  $encrypt    True to encrypt, false to decrypt.
 	 * @return array<string, string>
 	 */
-	private function encrypt_account( array $credential ): array {
+	private function map_account_secrets( array $credential, bool $encrypt ): array {
 		foreach ( self::ACCOUNT_SECRET_FIELDS as $field ) {
 			$value = (string) ( $credential[ $field ] ?? '' );
 			if ( '' === $value ) {
 				continue;
 			}
-			$credential[ $field ] = $this->encrypt_fields( array( $field => $value ) )[ $field ] ?? $value;
-		}
 
-		return $credential;
-	}
-
-	/**
-	 * Decrypt the secret fields of a single account entry.
-	 *
-	 * @param array $credential Stored account entry.
-	 * @return array<string, string>
-	 */
-	private function decrypt_account( array $credential ): array {
-		foreach ( self::ACCOUNT_SECRET_FIELDS as $field ) {
-			$value = (string) ( $credential[ $field ] ?? '' );
-			if ( '' === $value ) {
-				continue;
-			}
-			$credential[ $field ] = $this->decrypt_fields( array( $field => $value ) )[ $field ] ?? $value;
+			$mapped               = $encrypt
+				? $this->encrypt_fields( array( $field => $value ) )
+				: $this->decrypt_fields( array( $field => $value ) );
+			$credential[ $field ] = $mapped[ $field ] ?? $value;
 		}
 
 		return $credential;

--- a/inc/Core/OAuth/HttpBasicAuthProvider.php
+++ b/inc/Core/OAuth/HttpBasicAuthProvider.php
@@ -10,11 +10,19 @@ namespace DataMachine\Core\OAuth;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Stores one named HTTP Basic credential as an encrypted Data Machine auth ref.
+ * Stores named HTTP Basic credentials as encrypted Data Machine auth refs.
+ *
+ * One provider, many accounts: `http_basic:logstash` and `http_basic:matticspace` coexist, so a
+ * second service does not evict the first. Accounts are the "which credential" axis and are
+ * distinct from principal scoping, which is the "whose credential" axis the base class already
+ * provides -- both apply, and a user-scoped config holds its own account set.
  */
 final class HttpBasicAuthProvider extends BaseAuthProvider {
 
 	public const PROVIDER_SLUG = 'http_basic';
+
+	/** Per-account fields that must never be stored in the clear. */
+	private const ACCOUNT_SECRET_FIELDS = array( 'password' );
 
 	public function __construct() {
 		parent::__construct( self::PROVIDER_SLUG );
@@ -29,7 +37,7 @@ final class HttpBasicAuthProvider extends BaseAuthProvider {
 				'label'       => __( 'Account', 'data-machine' ),
 				'type'        => 'text',
 				'required'    => true,
-				'description' => __( 'Local auth ref account name, for example logstash.', 'data-machine' ),
+				'description' => __( 'Local auth ref account name, for example logstash. Configuring a new name adds a credential; reusing a name replaces that one.', 'data-machine' ),
 			),
 			'username'  => array(
 				'label'    => __( 'Username', 'data-machine' ),
@@ -51,21 +59,51 @@ final class HttpBasicAuthProvider extends BaseAuthProvider {
 	}
 
 	/**
-	 * Whether a usable credential is stored.
+	 * Whether at least one usable credential is stored.
 	 */
 	public function is_authenticated(): bool {
-		$config = $this->get_config();
-		return ! empty( $config['account'] ) && ! empty( $config['username'] ) && ! empty( $config['password'] );
+		return array() !== $this->stored_accounts();
+	}
+
+	/**
+	 * Merge a submitted credential into the account set rather than replacing it.
+	 *
+	 * The base implementation writes the whole config blob, which for this provider would mean
+	 * configuring a second service silently deleted the first. Each account is encrypted here
+	 * because the base encrypt pass only walks top-level string fields and would leave passwords
+	 * nested inside the account map in the clear.
+	 *
+	 * @param array $data    Submitted config; an `account` key selects which credential to write.
+	 * @param array $context Optional principal context.
+	 */
+	public function save_config( array $data, array $context = array() ): bool {
+		$account = trim( (string) ( $data['account'] ?? '' ) );
+		if ( '' === $account ) {
+			return parent::save_config( $data, $context );
+		}
+
+		$accounts             = $this->stored_accounts( $context, false );
+		$accounts[ $account ] = $this->encrypt_account(
+			array(
+				'username'  => (string) ( $data['username'] ?? '' ),
+				'password'  => (string) ( $data['password'] ?? '' ),
+				'proxy_url' => trim( (string) ( $data['proxy_url'] ?? '' ) ),
+			)
+		);
+
+		return parent::save_config( array( 'accounts' => $accounts ), $context );
 	}
 
 	/**
 	 * Resolve http_basic:<account> into HttpClient auth/proxy options.
 	 */
 	public function resolve_auth_ref( string $account, string $handler_slug = '', array $context = array() ): array|\WP_Error {
-		unset( $handler_slug, $context );
+		unset( $handler_slug );
 
-		$config = $this->get_config();
-		if ( (string) ( $config['account'] ?? '' ) !== $account || empty( $config['username'] ) || empty( $config['password'] ) ) {
+		$accounts   = $this->stored_accounts( $context );
+		$credential = $accounts[ $account ] ?? null;
+
+		if ( ! is_array( $credential ) || empty( $credential['username'] ) || empty( $credential['password'] ) ) {
 			return new \WP_Error(
 				'auth_ref_unresolved',
 				sprintf(
@@ -79,15 +117,120 @@ final class HttpBasicAuthProvider extends BaseAuthProvider {
 		$resolved = array(
 			'auth' => array(
 				'type'     => 'basic',
-				'username' => (string) $config['username'],
-				'password' => (string) $config['password'],
+				'username' => (string) $credential['username'],
+				'password' => (string) $credential['password'],
 			),
 		);
 
-		if ( ! empty( $config['proxy_url'] ) ) {
-			$resolved['proxy_url'] = (string) $config['proxy_url'];
+		if ( ! empty( $credential['proxy_url'] ) ) {
+			$resolved['proxy_url'] = (string) $credential['proxy_url'];
 		}
 
 		return $resolved;
+	}
+
+	/**
+	 * Account names that currently hold a usable credential.
+	 *
+	 * @param array $context Optional principal context.
+	 * @return string[]
+	 */
+	public function get_account_names( array $context = array() ): array {
+		return array_keys( $this->stored_accounts( $context ) );
+	}
+
+	/**
+	 * Remove one stored credential. Returns false when the account does not exist.
+	 *
+	 * @param string $account Account name to remove.
+	 * @param array  $context Optional principal context.
+	 */
+	public function delete_account( string $account, array $context = array() ): bool {
+		$accounts = $this->stored_accounts( $context, false );
+		if ( ! isset( $accounts[ $account ] ) ) {
+			return false;
+		}
+
+		unset( $accounts[ $account ] );
+
+		return parent::save_config( array( 'accounts' => $accounts ), $context );
+	}
+
+	/**
+	 * The stored account map, reading the pre-multi-account shape when that is what is there.
+	 *
+	 * Installs configured before this change hold a single flat credential alongside the account
+	 * name it was given. Presenting it as a one-entry map means those installs keep resolving
+	 * without a migration step, and the next save rewrites them into the map.
+	 *
+	 * @param array $context Optional principal context.
+	 * @param bool  $decrypt Whether to decrypt secrets; false when reading for a re-save.
+	 * @return array<string, array<string, string>>
+	 */
+	private function stored_accounts( array $context = array(), bool $decrypt = true ): array {
+		$config = $this->get_config( $context );
+		$stored = $config['accounts'] ?? null;
+
+		if ( ! is_array( $stored ) ) {
+			$legacy_account = trim( (string) ( $config['account'] ?? '' ) );
+			if ( '' === $legacy_account || empty( $config['username'] ) ) {
+				return array();
+			}
+
+			// get_config() already decrypted the legacy top-level password.
+			$legacy = array(
+				'username'  => (string) $config['username'],
+				'password'  => (string) ( $config['password'] ?? '' ),
+				'proxy_url' => trim( (string) ( $config['proxy_url'] ?? '' ) ),
+			);
+
+			return array( $legacy_account => $decrypt ? $legacy : $this->encrypt_account( $legacy ) );
+		}
+
+		$accounts = array();
+		foreach ( $stored as $name => $credential ) {
+			if ( ! is_array( $credential ) ) {
+				continue;
+			}
+			$accounts[ (string) $name ] = $decrypt ? $this->decrypt_account( $credential ) : $credential;
+		}
+
+		return $accounts;
+	}
+
+	/**
+	 * Encrypt the secret fields of a single account entry.
+	 *
+	 * @param array $credential Plaintext account entry.
+	 * @return array<string, string>
+	 */
+	private function encrypt_account( array $credential ): array {
+		foreach ( self::ACCOUNT_SECRET_FIELDS as $field ) {
+			$value = (string) ( $credential[ $field ] ?? '' );
+			if ( '' === $value ) {
+				continue;
+			}
+			$credential[ $field ] = $this->encrypt_fields( array( $field => $value ) )[ $field ] ?? $value;
+		}
+
+		return $credential;
+	}
+
+	/**
+	 * Decrypt the secret fields of a single account entry.
+	 *
+	 * @param array $credential Stored account entry.
+	 * @return array<string, string>
+	 */
+	private function decrypt_account( array $credential ): array {
+		foreach ( self::ACCOUNT_SECRET_FIELDS as $field ) {
+			$value = (string) ( $credential[ $field ] ?? '' );
+			if ( '' === $value ) {
+				continue;
+			}
+			$credential[ $field ] = $this->decrypt_fields( array( $field => $value ) )[ $field ] ?? $value;
+		}
+
+		return $credential;
 	}
 }

--- a/tests/http-basic-auth-provider-smoke.php
+++ b/tests/http-basic-auth-provider-smoke.php
@@ -45,6 +45,12 @@ if ( ! function_exists( 'apply_filters' ) ) {
     }
 }
 
+if ( ! function_exists( 'wp_json_encode' ) ) {
+    function wp_json_encode( mixed $data, int $flags = 0 ): string|false {
+    	return json_encode( $data, $flags );
+    }
+}
+
 if ( ! function_exists( 'is_wp_error' ) ) {
     function is_wp_error( mixed $thing ): bool {
     	return $thing instanceof \WP_Error;
@@ -70,6 +76,16 @@ require_once dirname( __DIR__ ) . '/inc/Core/OAuth/BaseAuthProvider.php';
 require_once dirname( __DIR__ ) . '/inc/Core/OAuth/HttpBasicAuthProvider.php';
 
 $provider = new HttpBasicAuthProvider();
+
+$fail = static function ( string $message ): void {
+	fwrite( fopen( 'php://stderr', 'w' ), $message . "\n" );
+	exit( 1 );
+};
+
+$stored_accounts = static function (): array {
+	return $GLOBALS['datamachine_http_basic_options']['datamachine_auth_data']['http_basic']['config']['accounts'] ?? array();
+};
+
 $provider->save_config(
 	array(
 		'account'   => 'logstash',
@@ -79,26 +95,115 @@ $provider->save_config(
 	)
 );
 
-$stored = $GLOBALS['datamachine_http_basic_options']['datamachine_auth_data']['http_basic']['config']['password'] ?? '';
+// Secrets nest one level deeper now, and the base encrypt pass only walks top-level fields --
+// so this asserts the provider encrypts each account itself rather than storing it in the clear.
+$stored = $stored_accounts()['logstash']['password'] ?? '';
 if ( ! is_string( $stored ) || ! str_starts_with( $stored, BaseAuthProvider::ENCRYPTION_PREFIX ) ) {
-	fwrite( fopen( 'php://stderr', 'w' ), "password was not encrypted at rest\n" );
-	exit( 1 );
+	$fail( 'password was not encrypted at rest' );
+}
+if ( str_contains( wp_json_encode( $GLOBALS['datamachine_http_basic_options'] ) ?: '', 'secret-password' ) ) {
+	$fail( 'plaintext password found anywhere in stored options' );
 }
 
 $resolved = $provider->resolve_auth_ref( 'logstash' );
 if ( is_wp_error( $resolved ) ) {
-	fwrite( fopen( 'php://stderr', 'w' ), "auth ref unexpectedly failed\n" );
-	exit( 1 );
+	$fail( 'auth ref unexpectedly failed' );
 }
-
 if ( 'basic' !== ( $resolved['auth']['type'] ?? '' ) || 'chubes4' !== ( $resolved['auth']['username'] ?? '' ) || 'secret-password' !== ( $resolved['auth']['password'] ?? '' ) ) {
-	fwrite( fopen( 'php://stderr', 'w' ), "auth ref did not resolve Basic credentials\n" );
-	exit( 1 );
+	$fail( 'auth ref did not resolve Basic credentials' );
+}
+if ( 'socks5://127.0.0.1:8080' !== ( $resolved['proxy_url'] ?? '' ) ) {
+	$fail( 'auth ref did not resolve proxy URL' );
 }
 
-if ( 'socks5://127.0.0.1:8080' !== ( $resolved['proxy_url'] ?? '' ) ) {
-	fwrite( fopen( 'php://stderr', 'w' ), "auth ref did not resolve proxy URL\n" );
-	exit( 1 );
+// A second account must not evict the first: this is the whole point of the change.
+$provider->save_config(
+	array(
+		'account'   => 'matticspace',
+		'username'  => 'chubes',
+		'password'  => 'other-password',
+		'proxy_url' => 'socks5h://127.0.0.1:8080',
+	)
+);
+
+$first = $provider->resolve_auth_ref( 'logstash' );
+if ( is_wp_error( $first ) || 'secret-password' !== ( $first['auth']['password'] ?? '' ) ) {
+	$fail( 'configuring a second account evicted the first' );
+}
+
+$second = $provider->resolve_auth_ref( 'matticspace' );
+if ( is_wp_error( $second ) || 'chubes' !== ( $second['auth']['username'] ?? '' ) || 'other-password' !== ( $second['auth']['password'] ?? '' ) ) {
+	$fail( 'second account did not resolve' );
+}
+if ( 'socks5h://127.0.0.1:8080' !== ( $second['proxy_url'] ?? '' ) ) {
+	$fail( 'second account did not keep its own proxy' );
+}
+
+$names = $provider->get_account_names();
+sort( $names );
+if ( array( 'logstash', 'matticspace' ) !== $names ) {
+	$fail( 'account listing did not report both credentials' );
+}
+
+// Re-saving an existing name replaces only that credential.
+$provider->save_config( array( 'account' => 'logstash', 'username' => 'chubes4', 'password' => 'rotated' ) );
+if ( 'rotated' !== ( $provider->resolve_auth_ref( 'logstash' )['auth']['password'] ?? '' ) ) {
+	$fail( 'rotating a credential did not take effect' );
+}
+if ( 'other-password' !== ( $provider->resolve_auth_ref( 'matticspace' )['auth']['password'] ?? '' ) ) {
+	$fail( 'rotating one credential disturbed another' );
+}
+
+if ( ! is_wp_error( $provider->resolve_auth_ref( 'never-configured' ) ) ) {
+	$fail( 'an unconfigured account resolved' );
+}
+
+if ( ! $provider->delete_account( 'matticspace' ) || $provider->delete_account( 'matticspace' ) ) {
+	$fail( 'delete_account did not report what it did' );
+}
+if ( ! is_wp_error( $provider->resolve_auth_ref( 'matticspace' ) ) ) {
+	$fail( 'deleted account still resolved' );
+}
+if ( is_wp_error( $provider->resolve_auth_ref( 'logstash' ) ) ) {
+	$fail( 'deleting one account removed another' );
+}
+
+// An install configured before multi-account support stores a flat credential. It must keep
+// resolving without a migration step, otherwise upgrading silently breaks live auth refs.
+$legacy_provider = new HttpBasicAuthProvider();
+$GLOBALS['datamachine_http_basic_options']['datamachine_auth_data']['http_basic']['config'] = array(
+	'account'   => 'legacy',
+	'username'  => 'olduser',
+	'password'  => 'legacy-password',
+	'proxy_url' => 'socks5://127.0.0.1:9999',
+);
+$legacy = $legacy_provider->resolve_auth_ref( 'legacy' );
+if ( is_wp_error( $legacy ) || 'olduser' !== ( $legacy['auth']['username'] ?? '' ) || 'legacy-password' !== ( $legacy['auth']['password'] ?? '' ) ) {
+	$fail( 'pre-multi-account credential stopped resolving' );
+}
+if ( 'socks5://127.0.0.1:9999' !== ( $legacy['proxy_url'] ?? '' ) ) {
+	$fail( 'pre-multi-account proxy stopped resolving' );
+}
+if ( array( 'legacy' ) !== $legacy_provider->get_account_names() ) {
+	$fail( 'pre-multi-account credential was not listed' );
+}
+if ( ! $legacy_provider->is_authenticated() ) {
+	$fail( 'pre-multi-account credential did not read as authenticated' );
+}
+
+// Adding an account alongside a legacy credential must carry the legacy one forward.
+$legacy_provider->save_config( array( 'account' => 'added', 'username' => 'u2', 'password' => 'p2' ) );
+if ( is_wp_error( $legacy_provider->resolve_auth_ref( 'legacy' ) ) ) {
+	$fail( 'adding an account dropped the migrated legacy credential' );
+}
+if ( 'legacy-password' !== ( $legacy_provider->resolve_auth_ref( 'legacy' )['auth']['password'] ?? '' ) ) {
+	$fail( 'migrated legacy credential lost its password' );
+}
+
+$empty = new HttpBasicAuthProvider();
+$GLOBALS['datamachine_http_basic_options']['datamachine_auth_data']['http_basic']['config'] = array();
+if ( $empty->is_authenticated() || array() !== $empty->get_account_names() ) {
+	$fail( 'an unconfigured provider reported credentials' );
 }
 
 echo "=== http-basic-auth-provider-smoke: ALL PASS ===\n";


### PR DESCRIPTION
## Summary

- `http_basic` now stores an account-keyed credential map instead of a single credential
- adds `get_account_names()` and `delete_account()`
- credentials configured before this change keep resolving with no migration step

## Problem

The provider is documented as generic, and its config field reads *"Local auth ref account name, for example logstash"* — implying many. It stored exactly one:

```php
if ( (string) ( $config['account'] ?? '' ) !== $account || ... ) {
    return new WP_Error( 'auth_ref_unresolved', ... );
}
```

`save_config()` replaced the whole blob, so configuring a second service silently evicted the first. On an install already using `http_basic:logstash`, adding `http_basic:matticspace` would have broken Logstash with no error at write time and a confusing `auth_ref_unresolved` later.

This is the "which credential" axis. It is orthogonal to the principal scoping the base class already provides, which is the "whose credential" axis — both now apply, and a user-scoped config holds its own account set.

## Encryption

`encrypt_fields()` only walks top-level string keys, so nesting credentials under `accounts` would have written every password to `wp_sitemeta` in plaintext. Each account entry is therefore encrypted explicitly by the provider on write and decrypted on read. A regression test asserts the plaintext password appears nowhere in the stored option, not merely that the expected key is enveloped.

## Compatibility

Installs holding the pre-change flat shape are read as a single-entry map, so existing auth refs resolve untouched and the next save rewrites them into the map. Covered by tests, including adding a new account alongside a legacy one.

## Verification

- `tests/http-basic-auth-provider-smoke.php` — rewritten: coexistence, rotation isolation, deletion, unconfigured lookups, legacy shape, legacy+new coexistence, and no-plaintext-at-rest
- every auth/oauth/proxy smoke in the repo re-run, all passing
- deployed to a live install and confirmed an existing `http_basic:logstash` credential still resolves against production Logstash after the storage change

## AI assistance

OpenAI gpt-5.6-sol via OpenCode found the single-credential limitation while wiring a second Matticspace-backed service, implemented the account map and per-entry encryption, and wrote the regression coverage. Chris Huber directed the work and is responsible for every line.