### PR TITLE
fix: drop settled-claim packets before explicit disposition routing

### DIFF
--- a/inc/Abilities/Engine/ExecuteStepAbility.php
+++ b/inc/Abilities/Engine/ExecuteStepAbility.php
@@ -1348,11 +1348,37 @@ class ExecuteStepAbility {
 		);
 	}
 
-	/** Remove terminal disposition results and exhausted identities while preserving live packets. */
+	/**
+	 * Remove terminal disposition results and settled claim identities while preserving live packets.
+	 *
+	 * A claim is settled when this reconciliation exhausted it, or when an
+	 * explicit disposition result packet (reject_source, defer_item,
+	 * defer_exhausted) resolved it. A packet carrying only settled claims has
+	 * nothing left to route. This covers the failed handler-tool `tool_result`
+	 * packet emitted before the agent explicitly rejected or deferred the same
+	 * item: the later disposition settles its claim, and leaving it routable
+	 * would push the job into `resolveTransitionRoute()` where it fails as a
+	 * missing handler packet.
+	 *
+	 * Settled identities are derived from the disposition result packets rather
+	 * than from `evidence.completed_ids`/`released_ids`, because those lists
+	 * also contain claims released by a plain failed tool result or omitted by
+	 * the agent. Such packets must stay routable so a genuine missing-handler
+	 * outcome still fails downstream instead of short-circuiting as
+	 * explicitly dispositioned.
+	 *
+	 * @see https://github.com/Extra-Chill/data-machine/issues/3444
+	 */
 	private static function filterReconciledPacketsForRouting( array $packets, array $reconciliation ): array {
-		$exhausted           = array_fill_keys( (array) ( $reconciliation['evidence']['exhausted_ids'] ?? array() ), true );
+		$settled             = array_fill_keys( (array) ( $reconciliation['evidence']['exhausted_ids'] ?? array() ), true );
 		$disposition_results = array_fill_keys( (array) ( $reconciliation['routing']['disposition_result_packet_indexes'] ?? array() ), true );
-		if ( empty( $exhausted ) && empty( $disposition_results ) ) {
+		foreach ( array_keys( $disposition_results ) as $packet_index ) {
+			$result_metadata = is_array( $packets[ $packet_index ]['metadata'] ?? null ) ? $packets[ $packet_index ]['metadata'] : array();
+			foreach ( array_keys( ProcessedItems::disposition_claims( $result_metadata ) ) as $disposition_id ) {
+				$settled[ $disposition_id ] = true;
+			}
+		}
+		if ( empty( $settled ) && empty( $disposition_results ) ) {
 			return $packets;
 		}
 
@@ -1363,12 +1389,12 @@ class ExecuteStepAbility {
 			}
 			$metadata = is_array( $packet['metadata'] ?? null ) ? $packet['metadata'] : array();
 			$claims   = ProcessedItems::disposition_claims( $metadata );
-			if ( empty( $claims ) || empty( array_intersect_key( $claims, $exhausted ) ) ) {
+			if ( empty( $claims ) || empty( array_intersect_key( $claims, $settled ) ) ) {
 				$routable[] = $packet;
 				continue;
 			}
 
-			$live = array_diff_key( $claims, $exhausted );
+			$live = array_diff_key( $claims, $settled );
 			if ( empty( $live ) ) {
 				continue;
 			}

--- a/tests/Unit/Abilities/Engine/ExecuteStepMixedClaimRoutingTest.php
+++ b/tests/Unit/Abilities/Engine/ExecuteStepMixedClaimRoutingTest.php
@@ -35,7 +35,7 @@ class ExecuteStepMixedClaimRoutingTest extends WP_UnitTestCase {
 		MixedClaimFetchStep::$packets = array();
 
 		$this->step_types_filter = static function ( array $types ): array {
-			$types['fetch'] = array(
+			$types['fetch']        = array(
 				'class'                     => MixedClaimFetchStep::class,
 				'uses_handler'              => false,
 				'source_ingestion'          => true,
@@ -43,13 +43,17 @@ class ExecuteStepMixedClaimRoutingTest extends WP_UnitTestCase {
 				'supports_item_disposition' => true,
 				'handler_category'          => 'source',
 			);
-			$types['ai'] = array(
+			$types['ai']           = array(
 				'class'        => MixedClaimAIStep::class,
 				'uses_handler' => false,
 			);
-			$types['passthrough'] = array(
+			$types['passthrough']  = array(
 				'class'        => MixedClaimFetchStep::class,
 				'uses_handler' => false,
+			);
+			$types['handler_sink'] = array(
+				'class'        => MixedClaimFetchStep::class,
+				'uses_handler' => true,
 			);
 			return $types;
 		};
@@ -340,7 +344,172 @@ class ExecuteStepMixedClaimRoutingTest extends WP_UnitTestCase {
 		$this->assertSame( 'reject_source', $this->scheduled[0]['packets'][0]['metadata']['packet_disposition'] );
 	}
 
-	private function create_job( string $step_type = 'fetch' ): int {
+	/**
+	 * Issue #3444: a failed handler-tool result must not block the explicit
+	 * disposition short-circuit when the agent subsequently rejects the item.
+	 */
+	public function test_failed_handler_tool_then_reject_terminalizes_before_handler_requiring_step(): void {
+		$job_id = $this->create_job( 'ai', 'handler_sink' );
+		$claim  = $this->claim( $job_id, 'ai-failed-then-reject', false );
+		$this->set_engine_claims( $job_id, array( $claim ) );
+		MixedClaimAIStep::$packets[ $job_id ] = array(
+			$this->failed_handler_tool_result_packet( $claim ),
+			$this->disposition_result_packet( $claim, 'reject_source' ),
+		);
+
+		$result = $this->execute( $job_id );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'packets_dispositioned', $result['outcome'] );
+		$this->assertSame( JobStatus::COMPLETED_NO_ITEMS, $result['status'] );
+		$this->assertSame( JobStatus::COMPLETED_NO_ITEMS, $this->jobs->get_job( $job_id )['status'] );
+		$this->assertSame( array(), $this->scheduled );
+		$this->assertTrue( $this->processed->has_item_been_processed( 'mixed-scope', 'mixed-source', 'ai-failed-then-reject' ) );
+		$this->assertNotSame( 'handler_requiring_step_missing_handler_packets', datamachine_get_engine_data( $job_id )['job_status_reason'] ?? '' );
+	}
+
+	/**
+	 * Issue #3444: same as above with defer_item, which releases (not completes) the claim.
+	 */
+	public function test_failed_handler_tool_then_defer_terminalizes_before_handler_requiring_step(): void {
+		$job_id = $this->create_job( 'ai', 'handler_sink' );
+		$claim  = $this->claim( $job_id, 'ai-failed-then-defer', false );
+		$this->assertSame( 1, $this->processed->record_owned_deferral_attempt( $claim, $job_id )['attempts'] );
+		$this->set_engine_claims( $job_id, array( $claim ) );
+		MixedClaimAIStep::$packets[ $job_id ] = array(
+			$this->failed_handler_tool_result_packet( $claim ),
+			$this->disposition_result_packet( $claim, 'defer_item' ),
+		);
+
+		$result = $this->execute( $job_id );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'packets_dispositioned', $result['outcome'] );
+		$this->assertSame( JobStatus::COMPLETED_NO_ITEMS, $result['status'] );
+		$this->assertSame( JobStatus::COMPLETED_NO_ITEMS, $this->jobs->get_job( $job_id )['status'] );
+		$this->assertSame( array(), $this->scheduled );
+		$evidence = datamachine_get_engine_data( $job_id )['packet_disposition_evidence'][0];
+		$this->assertSame( array( $claim['disposition_id'] ), $evidence['released_ids'] );
+		$this->assertFalse( $this->processed->has_item_been_processed( 'mixed-scope', 'mixed-source', 'ai-failed-then-defer' ) );
+	}
+
+	/**
+	 * Issue #3444: multiple rejected handler attempts before the disposition
+	 * (the most common production shape) must also short-circuit.
+	 */
+	public function test_repeated_failed_handler_tool_then_defer_terminalizes_before_handler_requiring_step(): void {
+		$job_id = $this->create_job( 'ai', 'handler_sink' );
+		$claim  = $this->claim( $job_id, 'ai-repeat-failed-then-defer', false );
+		$this->assertSame( 1, $this->processed->record_owned_deferral_attempt( $claim, $job_id )['attempts'] );
+		$this->set_engine_claims( $job_id, array( $claim ) );
+		MixedClaimAIStep::$packets[ $job_id ] = array(
+			$this->failed_handler_tool_result_packet( $claim ),
+			$this->failed_handler_tool_result_packet( $claim ),
+			$this->failed_handler_tool_result_packet( $claim ),
+			$this->disposition_result_packet( $claim, 'defer_item' ),
+		);
+
+		$result = $this->execute( $job_id );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'packets_dispositioned', $result['outcome'] );
+		$this->assertSame( JobStatus::COMPLETED_NO_ITEMS, $this->jobs->get_job( $job_id )['status'] );
+		$this->assertSame( array(), $this->scheduled );
+	}
+
+	/**
+	 * Regression guard for #3444: an AI step that only produced a summary
+	 * response (no tool call, no disposition) is an unsuccessful step and must
+	 * still fail rather than terminalize as dispositioned.
+	 */
+	public function test_ai_response_without_disposition_still_fails_handler_requiring_step(): void {
+		$job_id = $this->create_job( 'ai', 'handler_sink' );
+		$claim  = $this->claim( $job_id, 'ai-no-disposition', false );
+		$this->set_engine_claims( $job_id, array( $claim ) );
+		MixedClaimAIStep::$packets[ $job_id ] = array( $this->ai_response_packet() );
+
+		$result = $this->execute( $job_id );
+
+		$this->assertFalse( $result['step_success'] );
+		$this->assertNotSame( 'packets_dispositioned', $result['outcome'] );
+		$this->assertSame( 'ai_response_without_tool_result', $result['reason'] );
+		$this->assertSame( JobStatus::FAILED, $this->jobs->get_job( $job_id )['status'] );
+		$this->assertSame( array(), $this->scheduled );
+		$this->assertFalse( $this->processed->has_item_been_processed( 'mixed-scope', 'mixed-source', 'ai-no-disposition' ) );
+	}
+
+	/**
+	 * Regression guard for #3444: a successful non-handler tool call with no
+	 * disposition and no handler completion must still fail routing into a
+	 * handler-requiring step with the missing-handler-packet reason.
+	 */
+	public function test_successful_non_handler_tool_without_disposition_still_fails_handler_requiring_step(): void {
+		$job_id = $this->create_job( 'ai', 'handler_sink' );
+		$claim  = $this->claim( $job_id, 'ai-search-no-disposition', false );
+		$this->set_engine_claims( $job_id, array( $claim ) );
+		MixedClaimAIStep::$packets[ $job_id ] = array( $this->successful_non_handler_tool_result_packet() );
+
+		$result = $this->execute( $job_id );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertFalse( $result['step_success'] );
+		$this->assertSame( 'failed', $result['outcome'] );
+		$this->assertSame( 'handler_requiring_step_missing_handler_packets', $result['reason'] );
+		$this->assertSame( JobStatus::FAILED, $this->jobs->get_job( $job_id )['status'] );
+		$this->assertSame( array(), $this->scheduled );
+		$evidence = datamachine_get_engine_data( $job_id )['packet_disposition_evidence'][0];
+		$this->assertSame( array( $claim['disposition_id'] ), $evidence['omitted_ids'] );
+	}
+
+	/**
+	 * Regression guard for #3444: a failed handler tool whose claim was merely
+	 * released (no explicit reject/defer) must remain routable so the job still
+	 * fails as a missing handler packet. This is the case that distinguishes
+	 * "settled by a disposition result" from "present in evidence.released_ids".
+	 */
+	public function test_failed_handler_tool_without_disposition_still_fails_handler_requiring_step(): void {
+		$job_id = $this->create_job( 'ai', 'handler_sink' );
+		$claim  = $this->claim( $job_id, 'ai-failed-no-disposition', false );
+		$this->set_engine_claims( $job_id, array( $claim ) );
+		MixedClaimAIStep::$packets[ $job_id ] = array(
+			$this->successful_non_handler_tool_result_packet(),
+			$this->failed_handler_tool_result_packet( $claim ),
+		);
+
+		$result = $this->execute( $job_id );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertFalse( $result['step_success'] );
+		$this->assertSame( 'failed', $result['outcome'] );
+		$this->assertSame( 'handler_requiring_step_missing_handler_packets', $result['reason'] );
+		$this->assertSame( JobStatus::FAILED, $this->jobs->get_job( $job_id )['status'] );
+		$this->assertSame( array(), $this->scheduled );
+		$evidence = datamachine_get_engine_data( $job_id )['packet_disposition_evidence'][0];
+		$this->assertSame( array( $claim['disposition_id'] ), $evidence['released_ids'] );
+		$this->assertSame( array(), $evidence['completed_ids'] );
+		$this->assertFalse( $this->processed->has_item_been_processed( 'mixed-scope', 'mixed-source', 'ai-failed-no-disposition' ) );
+	}
+
+	/**
+	 * Regression guard for #3444: a failed handler tool alone is an unsuccessful
+	 * step and must still fail rather than terminalize as dispositioned.
+	 */
+	public function test_failed_handler_tool_alone_still_fails(): void {
+		$job_id = $this->create_job( 'ai', 'handler_sink' );
+		$claim  = $this->claim( $job_id, 'ai-failed-alone', false );
+		$this->set_engine_claims( $job_id, array( $claim ) );
+		MixedClaimAIStep::$packets[ $job_id ] = array( $this->failed_handler_tool_result_packet( $claim ) );
+
+		$result = $this->execute( $job_id );
+
+		$this->assertFalse( $result['step_success'] );
+		$this->assertNotSame( 'packets_dispositioned', $result['outcome'] );
+		$this->assertSame( 'tool_result_failed', $result['reason'] );
+		$this->assertSame( JobStatus::FAILED, $this->jobs->get_job( $job_id )['status'] );
+		$this->assertSame( array(), $this->scheduled );
+	}
+
+	private function create_job( string $step_type = 'fetch', string $sink_step_type = 'passthrough' ): int {
 		$job_id = $this->jobs->create_job(
 			array(
 				'pipeline_id' => 'direct',
@@ -368,7 +537,7 @@ class ExecuteStepMixedClaimRoutingTest extends WP_UnitTestCase {
 						),
 						'sink'   => array(
 							'flow_step_id'    => 'sink',
-							'step_type'       => 'passthrough',
+							'step_type'       => $sink_step_type,
 							'execution_order' => 1,
 							'pipeline_id'     => 'direct',
 							'flow_id'         => 'direct',
@@ -443,6 +612,87 @@ class ExecuteStepMixedClaimRoutingTest extends WP_UnitTestCase {
 			'timestamp' => time(),
 			'data'      => array( 'title' => 'Claimless packet', 'body' => 'This packet remains routable.' ),
 			'metadata'  => array( 'origin' => 'claimless' ),
+		);
+	}
+
+	/**
+	 * Mirror AIStep::processLoopResults() output for a handler tool call that
+	 * failed parameter validation: a `tool_result` packet bound to the claim
+	 * with packet_disposition 'failed'.
+	 */
+	private function failed_handler_tool_result_packet( array $claim ): array {
+		$error    = 'Tool "upsert_event" requires the following parameters: startTime.';
+		$metadata = array(
+			'tool_name'              => 'upsert_event',
+			'handler_tool'           => 'upsert_event',
+			'tool_parameters'        => array( 'disposition_id' => $claim['disposition_id'] ),
+			'tool_success'           => false,
+			'tool_failure_non_fatal' => false,
+			'tool_result_envelope'   => array(
+				'success'   => false,
+				'error'     => $error,
+				'tool_name' => 'upsert_event',
+			),
+			'source_type'            => 'mixed-source',
+			'packet_disposition'     => 'failed',
+			'disposition_id'         => $claim['disposition_id'],
+		);
+
+		$metadata[ ProcessedItems::CLAIM_METADATA_KEY ]          = $claim;
+		$metadata[ ProcessedItems::DISPOSITION_ID_METADATA_KEY ] = $claim['disposition_id'];
+
+		return array(
+			'type'      => 'tool_result',
+			'timestamp' => time(),
+			'data'      => array(
+				'title' => 'Upsert Event Result',
+				'body'  => $error,
+			),
+			'metadata'  => $metadata,
+		);
+	}
+
+	/** Mirror a successful, claimless `tool_result` from a non-handler tool (e.g. a search). */
+	private function successful_non_handler_tool_result_packet(): array {
+		return array(
+			'type'      => 'tool_result',
+			'timestamp' => time(),
+			'data'      => array(
+				'title' => 'Web Search Result',
+				'body'  => 'Found 3 results.',
+			),
+			'metadata'  => array(
+				'tool_name'              => 'web_search',
+				'handler_tool'           => null,
+				'tool_parameters'        => array( 'query' => 'event start time' ),
+				'tool_success'           => true,
+				'tool_failure_non_fatal' => false,
+				'tool_result_envelope'   => array(
+					'success' => true,
+					'data'    => array( 'results' => array() ),
+				),
+				'source_type'            => 'mixed-source',
+				'packet_disposition'     => 'succeeded',
+			),
+		);
+	}
+
+	/** Mirror the claimless `ai_response` summary packet emitted when no tool was called. */
+	private function ai_response_packet(): array {
+		return array(
+			'type'      => 'ai_response',
+			'timestamp' => time(),
+			'data'      => array(
+				'title' => 'AI Response',
+				'body'  => 'I could not find enough detail to proceed.',
+			),
+			'metadata'  => array(
+				'source_type'            => 'ai_response',
+				'flow_step_id'           => 'source',
+				'conversation_turn'      => 1,
+				'step_execution_success' => false,
+				'failure_reason'         => 'ai_response_without_tool_result',
+			),
 		);
 	}
 


### PR DESCRIPTION
Closes #3444

## Root cause

After an AI step, `ExecuteStepAbility::routeAfterExecution()` gates the `explicitly_dispositioned` short-circuit on `empty( $dataPackets )` (~L772). `$dataPackets` has just been through `filterReconciledPacketsForRouting()` (~L1352), which only removed (a) the disposition result packet itself and (b) packets whose claims were **exhausted**.

When the agent first calls the handler tool (`upsert_event`), gets a parameter-validation rejection, and *then* calls `reject_source` / `defer_item`, the failed `tool_result` packet still carries the claim. That claim was **completed** (reject) or **released** (defer) in the same reconciliation — not exhausted — so the packet survived filtering, `$dataPackets` was non-empty, the short-circuit was skipped, and `resolveTransitionRoute()` failed the job with `handler_requiring_step_missing_handler_packets` because no `ai_handler_complete` packet existed for the handler-requiring next step.

Confirmed on job 983411 (events.extrachill.com): `tool_execution_summary` = failed `upsert_event` then successful `reject_source`; AI-step `packet_disposition_evidence` shows the claim in `completed_ids`; `run_result.outputs.counts` has both `missing_handler_packet: 1` and `source_rejected: 1`. Production shape of the 134 misclassified jobs (7 days):

| shape | jobs |
|---|---|
| `upsert_event`×1..5 fail → `defer_item` | 108 |
| `upsert_event`×1..4 fail → `reject_source` | 26 |

## Fix chosen: option 1, with a precision adjustment

In `filterReconciledPacketsForRouting()`, treat a claim as **settled** when either the reconciliation exhausted it *or* an explicit disposition result packet (`reject_source` / `defer_item` / `defer_exhausted`, per `routing.disposition_result_packet_indexes`) resolved it. Packets carrying only settled claims are dropped; mixed packets keep their live claims, exactly as the existing exhausted path already did.

**Why not literally `evidence.completed_ids ∪ released_ids`** (the issue's suggestion 1): those lists are broader than "explicitly dispositioned". `StepLifecycleHandler::commitReconciliationAttempt()` also puts a claim in `released_ids` when a packet's `packet_disposition` is `failed` (failed handler tool with no follow-up) or when the agent omitted the claim, and `$reconciled['explicit']` counts a `failed` disposition as explicit. Stripping those packets would let a genuine missing-handler case short-circuit to `completed_no_items`. I verified this empirically: the naive variant regresses the pre-existing `test_execute_step_does_not_classify_source_packet_disposition_field_as_tool_result` (a source packet with a `packet_disposition` field is completed by reconciliation but is not a disposition *result*, and must stay routable). Deriving "settled" from the disposition result packets' own claims is precise and self-contained.

**Transfer path:** `transferred` dispositions are produced by `StepLifecycleHandler::transferClaimsToFanout()`, which runs *after* `resolveTransitionRoute()` has already returned fan-out packets — they never flow through `reconcileStepOutput()` and therefore never reach this filter. No risk to fan-out.

**Source-ingestion path unchanged:** there `released_ids` is always empty and `completed_ids == exhausted_ids`, and there are no disposition result packets, so the filter behaves exactly as before.

`resolveTransitionRoute()` is untouched.

## Tests

Added to `tests/Unit/Abilities/Engine/ExecuteStepMixedClaimRoutingTest.php` (new `handler_sink` step type with `uses_handler => true` so the next step is handler-requiring):

1. `test_failed_handler_tool_then_reject_terminalizes_before_handler_requiring_step` — `[tool_result(failed upsert_event, claim), reject_source]` → `packets_dispositioned` / `completed_no_items`, item marked processed.
2. `test_failed_handler_tool_then_defer_terminalizes_before_handler_requiring_step` — same with `defer_item` → `completed_no_items`, claim in `released_ids`, item **not** processed (retryable).
3. `test_repeated_failed_handler_tool_then_defer_terminalizes_before_handler_requiring_step` — 3 failed attempts then `defer_item` (most common production shape).
4. `test_ai_response_without_disposition_still_fails_handler_requiring_step` — `[ai_response]` only → still fails. Note: this shape is failed by `StepExecutionResult::classify()` (`ai_response_without_tool_result`) before routing runs, both before and after this change, so the reason is that one rather than `handler_requiring_step_missing_handler_packets`.
5. `test_successful_non_handler_tool_without_disposition_still_fails_handler_requiring_step` — successful step with no disposition and no handler packet → still fails with **`handler_requiring_step_missing_handler_packets`**, claim in `omitted_ids`.
6. `test_failed_handler_tool_without_disposition_still_fails_handler_requiring_step` — `[tool_result(success, claimless), tool_result(failed upsert_event, claim)]` → still fails with **`handler_requiring_step_missing_handler_packets`**, claim in `released_ids` not `completed_ids`. This is the guard that distinguishes "settled by a disposition result" from "present in `released_ids`".
7. `test_failed_handler_tool_alone_still_fails` — `[tool_result(failed)]` only → still fails (`tool_result_failed`).

Tests 1–3 fail on `main` (`'failed'` instead of `'packets_dispositioned'`) and pass with the fix; 4–7 pass on both.

## Verification

This test file is excluded from `phpunit.sqlite.xml.dist` (needs MySQL row locking); PR CI runs it via the MySQL profile. The local homeboy/Codebox MySQL runner is unavailable on this host (no Docker), so I ran it against a disposable local MariaDB 10.11 with the classic WP test lib (WP 7.1 core, plugin loaded on `muplugins_loaded`):

```
$ vendor/bin/phpunit --bootstrap <disposable-bootstrap> tests/Unit/Abilities/Engine/ExecuteStepMixedClaimRoutingTest.php
OK (19 tests, 218 assertions)

$ vendor/bin/phpunit --bootstrap <disposable-bootstrap> tests/Unit/Abilities/Engine/
OK (79 tests, 634 assertions)

# with inc/ change stashed (main behaviour), same test file:
Tests: 19, Assertions: 206, Failures: 3   # exactly the 3 new positive cases

$ php tests/transition-fanout-policy-smoke.php
All 13 transition fan-out policy assertions passed.
$ php tests/packet-disposition-contract-smoke.php
packet-disposition-contract-smoke: 6 passed, 0 failed
```

Lint (homeboy WordPress ruleset, `testVersion 8.2-`):
- `inc/Abilities/Engine/ExecuteStepAbility.php`: 0 errors, 0 warnings.
- test file: 4 errors / 30 warnings vs 4 / 32 on `main` — all remaining findings are pre-existing (multi-class file, unused hook params, alignment in untouched blocks). `git diff --check` clean.

Not related to this change but noticed while verifying: `tests/packet-disposition-route-smoke.php` and `tests/successful-child-routing-smoke.php` crash identically on `main` (StepTypeMetadata / `apply_filters` not loaded in the standalone stubs) — filed #3446. The one job in the 7-day sample not covered by this fix (977495: handler tool called with no `disposition_id` at all → claimless residue packet) is filed as #3447 since it needs a predicate change rather than a filter change.

---
AI-authored: this change was written and verified by an AI coding agent (Extra Chill Bot / Claude) under human direction; please review accordingly.