### PR TITLE
fix(cli): prevent global-option registration warnings

### DIFF
--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -1198,7 +1198,7 @@ class MemoryCommand extends BaseCommand {
 	 *     # List all sections across all composable files
 	 *     wp datamachine memory compose --list
 	 *
-		 * @subcommand compose
+	 * @subcommand compose
 	 */
 	public function compose( array $args, array $assoc_args ): void {
 		$filename = $args[0] ?? '';

--- a/inc/Cli/Commands/MemoryCommand.php
+++ b/inc/Cli/Commands/MemoryCommand.php
@@ -1198,10 +1198,7 @@ class MemoryCommand extends BaseCommand {
 	 *     # List all sections across all composable files
 	 *     wp datamachine memory compose --list
 	 *
-	 *     # Suppress informational output with WP-CLI's global option
-	 *     wp --quiet datamachine memory compose
-	 *
-	 * @subcommand compose
+		 * @subcommand compose
 	 */
 	public function compose( array $args, array $assoc_args ): void {
 		$filename = $args[0] ?? '';

--- a/tests/cli-global-options-smoke.php
+++ b/tests/cli-global-options-smoke.php
@@ -11,13 +11,13 @@ if ( '1' === getenv( 'DATAMACHINE_CLI_REGISTRATION_BOOT' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 
 	spl_autoload_register(
-		static function ( string $class ): void {
+		static function ( string $class_name ): void {
 			$prefix = 'DataMachine\\';
-			if ( ! str_starts_with( $class, $prefix ) ) {
+			if ( ! str_starts_with( $class_name, $prefix ) ) {
 				return;
 			}
 
-			$path = dirname( __DIR__ ) . '/inc/' . str_replace( '\\', '/', substr( $class, strlen( $prefix ) ) ) . '.php';
+			$path = dirname( __DIR__ ) . '/inc/' . str_replace( '\\', '/', substr( $class_name, strlen( $prefix ) ) ) . '.php';
 			if ( is_file( $path ) ) {
 				require_once $path;
 			}
@@ -55,7 +55,14 @@ $assert = static function ( bool $condition, string $message ) use ( &$failures,
 };
 
 $run = static function ( array $command ): array {
-	$process = proc_open( $command, array( 1 => array( 'pipe', 'w' ), 2 => array( 'pipe', 'w' ) ), $pipes );
+	$process = proc_open(
+		$command,
+		array(
+			1 => array( 'pipe', 'w' ),
+			2 => array( 'pipe', 'w' ),
+		),
+		$pipes
+	);
 	if ( ! is_resource( $process ) ) {
 		return array( 1, '', 'Failed to start WP-CLI.' );
 	}
@@ -97,14 +104,14 @@ $help_commands = array(
 putenv( 'DATAMACHINE_CLI_REGISTRATION_BOOT=1' );
 try {
 	foreach ( $help_commands as $command => $expected_options ) {
-		list( $status, $stdout, $stderr ) = $run(
+		list( $exit_code, $stdout, $stderr ) = $run(
 			array_merge(
 				array( 'wp', '--skip-wordpress', '--require=' . __FILE__, 'help', 'datamachine' ),
 				explode( ' ', $command )
 			)
 		);
 
-		$assert( 0 === $status, "fresh WP-CLI process registers datamachine {$command}" );
+		$assert( 0 === $exit_code, "fresh WP-CLI process registers datamachine {$command}" );
 		foreach ( $expected_options as $option ) {
 			$assert( str_contains( $stdout, $option ), "datamachine {$command} exposes {$option}" );
 		}

--- a/tests/cli-global-options-smoke.php
+++ b/tests/cli-global-options-smoke.php
@@ -7,6 +7,28 @@
  * @package DataMachine\Tests
  */
 
+if ( '1' === getenv( 'DATAMACHINE_CLI_REGISTRATION_BOOT' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+
+	spl_autoload_register(
+		static function ( string $class ): void {
+			$prefix = 'DataMachine\\';
+			if ( ! str_starts_with( $class, $prefix ) ) {
+				return;
+			}
+
+			$path = dirname( __DIR__ ) . '/inc/' . str_replace( '\\', '/', substr( $class, strlen( $prefix ) ) ) . '.php';
+			if ( is_file( $path ) ) {
+				require_once $path;
+			}
+		}
+	);
+
+	require_once dirname( __DIR__ ) . '/inc/Core/Bootstrap/CliServiceProvider.php';
+	\DataMachine\Core\Bootstrap\CliServiceProvider::register();
+	return;
+}
+
 $root = dirname( __DIR__ );
 
 $sources = array(
@@ -32,6 +54,20 @@ $assert = static function ( bool $condition, string $message ) use ( &$failures,
 	echo "FAIL: {$message}\n";
 };
 
+$run = static function ( array $command ): array {
+	$process = proc_open( $command, array( 1 => array( 'pipe', 'w' ), 2 => array( 'pipe', 'w' ) ), $pipes );
+	if ( ! is_resource( $process ) ) {
+		return array( 1, '', 'Failed to start WP-CLI.' );
+	}
+
+	$stdout = stream_get_contents( $pipes[1] );
+	$stderr = stream_get_contents( $pipes[2] );
+	fclose( $pipes[1] );
+	fclose( $pipes[2] );
+
+	return array( proc_close( $process ), (string) $stdout, (string) $stderr );
+};
+
 foreach ( $sources as $command => $source ) {
 	preg_match_all( '/\[--([a-z0-9-]+)(?:=<[^>]+>)?\]/', $source, $matches );
 	$declared_globals = array_intersect( $global_options, $matches[1] );
@@ -49,6 +85,34 @@ $assert( str_contains( $chat, "\$assoc_args['session-context']" ), 'chat command
 $assert( str_contains( $email, "\$assoc_args['template-context']" ) && str_contains( $email, "\$input['context'] = \$decoded" ), 'queued email maps --template-context to the internal context payload' );
 $assert( ! str_contains( $memory, "get_flag_value( \$assoc_args, 'quiet'" ), 'memory compose relies on WP-CLI global quiet handling' );
 $assert( str_contains( $documentation, '--target-user=42' ) && str_contains( $documentation, '--owner-user=1' ) && str_contains( $documentation, '--session-context=sidebar' ), 'public CLI documentation uses renamed domain options' );
+
+$help_commands = array(
+	'auth revoke'    => array( '--target-user=<id>' ),
+	'chat list'      => array( '--owner-user=<id>', '--session-context=<type>' ),
+	'chat get'       => array( '--owner-user=<id>' ),
+	'chat create'    => array( '--owner-user=<id>', '--session-context=<type>' ),
+	'memory compose' => array( '--agent=<slug>' ),
+);
+
+putenv( 'DATAMACHINE_CLI_REGISTRATION_BOOT=1' );
+try {
+	foreach ( $help_commands as $command => $expected_options ) {
+		list( $status, $stdout, $stderr ) = $run(
+			array_merge(
+				array( 'wp', '--skip-wordpress', '--require=' . __FILE__, 'help', 'datamachine' ),
+				explode( ' ', $command )
+			)
+		);
+
+		$assert( 0 === $status, "fresh WP-CLI process registers datamachine {$command}" );
+		foreach ( $expected_options as $option ) {
+			$assert( str_contains( $stdout, $option ), "datamachine {$command} exposes {$option}" );
+		}
+		$assert( ! str_contains( $stderr, 'conflicts with a global argument' ), "fresh WP-CLI registration for {$command} emits no global-argument conflict warnings" );
+	}
+} finally {
+	putenv( 'DATAMACHINE_CLI_REGISTRATION_BOOT' );
+}
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " CLI global option assertions failed.\n";


### PR DESCRIPTION
## Summary

Fixes #3476.

Remove an example containing the global `--quiet` flag from the `memory compose` command docblock. WP-CLI parses it during command registration, causing a global-option conflict warning even though the command uses the global flag correctly.

Extend the existing CLI regression with fresh WP-CLI processes that register the production command map, assert warning-free registration, and check the already-renamed domain options in command help.

## Verification

- `php tests/cli-global-options-smoke.php`: 27 assertions passed.
- `php tests/command-registry-canonical-roots-smoke.php`: passed.
- PHP syntax and diff checks passed.
- Broad WordPress PHPCS checks also report pre-existing production-file findings and CLI-test output warnings; this change does not claim a clean repository-wide lint baseline.

## AI Assistance

GPT-5.6 Terra via OpenCode implemented the repair and process-boundary regression. GPT-6 Astra via OpenCode reviewed the diff, corrected formatting and test variable naming, and reran verification. Chris directed the work; direct execution was explicitly authorized while the orchestration control plane was blocked.
