### PR TITLE
fix(flow-create): inherit pipeline agent_id when no agent context resolves

### DIFF
--- a/inc/Abilities/Flow/CreateFlowAbility.php
+++ b/inc/Abilities/Flow/CreateFlowAbility.php
@@ -195,6 +195,28 @@ class CreateFlowAbility {
 			}
 		}
 
+		// Final fallback: inherit the parent pipeline's agent (#3450). A flow
+		// created on an agent-owned pipeline should be owned by that pipeline's
+		// agent out of the box — every sibling flow already carries it, and a
+		// NULL-owned flow dies on its first run at the AI step with
+		// `ai_agent_context_required`. DuplicateFlowAbility propagates from the
+		// source flow for the same reason.
+		if ( null === $agent_id || $agent_id <= 0 ) {
+			$pipeline_agent_id = isset( $pipeline['agent_id'] ) ? (int) $pipeline['agent_id'] : 0;
+			if ( $pipeline_agent_id > 0 ) {
+				$agent_id = $pipeline_agent_id;
+				do_action(
+					'datamachine_log',
+					'info',
+					'Flow creation inherited agent from parent pipeline',
+					array(
+						'pipeline_id'        => $pipeline_id,
+						'inherited_agent_id' => $pipeline_agent_id,
+					)
+				);
+			}
+		}
+
 		// Validate and resolve interval aliases before storing.
 		$validation = datamachine_validate_interval( $scheduling_config['interval'] ?? 'manual', $scheduling_config );
 		if ( ! $validation['valid'] ) {

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -1125,6 +1125,26 @@ class FlowsCommand extends BaseCommand {
 		WP_CLI::log( sprintf( 'Pipeline ID: %d', $result['pipeline_id'] ) );
 		WP_CLI::log( sprintf( 'Synced steps: %d', $result['synced_steps'] ?? 0 ) );
 
+		// Belt-and-suspenders check (#3450): warn when the flow landed unowned
+		// on a pipeline that carries an agent. The create-flow ability should
+		// inherit the pipeline's agent_id; if this fires, something resolved
+		// the agent away after inheritance.
+		if ( empty( $result['flow_data']['agent_id'] ) ) {
+			$pipeline = ( new \DataMachine\Core\Database\Pipelines\Pipelines() )->get_pipeline( (int) $result['pipeline_id'] );
+			if ( $pipeline && ! empty( $pipeline['agent_id'] ) ) {
+				WP_CLI::warning(
+					sprintf(
+						'Flow %d has no agent but pipeline %d is owned by agent %d. First run will fail with ai_agent_context_required — fix with: wp datamachine flows update %d --agent=%d',
+						$result['flow_id'],
+						(int) $result['pipeline_id'],
+						(int) $pipeline['agent_id'],
+						$result['flow_id'],
+						(int) $pipeline['agent_id']
+					)
+				);
+			}
+		}
+
 		if ( ! empty( $result['configured_steps'] ) ) {
 			WP_CLI::log( sprintf( 'Configured steps: %s', implode( ', ', $result['configured_steps'] ) ) );
 		}

--- a/tests/Unit/Abilities/AgentContextPropagationTest.php
+++ b/tests/Unit/Abilities/AgentContextPropagationTest.php
@@ -197,6 +197,121 @@ class AgentContextPropagationTest extends WP_UnitTestCase {
 	}
 
 	// =========================================================================
+	// CreateFlowAbility — pipeline agent_id inheritance (#3450)
+	// =========================================================================
+
+	/**
+	 * Create an administrator who owns no agent, so neither an explicit
+	 * agent_id nor any resolvable agent context is present.
+	 */
+	private function switch_to_agentless_admin(): int {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		return $user_id;
+	}
+
+	/**
+	 * Test creating a flow without agent_id or context inherits the parent
+	 * pipeline's agent_id (#3450). Regression: plain WP-CLI on an agent-owned
+	 * pipeline persisted agent_id=NULL and the flow died on its first run
+	 * with ai_agent_context_required.
+	 */
+	public function test_create_flow_without_agent_or_context_inherits_pipeline_agent(): void {
+		// Pipeline explicitly owned by the test agent.
+		$pipeline_result = $this->create_pipeline_ability->execute(
+			array(
+				'pipeline_name' => 'Inheritance Pipeline',
+				'agent_id'      => $this->agent_id,
+			)
+		);
+		$pipeline_id     = $pipeline_result['pipeline_id'];
+
+		// Agentless admin: no explicit agent, no owned agent to resolve.
+		$this->switch_to_agentless_admin();
+
+		$result = wp_get_ability( 'datamachine/create-flow' )->execute(
+			array(
+				'pipeline_id' => $pipeline_id,
+				'flow_name'   => 'Inherited Agent Flow',
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+
+		$db_flows = new Flows();
+		$flow     = $db_flows->get_flow( $result['flow_id'] );
+		$this->assertEquals( $this->agent_id, (int) $flow['agent_id'] );
+	}
+
+	/**
+	 * Test an explicit input agent_id wins over the pipeline's agent.
+	 */
+	public function test_create_flow_explicit_agent_wins_over_pipeline_agent(): void {
+		$pipeline_result = $this->create_pipeline_ability->execute(
+			array(
+				'pipeline_name' => 'Explicit Wins Pipeline',
+				'agent_id'      => $this->agent_id,
+			)
+		);
+		$pipeline_id     = $pipeline_result['pipeline_id'];
+
+		// A different agent to request explicitly.
+		$other_admin_id = $this->switch_to_agentless_admin();
+		$other_agent_id = ( new Agents() )->create_if_missing(
+			'other-explicit-agent',
+			'Other Explicit Agent',
+			$other_admin_id
+		);
+		$this->assertGreaterThan( 0, $other_agent_id );
+		$this->assertNotSame( $this->agent_id, $other_agent_id );
+
+		$result = wp_get_ability( 'datamachine/create-flow' )->execute(
+			array(
+				'pipeline_id' => $pipeline_id,
+				'flow_name'   => 'Explicit Agent Flow',
+				'agent_id'    => $other_agent_id,
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+
+		$db_flows = new Flows();
+		$flow     = $db_flows->get_flow( $result['flow_id'] );
+		$this->assertEquals( $other_agent_id, (int) $flow['agent_id'] );
+	}
+
+	/**
+	 * Test a flow on an unowned pipeline (agent_id NULL) with no context
+	 * still persists agent_id NULL — unchanged unowned/system behavior.
+	 */
+	public function test_create_flow_stays_unowned_when_pipeline_unowned_and_no_context(): void {
+		// Agentless admin: pipeline creation resolves no agent → NULL.
+		$this->switch_to_agentless_admin();
+
+		$pipeline_result = $this->create_pipeline_ability->execute(
+			array( 'pipeline_name' => 'Unowned Inheritance Pipeline' )
+		);
+		$pipeline_id     = $pipeline_result['pipeline_id'];
+
+		$db_pipelines = new Pipelines();
+		$pipeline     = $db_pipelines->get_pipeline( $pipeline_id );
+		$this->assertTrue( empty( $pipeline['agent_id'] ) );
+
+		$result = wp_get_ability( 'datamachine/create-flow' )->execute(
+			array(
+				'pipeline_id' => $pipeline_id,
+				'flow_name'   => 'Unowned Flow',
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+
+		$db_flows = new Flows();
+		$flow     = $db_flows->get_flow( $result['flow_id'] );
+		$this->assertTrue( empty( $flow['agent_id'] ) );
+	}
+
+	// =========================================================================
 	// DuplicatePipelineAbility — agent_id carried or overridden
 	// =========================================================================
 

--- a/tests/create-flow-resolves-owning-agent-smoke.php
+++ b/tests/create-flow-resolves-owning-agent-smoke.php
@@ -51,15 +51,26 @@ function datamachine_resolve_agent_id( array $context = array() ): ?int {
  * row stays DEFAULT NULL).
  *
  * @param int|null $input_agent_id The agent_id from caller input (or null).
+ * @param int|null $pipeline_agent_id The parent pipeline's agent_id (or null).
  * @return int|null Effective agent_id to persist.
  */
-function resolve_effective_agent_id( ?int $input_agent_id ): ?int {
+function resolve_effective_agent_id( ?int $input_agent_id, ?int $pipeline_agent_id = null ): ?int {
 	$agent_id = ( null !== $input_agent_id ) ? (int) $input_agent_id : null;
 
 	if ( ( null === $agent_id || $agent_id <= 0 ) && function_exists( 'datamachine_resolve_agent_id' ) ) {
 		$resolved_agent_id = datamachine_resolve_agent_id();
 		if ( null !== $resolved_agent_id && $resolved_agent_id > 0 ) {
 			$agent_id = $resolved_agent_id;
+		}
+	}
+
+	// Pipeline inheritance fallback (#3450): an agent-owned pipeline's new
+	// flow is owned by the pipeline's agent even when neither the caller nor
+	// any runtime context supplies one.
+	if ( null === $agent_id || $agent_id <= 0 ) {
+		$pipeline_agent_id = ( null !== $pipeline_agent_id ) ? (int) $pipeline_agent_id : 0;
+		if ( $pipeline_agent_id > 0 ) {
+			$agent_id = $pipeline_agent_id;
 		}
 	}
 
@@ -161,6 +172,42 @@ smoke_assert(
 	'batch-imported flow with active events-bot context is owned by 6, not orphaned',
 	6 === $result,
 	'got ' . var_export( $result, true ) . ' — pre-fix: 72 flows shipped as NULL, lost on bundle round-trip'
+);
+
+// ─── Test 5: pipeline inheritance fallback (#3450) ─────────────────
+
+echo "\n[5] Pipeline inheritance fallback (#3450)\n";
+
+$GLOBALS['__smoke_resolved_agent_id'] = null; // plain WP-CLI, no --user/--agent
+$result = resolve_effective_agent_id( null, 6 );
+smoke_assert(
+	'no input + no context + pipeline agent_id=6 → inherits 6',
+	6 === $result,
+	'got ' . var_export( $result, true ) . ' — pre-fix bug #3450: flow persisted NULL, first run died ai_agent_context_required'
+);
+
+$GLOBALS['__smoke_resolved_agent_id'] = null;
+$result = resolve_effective_agent_id( 3, 6 );
+smoke_assert(
+	'explicit input agent_id=3 wins over pipeline agent_id=6',
+	3 === $result,
+	'got ' . var_export( $result, true )
+);
+
+$GLOBALS['__smoke_resolved_agent_id'] = 9;
+$result = resolve_effective_agent_id( null, 6 );
+smoke_assert(
+	'context agent_id=9 wins over pipeline agent_id=6 (inheritance is last fallback)',
+	9 === $result,
+	'got ' . var_export( $result, true )
+);
+
+$GLOBALS['__smoke_resolved_agent_id'] = null;
+$result = resolve_effective_agent_id( null, null );
+smoke_assert(
+	'unowned pipeline + no input + no context → persists NULL (unchanged)',
+	null === $result,
+	'got ' . var_export( $result, true )
 );
 
 // ─── Done ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Root cause

`CreateFlowAbility::executeSingle()` resolved `agent_id` via a two-step chain: explicit input → `datamachine_resolve_agent_id()` (active-agent context → acting user → owned-agent fallback) → NULL. The parent pipeline's `agent_id` was never consulted. From plain WP-CLI (no `--user`/`--agent`) on an agent-owned pipeline, the flow persisted with `agent_id = NULL` while every sibling flow carries the pipeline's agent, and the first run died at the AI step with `ai_agent_context_required`.

Observed on events.extrachill.com 2026-09-07: `wp datamachine flows create --pipeline_id=3 ...` (pipeline 3, agent_id=6) → flows 860/861 persisted NULL → job 983474 failed `ai_agent_context_required`.

## What changed

- **inc/Abilities/Flow/CreateFlowAbility.php** — added a final fallback in `executeSingle()` after the context/user resolution: if `agent_id` is still unset and the pipeline row (already loaded at the top of the method) has `agent_id > 0`, inherit it and emit a `datamachine_log` info line (`Flow creation inherited agent from parent pipeline` with `pipeline_id` + `inherited_agent_id`). No change was needed in the bulk-create method: both the preview pass and the create pass delegate to `executeSingle()` per item with the item's own `pipeline_id`, so each bulk flow inherits from its own pipeline automatically.
- **inc/Cli/Commands/Flows/FlowsCommand.php** — `createFlow()` now prints a `WP_CLI::warning` when the resulting flow has no agent while its pipeline does, including the exact `flows update` remediation command. Belt-and-suspenders only; the ability fix should make it unreachable.
- **tests/Unit/Abilities/AgentContextPropagationTest.php** — three new PHPUnit cases covering the required matrix: (a) agent-owned pipeline + no input agent + no context → flow inherits the pipeline's agent; (b) explicit input `agent_id` wins over the pipeline's; (c) unowned pipeline + no context → flow stays NULL (unchanged behavior). Cases (a)/(c) use a new agentless-admin helper (administrator who owns no agent) so the resolver legitimately returns NULL.
- **tests/create-flow-resolves-owning-agent-smoke.php** — extended the pure-PHP branch-replication smoke with the pipeline fallback and four new cases (inherit, explicit-wins-over-pipeline, context-wins-over-pipeline, unowned-stays-NULL), keeping it in sync with the production branch. Mirrors the #2481 fix pattern and `DuplicateFlowAbility`'s source-flow propagation.

## Tests added

- 3 PHPUnit cases in `AgentContextPropagationTest` (inherit / explicit-wins / unowned-stays-NULL) via `wp_get_ability('datamachine/create-flow')` with DB verification through `Flows::get_flow()`.
- 4 new assertions in the pure-PHP smoke (11 total, all passing locally).

## Verification

- `php -l`: clean on all four touched files.
- `php tests/create-flow-resolves-owning-agent-smoke.php`: 11 passed, 0 failed.
- `homeboy review lint` / `homeboy review test`: deferred by resource policy — machine warm (load ~7.3 on 8 CPUs) and no Lab runner configured; both attempts returned `status: deferred` with recovery guidance to defer to CI. **CI is the real run** for phpstan (baseline untouched — zero expected findings in touched files) and the PHPUnit suite.

Closes #3450