### PR TITLE
Accept proven transactional table backends for identity reservation

### DIFF
--- a/inc/Core/Database/PostIdentityReservations/PostIdentityReservations.php
+++ b/inc/Core/Database/PostIdentityReservations/PostIdentityReservations.php
@@ -213,9 +213,7 @@ class PostIdentityReservations extends BaseRepository {
 				$this->table_name
 			)
 		);
-		if ( 'INNODB' !== strtoupper( (string) $engine ) ) {
-			return new \WP_Error( 'identity_schema_engine', 'Post identity reservation table must use InnoDB.' );
-		}
+		$uses_innodb = 'INNODB' === strtoupper( (string) $engine );
 
 		$required_columns = array(
 			'identity_hash'      => array(
@@ -323,6 +321,9 @@ class PostIdentityReservations extends BaseRepository {
 		}
 		if ( ! $has_nonunique_post_id || $has_unique_post_id ) {
 			return new \WP_Error( 'identity_schema_post_index', 'Post identity reservation post_id requires a nonunique index.' );
+		}
+		if ( ! $uses_innodb && ! $this->supports_transactional_tables( array( $this->table_name, $this->wpdb->posts ) ) ) {
+			return new \WP_Error( 'identity_schema_engine', 'Post identity reservation table must use InnoDB.' );
 		}
 
 		return true;
@@ -705,6 +706,9 @@ class PostIdentityReservations extends BaseRepository {
 				return new \WP_Error( 'identity_storage_invalid', 'Post identity storage has an invalid table name.' );
 			}
 		}
+		if ( $this->supports_transactional_tables( $tables ) ) {
+			return true;
+		}
 
 		$placeholders = implode( ',', array_fill( 0, count( $tables ), '%s' ) );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -727,6 +731,24 @@ class PostIdentityReservations extends BaseRepository {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Ask an optional database implementation to prove one atomic table set.
+	 *
+	 * The capability is deliberately exact: it may replace the InnoDB engine
+	 * check only when every table in this reservation operation participates.
+	 */
+	private function supports_transactional_tables( array $tables ): bool {
+		if ( ! method_exists( $this->wpdb, 'supports_transactional_tables' ) ) {
+			return false;
+		}
+
+		try {
+			return true === $this->wpdb->supports_transactional_tables( $tables );
+		} catch ( \Throwable ) {
+			return false;
+		}
 	}
 
 	/** @return int[] */

--- a/inc/Core/Database/PostIdentityReservations/PostIdentityReservations.php
+++ b/inc/Core/Database/PostIdentityReservations/PostIdentityReservations.php
@@ -206,7 +206,7 @@ class PostIdentityReservations extends BaseRepository {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$database = (string) $this->wpdb->get_var( 'SELECT DATABASE()' );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$engine = $this->wpdb->get_var(
+		$engine      = $this->wpdb->get_var(
 			$this->wpdb->prepare(
 				'SELECT ENGINE FROM information_schema.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s',
 				$database,

--- a/tests/Unit/Core/Database/PostIdentityReservations/PostIdentityReservationsTest.php
+++ b/tests/Unit/Core/Database/PostIdentityReservations/PostIdentityReservationsTest.php
@@ -147,13 +147,13 @@ class PostIdentityReservationsTest extends WP_UnitTestCase {
 		$original = $wpdb;
 		$capable  = new class( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ) extends \wpdb {
 			public array $supported_tables = array();
-			public mixed $result = false;
+			public mixed $capability_result = false;
 
 			public function supports_transactional_tables( array $tables ) {
-				if ( 'throw' === $this->result ) {
+				if ( 'throw' === $this->capability_result ) {
 					throw new \RuntimeException( 'Unsupported transactional table capability.' );
 				}
-				return $tables === $this->supported_tables ? $this->result : false;
+				return $tables === $this->supported_tables ? $this->capability_result : false;
 			}
 		};
 		$capable->set_prefix( $original->prefix );
@@ -167,17 +167,17 @@ class PostIdentityReservationsTest extends WP_UnitTestCase {
 			$this->assertSame( 'identity_schema_engine', $incomplete->get_error_code() );
 
 			$capable->supported_tables = array( $repository->get_table_name(), $capable->posts );
-			$capable->result = 1;
+			$capable->capability_result = 1;
 			$strict_false = $repository->validate_schema();
 			$this->assertWPError( $strict_false );
 			$this->assertSame( 'identity_schema_engine', $strict_false->get_error_code() );
 
-			$capable->result = 'throw';
+			$capable->capability_result = 'throw';
 			$thrown = $repository->validate_schema();
 			$this->assertWPError( $thrown );
 			$this->assertSame( 'identity_schema_engine', $thrown->get_error_code() );
 
-			$capable->result = true;
+			$capable->capability_result = true;
 			$this->assertTrue( $repository->validate_schema() );
 
 			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP COLUMN completed_at', $repository->get_table_name() ) );

--- a/tests/Unit/Core/Database/PostIdentityReservations/PostIdentityReservationsTest.php
+++ b/tests/Unit/Core/Database/PostIdentityReservations/PostIdentityReservationsTest.php
@@ -138,6 +138,46 @@ class PostIdentityReservationsTest extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_exact_transactional_table_capability_can_replace_the_engine_check(): void {
+		global $wpdb;
+
+		$this->assertNotFalse( $wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ENGINE=MyISAM', $this->repository->get_table_name() ) ) );
+		$original = $wpdb;
+		$capable  = new class( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ) extends \wpdb {
+			public array $supported_tables = array();
+			public bool $throws = false;
+
+			public function supports_transactional_tables( array $tables ): bool {
+				if ( $this->throws ) {
+					throw new \RuntimeException( 'Unsupported transactional table capability.' );
+				}
+				return $tables === $this->supported_tables;
+			}
+		};
+		$capable->set_prefix( $original->prefix );
+		$wpdb = $capable;
+
+		try {
+			$repository = new PostIdentityReservations();
+			$capable->supported_tables = array( $repository->get_table_name() );
+			$incomplete = $repository->validate_schema();
+			$this->assertWPError( $incomplete );
+			$this->assertSame( 'identity_schema_engine', $incomplete->get_error_code() );
+
+			$capable->throws = true;
+			$thrown = $repository->validate_schema();
+			$this->assertWPError( $thrown );
+			$this->assertSame( 'identity_schema_engine', $thrown->get_error_code() );
+
+			$capable->throws = false;
+			$capable->supported_tables = array( $repository->get_table_name(), $capable->posts );
+			$this->assertTrue( $repository->validate_schema() );
+		} finally {
+			$wpdb = $original;
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ENGINE=InnoDB', $this->repository->get_table_name() ) );
+		}
+	}
+
 	public function test_create_table_repairs_myisam_to_innodb(): void {
 		global $wpdb;
 

--- a/tests/Unit/Core/Database/PostIdentityReservations/PostIdentityReservationsTest.php
+++ b/tests/Unit/Core/Database/PostIdentityReservations/PostIdentityReservationsTest.php
@@ -121,9 +121,10 @@ class PostIdentityReservationsTest extends WP_UnitTestCase {
 		}
 	}
 
-	public function test_nontransactional_reservation_table_fails_closed(): void {
+	public function test_nontransactional_reservation_table_fails_closed_without_the_capability(): void {
 		global $wpdb;
 
+		$this->assertFalse( method_exists( $wpdb, 'supports_transactional_tables' ) );
 		$changed = $wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ENGINE=MyISAM', $this->repository->get_table_name() ) );
 		$this->assertNotFalse( $changed );
 		try {
@@ -138,20 +139,21 @@ class PostIdentityReservationsTest extends WP_UnitTestCase {
 		}
 	}
 
-	public function test_exact_transactional_table_capability_can_replace_the_engine_check(): void {
+	/** This fake wpdb covers consumer routing, not native capability conformance. */
+	public function test_exact_transactional_table_capability_routes_only_a_complete_valid_schema(): void {
 		global $wpdb;
 
 		$this->assertNotFalse( $wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ENGINE=MyISAM', $this->repository->get_table_name() ) ) );
 		$original = $wpdb;
 		$capable  = new class( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ) extends \wpdb {
 			public array $supported_tables = array();
-			public bool $throws = false;
+			public mixed $result = false;
 
-			public function supports_transactional_tables( array $tables ): bool {
-				if ( $this->throws ) {
+			public function supports_transactional_tables( array $tables ) {
+				if ( 'throw' === $this->result ) {
 					throw new \RuntimeException( 'Unsupported transactional table capability.' );
 				}
-				return $tables === $this->supported_tables;
+				return $tables === $this->supported_tables ? $this->result : false;
 			}
 		};
 		$capable->set_prefix( $original->prefix );
@@ -164,17 +166,27 @@ class PostIdentityReservationsTest extends WP_UnitTestCase {
 			$this->assertWPError( $incomplete );
 			$this->assertSame( 'identity_schema_engine', $incomplete->get_error_code() );
 
-			$capable->throws = true;
+			$capable->supported_tables = array( $repository->get_table_name(), $capable->posts );
+			$capable->result = 1;
+			$strict_false = $repository->validate_schema();
+			$this->assertWPError( $strict_false );
+			$this->assertSame( 'identity_schema_engine', $strict_false->get_error_code() );
+
+			$capable->result = 'throw';
 			$thrown = $repository->validate_schema();
 			$this->assertWPError( $thrown );
 			$this->assertSame( 'identity_schema_engine', $thrown->get_error_code() );
 
-			$capable->throws = false;
-			$capable->supported_tables = array( $repository->get_table_name(), $capable->posts );
+			$capable->result = true;
 			$this->assertTrue( $repository->validate_schema() );
+
+			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i DROP COLUMN completed_at', $repository->get_table_name() ) );
+			$invalid_schema = $repository->validate_schema();
+			$this->assertWPError( $invalid_schema );
+			$this->assertSame( 'identity_schema_columns', $invalid_schema->get_error_code() );
 		} finally {
 			$wpdb = $original;
-			$wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ENGINE=InnoDB', $this->repository->get_table_name() ) );
+			PostIdentityReservations::create_table();
 		}
 	}
 

--- a/tests/Unit/Core/Database/PostIdentityReservations/PostIdentityReservationsTest.php
+++ b/tests/Unit/Core/Database/PostIdentityReservations/PostIdentityReservationsTest.php
@@ -151,8 +151,10 @@ class PostIdentityReservationsTest extends WP_UnitTestCase {
 			public mixed $capability_result = false;
 
 			public function __construct( \wpdb $delegate ) {
-				$this->delegate = $delegate;
-				$this->set_prefix( $delegate->prefix );
+				$this->delegate    = $delegate;
+				$this->prefix      = $delegate->prefix;
+				$this->base_prefix = $delegate->base_prefix;
+				$this->posts       = $delegate->posts;
 			}
 
 			public function prepare( $query, ...$args ) {

--- a/tests/Unit/Core/Database/PostIdentityReservations/PostIdentityReservationsTest.php
+++ b/tests/Unit/Core/Database/PostIdentityReservations/PostIdentityReservationsTest.php
@@ -145,9 +145,31 @@ class PostIdentityReservationsTest extends WP_UnitTestCase {
 
 		$this->assertNotFalse( $wpdb->query( $wpdb->prepare( 'ALTER TABLE %i ENGINE=MyISAM', $this->repository->get_table_name() ) ) );
 		$original = $wpdb;
-		$capable  = new class( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST ) extends \wpdb {
+		$capable  = new class( $original ) extends \wpdb {
+			private \wpdb $delegate;
 			public array $supported_tables = array();
 			public mixed $capability_result = false;
+
+			public function __construct( \wpdb $delegate ) {
+				$this->delegate = $delegate;
+				$this->set_prefix( $delegate->prefix );
+			}
+
+			public function prepare( $query, ...$args ) {
+				return $this->delegate->prepare( $query, ...$args );
+			}
+
+			public function query( $query ) {
+				return $this->delegate->query( $query );
+			}
+
+			public function get_var( $query = null, $x = 0, $y = 0 ) {
+				return $this->delegate->get_var( $query, $x, $y );
+			}
+
+			public function get_results( $query = null, $output = OBJECT ) {
+				return $this->delegate->get_results( $query, $output );
+			}
 
 			public function supports_transactional_tables( array $tables ) {
 				if ( 'throw' === $this->capability_result ) {
@@ -156,7 +178,6 @@ class PostIdentityReservationsTest extends WP_UnitTestCase {
 				return $tables === $this->supported_tables ? $this->capability_result : false;
 			}
 		};
-		$capable->set_prefix( $original->prefix );
 		$wpdb = $capable;
 
 		try {


### PR DESCRIPTION
## Summary

The maintainer approved this generic capability API; the previous hold is lifted. This is backend-neutral application integration, not proof that MDI implements the original MySQL-specific consumer contract unchanged.

- Ask optional `wpdb::supports_transactional_tables(array $tables)` about the exact reservation and posts table set.
- Accept only strict `true`. Missing methods, incomplete coverage, false-like answers and exceptions fail closed.
- Preserve schema column/index validation, the default MySQL/InnoDB verification and SQLite safeguards.
- Introduce no MDI class dependency or fake InnoDB label.

Engine prerequisite: https://github.com/Automattic/markdown-database-integration/pull/403. Track remaining MySQL parity separately in Automattic/markdown-database-integration#377.

## Verification

Data Machine `4432c2433dbce2985654cc88f57dc3d5abc411f0` passed the following runs. Current `b6fe3762ea92a31b30d63cb72607dfaaa8582b4f` adds only a PHPCS assignment-alignment fix; its lint, audit, refactor and all four test shards passed. MDI prerequisite #403 is merged as `d4907227f4c252d1f781134bd79f00f4e1a112b1`.

- Dedicated reservation tests on MySQL: **26 passed, 0 failed, 1 skipped / 27**.
- Full DME with the native provider and this consumer adapter: **1040 passed, 4 failed, 9 skipped / 1053**.
- Full DME with physical MySQL and this consumer adapter: **1046 passed, 0 failed, 7 skipped / 1053**.

All 15 prior identity/upsert failure identities disappear with the adapter. The four remaining native failures require physical mysqli connections or handles. The native provider is tested at `dcfe6b4`; restored PR403 head `34057b0` has the identical tree. Its transaction behavior is bounded coarse serialization, not MVCC.

With the repository's configured WordPress PHPUnit database and fixtures:

```sh
vendor/bin/phpunit --configuration phpunit.xml tests/Unit/Core/Database/PostIdentityReservations/PostIdentityReservationsTest.php
```

The managed test runner used `tests/fixtures/phpunit-isolation.php` and the shared WP-CLI bootstrap. The capability fake tests routing and failure handling, not transactional behavior of MyISAM. Independent-process conformance belongs to the native prerequisite.

Operator-retained evidence: `transaction-capability-full-native-dcfe6b4-4432c243`, `transaction-capability-full-mysql-dcfe6b4-4432c243`, and `dm-post-identity-mysql-4432c243-dedicated`, with full JUnit and effective recipes. No consumer assertions were weakened. No release or deployment is included.

## AI Assistance

OpenAI GPT-6 Astra (`openai/gpt-6-astra`) via OpenCode investigated transactional requirements, implemented and reviewed the generic adapter through isolated agents, corrected test-double/bootstrap and lint issues, and ran dedicated MySQL and paired native/MySQL consumer verification under maintainer direction.
