### PR TITLE
fix: match near-identical short colon suffixes in SimilarityEngine

### DIFF
--- a/inc/Core/Similarity/SimilarityEngine.php
+++ b/inc/Core/Similarity/SimilarityEngine.php
@@ -52,6 +52,50 @@ class SimilarityEngine {
 	const MIN_PREFIX_LENGTH = 5;
 
 	/**
+	 * Ordinal-like tokens that distinguish one instance of a series from another.
+	 *
+	 * When two colon suffixes carry different ordinal tokens they name different
+	 * occurrences ("Night One" vs "Night Two", "Stage 3" vs "Stage 4") and must
+	 * never be collapsed, no matter how close their edit distance is. Bare digits
+	 * are detected numerically rather than enumerated here.
+	 *
+	 * @var array
+	 */
+	const ORDINAL_TOKENS = array(
+		// Cardinal words.
+		'one',
+		'two',
+		'three',
+		'four',
+		'five',
+		'six',
+		'seven',
+		'eight',
+		'nine',
+		'ten',
+		// Ordinal words.
+		'first',
+		'second',
+		'third',
+		'fourth',
+		'fifth',
+		'sixth',
+		'seventh',
+		'eighth',
+		'ninth',
+		'tenth',
+		// Roman numerals (also covers single-letter series markers a/b/c via
+		// the single-character check in isOrdinalToken()).
+		'ii',
+		'iii',
+		'iv',
+		'vi',
+		'vii',
+		'viii',
+		'ix',
+	);
+
+	/**
 	 * Stop words excluded from Jaccard tokenization.
 	 *
 	 * @var array
@@ -130,7 +174,11 @@ class SimilarityEngine {
 	 * 3. Levenshtein distance (≤15% diff for titles ≥15 chars)
 	 *
 	 * Distinct meaningful suffixes on two colon-delimited titles short-circuit
-	 * this cascade with a no-match result and score 0.0. Thresholds are unchanged.
+	 * this cascade with a no-match result and score 0.0. Two suffixes are treated
+	 * as equivalent when they carry the same ordinal tokens and are within the
+	 * standard proportional edit-distance tolerance, so a typo variant such as
+	 * "Royale Finale" vs "Royal Finale" still matches while genuinely distinct
+	 * occurrences such as "Night 1" vs "Night 2" never do. Thresholds are unchanged.
 	 *
 	 * Returns a SimilarityResult with match, score, and strategy.
 	 *
@@ -155,10 +203,21 @@ class SimilarityEngine {
 			$suffix2 = preg_match( '/[a-z0-9]/i', $suffix2 ) ? $suffix2 : '';
 
 			if ( '' !== $suffix1 && '' !== $suffix2 && $suffix1 !== $suffix2 ) {
+				// Differing ordinal tokens name different occurrences of the same
+				// series. These are never duplicates regardless of edit distance,
+				// which would otherwise collapse "Night 1" and "Night 2".
+				if ( self::ordinalTokens( $suffix1 ) !== self::ordinalTokens( $suffix2 ) ) {
+					return SimilarityResult::noMatch( $core1, $core2 );
+				}
+
+				// Otherwise let proportional edit distance decide. No minimum
+				// length applies: suffixes are fragments, and most real ones are
+				// shorter than MIN_LEVENSHTEIN_LENGTH, so a length floor here
+				// would reject every near-identical short suffix outright.
+				// Proportional tolerance already collapses to zero on very short
+				// suffixes, so those still require an exact match.
 				$max_suffix_length = max( strlen( $suffix1 ), strlen( $suffix2 ) );
-				$suffixes_match    = strlen( $suffix1 ) >= self::MIN_LEVENSHTEIN_LENGTH
-					&& strlen( $suffix2 ) >= self::MIN_LEVENSHTEIN_LENGTH
-					&& levenshtein( $suffix1, $suffix2 ) <= (int) ( $max_suffix_length * self::DEFAULT_LEVENSHTEIN_TOLERANCE );
+				$suffixes_match    = levenshtein( $suffix1, $suffix2 ) <= (int) ( $max_suffix_length * self::DEFAULT_LEVENSHTEIN_TOLERANCE );
 
 				if ( ! $suffixes_match ) {
 					return SimilarityResult::noMatch( $core1, $core2 );
@@ -196,6 +255,41 @@ class SimilarityEngine {
 		}
 
 		return SimilarityResult::noMatch( $core1, $core2 );
+	}
+
+	/**
+	 * Extract the ordered list of ordinal-like tokens from a normalized suffix.
+	 *
+	 * Two suffixes carrying different ordinal sequences describe different
+	 * occurrences in a series and must not be treated as duplicates.
+	 *
+	 * @param string $suffix Normalized suffix.
+	 * @return array Ordered ordinal tokens (empty when the suffix carries none).
+	 */
+	private static function ordinalTokens( string $suffix ): array {
+		preg_match_all( '/[a-z0-9]+/', strtolower( $suffix ), $matches );
+
+		return array_values( array_filter( $matches[0], array( self::class, 'isOrdinalToken' ) ) );
+	}
+
+	/**
+	 * Determine whether a single token reads as an ordinal/series marker.
+	 *
+	 * @param string $token Lowercase alphanumeric token.
+	 * @return bool True when the token distinguishes one instance from another.
+	 */
+	private static function isOrdinalToken( string $token ): bool {
+		// Bare numbers: "1", "02", "2026".
+		if ( ctype_digit( $token ) ) {
+			return true;
+		}
+
+		// Single-letter series markers: "Set A" vs "Set B", and roman "i"/"v"/"x".
+		if ( 1 === strlen( $token ) && ctype_alpha( $token ) ) {
+			return true;
+		}
+
+		return in_array( $token, self::ORDINAL_TOKENS, true );
 	}
 
 	// -----------------------------------------------------------------------

--- a/inc/Core/Similarity/SimilarityEngine.php
+++ b/inc/Core/Similarity/SimilarityEngine.php
@@ -279,7 +279,7 @@ class SimilarityEngine {
 	 * @return bool True when the token distinguishes one instance from another.
 	 */
 	private static function isOrdinalToken( string $token ): bool {
-		// Bare numbers: "1", "02", "2026".
+		// Bare numeric tokens such as 1, 02 or 2026.
 		if ( ctype_digit( $token ) ) {
 			return true;
 		}

--- a/tests/Unit/Core/Similarity/SimilarityEngineTest.php
+++ b/tests/Unit/Core/Similarity/SimilarityEngineTest.php
@@ -252,6 +252,56 @@ class SimilarityEngineTest extends WP_UnitTestCase {
 				'Series: Advanced Programing Techniques',
 				true,
 			),
+			// Short suffixes are fragments, so no minimum length gates the
+			// near-equality check. A one-character typo still matches.
+			'close short suffix variants'          => array(
+				'Rap-A-Lot: Royale Finale',
+				'Rap-A-Lot: Royal Finale',
+				true,
+			),
+			'close short suffix variants reversed' => array(
+				'Rap-A-Lot: Royal Finale',
+				'Rap-A-Lot: Royale Finale',
+				true,
+			),
+			// Ordinal tokens name distinct occurrences and must never collapse,
+			// even when edit distance alone would allow it. Prefixes here are
+			// deliberately long: with a short prefix the whole-title Levenshtein
+			// floor rejects these incidentally, which would let the cases pass
+			// for the wrong reason and hide a regression in the ordinal guard.
+			'numeric ordinal suffixes'             => array(
+				'Charleston Music Festival: Night 1',
+				'Charleston Music Festival: Night 2',
+				false,
+			),
+			'word ordinal suffixes'                => array(
+				'Charleston Music Festival: Night One',
+				'Charleston Music Festival: Night Two',
+				false,
+			),
+			'roman numeral suffixes'               => array(
+				'Charleston Music Festival: Part II',
+				'Charleston Music Festival: Part III',
+				false,
+			),
+			'letter series suffixes'               => array(
+				'Charleston Music Festival: Stage A',
+				'Charleston Music Festival: Stage B',
+				false,
+			),
+			'ordinal present on one side only'     => array(
+				'Charleston Music Festival: Late Night',
+				'Charleston Music Festival: Late Night 2',
+				false,
+			),
+			'short ordinal suffixes'               => array( 'Fest: Stage 3', 'Fest: Stage 4', false ),
+			// Matching ordinals on both sides must not block an otherwise-close
+			// suffix pair from matching.
+			'shared ordinal with typo'             => array(
+				'Fest: Night 2 Finale',
+				'Fest: Night 2 Finalle',
+				true,
+			),
 		);
 	}
 


### PR DESCRIPTION
Fixes #3443

## Problem

`SimilarityEngine::titlesMatch()` short-circuits to `noMatch` whenever two colon-delimited titles have differing suffixes. The escape hatch for near-identical suffixes required **both** suffixes to be at least `MIN_LEVENSHTEIN_LENGTH` (15) characters:

```php
$suffixes_match = strlen( $suffix1 ) >= self::MIN_LEVENSHTEIN_LENGTH
    && strlen( $suffix2 ) >= self::MIN_LEVENSHTEIN_LENGTH
    && levenshtein( ... ) <= ...;
```

That floor is inherited from *whole-title* matching, where it exists to stop noisy edit-distance comparisons on short strings. Applied to a suffix fragment it is meaningless — most real suffixes (`Royale Finale`, `Night One`, `Late Show`) are under 15 characters — so the hatch almost never fired and the guard degraded into "colon-titled records with non-identical suffixes are never duplicates."

**Live impact.** Two scrapes of the same show published as separate events on events.extrachill.com:

| Post | Title | Organizer | Created |
|---|---|---|---|
| 255296 | `Rap-A-Lot: Royale Finale` | Sound**s** of Cannae | 2026-06-17 |
| 258008 | `Rap-A-Lot: Royal Finale` | Sound of Cannae | 2026-06-21 |

Same venue, same `2026-09-04 21:00:00` start, same lineup. Neither had a ticket URL, so the decision fell to title matching:

```
core:   "raplot royale finale" (20) vs "raplot royal finale" (19)
        levenshtein = 1, tolerance = 3   -> would have matched
suffix: "royale finale" (13) vs "royal finale" (12)
        levenshtein = 1, but both < 15   -> hard fail, cascade never runs
```

## Fix

Two parts, both load-bearing.

**1. Drop the length floor.** Suffixes are fragments; proportional tolerance already collapses to zero on very short strings, so `Day 1` vs `Day 2` still requires an exact match without needing a floor.

**2. Add an explicit ordinal guard.** Removing the floor alone introduces false positives: `Night 1` vs `Night 2` is one edit, which is *within* the 15% tolerance at that length. Ordinal protection previously came incidentally from the blanket veto, so this makes it intentional — suffixes carrying different ordinal tokens (digits, cardinal/ordinal words, roman numerals, single-letter series markers) are never duplicates regardless of edit distance.

Thresholds are unchanged. `MIN_LEVENSHTEIN_LENGTH` still gates whole-title matching.

## Verification

All 69 tests in `SimilarityEngineTest` pass, including the 12 pre-existing colon cases.

**Positive direction** — reverting the source change fails exactly the 3 new match-expected cases:
```
1) "close short suffix variants"          ('Rap-A-Lot: Royale Finale', 'Rap-A-Lot: Royal Finale', true)
2) "close short suffix variants reversed" (...)
3) "shared ordinal with typo"             ('Fest: Night 2 Finale', 'Fest: Night 2 Finalle', true)
```

**Negative direction** — stubbing out the ordinal guard fails the cases it protects:
```
1) "numeric ordinal suffixes" ('Charleston Music Festival: Night 1', '... Night 2', false)
2) "roman numeral suffixes"   ('Charleston Music Festival: Part II', '... Part III', false)
```

Note on test design: the ordinal cases deliberately use a **long** prefix. With a short prefix (`Fest: Night 1`) the whole-title Levenshtein floor rejects them incidentally, so they would pass even with the ordinal guard removed — hiding a regression. The long prefix makes them genuinely exercise the guard, which is how the second mutation run above produces failures.

End-to-end on the reported pair:
```
match => true, score => 0.95, strategy => levenshtein
```

## Blast radius

Only `titlesMatch()` changes. Consumers:

- `DuplicateCheckAbility` (lines 273, 436) — intended target, backs the `datamachine/titles-match` ability and event dedup strategies 2 and 4 in `data-machine-events`.
- `QueueValidator` — uses only `getBestSearchWord`, `tokenize`, `jaccard`, and `DEFAULT_JACCARD_THRESHOLD`. Untouched.

## Notes

- The production duplicate (post `258008`) was already removed manually; canonical `255296` retained with the fuller artist term set.
- `wp data-machine-events check quality --issue=duplicates` reports 53 probable duplicate groups across 32,014 upcoming events. This guard is one contributing cause, not all of them.
- `SimilarityEngineTest` extends `WP_UnitTestCase` but creates no fixtures and `SimilarityEngine` calls no WP functions, so it was run WP-free via a throwaway bootstrap aliasing the base to PHPUnit's `TestCase`. No test scaffolding is included in this PR.

🤖 Authored by Extra Chill Bot on Chris's behalf.