### PR TITLE
fix(flow-step): preserve sanitizer-derived keys in handler config patches

### DIFF
--- a/inc/Abilities/FlowStep/FlowStepHelpers.php
+++ b/inc/Abilities/FlowStep/FlowStepHelpers.php
@@ -136,6 +136,10 @@ trait FlowStepHelpers {
 	 * type coercion, term ID resolution, and value validation. This ensures all
 	 * write paths (REST, CLI, chat tools, abilities API) produce consistent data.
 	 *
+	 * A sanitizer that synthesizes keys the caller did not pass (e.g. resolving
+	 * a venue name into a venue term ID) must declare those keys via
+	 * SettingsClass::derived_fields() so patch-based write paths keep them (#3449).
+	 *
 	 * @since 0.38.0
 	 * @param string $handler_slug Handler slug.
 	 * @param array  $handler_config Raw configuration values to sanitize.
@@ -174,6 +178,11 @@ trait FlowStepHelpers {
 	 * explicitly patched top-level fields are merged so omitted stored values
 	 * retain their value and type.
 	 *
+	 * Keys a sanitizer synthesizes that the caller did not pass (term ID
+	 * resolution and similar derivations) are kept when the settings class
+	 * declares them via derived_fields(); the sparse-patch intersect cannot
+	 * tell "declared derived key" from "untouched default" on its own (#3449).
+	 *
 	 * @param string $handler_slug Handler slug.
 	 * @param array  $existing_config Stored configuration.
 	 * @param array  $handler_patch Sparse configuration patch.
@@ -190,13 +199,40 @@ trait FlowStepHelpers {
 		}
 
 		$sanitized = $this->sanitizeHandlerConfig( $handler_slug, $handler_patch, $log_errors );
-		$sanitized = array_intersect_key( $sanitized, $handler_patch );
+		$sanitized = array_intersect_key( $sanitized, $handler_patch + $this->getDerivedHandlerConfigFields( $handler_slug ) );
 		$merged    = self::deepMergeConfig( $existing_config, $sanitized );
 
 		return array(
 			'valid'  => true,
 			'config' => $this->handler_abilities->applyDefaults( $handler_slug, $merged ),
 		);
+	}
+
+	/**
+	 * Get the sanitizer-declared derived config field keys for a handler.
+	 *
+	 * A settings class whose sanitize() synthesizes keys the caller did not
+	 * pass (e.g. resolving venue_name plus an address into a venue term ID)
+	 * declares those keys via `public static function derived_fields(): array`.
+	 * prepareHandlerConfigPatch() keeps declared keys through the sparse-patch
+	 * intersect so derived values are stored rather than discarded (#3449).
+	 *
+	 * A declared key should also be a declared config field; applyDefaults()
+	 * drops stored keys that are absent from the field schema.
+	 *
+	 * @param string $handler_slug Handler slug.
+	 * @return array Derived field names as array keys.
+	 */
+	protected function getDerivedHandlerConfigFields( string $handler_slug ): array {
+		$settings_class = $this->handler_abilities->getSettingsClass( $handler_slug );
+
+		if ( ! $settings_class || ! method_exists( $settings_class, 'derived_fields' ) ) {
+			return array();
+		}
+
+		$derived_fields = $settings_class::derived_fields();
+
+		return is_array( $derived_fields ) ? array_flip( $derived_fields ) : array();
 	}
 
 	/**

--- a/tests/Unit/Abilities/FlowStepPatchDerivedKeysTest.php
+++ b/tests/Unit/Abilities/FlowStepPatchDerivedKeysTest.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Sparse handler-config patch derived-key tests (#3449).
+ *
+ * prepareHandlerConfigPatch() intersects sanitized config against the caller's
+ * patch so complete-object sanitizers cannot clobber stored values with
+ * defaults. Settings classes that synthesize keys the caller did not pass
+ * (term ID resolution) declare them via derived_fields() so those keys survive
+ * the intersect instead of being discarded after the side effect ran.
+ *
+ * @package DataMachine\Tests\Unit\Abilities
+ */
+
+namespace DataMachine\Tests\Unit\Abilities;
+
+use DataMachine\Abilities\HandlerAbilities;
+use DataMachine\Core\Database\Flows\Flows;
+use DataMachine\Core\Database\Pipelines\Pipelines;
+use DataMachine\Core\Steps\Settings\SettingsHandler;
+use WP_UnitTestCase;
+
+class DerivedResolvingSettings extends SettingsHandler {
+	public static function get_fields(): array {
+		return array(
+			'name'        => array(
+				'type' => 'text',
+			),
+			'limit'       => array(
+				'type'    => 'number',
+				'default' => 10,
+			),
+			'resolved_id' => array(
+				'type' => 'number',
+			),
+		);
+	}
+
+	public static function sanitize( array $raw_settings ): array {
+		// Complete-object emitter mirroring SettingsHandler::sanitize(), plus a
+		// term-ID-resolution style derivation the caller never passes.
+		return array(
+			'name'        => (string) ( $raw_settings['name'] ?? '' ),
+			'limit'       => (int) ( $raw_settings['limit'] ?? 10 ),
+			'resolved_id' => 42,
+		);
+	}
+
+	public static function derived_fields(): array {
+		return array( 'resolved_id' );
+	}
+}
+
+class LegacyDerivingSettings extends SettingsHandler {
+	public static function get_fields(): array {
+		return array(
+			'name'  => array(
+				'type' => 'text',
+			),
+			'limit' => array(
+				'type'    => 'number',
+				'default' => 10,
+			),
+		);
+	}
+
+	public static function sanitize( array $raw_settings ): array {
+		return array(
+			'name'        => (string) ( $raw_settings['name'] ?? '' ),
+			'limit'       => (int) ( $raw_settings['limit'] ?? 10 ),
+			'resolved_id' => 42,
+		);
+	}
+
+	// No derived_fields(): a pre-contract settings class. Its derived key is
+	// dropped by the sparse-patch intersect, preserving legacy behaviour.
+}
+
+class FlowStepPatchDerivedKeysTest extends WP_UnitTestCase {
+
+	private int $pipeline_id;
+	private \Closure $handlers_filter;
+	private \Closure $settings_filter;
+
+	public function set_up(): void {
+		parent::set_up();
+		datamachine_test_prepare_site();
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$this->handlers_filter = static function ( array $handlers, ?string $step_type ): array {
+			if ( null === $step_type || 'event_import' === $step_type ) {
+				$handlers['derived_api'] = array(
+					'type'  => 'event_import',
+					'label' => 'Derived API',
+				);
+			}
+			if ( null === $step_type || 'fetch' === $step_type ) {
+				$handlers['legacy_api'] = array(
+					'type'  => 'fetch',
+					'label' => 'Legacy API',
+				);
+			}
+
+			return $handlers;
+		};
+		add_filter( 'datamachine_handlers', $this->handlers_filter, 10, 2 );
+
+		$this->settings_filter = static function ( array $settings, ?string $handler_slug ): array {
+			if ( null === $handler_slug || 'derived_api' === $handler_slug ) {
+				$settings['derived_api'] = new DerivedResolvingSettings();
+			}
+			if ( null === $handler_slug || 'legacy_api' === $handler_slug ) {
+				$settings['legacy_api'] = new LegacyDerivingSettings();
+			}
+
+			return $settings;
+		};
+		add_filter( 'datamachine_handler_settings', $this->settings_filter, 10, 2 );
+		HandlerAbilities::clearCache();
+
+		$pipelines         = new Pipelines();
+		$this->pipeline_id = (int) $pipelines->create_pipeline(
+			array(
+				'pipeline_name'   => 'Derived Keys Patch Pipeline',
+				'pipeline_config' => array(),
+			)
+		);
+
+		$pipeline_config = array();
+		foreach ( array( 'event_import', 'fetch' ) as $order => $step_type ) {
+			$pipeline_step_id                     = $this->pipeline_id . '_' . $step_type;
+			$pipeline_config[ $pipeline_step_id ] = array(
+				'pipeline_step_id' => $pipeline_step_id,
+				'step_type'        => $step_type,
+				'execution_order'  => $order,
+				'label'            => $step_type,
+			);
+		}
+		$pipelines->update_pipeline( $this->pipeline_id, array( 'pipeline_config' => $pipeline_config ) );
+	}
+
+	public function tear_down(): void {
+		remove_filter( 'datamachine_handlers', $this->handlers_filter, 10 );
+		remove_filter( 'datamachine_handler_settings', $this->settings_filter, 10 );
+		HandlerAbilities::clearCache();
+		delete_option( 'datamachine_handler_defaults' );
+
+		parent::tear_down();
+	}
+
+	public function test_create_flow_stores_sanitizer_derived_key(): void {
+		$result = wp_get_ability( 'datamachine/create-flow' )->execute(
+			array(
+				'pipeline_id'  => $this->pipeline_id,
+				'flow_name'    => 'Derived Create Flow',
+				'step_configs' => array(
+					'event_import' => array(
+						'handler_slug'   => 'derived_api',
+						'handler_config' => array( 'name' => 'x' ),
+					),
+				),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+
+		$stored = $this->getStoredHandlerConfig( (int) $result['flow_id'], 'event_import' );
+		$this->assertSame( 'x', $stored['name'] );
+		$this->assertSame( 10, $stored['limit'] );
+		$this->assertArrayHasKey( 'resolved_id', $stored, 'Derived key must survive the sparse-patch intersect on create.' );
+		$this->assertSame( 42, $stored['resolved_id'] );
+	}
+
+	public function test_sparse_patch_keeps_derived_key_and_preserves_non_default_stored_value(): void {
+		$flow_id = $this->createFlowWithDerivedHandler();
+		$step_id = $this->getEventImportStepId( $flow_id );
+
+		$patch_limit = wp_get_ability( 'datamachine/update-flow-step' )->execute(
+			array(
+				'flow_step_id'   => $step_id,
+				'handler_config' => array( 'limit' => 99 ),
+			)
+		);
+		$this->assertTrue( $patch_limit['success'] );
+
+		$patch_name = wp_get_ability( 'datamachine/update-flow-step' )->execute(
+			array(
+				'flow_step_id'   => $step_id,
+				'handler_config' => array( 'name' => 'y' ),
+			)
+		);
+		$this->assertTrue( $patch_name['success'] );
+
+		$stored = $this->getStoredHandlerConfig( $flow_id, 'event_import' );
+		$this->assertSame( 'y', $stored['name'] );
+		$this->assertSame( 99, $stored['limit'], 'Sparse patch of one key must not overwrite another stored key with its default.' );
+		$this->assertSame( 42, $stored['resolved_id'], 'Derived key must survive a sparse patch that did not mention it.' );
+	}
+
+	public function test_settings_class_without_derived_fields_contract_drops_derived_key(): void {
+		$result = wp_get_ability( 'datamachine/create-flow' )->execute(
+			array(
+				'pipeline_id'  => $this->pipeline_id,
+				'flow_name'    => 'Legacy Create Flow',
+				'step_configs' => array(
+					'fetch' => array(
+						'handler_slug'   => 'legacy_api',
+						'handler_config' => array( 'name' => 'x' ),
+					),
+				),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+
+		$stored = $this->getStoredHandlerConfig( (int) $result['flow_id'], 'fetch' );
+		$this->assertSame( 'x', $stored['name'] );
+		$this->assertArrayNotHasKey( 'resolved_id', $stored, 'Without derived_fields() the intersect keeps legacy sparse-patch behaviour.' );
+	}
+
+	public function test_full_object_update_keeps_all_patched_fields(): void {
+		$flow_id = $this->createFlowWithDerivedHandler();
+		$step_id = $this->getEventImportStepId( $flow_id );
+
+		$result = wp_get_ability( 'datamachine/update-flow-step' )->execute(
+			array(
+				'flow_step_id'   => $step_id,
+				'handler_config' => array(
+					'name'  => 'full',
+					'limit' => 25,
+				),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+
+		$stored = $this->getStoredHandlerConfig( $flow_id, 'event_import' );
+		$this->assertSame( 'full', $stored['name'] );
+		$this->assertSame( 25, $stored['limit'] );
+		$this->assertSame( 42, $stored['resolved_id'] );
+	}
+
+	private function createFlowWithDerivedHandler(): int {
+		$result = wp_get_ability( 'datamachine/create-flow' )->execute(
+			array(
+				'pipeline_id'  => $this->pipeline_id,
+				'flow_name'    => 'Derived Patch Flow ' . uniqid(),
+				'step_configs' => array(
+					'event_import' => array(
+						'handler_slug'   => 'derived_api',
+						'handler_config' => array( 'name' => 'x' ),
+					),
+				),
+			)
+		);
+
+		$this->assertTrue( $result['success'] );
+
+		return (int) $result['flow_id'];
+	}
+
+	private function getEventImportStepId( int $flow_id ): string {
+		$flow = ( new Flows() )->get_flow( $flow_id );
+		foreach ( $flow['flow_config'] as $flow_step_id => $step ) {
+			if ( 'event_import' === ( $step['step_type'] ?? '' ) ) {
+				return (string) $flow_step_id;
+			}
+		}
+
+		$this->fail( 'event_import flow step not found.' );
+	}
+
+	private function getStoredHandlerConfig( int $flow_id, string $step_type ): array {
+		$flow      = ( new Flows() )->get_flow( $flow_id );
+		$step_type = array_column( $flow['flow_config'], null, 'step_type' )[ $step_type ];
+
+		return $step_type['handler_configs'][ $step_type['handler_slugs'][0] ];
+	}
+}

--- a/tests/Unit/Abilities/FlowStepPatchDerivedKeysTest.php
+++ b/tests/Unit/Abilities/FlowStepPatchDerivedKeysTest.php
@@ -14,6 +14,7 @@
 namespace DataMachine\Tests\Unit\Abilities;
 
 use DataMachine\Abilities\HandlerAbilities;
+use DataMachine\Abilities\SettingsAbilities;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\Steps\Settings\SettingsHandler;
@@ -144,7 +145,7 @@ class FlowStepPatchDerivedKeysTest extends WP_UnitTestCase {
 		remove_filter( 'datamachine_handlers', $this->handlers_filter, 10 );
 		remove_filter( 'datamachine_handler_settings', $this->settings_filter, 10 );
 		HandlerAbilities::clearCache();
-		delete_option( 'datamachine_handler_defaults' );
+		delete_option( SettingsAbilities::HANDLER_DEFAULTS_OPTION );
 
 		parent::tear_down();
 	}

--- a/tests/flow-step-patch-derived-keys-smoke.php
+++ b/tests/flow-step-patch-derived-keys-smoke.php
@@ -1,0 +1,342 @@
+<?php
+/**
+ * Behavioral smoke for sparse handler-config patch derived keys (#3449).
+ *
+ * Run with: php tests/flow-step-patch-derived-keys-smoke.php
+ *
+ * Pins three behaviours of prepareHandlerConfigPatch():
+ *
+ *   1. A settings class that derives a key the caller did not pass (term ID
+ *      resolution) declares it via derived_fields(); the derived key survives
+ *      the sparse-patch intersect on both the create and update paths.
+ *   2. A sparse patch of one key still does not overwrite a different stored
+ *      key with its sanitize-time default (the original intersect intent).
+ *   3. A settings class WITHOUT derived_fields() keeps legacy behaviour: its
+ *      derived keys are dropped (the contract is strictly opt-in).
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	$GLOBALS['derived_keys_smoke_flow']   = array();
+	$GLOBALS['derived_keys_smoke_logs']   = array();
+	$GLOBALS['derived_keys_smoke_writes'] = array();
+
+	class WP_Error {}
+
+	function apply_filters( $hook, $value, ...$args ) {
+		if ( 'datamachine_split_flow_step_id' === $hook ) {
+			return array(
+				'pipeline_step_id' => 'import_1',
+				'flow_id'          => 900,
+			);
+		}
+		return $value;
+	}
+
+	function do_action( $hook, ...$args ): void {
+		if ( 'datamachine_log' === $hook ) {
+			$GLOBALS['derived_keys_smoke_logs'][] = $args;
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\Flows {
+	class Flows {
+		public function get_flow( $flow_id ) {
+			return $GLOBALS['derived_keys_smoke_flow'];
+		}
+
+		public function update_flow( $flow_id, $data ) {
+			$GLOBALS['derived_keys_smoke_writes'][] = $data;
+			$GLOBALS['derived_keys_smoke_flow']['flow_config'] = $data['flow_config'];
+			return true;
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\Pipelines {
+	class Pipelines {}
+}
+
+namespace DataMachine\Abilities {
+	class AbilityRegistration {
+		public static function on_abilities_api_init( callable $callback ): void {}
+	}
+
+	class DerivedResolvingSettings {
+		public static function get_fields(): array {
+			return array(
+				'name'        => array( 'type' => 'text' ),
+				'limit'       => array( 'type' => 'number', 'default' => 10 ),
+				'resolved_id' => array( 'type' => 'number' ),
+			);
+		}
+
+		public static function sanitize( array $raw ): array {
+			return array(
+				'name'        => (string) ( $raw['name'] ?? '' ),
+				'limit'       => (int) ( $raw['limit'] ?? 10 ),
+				'resolved_id' => 42,
+			);
+		}
+
+		public static function derived_fields(): array {
+			return array( 'resolved_id' );
+		}
+	}
+
+	class LegacyDerivingSettings {
+		public static function get_fields(): array {
+			return array(
+				'name'  => array( 'type' => 'text' ),
+				'limit' => array( 'type' => 'number', 'default' => 10 ),
+			);
+		}
+
+		public static function sanitize( array $raw ): array {
+			return array(
+				'name'        => (string) ( $raw['name'] ?? '' ),
+				'limit'       => (int) ( $raw['limit'] ?? 10 ),
+				'resolved_id' => 42,
+			);
+		}
+
+		// No derived_fields(): pre-contract settings class.
+	}
+
+	class HandlerAbilities {
+		public function getSettingsClass( $slug ) {
+			if ( 'derived_api' === $slug ) {
+				return new DerivedResolvingSettings();
+			}
+			if ( 'legacy_api' === $slug ) {
+				return new LegacyDerivingSettings();
+			}
+			return null;
+		}
+
+		public function getConfigFields( $slug ): array {
+			if ( 'derived_api' === $slug ) {
+				return DerivedResolvingSettings::get_fields();
+			}
+			if ( 'legacy_api' === $slug ) {
+				return LegacyDerivingSettings::get_fields();
+			}
+			return array();
+		}
+
+		public function applyDefaults( $slug, array $config ): array {
+			$complete = array();
+			foreach ( $this->getConfigFields( $slug ) as $key => $field ) {
+				if ( array_key_exists( $key, $config ) ) {
+					$complete[ $key ] = $config[ $key ];
+				} elseif ( isset( $field['default'] ) ) {
+					$complete[ $key ] = $field['default'];
+				}
+			}
+			return $complete;
+		}
+	}
+
+	class PermissionHelper {}
+}
+
+namespace DataMachine\Core\Steps {
+	class FlowStepConfig {
+		public static function usesHandler( array $step ): bool {
+			return true;
+		}
+
+		public static function getEffectiveSlug( array $step, string $fallback = '' ): string {
+			return '' !== $fallback ? $fallback : ( $step['handler_slugs'][0] ?? '' );
+		}
+
+		public static function getHandlerConfigForSlug( array $step, string $slug ): array {
+			return $step['handler_configs'][ $slug ] ?? array();
+		}
+
+		public static function getPrimaryHandlerSlug( array $step ): ?string {
+			return $step['handler_slugs'][0] ?? null;
+		}
+
+		public static function getHandlerSlugs( array $step ): array {
+			return $step['handler_slugs'] ?? array();
+		}
+
+		public static function getHandlerConfigs( array $step ): array {
+			return $step['handler_configs'] ?? array();
+		}
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Abilities/FlowStep/FlowStepHelpers.php';
+	require_once dirname( __DIR__ ) . '/inc/Abilities/FlowStep/UpdateFlowStepAbility.php';
+
+	$failures = array();
+	$passes   = 0;
+
+	function derived_keys_assert_same( $expected, $actual, string $name ): void {
+		global $failures, $passes;
+		if ( $expected === $actual ) {
+			++$passes;
+			return;
+		}
+		$failures[] = $name;
+		fwrite( STDERR, "FAIL: {$name}\nExpected: " . var_export( $expected, true ) . "\nActual: " . var_export( $actual, true ) . "\n" );
+	}
+
+	function derived_keys_assert_false( bool $condition, string $name ): void {
+		global $failures, $passes;
+		if ( ! $condition ) {
+			++$passes;
+			return;
+		}
+		$failures[] = $name;
+		fwrite( STDERR, "FAIL: {$name}\n" );
+	}
+
+	function derived_keys_reset_flow( array $flow_config = array() ): void {
+		$GLOBALS['derived_keys_smoke_flow'] = array(
+			'flow_id'     => 900,
+			'pipeline_id' => 300,
+			'flow_config' => $flow_config,
+		);
+		$GLOBALS['derived_keys_smoke_writes'] = array();
+		$GLOBALS['derived_keys_smoke_logs']   = array();
+	}
+
+	function derived_keys_stored_config(): array {
+		$step = $GLOBALS['derived_keys_smoke_flow']['flow_config']['import_1_900'] ?? array();
+		return $step['handler_configs']['derived_api']
+			?? $step['handler_configs']['legacy_api']
+			?? array();
+	}
+
+	$ability = new \DataMachine\Abilities\FlowStep\UpdateFlowStepAbility();
+
+	// ─── Scenario 1: create path stores sanitizer-derived keys ──────────
+
+	// Step skeleton as left by pipeline sync before any handler config write.
+	derived_keys_reset_flow(
+		array(
+			'import_1_900' => array(
+				'flow_step_id'     => 'import_1_900',
+				'pipeline_step_id' => 'import_1',
+				'pipeline_id'      => 300,
+				'flow_id'          => 900,
+				'step_type'        => 'event_import',
+				'enabled'          => false,
+			),
+		)
+	);
+	$create = $ability->execute(
+		array(
+			'flow_step_id'   => 'import_1_900',
+			'handler_slug'   => 'derived_api',
+			'handler_config' => array( 'name' => 'x' ),
+		)
+	);
+	derived_keys_assert_same( true, $create['success'] ?? false, 'create succeeds' );
+	derived_keys_assert_same( 'x', derived_keys_stored_config()['name'] ?? null, 'create stores patched key' );
+	derived_keys_assert_same( 10, derived_keys_stored_config()['limit'] ?? null, 'create fills schema default' );
+	derived_keys_assert_same( 42, derived_keys_stored_config()['resolved_id'] ?? null, 'create stores sanitizer-derived key (#3449)' );
+
+	// ─── Scenario 2: sparse patch preserves non-default stored values ───
+
+	derived_keys_reset_flow(
+		array(
+			'import_1_900' => array(
+				'flow_step_id'    => 'import_1_900',
+				'pipeline_step_id' => 'import_1',
+				'pipeline_id'     => 300,
+				'flow_id'         => 900,
+				'step_type'       => 'event_import',
+				'handler_slugs'   => array( 'derived_api' ),
+				'handler_configs' => array(
+					'derived_api' => array(
+						'name'        => 'orig',
+						'limit'       => 99,
+						'resolved_id' => 42,
+					),
+				),
+			),
+		)
+	);
+
+	$before = serialize( $GLOBALS['derived_keys_smoke_flow'] );
+	$preview = $ability->execute(
+		array(
+			'flow_step_id'  => 'import_1_900',
+			'handler_config' => array( 'name' => 'updated' ),
+			'validate_only' => true,
+		)
+	);
+	derived_keys_assert_same( array(), $GLOBALS['derived_keys_smoke_writes'], 'dry-run performs no persistence' );
+	derived_keys_assert_same( $before, serialize( $GLOBALS['derived_keys_smoke_flow'] ), 'dry-run leaves storage byte-identical' );
+	derived_keys_assert_same( 99, $preview['effective_handler_config']['limit'] ?? null, 'dry-run preview keeps non-default stored limit' );
+	derived_keys_assert_same( 42, $preview['effective_handler_config']['resolved_id'] ?? null, 'dry-run preview keeps derived key' );
+
+	$applied = $ability->execute(
+		array(
+			'flow_step_id'   => 'import_1_900',
+			'handler_config' => array( 'name' => 'updated' ),
+		)
+	);
+	derived_keys_assert_same( true, $applied['success'] ?? false, 'apply succeeds' );
+	derived_keys_assert_same( 'updated', derived_keys_stored_config()['name'] ?? null, 'patched key updated' );
+	derived_keys_assert_same( 99, derived_keys_stored_config()['limit'] ?? null, 'sparse patch does not overwrite stored key with default' );
+	derived_keys_assert_same( 42, derived_keys_stored_config()['resolved_id'] ?? null, 'derived key survives sparse patch' );
+
+	// ─── Scenario 3: legacy settings class keeps old intersect behaviour ─
+
+	derived_keys_reset_flow(
+		array(
+			'import_1_900' => array(
+				'flow_step_id'    => 'import_1_900',
+				'pipeline_step_id' => 'import_1',
+				'pipeline_id'     => 300,
+				'flow_id'         => 900,
+				'step_type'       => 'event_import',
+				'handler_slugs'   => array( 'legacy_api' ),
+				'handler_configs' => array(
+					'legacy_api' => array(
+						'name'  => 'orig',
+						'limit' => 99,
+					),
+				),
+			),
+		)
+	);
+
+	$legacy = $ability->execute(
+		array(
+			'flow_step_id'   => 'import_1_900',
+			'handler_config' => array( 'name' => 'updated' ),
+		)
+	);
+	derived_keys_assert_same( true, $legacy['success'] ?? false, 'legacy apply succeeds' );
+	derived_keys_assert_same( 'updated', derived_keys_stored_config()['name'] ?? null, 'legacy patched key updated' );
+	derived_keys_assert_same( 99, derived_keys_stored_config()['limit'] ?? null, 'legacy sparse patch still preserves non-default stored value' );
+	derived_keys_assert_false(
+		array_key_exists( 'resolved_id', derived_keys_stored_config() ),
+		'legacy settings class without derived_fields() still drops derived keys'
+	);
+
+	$error_logs = array_filter(
+		$GLOBALS['derived_keys_smoke_logs'],
+		static fn( array $log ): bool => in_array( $log[0] ?? '', array( 'error', 'warning' ), true )
+	);
+	derived_keys_assert_same( array(), array_values( $error_logs ), 'no error or warning logs emitted' );
+
+	if ( ! empty( $failures ) ) {
+		exit( 1 );
+	}
+
+	echo "{$passes} handler-config derived-keys assertions passed.\n";
+}


### PR DESCRIPTION
Closes #3449

## Root cause

`FlowStepHelpers::prepareHandlerConfigPatch()` did `array_intersect_key( $sanitized, $handler_patch )` after `sanitizeHandlerConfig()`. The docblock on `sanitizeHandlerConfig()` explicitly says settings classes perform *term ID resolution* — i.e. they derive keys the caller didn't pass. The intersect threw those away. Concrete case: data-machine-events `VenueFieldsTrait::save_venue_on_settings_save()` resolves `venue_name` + address → creates a term → sets `venue = <id>`. The term was created; the `venue` key was dropped. `flows create --step_configs` routes through the same path, so new flows stored only raw caller keys.

## Fix

Explicit contract instead of heuristics: a settings class declares synthesized keys via `public static function derived_fields(): array`. `prepareHandlerConfigPatch()` now intersects against `$handler_patch + derived_fields`, so declared derived keys survive while untouched defaults are still dropped (the original intent — a sparse patch must not clobber stored values — is preserved).

- `inc/Abilities/FlowStep/FlowStepHelpers.php` — new `getDerivedHandlerConfigFields()`; intersect widened; docblocks updated.

Settings classes without `derived_fields()` behave exactly as before. **Follow-up in data-machine-events:** `SingleRecurringSettings` (and the other `VenueFieldsTrait` consumers) need to declare `derived_fields(): ['venue']` for the venue case to actually benefit.

## Tests

- `tests/Unit/Abilities/FlowStepPatchDerivedKeysTest.php` — throwaway handler whose sanitizer derives `resolved_id`; asserts it's stored after a patch, a sparse patch of one key doesn't reset a different non-default stored key, and a legacy settings class without `derived_fields()` is unchanged.
- `tests/flow-step-patch-derived-keys-smoke.php` — standalone behavioral smoke, 17 assertions pass locally.

## Verification

- `php -l` clean; WPCS clean on all touched files.
- Local `homeboy review lint` refused under host load (placement guard); CI is the authoritative run.

Authored by a Kimaki minion (GLM 5.3 flash); finalized and shipped by Extra Chill Bot after the session stalled at the lint gate.