### PR TITLE
test(cli): cover global option collisions

### DIFF
--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -321,6 +321,9 @@ echo "- New lesson" | wp datamachine memory write "Lessons Learned" - --mode=app
 # Search memory
 wp datamachine memory search "deployment" --section="State"
 
+# Regenerate composable files quietly with WP-CLI's global option.
+wp --quiet datamachine memory compose
+
 # Daily memory operations
 wp datamachine memory daily list
 wp datamachine memory daily read 2026-03-15
@@ -522,6 +525,10 @@ wp datamachine analytics ga engagement --compare
 
 Authentication management. **Since**: 0.36.0
 
+WP-CLI's global `--user=<id>` selects the bootstrap user and must precede the
+command. `auth revoke --target-user=<id>` instead selects the per-user
+credential slot to revoke.
+
 ```bash
 # Check auth status for all providers
 wp datamachine auth status
@@ -550,6 +557,10 @@ wp datamachine auth config reddit --client_id=xxx --client_secret=xxx
 ### datamachine chat
 
 Manage chat sessions. **Since**: 0.40.0
+
+WP-CLI's global `--user=<id>` selects the bootstrap user. Chat's
+`--owner-user=<id>` selects a session owner, and `--session-context=<type>`
+selects a chat-session mode; neither changes WordPress bootstrap context.
 
 ```bash
 # List chat sessions
@@ -826,6 +837,9 @@ Send email and operate on an IMAP mailbox through configured email auth.
 ```bash
 # Send mail
 wp datamachine email send --to=user@example.com --subject="Report" --body="<p>Hello</p>"
+
+# Queue a template email with Data Machine template data.
+wp datamachine email send-queued --to=user@example.com --subject="Digest" --template=weekly-digest --template-context='{"week":"2026-W14"}'
 
 # Fetch and read mail
 wp datamachine email fetch --search=UNSEEN --max=10

--- a/docs/core-system/wp-cli.md
+++ b/docs/core-system/wp-cli.md
@@ -525,9 +525,8 @@ wp datamachine analytics ga engagement --compare
 
 Authentication management. **Since**: 0.36.0
 
-WP-CLI's global `--user=<id>` selects the bootstrap user and must precede the
-command. `auth revoke --target-user=<id>` instead selects the per-user
-credential slot to revoke.
+WP-CLI's global `--user=<id>` selects the bootstrap user. `auth revoke
+--target-user=<id>` instead selects the per-user credential slot to revoke.
 
 ```bash
 # Check auth status for all providers

--- a/tests/cli-global-options-smoke.php
+++ b/tests/cli-global-options-smoke.php
@@ -7,7 +7,7 @@
  * @package DataMachine\Tests
  */
 
