### PR TITLE
fix: add Connect/Reconnect button to the Auth Providers settings panel

### DIFF
--- a/inc/Core/Admin/Settings/assets/react/components/tabs/AuthProvidersTab.jsx
+++ b/inc/Core/Admin/Settings/assets/react/components/tabs/AuthProvidersTab.jsx
@@ -25,6 +25,7 @@ import {
 	useAuthProviders,
 	useSaveAuthConfig,
 	useDisconnectAuth,
+	useAuthorizeProvider,
 } from '../../queries/authProviders';
 
 /**
@@ -286,24 +287,36 @@ const CallbackUrlDisplay = ( { url } ) => {
  * @param {Object}   root0.provider        Provider metadata.
  * @param {Function} root0.onSave          Save callback.
  * @param {Function} root0.onDisconnect    Disconnect callback.
+ * @param {Function} root0.onAuthorize     Start-OAuth callback.
  * @param {boolean}  root0.isSaving        Whether a save is in progress.
  * @param {boolean}  root0.isDisconnecting Whether a disconnect is in progress.
+ * @param {boolean}  root0.isAuthorizing   Whether an authorization is starting.
  */
 const ProviderCard = ( {
 	provider,
 	onSave,
 	onDisconnect,
+	onAuthorize,
 	isSaving,
 	isDisconnecting,
+	isAuthorizing,
 } ) => {
 	const [ showConfig, setShowConfig ] = useState( false );
 	const [ feedback, setFeedback ] = useState( null );
 	const [ isDisconnectConfirmOpen, setIsDisconnectConfirmOpen ] = useState( false );
+	const supportsOAuth = provider.auth_type !== 'simple';
 	let configButtonLabel = __( 'Configure', 'data-machine' );
 	if ( showConfig ) {
 		configButtonLabel = __( 'Hide Config', 'data-machine' );
 	} else if ( provider.is_authenticated ) {
 		configButtonLabel = __( 'Edit Config', 'data-machine' );
+	}
+
+	let connectButtonLabel = __( 'Connect Account', 'data-machine' );
+	if ( isAuthorizing ) {
+		connectButtonLabel = __( 'Connecting\u2026', 'data-machine' );
+	} else if ( provider.is_authenticated ) {
+		connectButtonLabel = __( 'Reconnect', 'data-machine' );
 	}
 
 	const handleSave = useCallback(
@@ -326,6 +339,20 @@ const ProviderCard = ( {
 		},
 		[ onSave ]
 	);
+
+	const handleAuthorize = useCallback( async () => {
+		setFeedback( null );
+		try {
+			await onAuthorize( provider.provider_key );
+		} catch ( err ) {
+			setFeedback( {
+				type: 'error',
+				message:
+					err.message ||
+					__( 'Failed to start authorization.', 'data-machine' ),
+			} );
+		}
+	}, [ onAuthorize, provider.provider_key ] );
 
 	const handleDisconnect = useCallback( async () => {
 		setIsDisconnectConfirmOpen( false );
@@ -383,6 +410,18 @@ const ProviderCard = ( {
 			) }
 
 			<div className="datamachine-auth-card-actions">
+				{ supportsOAuth && (
+					<Button
+						variant="primary"
+						onClick={ handleAuthorize }
+						isBusy={ isAuthorizing }
+						disabled={ isAuthorizing || ! provider.is_configured }
+						className="button-small"
+					>
+						{ connectButtonLabel }
+					</Button>
+				) }
+
 				{ provider.is_authenticated && (
 					<Button
 						variant="secondary"
@@ -408,6 +447,15 @@ const ProviderCard = ( {
 					</Button>
 				) }
 			</div>
+
+			{ supportsOAuth && ! provider.is_configured && (
+				<p className="description">
+					{ __(
+						'Save this provider\u2019s credentials before connecting an account.',
+						'data-machine'
+					) }
+				</p>
+			) }
 
 			{ showConfig && (
 				<div className="datamachine-auth-card-config">
@@ -438,8 +486,10 @@ const AuthProvidersTab = () => {
 	const { data: providers, isLoading, error } = useAuthProviders();
 	const saveMutation = useSaveAuthConfig();
 	const disconnectMutation = useDisconnectAuth();
+	const authorizeMutation = useAuthorizeProvider();
 	const [ savingProvider, setSavingProvider ] = useState( null );
 	const [ disconnectingProvider, setDisconnectingProvider ] = useState( null );
+	const [ authorizingProvider, setAuthorizingProvider ] = useState( null );
 
 	const handleSave = async ( providerKey, config ) => {
 		setSavingProvider( providerKey );
@@ -447,6 +497,19 @@ const AuthProvidersTab = () => {
 			await saveMutation.mutateAsync( { providerKey, config } );
 		} finally {
 			setSavingProvider( null );
+		}
+	};
+
+	const handleAuthorize = async ( providerKey ) => {
+		setAuthorizingProvider( providerKey );
+		try {
+			const oauthUrl = await authorizeMutation.mutateAsync( providerKey );
+			// Full-page navigation: the provider redirects back to this page
+			// with auth_success / auth_error, which SettingsApp surfaces.
+			window.location.href = oauthUrl;
+		} catch ( err ) {
+			setAuthorizingProvider( null );
+			throw err;
 		}
 	};
 
@@ -511,9 +574,13 @@ const AuthProvidersTab = () => {
 						provider={ provider }
 						onSave={ handleSave }
 						onDisconnect={ handleDisconnect }
+						onAuthorize={ handleAuthorize }
 						isSaving={ savingProvider === provider.provider_key }
 						isDisconnecting={
 							disconnectingProvider === provider.provider_key
+						}
+						isAuthorizing={
+							authorizingProvider === provider.provider_key
 						}
 					/>
 				) ) }

--- a/inc/Core/Admin/Settings/assets/react/queries/authProviders.js
+++ b/inc/Core/Admin/Settings/assets/react/queries/authProviders.js
@@ -87,3 +87,37 @@ export const useDisconnectAuth = () => {
 		},
 	} );
 };
+
+/**
+ * Fetch the server-generated OAuth authorization URL for a provider.
+ *
+ * The URL must come from the server on every attempt because the provider's
+ * auth handler mints a single-use `state` parameter as a side effect of
+ * building it. Callers navigate to the returned URL; the provider redirects
+ * back to the settings page with `auth_success` / `auth_error`, which
+ * SettingsApp already turns into a notice.
+ */
+export const useAuthorizeProvider = () => {
+	return useMutation( {
+		mutationFn: async ( providerKey ) => {
+			const response = await client.get(
+				`/auth/${ providerKey }/status`
+			);
+			if ( ! response.success ) {
+				throw new Error(
+					response.message ||
+						'Failed to get authorization URL'
+				);
+			}
+
+			const oauthUrl = response.data?.oauth_url;
+			if ( ! oauthUrl ) {
+				throw new Error(
+					'This provider did not return an authorization URL.'
+				);
+			}
+
+			return oauthUrl;
+		},
+	} );
+};


### PR DESCRIPTION
Closes #3489.

## Problem

`admin.php?page=datamachine-settings` → Auth Providers rendered only **Configure** and **Disconnect**. There was no way to start an OAuth flow: not configured → Configure → Configured → dead end. First-time connects and re-auth after a scope change (e.g. Instagram adding `pages_manage_metadata`) were impossible from the UI — the only workaround was extracting `oauth_url` by hand via WP-CLI.

## Fix

The backend contract already existed and is unchanged:
- `AuthAbilities::executeGetAuthStatus()` returns a server-minted `oauth_url` (single-use `state` created as a side effect of building it), exposed at `GET /datamachine/v1/auth/{slug}/status`.
- `OAuthRedirects` sends the provider back to `page=datamachine-settings&auth_success=1&provider=…`.
- `SettingsApp` already turns `auth_success`/`auth_error` into a notice and cleans the params.

This PR adds the missing UI:
- `useAuthorizeProvider()` in `queries/authProviders.js` — mutation that fetches the URL fresh on every click (never cached, because state is single-use).
- `ProviderCard` gains a primary **Connect Account** button, labelled **Reconnect** when already authenticated and **Connecting…** while in flight. Rendered for any `auth_type !== 'simple'`, disabled until `is_configured`, with an inline hint telling the operator to save credentials first. Errors surface in the existing card `Notice`.
- Full-page navigation rather than a popup, matching the redirect contract the code flow already implements. (The popup handler on the Pipelines page depends on `postMessage`, which only the implicit-flow callback page emits.)

## Verification

- `npx eslint` clean on both touched files.
- `npm run build` succeeds; `Connect Account` / `Reconnect` / the hint string are present in the emitted `settings-react.js`.
- Manual: on extrachill.com the same `oauth_url` this button navigates to completes the Instagram flow and returns `auth_success=1`.