### PR TITLE
fix(cli): avoid WP-CLI global option collisions

### DIFF
--- a/docs/core-system/oauth-handlers.md
+++ b/docs/core-system/oauth-handlers.md
@@ -253,11 +253,11 @@ unscoped callbacks retain the site-administrator requirement.
 wp datamachine auth revoke <handler>
 
 # Per-user revoke.
-wp datamachine auth revoke <handler> --user=42
+wp datamachine auth revoke <handler> --target-user=42
 ```
 
 The pre-1.0 `auth disconnect` verb is not registered. Use `wp datamachine auth
-revoke <handler>` for site-wide credentials or add `--user=<id>` for a per-user
+revoke <handler>` for site-wide credentials or add `--target-user=<id>` for a per-user
 credential slot.
 
 Or via the abilities surface:

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -539,6 +539,9 @@ wp --user=42 datamachine auth connect google --agent=writer
 # Revoke site-wide credentials
 wp datamachine auth revoke google --yes
 
+# Revoke a user's credentials
+wp datamachine auth revoke google --target-user=42 --yes
+
 # View or save API config
 wp datamachine auth config google --show-secrets
 wp datamachine auth config reddit --client_id=xxx --client_secret=xxx
@@ -550,13 +553,13 @@ Manage chat sessions. **Since**: 0.40.0
 
 ```bash
 # List chat sessions
-wp datamachine chat list --user=1 --limit=20
+wp datamachine chat list --owner-user=1 --limit=20
 
 # Get a session with conversation
 wp datamachine chat get abc-123
 
 # Create a session
-wp datamachine chat create --user=1 --context=sidebar
+wp datamachine chat create --owner-user=1 --session-context=sidebar
 
 # Delete a session
 wp datamachine chat delete abc-123 --yes

--- a/inc/Cli/Commands/AuthCommand.php
+++ b/inc/Cli/Commands/AuthCommand.php
@@ -472,7 +472,6 @@ class AuthCommand extends BaseCommand {
 	 * @subcommand refresh
 	 */
 	public function refresh( array $args, array $assoc_args ): void {
-		$assoc_args;
 		if ( empty( $args[0] ) ) {
 			WP_CLI::error( 'Handler slug is required. Use "wp datamachine auth status" to see available providers.' );
 			return;
@@ -521,8 +520,6 @@ class AuthCommand extends BaseCommand {
 	 * @subcommand refresh-all
 	 */
 	public function refresh_all( array $args, array $assoc_args ): void {
-		$args;
-		$assoc_args;
 		$providers = $this->abilities->getAllProviders();
 
 		if ( empty( $providers ) ) {
@@ -535,6 +532,10 @@ class AuthCommand extends BaseCommand {
 		$failed    = 0;
 
 		foreach ( $providers as $key => $provider ) {
+			if ( ! is_object( $provider ) ) {
+				++$skipped;
+				continue;
+			}
 			$authenticated = method_exists( $provider, 'is_authenticated' ) && $provider->is_authenticated();
 			$can_refresh   = method_exists( $provider, 'get_valid_access_token' );
 
@@ -588,6 +589,9 @@ class AuthCommand extends BaseCommand {
 		$items = array();
 
 		foreach ( $providers as $key => $provider ) {
+			if ( ! is_object( $provider ) ) {
+				continue;
+			}
 			$authenticated = method_exists( $provider, 'is_authenticated' ) ? $provider->is_authenticated() : false;
 			$configured    = method_exists( $provider, 'is_configured' ) ? $provider->is_configured() : false;
 			$is_oauth      = method_exists( $provider, 'get_authorization_url' );
@@ -647,6 +651,10 @@ class AuthCommand extends BaseCommand {
 		}
 
 		$provider      = $auth_status['provider'];
+		if ( ! is_object( $provider ) ) {
+			WP_CLI::error( sprintf( 'Auth provider "%s" is invalid.', $handler_slug ) );
+			return;
+		}
 		$authenticated = $auth_status['authenticated'];
 		$configured    = method_exists( $provider, 'is_configured' ) ? $provider->is_configured() : false;
 		$is_oauth      = method_exists( $provider, 'get_authorization_url' );
@@ -687,7 +695,7 @@ class AuthCommand extends BaseCommand {
 				}
 			}
 
-			WP_CLI::log( wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			WP_CLI::log( (string) wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 			return;
 		}
 
@@ -961,7 +969,7 @@ class AuthCommand extends BaseCommand {
 		}
 
 		WP_CLI::log( '' );
-		$cli_key_example = str_replace( '_', '-', array_key_first( $config_fields ) );
+		$cli_key_example = str_replace( '_', '-', (string) array_key_first( $config_fields ) );
 		WP_CLI::log(
 			sprintf(
 				'To update: wp datamachine auth config %s --%s=<value>',

--- a/inc/Cli/Commands/AuthCommand.php
+++ b/inc/Cli/Commands/AuthCommand.php
@@ -650,7 +650,7 @@ class AuthCommand extends BaseCommand {
 			return;
 		}
 
-		$provider      = $auth_status['provider'];
+		$provider = $auth_status['provider'];
 		if ( ! is_object( $provider ) ) {
 			WP_CLI::error( sprintf( 'Auth provider "%s" is invalid.', $handler_slug ) );
 			return;

--- a/inc/Cli/Commands/AuthCommand.php
+++ b/inc/Cli/Commands/AuthCommand.php
@@ -154,8 +154,8 @@ class AuthCommand extends BaseCommand {
 	/**
 	 * Revoke authentication for a handler at site or per-user scope.
 	 *
-	 * Without --user, behaves like `disconnect` — clears the shared
-	 * site-wide account slot. With --user=<id>, clears only that user's
+	 * Without --target-user, behaves like `disconnect` — clears the shared
+	 * site-wide account slot. With --target-user=<id>, clears only that user's
 	 * per-user credential slot via the BaseAuthProvider per-user API.
 	 *
 	 * Providers that expose an upstream revoke endpoint are called first,
@@ -168,7 +168,7 @@ class AuthCommand extends BaseCommand {
 	 * <handler_slug>
 	 * : Handler to revoke (e.g., a registered handler slug).
 	 *
-	 * [--user=<id>]
+	 * [--target-user=<id>]
 	 * : Target user ID. When provided, revokes only that user's per-user
 	 *   credentials. When omitted, revokes the site-wide account.
 	 *
@@ -181,7 +181,7 @@ class AuthCommand extends BaseCommand {
 	 *     wp datamachine auth revoke <handler>
 	 *
 	 *     # Revoke a specific user's per-user credentials.
-	 *     wp datamachine auth revoke <handler> --user=42
+	 *     wp datamachine auth revoke <handler> --target-user=42
 	 *
 	 * @subcommand revoke
 	 */
@@ -198,7 +198,7 @@ class AuthCommand extends BaseCommand {
 			return;
 		}
 
-		$user_id = isset( $assoc_args['user'] ) ? absint( $assoc_args['user'] ) : 0;
+		$user_id = isset( $assoc_args['target-user'] ) ? absint( $assoc_args['target-user'] ) : 0;
 		$message = '';
 
 		// Per-user revoke path.

--- a/inc/Cli/Commands/ChatCommand.php
+++ b/inc/Cli/Commands/ChatCommand.php
@@ -25,14 +25,14 @@ class ChatCommand extends BaseCommand {
 	 * Pipeline transcript sessions (mode='pipeline') are hidden from the
 	 * default listing because they're forensic captures of AI conversation
 	 * loops, not human chats. Use --include-transcripts to include them, or
-	 * --context=pipeline to list only pipeline-mode sessions.
+	 * --session-context=pipeline to list only pipeline-mode sessions.
 	 *
 	 * ## OPTIONS
 	 *
-	 * [--user=<id>]
+	 * [--owner-user=<id>]
 	 * : User ID to list sessions for. Defaults to current user.
 	 *
-	 * [--context=<type>]
+	 * [--session-context=<type>]
 	 * : Filter by execution context (chat, pipeline, system). When set, the
 	 *   --include-transcripts flag is implicitly on for pipeline contexts.
 	 *
@@ -69,19 +69,19 @@ class ChatCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     # List human chat sessions for user 1 (transcripts hidden)
-	 *     wp datamachine chat list --user=1
+	 *     wp datamachine chat list --owner-user=1
 	 *
 	 *     # List chat-context sessions explicitly
-	 *     wp datamachine chat list --user=1 --context=chat
+	 *     wp datamachine chat list --owner-user=1 --session-context=chat
 	 *
 	 *     # Include pipeline transcripts in the list
-	 *     wp datamachine chat list --user=1 --include-transcripts
+	 *     wp datamachine chat list --owner-user=1 --include-transcripts
 	 *
 	 *     # List only pipeline transcripts
-	 *     wp datamachine chat list --user=1 --context=pipeline
+	 *     wp datamachine chat list --owner-user=1 --session-context=pipeline
 	 *
 	 *     # Get session IDs only
-	 *     wp datamachine chat list --user=1 --format=ids
+	 *     wp datamachine chat list --owner-user=1 --format=ids
 	 *
 	 * @subcommand list
 	 */
@@ -89,7 +89,7 @@ class ChatCommand extends BaseCommand {
 		$user_id = $this->get_user_id( $assoc_args );
 		$limit   = min( 100, max( 1, (int) ( $assoc_args['limit'] ?? 20 ) ) );
 		$offset  = max( 0, (int) ( $assoc_args['offset'] ?? 0 ) );
-		$context = ! empty( $assoc_args['context'] ) ? sanitize_text_field( $assoc_args['context'] ) : null;
+		$context = ! empty( $assoc_args['session-context'] ) ? sanitize_text_field( $assoc_args['session-context'] ) : null;
 
 		$include_transcripts = isset( $assoc_args['include-transcripts'] );
 
@@ -98,7 +98,7 @@ class ChatCommand extends BaseCommand {
 		$total    = $chat_db->get_user_session_count( $user_id, $context );
 
 		// Hide pipeline transcripts unless explicitly opted in or filtered to.
-		// When the caller passes an explicit --context, they've already chosen
+		// When the caller passes an explicit --session-context, they've already chosen
 		// what they want — don't second-guess them.
 		if ( null === $context && ! $include_transcripts ) {
 			$filtered = array_values(
@@ -177,7 +177,7 @@ class ChatCommand extends BaseCommand {
 	 * <session_id>
 	 * : Session ID to retrieve.
 	 *
-	 * [--user=<id>]
+	 * [--owner-user=<id>]
 	 * : User ID for ownership verification. Defaults to current user.
 	 *
 	 * [--format=<format>]
@@ -268,13 +268,13 @@ class ChatCommand extends BaseCommand {
 	 *
 	 * ## OPTIONS
 	 *
-	 * [--user=<id>]
+	 * [--owner-user=<id>]
 	 * : User ID who owns the session. Defaults to current user.
 	 *
 	 * [--agent-id=<id>]
 	 * : First-class agent ID for this session.
 	 *
-	 * [--context=<type>]
+	 * [--session-context=<type>]
 	 * : Execution context (chat, pipeline, system).
 	 * ---
 	 * default: chat
@@ -289,15 +289,15 @@ class ChatCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     # Create a session for user 1
-	 *     wp datamachine chat create --user=1
+	 *     wp datamachine chat create --owner-user=1
 	 *
 	 *     # Create a session with agent ID
-	 *     wp datamachine chat create --user=1 --agent-id=5
+	 *     wp datamachine chat create --owner-user=1 --agent-id=5
 	 */
 	public function create( array $args, array $assoc_args ): void {
 		$user_id  = $this->get_user_id( $assoc_args );
 		$agent_id = (int) ( $assoc_args['agent-id'] ?? 0 );
-		$context  = sanitize_text_field( $assoc_args['context'] ?? 'chat' );
+		$context  = sanitize_text_field( $assoc_args['session-context'] ?? 'chat' );
 		$source   = sanitize_text_field( $assoc_args['source'] ?? 'cli' );
 
 		$metadata = array(
@@ -326,7 +326,7 @@ class ChatCommand extends BaseCommand {
 	 * <session_id>
 	 * : Session ID to delete.
 	 *
-	 * [--user=<id>]
+	 * [--owner-user=<id>]
 	 * : User ID for ownership verification. Defaults to current user.
 	 *
 	 * [--yes]
@@ -438,14 +438,14 @@ class ChatCommand extends BaseCommand {
 	}
 
 	/**
-	 * Get user ID from args or current user.
+	 * Get the session owner ID from args or current user.
 	 *
 	 * @param array $assoc_args Command arguments.
 	 * @return int User ID.
 	 */
 	private function get_user_id( array $assoc_args ): int {
-		if ( isset( $assoc_args['user'] ) ) {
-			return (int) $assoc_args['user'];
+		if ( isset( $assoc_args['owner-user'] ) ) {
+			return (int) $assoc_args['owner-user'];
 		}
 
 		return get_current_user_id() ? get_current_user_id() : 1;

--- a/inc/Cli/Commands/EmailCommand.php
+++ b/inc/Cli/Commands/EmailCommand.php
@@ -136,7 +136,7 @@ class EmailCommand extends BaseCommand {
 	 * [--template=<id>]
 	 * : Template id resolved via the datamachine_email_templates filter at worker run time.
 	 *
-	 * [--context=<json>]
+	 * [--template-context=<json>]
 	 * : JSON-encoded context object passed to the template callable.
 	 *
 	 * [--mail-site-id=<int>]
@@ -178,7 +178,7 @@ class EmailCommand extends BaseCommand {
 	 * ## EXAMPLES
 	 *
 	 *     wp datamachine email send-queued --to=user@example.com --subject="Report" --body="<p>Hello</p>"
-	 *     wp datamachine email send-queued --to=a@x.com --subject="Digest" --template=weekly-digest --context='{"week":"2026-W14"}'
+	 *     wp datamachine email send-queued --to=a@x.com --subject="Digest" --template=weekly-digest --template-context='{"week":"2026-W14"}'
 	 *     wp datamachine email send-queued --to=a@x.com --subject="Later" --body="..." --send-at=2026-04-01T09:00:00Z
 	 *
 	 * @subcommand send-queued
@@ -211,10 +211,10 @@ class EmailCommand extends BaseCommand {
 			$input['attachments'] = array_map( 'trim', explode( ',', $assoc_args['attachments'] ) );
 		}
 
-		if ( ! empty( $assoc_args['context'] ) ) {
-			$decoded = json_decode( (string) $assoc_args['context'], true );
+		if ( ! empty( $assoc_args['template-context'] ) ) {
+			$decoded = json_decode( (string) $assoc_args['template-context'], true );
 			if ( ! is_array( $decoded ) ) {
-				WP_CLI::error( '--context must be a JSON-encoded object.' );
+				WP_CLI::error( '--template-context must be a JSON-encoded object.' );
 			}
 			$input['context'] = $decoded;
 		}

--- a/inc/Cli/Commands/EmailCommand.php
+++ b/inc/Cli/Commands/EmailCommand.php
@@ -15,10 +15,6 @@ use WP_CLI;
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
-	return;
-}
-
 class EmailCommand extends BaseCommand {
 
 	/**
@@ -451,7 +447,7 @@ class EmailCommand extends BaseCommand {
 
 		$format = $assoc_args['format'] ?? 'text';
 		if ( 'json' === $format ) {
-			WP_CLI::line( wp_json_encode( $item, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			WP_CLI::line( (string) wp_json_encode( $item, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 			return;
 		}
 
@@ -1157,16 +1153,6 @@ class EmailCommand extends BaseCommand {
 		} else {
 			WP_CLI::error( $result['error'] ?? 'Connection failed.' );
 		}
-	}
-
-	/**
-	 * Get the IMAP auth provider.
-	 *
-	 * @return object|null
-	 */
-	private function getAuthProvider(): ?object {
-		$providers = apply_filters( 'datamachine_auth_providers', array() );
-		return $providers['email_imap'] ?? null;
 	}
 
 	private function mailboxRef( array $assoc_args, bool $use_default = true ): string {

--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -1184,9 +1184,6 @@ class MemoryCommand extends BaseCommand {
 	 *   - yaml
 	 * ---
 	 *
-	 * [--quiet]
-	 * : Suppress output on success.
-	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Regenerate all composable files
@@ -1201,12 +1198,14 @@ class MemoryCommand extends BaseCommand {
 	 *     # List all sections across all composable files
 	 *     wp datamachine memory compose --list
 	 *
+	 *     # Suppress informational output with WP-CLI's global option
+	 *     wp --quiet datamachine memory compose
+	 *
 	 * @subcommand compose
 	 */
 	public function compose( array $args, array $assoc_args ): void {
 		$filename = $args[0] ?? '';
 		$list     = \WP_CLI\Utils\get_flag_value( $assoc_args, 'list', false );
-		$quiet    = \WP_CLI\Utils\get_flag_value( $assoc_args, 'quiet', false );
 
 		if ( $list ) {
 			$this->compose_list( $filename, $assoc_args );
@@ -1234,9 +1233,7 @@ class MemoryCommand extends BaseCommand {
 					WP_CLI::error( $message );
 				}
 
-				if ( ! $quiet ) {
-					WP_CLI::success( $result['message'] );
-				}
+				WP_CLI::success( $result['message'] );
 			} else {
 				// Regenerate all composable files.
 				$result = ComposableFileGenerator::regenerate_all( $context );
@@ -1247,9 +1244,7 @@ class MemoryCommand extends BaseCommand {
 					if ( isset( $file_result['blocker'] ) ) {
 						$message .= ' Blocker: ' . wp_json_encode( $file_result['blocker'], JSON_UNESCAPED_SLASHES );
 					}
-					if ( ! $quiet || empty( $file_result['success'] ) ) {
-						WP_CLI::log( sprintf( '  [%s] %s — %s', $status, $file_result['filename'], $message ) );
-					}
+					WP_CLI::log( sprintf( '  [%s] %s — %s', $status, $file_result['filename'], $message ) );
 				}
 				if ( ! $result['success'] ) {
 					if ( $monitoring ) {
@@ -1258,9 +1253,7 @@ class MemoryCommand extends BaseCommand {
 					}
 					WP_CLI::error( $result['message'] );
 				}
-				if ( ! $quiet ) {
-					WP_CLI::success( $result['message'] );
-				}
+				WP_CLI::success( $result['message'] );
 			}
 		} finally {
 			if ( $monitoring ) {

--- a/tests/cli-global-options-smoke.php
+++ b/tests/cli-global-options-smoke.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * CLI option collision and dispatch contracts.
+ *
+ * Run with: php tests/cli-global-options-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+$root = dirname( __DIR__ );
+
+$sources = array(
+	'auth revoke'        => (string) file_get_contents( $root . '/inc/Cli/Commands/AuthCommand.php' ),
+	'chat'               => (string) file_get_contents( $root . '/inc/Cli/Commands/ChatCommand.php' ),
+	'email send-queued'  => (string) file_get_contents( $root . '/inc/Cli/Commands/EmailCommand.php' ),
+	'memory compose'     => (string) file_get_contents( $root . '/inc/Cli/Commands/MemoryCommand.php' ),
+);
+$documentation = (string) file_get_contents( $root . '/docs/core-system/wp-cli.md' )
+	. (string) file_get_contents( $root . '/docs/core-system/oauth-handlers.md' );
+$global_options = array( 'user', 'context', 'quiet' );
+$failures       = array();
+$passes         = 0;
+
+$assert = static function ( bool $condition, string $message ) use ( &$failures, &$passes ): void {
+	if ( $condition ) {
+		++$passes;
+		echo "PASS: {$message}\n";
+		return;
+	}
+
+	$failures[] = $message;
+	echo "FAIL: {$message}\n";
+};
+
+foreach ( $sources as $command => $source ) {
+	preg_match_all( '/\[--([a-z0-9-]+)(?:=<[^>]+>)?\]/', $source, $matches );
+	$declared_globals = array_intersect( $global_options, $matches[1] );
+	$assert( array() === $declared_globals, "{$command} declares no WP-CLI global options" );
+}
+
+$auth  = $sources['auth revoke'];
+$chat  = $sources['chat'];
+$email = $sources['email send-queued'];
+$memory = $sources['memory compose'];
+
+$assert( str_contains( $auth, "\$assoc_args['target-user']" ), 'auth revoke receives --target-user' );
+$assert( str_contains( $chat, "\$assoc_args['owner-user']" ), 'chat commands receive --owner-user' );
+$assert( str_contains( $chat, "\$assoc_args['session-context']" ), 'chat commands receive --session-context' );
+$assert( str_contains( $email, "\$assoc_args['template-context']" ) && str_contains( $email, "\$input['context'] = \$decoded" ), 'queued email maps --template-context to the internal context payload' );
+$assert( ! str_contains( $memory, "get_flag_value( \$assoc_args, 'quiet'" ), 'memory compose relies on WP-CLI global quiet handling' );
+$assert( str_contains( $documentation, '--target-user=42' ) && str_contains( $documentation, '--owner-user=1' ) && str_contains( $documentation, '--session-context=sidebar' ), 'public CLI documentation uses renamed domain options' );
+
+if ( $failures ) {
+	echo "\nFAILED: " . count( $failures ) . " CLI global option assertions failed.\n";
+	exit( 1 );
+}
+
+echo "\nAll {$passes} CLI global option assertions passed.\n";


### PR DESCRIPTION
## Summary

- rename command-local user selectors to explicit target or owner options
- rename chat and email context inputs to domain-specific options
- rely on WP-CLI global quiet handling instead of redeclaring `--quiet`
- update examples, documentation, parsing, and collision coverage

## Verification

- `php tests/cli-global-options-smoke.php`
- PHP syntax checks for all changed command and test files

Closes #3439.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode inventoried the WP-CLI collisions, implemented the domain-specific option names and coverage, and assisted with review and verification. Chris Huber directed the work and reviewed the resulting candidate.