### PR TITLE
build: declare dev-only tracked files as intentional release exclusions

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -59,7 +59,7 @@
         },
         {
           "context": "line",
-          "description": "Replace '(class_exists(WP_Abilities_Registry) ? WP_Abilities_Registry::get_instance() : null)' with a direct call \u2014 the ternary is unreachable.",
+          "description": "Replace '(class_exists(WP_Abilities_Registry) ? WP_Abilities_Registry::get_instance() : null)' with a direct call — the ternary is unreachable.",
           "files": "inc/**/*.php",
           "find": "class_exists\\( 'WP_Abilities_Registry' \\) \\? \\\\WP_Abilities_Registry::get_instance\\(\\) : null",
           "id": "ternary_registry_guard",

--- a/homeboy.json
+++ b/homeboy.json
@@ -59,7 +59,7 @@
         },
         {
           "context": "line",
-          "description": "Replace '(class_exists(WP_Abilities_Registry) ? WP_Abilities_Registry::get_instance() : null)' with a direct call — the ternary is unreachable.",
+          "description": "Replace '(class_exists(WP_Abilities_Registry) ? WP_Abilities_Registry::get_instance() : null)' with a direct call \u2014 the ternary is unreachable.",
           "files": "inc/**/*.php",
           "find": "class_exists\\( 'WP_Abilities_Registry' \\) \\? \\\\WP_Abilities_Registry::get_instance\\(\\) : null",
           "id": "ternary_registry_guard",
@@ -93,5 +93,15 @@
       "file": "package.json",
       "pattern": "\"version\":\\s*\"([0-9.]+)\""
     }
-  ]
+  ],
+  "scopes": {
+    "release": {
+      "exclude": [
+        "bench/**",
+        "eslint.config.js",
+        "jsconfig.json",
+        "webpack.config.js"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Unblocks releasing #3453. After #3361, `homeboy release data-machine` fails at the package step:

```
Release package 'build/data-machine.zip' is missing 4 tracked runtime file(s): bench/fixtures/admin-scale.php, eslint.config.js, jsconfig.json, webpack.config.js
```

Homeboy's guidance for this gate is to "add an explicit release scope exclude for intentional omissions". These are dev-only files (already in `.buildignore`), so this declares them in `homeboy.json` `scopes.release.exclude` — the same pattern data-machine-events uses for its webpack configs. No runtime change.

Implemented by an AI coding agent (Extra Chill Bot) under operator direction.