-if ( '1' === getenv( 'DATAMACHINE_CLI_REGISTRATION_BOOT' ) ) {
+if ( '1' === getenv( 'DATAMACHINE_CLI_REGISTRATION_BOOT' ) || '1' === getenv( 'DATAMACHINE_CLI_SEMANTICS_BOOT' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 
 	spl_autoload_register(
@@ -24,22 +24,52 @@ if ( '1' === getenv( 'DATAMACHINE_CLI_REGISTRATION_BOOT' ) ) {
 		}
 	);
 
+	if ( '1' === getenv( 'DATAMACHINE_CLI_SEMANTICS_BOOT' ) ) {
+		function wp_get_ability( string $name ): object {
+			return new class {
+				public function execute( array $input ): array {
+					WP_CLI::line( 'DATAMACHINE_TEST_EMAIL_CONTEXT=' . json_encode( $input['context'] ?? null ) );
+					return array( 'success' => true );
+				}
+			};
+		}
+
+		function is_wp_error( mixed $thing ): bool {
+			return false;
+		}
+	}
+
 	require_once dirname( __DIR__ ) . '/inc/Core/Bootstrap/CliServiceProvider.php';
 	\DataMachine\Core\Bootstrap\CliServiceProvider::register();
+
+	if ( '1' === getenv( 'DATAMACHINE_CLI_SEMANTICS_BOOT' ) ) {
+		$chat_command = ( new ReflectionClass( \DataMachine\Cli\Commands\ChatCommand::class ) )->newInstanceWithoutConstructor();
+		$get_owner    = new ReflectionMethod( $chat_command, 'get_user_id' );
+
+		WP_CLI::line( 'DATAMACHINE_TEST_CHAT_OWNER=' . $get_owner->invoke( $chat_command, array( 'owner-user' => '37' ) ) );
+		( new \DataMachine\Cli\Commands\EmailCommand() )->send_queued(
+			array(),
+			array(
+				'to'               => 'recipient@example.test',
+				'subject'          => 'Test',
+				'template-context' => '{"week":"2026-W14"}',
+			)
+		);
+	}
 	return;
 }
 
 $root = dirname( __DIR__ );
 
-$sources = array(
-	'auth revoke'        => (string) file_get_contents( $root . '/inc/Cli/Commands/AuthCommand.php' ),
-	'chat'               => (string) file_get_contents( $root . '/inc/Cli/Commands/ChatCommand.php' ),
-	'email send-queued'  => (string) file_get_contents( $root . '/inc/Cli/Commands/EmailCommand.php' ),
-	'memory compose'     => (string) file_get_contents( $root . '/inc/Cli/Commands/MemoryCommand.php' ),
-);
+$provider      = (string) file_get_contents( $root . '/inc/Core/Bootstrap/CliServiceProvider.php' );
+$sources       = array();
+preg_match_all( '/DataMachine\\\\Cli\\\\([A-Za-z\\\\]+)::class/', $provider, $command_classes );
+foreach ( $command_classes[1] as $class ) {
+	$path = $root . '/inc/Cli/' . str_replace( '\\', '/', $class ) . '.php';
+	$sources[ $class ] = (string) file_get_contents( $path );
+}
 $documentation = (string) file_get_contents( $root . '/docs/core-system/wp-cli.md' )
 	. (string) file_get_contents( $root . '/docs/core-system/oauth-handlers.md' );
-$global_options = array( 'user', 'context', 'quiet' );
 $failures       = array();
 $passes         = 0;
 
@@ -54,7 +84,14 @@ $assert = static function ( bool $condition, string $message ) use ( &$failures,
 	echo "FAIL: {$message}\n";
 };
 
-$run = static function ( array $command ): array {
+
+$run = static function ( array $command, array $environment = array() ): array {
+	$previous_environment = array();
+	foreach ( $environment as $name => $value ) {
+		$previous_environment[ $name ] = getenv( $name );
+		putenv( "{$name}={$value}" );
+	}
+
 	$process = proc_open(
 		$command,
 		array(
@@ -63,6 +100,9 @@ $run = static function ( array $command ): array {
 		),
 		$pipes
 	);
+	foreach ( $previous_environment as $name => $value ) {
+		putenv( false === $value ? $name : "{$name}={$value}" );
+	}
 	if ( ! is_resource( $process ) ) {
 		return array( 1, '', 'Failed to start WP-CLI.' );
 	}
@@ -75,51 +115,71 @@ $run = static function ( array $command ): array {
 	return array( proc_close( $process ), (string) $stdout, (string) $stderr );
 };
 
+
+list( $wp_help_exit, $wp_help, $wp_help_stderr ) = $run( array( 'wp', '--help' ) );
+$assert( 0 === $wp_help_exit, 'WP-CLI global parameter list is available' );
+$assert( '' === $wp_help_stderr, 'WP-CLI global parameter lookup emits no errors' );
+preg_match_all( '/^  --(?:\[no-\])?([a-z0-9-]+)/m', $wp_help, $global_matches );
+$global_options = $global_matches[1];
+
 foreach ( $sources as $command => $source ) {
 	preg_match_all( '/\[--([a-z0-9-]+)(?:=<[^>]+>)?\]/', $source, $matches );
 	$declared_globals = array_intersect( $global_options, $matches[1] );
-	$assert( array() === $declared_globals, "{$command} declares no WP-CLI global options" );
+	$assert( array() === $declared_globals, "registered {$command} command declares no WP-CLI global options" );
 }
 
-$auth  = $sources['auth revoke'];
-$chat  = $sources['chat'];
-$email = $sources['email send-queued'];
-$memory = $sources['memory compose'];
+$auth   = $sources['Commands\\AuthCommand'];
+$chat   = $sources['Commands\\ChatCommand'];
+$email  = $sources['Commands\\EmailCommand'];
+$memory = $sources['Commands\\MemoryCommand'];
 
 $assert( str_contains( $auth, "\$assoc_args['target-user']" ), 'auth revoke receives --target-user' );
 $assert( str_contains( $chat, "\$assoc_args['owner-user']" ), 'chat commands receive --owner-user' );
 $assert( str_contains( $chat, "\$assoc_args['session-context']" ), 'chat commands receive --session-context' );
 $assert( str_contains( $email, "\$assoc_args['template-context']" ) && str_contains( $email, "\$input['context'] = \$decoded" ), 'queued email maps --template-context to the internal context payload' );
 $assert( ! str_contains( $memory, "get_flag_value( \$assoc_args, 'quiet'" ), 'memory compose relies on WP-CLI global quiet handling' );
-$assert( str_contains( $documentation, '--target-user=42' ) && str_contains( $documentation, '--owner-user=1' ) && str_contains( $documentation, '--session-context=sidebar' ), 'public CLI documentation uses renamed domain options' );
+$assert( str_contains( $documentation, '--target-user=42' ) && str_contains( $documentation, '--owner-user=1' ) && str_contains( $documentation, '--session-context=sidebar' ) && str_contains( $documentation, '--template-context=' ) && str_contains( $documentation, 'wp --quiet datamachine memory compose' ), 'public CLI documentation distinguishes application options from WP-CLI globals' );
 
 $help_commands = array(
 	'auth revoke'    => array( '--target-user=<id>' ),
 	'chat list'      => array( '--owner-user=<id>', '--session-context=<type>' ),
 	'chat get'       => array( '--owner-user=<id>' ),
 	'chat create'    => array( '--owner-user=<id>', '--session-context=<type>' ),
+	'email send-queued' => array( '--template-context=<json>' ),
 	'memory compose' => array( '--agent=<slug>' ),
 );
 
-putenv( 'DATAMACHINE_CLI_REGISTRATION_BOOT=1' );
-try {
-	foreach ( $help_commands as $command => $expected_options ) {
-		list( $exit_code, $stdout, $stderr ) = $run(
-			array_merge(
-				array( 'wp', '--skip-wordpress', '--require=' . __FILE__, 'help', 'datamachine' ),
-				explode( ' ', $command )
-			)
-		);
 
-		$assert( 0 === $exit_code, "fresh WP-CLI process registers datamachine {$command}" );
-		foreach ( $expected_options as $option ) {
-			$assert( str_contains( $stdout, $option ), "datamachine {$command} exposes {$option}" );
-		}
-		$assert( ! str_contains( $stderr, 'conflicts with a global argument' ), "fresh WP-CLI registration for {$command} emits no global-argument conflict warnings" );
+list( $exit_code, $stdout, $stderr ) = $run(
+	array( 'wp', '--skip-wordpress', '--require=' . __FILE__, 'help', 'datamachine' ),
+	array( 'DATAMACHINE_CLI_REGISTRATION_BOOT' => '1' )
+);
+$assert( 0 === $exit_code, 'fresh WP-CLI process registers every Data Machine command' );
+$assert( ! str_contains( $stderr, 'conflicts with a global argument' ), 'full CommandRegistry registration emits no global-argument conflict warnings' );
+
+foreach ( $help_commands as $command => $expected_options ) {
+	list( $exit_code, $stdout, $stderr ) = $run(
+		array_merge(
+			array( 'wp', '--skip-wordpress', '--require=' . __FILE__, 'help', 'datamachine' ),
+			explode( ' ', $command )
+		),
+		array( 'DATAMACHINE_CLI_REGISTRATION_BOOT' => '1' )
+	);
+
+	$assert( 0 === $exit_code, "fresh WP-CLI process registers datamachine {$command}" );
+	foreach ( $expected_options as $option ) {
+		$assert( str_contains( $stdout, $option ), "datamachine {$command} exposes {$option}" );
 	}
-} finally {
-	putenv( 'DATAMACHINE_CLI_REGISTRATION_BOOT' );
 }
+
+list( $exit_code, $stdout, $stderr ) = $run(
+	array( 'wp', '--skip-wordpress', '--require=' . __FILE__, 'help', 'datamachine' ),
+	array( 'DATAMACHINE_CLI_SEMANTICS_BOOT' => '1' )
+);
+$assert( 0 === $exit_code, 'email option probe runs without WordPress state' );
+$assert( str_contains( $stdout, 'DATAMACHINE_TEST_CHAT_OWNER=37' ), '--owner-user resolves as the chat session owner, not the WP-CLI bootstrap user' );
+$assert( str_contains( $stdout, 'DATAMACHINE_TEST_EMAIL_CONTEXT={"week":"2026-W14"}' ), '--template-context resolves to the email template context payload' );
+$assert( ! str_contains( $stderr, 'conflicts with a global argument' ), 'option-resolution probe emits no global-argument conflict warnings' );
 
 if ( $failures ) {
 	echo "\nFAILED: " . count( $failures ) . " CLI global option assertions failed.\n";

--- a/tests/cli-global-options-smoke.php
+++ b/tests/cli-global-options-smoke.php
@@ -138,7 +138,7 @@ $assert( str_contains( $chat, "\$assoc_args['owner-user']" ), 'chat commands rec
 $assert( str_contains( $chat, "\$assoc_args['session-context']" ), 'chat commands receive --session-context' );
 $assert( str_contains( $email, "\$assoc_args['template-context']" ) && str_contains( $email, "\$input['context'] = \$decoded" ), 'queued email maps --template-context to the internal context payload' );
 $assert( ! str_contains( $memory, "get_flag_value( \$assoc_args, 'quiet'" ), 'memory compose relies on WP-CLI global quiet handling' );
-$assert( str_contains( $documentation, '--target-user=42' ) && str_contains( $documentation, '--owner-user=1' ) && str_contains( $documentation, '--session-context=sidebar' ) && str_contains( $documentation, '--template-context=' ) && str_contains( $documentation, 'wp --quiet datamachine memory compose' ), 'public CLI documentation distinguishes application options from WP-CLI globals' );
+$assert( str_contains( $documentation, '--target-user=42' ) && str_contains( $documentation, '--owner-user=1' ) && str_contains( $documentation, '--session-context=sidebar' ) && str_contains( $documentation, '--template-context=' ) && str_contains( $documentation, 'wp --quiet datamachine memory compose' ) && ! str_contains( $documentation, 'must precede the command' ), 'public CLI documentation distinguishes application options from WP-CLI globals' );
 
 $help_commands = array(
 	'auth revoke'    => array( '--target-user=<id>' ),
@@ -156,6 +156,13 @@ list( $exit_code, $stdout, $stderr ) = $run(
 );
 $assert( 0 === $exit_code, 'fresh WP-CLI process registers every Data Machine command' );
 $assert( ! str_contains( $stderr, 'conflicts with a global argument' ), 'full CommandRegistry registration emits no global-argument conflict warnings' );
+
+list( $exit_code, $stdout, $stderr ) = $run(
+	array( 'wp', '--skip-wordpress', '--require=' . __FILE__, 'help', 'datamachine', 'auth', 'revoke', '--user=42' ),
+	array( 'DATAMACHINE_CLI_REGISTRATION_BOOT' => '1' )
+);
+$assert( 0 === $exit_code, 'WP-CLI accepts global --user after a Data Machine subcommand' );
+$assert( ! str_contains( $stderr, 'conflicts with a global argument' ), 'post-subcommand global --user emits no registration collision warning' );
 
 foreach ( $help_commands as $command => $expected_options ) {
 	list( $exit_code, $stdout, $stderr ) = $run(


### PR DESCRIPTION
## Summary

The command-registration collisions were already fixed in #3477. This follow-up adds registry-wide collision coverage and corrects CLI documentation to distinguish WP-CLI bootstrap globals from Data Machine application options.

Relates to #3480.

## Validation

- `php tests/cli-global-options-smoke.php` (61 assertions)
- `php -l tests/cli-global-options-smoke.php`
- `git diff --check origin/main...HEAD`

The test launches fresh `wp --skip-wordpress` processes to register the full command surface and render help, including post-subcommand global `--user`. Its `--owner-user` and `--template-context` probes call command methods against a fake ability, so they validate argument mapping only, not WordPress authentication, authorization, or a fully bootstrapped ability request.

## AI Assistance

OpenAI gpt-5.6-terra via direct OpenCode implementation and verification; OpenAI gpt-6-astra via OpenCode orchestration and review.