### PR TITLE
fix: read SectionRegistry inspection back from the agents-api context registry

### DIFF
--- a/inc/Engine/AI/SectionRegistry.php
+++ b/inc/Engine/AI/SectionRegistry.php
@@ -23,13 +23,6 @@ use WP_Agent_Context_Section_Registry;
 class SectionRegistry {
 
 	/**
-	 * Registered sections, keyed by filename then slug.
-	 *
-	 * @var array<string, array<string, array>> Filename => slug => section metadata.
-	 */
-	private static array $sections = array();
-
-	/**
 	 * Whether the action has been fired.
 	 *
 	 * @var bool
@@ -70,10 +63,6 @@ class SectionRegistry {
 			return;
 		}
 
-		if ( ! isset( self::$sections[ $filename ] ) ) {
-			self::$sections[ $filename ] = array();
-		}
-
 		$section_callback = static function ( array $context, array $section ) use ( $callback ) {
 			unset( $section );
 			return call_user_func( $callback, $context );
@@ -84,44 +73,30 @@ class SectionRegistry {
 		$site_id    = isset( $args['site_id'] ) ? (int) $args['site_id'] : ( function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0 );
 		$site_url   = isset( $args['site_url'] ) ? (string) $args['site_url'] : ( function_exists( 'get_home_url' ) && $site_id > 0 ? (string) get_home_url( $site_id, '/' ) : '' );
 
-		self::$sections[ $filename ][ $slug ] = array(
-			'slug'            => $slug,
-			'priority'        => $priority,
-			'callback'        => $section_callback,
-			'label'           => $args['label'] ?? self::slug_to_label( $slug ),
-			'description'     => $args['description'] ?? '',
-			'owner'           => is_string( $owner ) && '' !== trim( $owner ) ? trim( $owner ) : '-',
-			'freshness'       => isset( $args['freshness'] ) && is_string( $args['freshness'] ) && '' !== trim( $args['freshness'] ) ? trim( $args['freshness'] ) : '-',
-			'conditions'      => isset( $args['conditions'] ) && is_string( $args['conditions'] ) && '' !== trim( $args['conditions'] ) ? trim( $args['conditions'] ) : '-',
-			'source_plugin'   => $provenance['source_plugin'],
-			'source_file'     => $provenance['source_file'],
-			'source_callback' => $provenance['source_callback'],
-			'registered_at'   => $provenance['registered_at'],
-			'site_id'         => $site_id,
-			'site_url'        => $site_url,
-		);
-
+		// The agents-api context registry is the single source of truth. Every
+		// DM-specific attribute travels in `meta` so get_sections() can read it
+		// back without keeping a parallel copy here.
 		WP_Agent_Context_Section_Registry::register(
 			MemoryFileRegistry::context_slug_for_filename( $filename ),
 			$slug,
 			$priority,
 			$section_callback,
 			array(
-				'label'            => self::$sections[ $filename ][ $slug ]['label'],
-				'description'      => self::$sections[ $filename ][ $slug ]['description'],
+				'label'            => $args['label'] ?? self::slug_to_label( $slug ),
+				'description'      => $args['description'] ?? '',
 				'retrieval_policy' => $args['retrieval_policy'] ?? null,
 				'modes'            => $args['modes'] ?? array( MemoryFileRegistry::MODE_ALL ),
 				'meta'             => array(
 					'filename'        => $filename,
-					'owner'           => self::$sections[ $filename ][ $slug ]['owner'],
-					'freshness'       => self::$sections[ $filename ][ $slug ]['freshness'],
-					'conditions'      => self::$sections[ $filename ][ $slug ]['conditions'],
-					'source_plugin'   => self::$sections[ $filename ][ $slug ]['source_plugin'],
-					'source_file'     => self::$sections[ $filename ][ $slug ]['source_file'],
-					'source_callback' => self::$sections[ $filename ][ $slug ]['source_callback'],
-					'registered_at'   => self::$sections[ $filename ][ $slug ]['registered_at'],
-					'site_id'         => self::$sections[ $filename ][ $slug ]['site_id'],
-					'site_url'        => self::$sections[ $filename ][ $slug ]['site_url'],
+					'owner'           => is_string( $owner ) && '' !== trim( $owner ) ? trim( $owner ) : '-',
+					'freshness'       => isset( $args['freshness'] ) && is_string( $args['freshness'] ) && '' !== trim( $args['freshness'] ) ? trim( $args['freshness'] ) : '-',
+					'conditions'      => isset( $args['conditions'] ) && is_string( $args['conditions'] ) && '' !== trim( $args['conditions'] ) ? trim( $args['conditions'] ) : '-',
+					'source_plugin'   => $provenance['source_plugin'],
+					'source_file'     => $provenance['source_file'],
+					'source_callback' => $provenance['source_callback'],
+					'registered_at'   => $provenance['registered_at'],
+					'site_id'         => $site_id,
+					'site_url'        => $site_url,
 				),
 			)
 		);
@@ -140,7 +115,6 @@ class SectionRegistry {
 		$filename = sanitize_file_name( $filename );
 		$slug     = sanitize_key( $slug );
 
-		unset( self::$sections[ $filename ][ $slug ] );
 		WP_Agent_Context_Section_Registry::unregister( MemoryFileRegistry::context_slug_for_filename( $filename ), $slug );
 	}
 
@@ -149,6 +123,10 @@ class SectionRegistry {
 	 *
 	 * @since 0.66.0
 	 *
+	 * Reads back from the agents-api context registry, so sections registered
+	 * directly on `WP_Agent_Context_Section_Registry` by plugins that do not
+	 * depend on Data Machine are reported alongside DM-registered ones.
+	 *
 	 * @param string $filename Composable filename.
 	 * @return array<string, array> Slug => section metadata, sorted by priority ascending.
 	 */
@@ -156,15 +134,14 @@ class SectionRegistry {
 		self::ensure_action_fired();
 
 		$filename = sanitize_file_name( $filename );
-		$sections = self::$sections[ $filename ] ?? array();
+		if ( '' === $filename ) {
+			return array();
+		}
 
-		uasort(
-			$sections,
-			function ( $a, $b ) {
-				$priority = $a['priority'] <=> $b['priority'];
-				return 0 !== $priority ? $priority : strcmp( $a['slug'], $b['slug'] );
-			}
-		);
+		$sections = array();
+		foreach ( WP_Agent_Context_Section_Registry::get_sections( MemoryFileRegistry::context_slug_for_filename( $filename ) ) as $slug => $section ) {
+			$sections[ $slug ] = self::from_context_section( $filename, $section );
+		}
 
 		return $sections;
 	}
@@ -276,7 +253,11 @@ class SectionRegistry {
 		self::ensure_action_fired();
 
 		$filename = sanitize_file_name( $filename );
-		return ! empty( self::$sections[ $filename ] );
+		if ( '' === $filename ) {
+			return false;
+		}
+
+		return ! empty( WP_Agent_Context_Section_Registry::get_sections( MemoryFileRegistry::context_slug_for_filename( $filename ) ) );
 	}
 
 	/**
@@ -289,10 +270,15 @@ class SectionRegistry {
 	public static function get_filenames(): array {
 		self::ensure_action_fired();
 
-		return array_keys( array_filter(
-			self::$sections,
-			function ( $sections ) {
-				return ! empty( $sections );
+		$context_slugs = WP_Agent_Context_Section_Registry::get_context_slugs();
+		if ( empty( $context_slugs ) ) {
+			return array();
+		}
+
+		return array_values( array_filter(
+			MemoryFileRegistry::get_filenames(),
+			static function ( string $filename ) use ( $context_slugs ): bool {
+				return in_array( MemoryFileRegistry::context_slug_for_filename( $filename ), $context_slugs, true );
 			}
 		) );
 	}
@@ -305,7 +291,6 @@ class SectionRegistry {
 	 * @return void
 	 */
 	public static function reset(): void {
-		self::$sections     = array();
 		self::$action_fired = false;
 		WP_Agent_Context_Section_Registry::reset();
 	}
@@ -324,12 +309,56 @@ class SectionRegistry {
 			 * SectionRegistry::register() inside this action callback.
 			 *
 			 * @since 0.66.0
-			 *
-			 * @param array<string, array<string, array>> $sections Current registry state (read-only snapshot).
 			 */
-			do_action( 'datamachine_sections', self::$sections );
+			do_action( 'datamachine_sections' );
 			self::$action_fired = true;
 		}
+	}
+
+	/**
+	 * Map an agents-api context section back to Data Machine's section shape.
+	 *
+	 * DM-registered sections carry their operator metadata in `meta`; sections
+	 * registered directly on the substrate by other plugins may carry none, so
+	 * every DM-specific column falls back to '-' rather than being dropped.
+	 *
+	 * @param string $filename Composable filename.
+	 * @param array  $section  Section as stored by WP_Agent_Context_Section_Registry.
+	 * @return array<string, mixed>
+	 */
+	private static function from_context_section( string $filename, array $section ): array {
+		$meta = is_array( $section['meta'] ?? null ) ? $section['meta'] : array();
+		$slug = is_string( $section['slug'] ?? null ) ? $section['slug'] : '';
+
+		$string_meta = static function ( string $key ) use ( $meta ): string {
+			$value = $meta[ $key ] ?? null;
+			return is_string( $value ) && '' !== trim( $value ) ? trim( $value ) : '-';
+		};
+
+		$owner = $string_meta( 'owner' );
+		if ( '-' === $owner ) {
+			$owner = $string_meta( 'source_plugin' );
+		}
+
+		$site_id = isset( $meta['site_id'] ) ? (int) $meta['site_id'] : 0;
+
+		return array(
+			'slug'            => $slug,
+			'priority'        => (int) ( $section['priority'] ?? 10 ),
+			'callback'        => $section['callback'],
+			'label'           => is_string( $section['label'] ?? null ) && '' !== $section['label'] ? $section['label'] : self::slug_to_label( $slug ),
+			'description'     => is_string( $section['description'] ?? null ) ? $section['description'] : '',
+			'owner'           => $owner,
+			'freshness'       => $string_meta( 'freshness' ),
+			'conditions'      => $string_meta( 'conditions' ),
+			'source_plugin'   => $string_meta( 'source_plugin' ),
+			'source_file'     => $string_meta( 'source_file' ),
+			'source_callback' => $string_meta( 'source_callback' ),
+			'registered_at'   => $string_meta( 'registered_at' ),
+			'site_id'         => $site_id,
+			'site_url'        => is_string( $meta['site_url'] ?? null ) ? $meta['site_url'] : '',
+			'filename'        => is_string( $meta['filename'] ?? null ) && '' !== $meta['filename'] ? $meta['filename'] : $filename,
+		);
 	}
 
 	/**

--- a/tests/section-registry-substrate-readback-smoke.php
+++ b/tests/section-registry-substrate-readback-smoke.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Smoke coverage: SectionRegistry reads back from the agents-api context
+ * registry instead of a private shadow copy.
+ *
+ * Proves that a section registered directly on
+ * WP_Agent_Context_Section_Registry (by a plugin with no Data Machine
+ * dependency) is visible to SectionRegistry::get_sections(), get_section(),
+ * has_sections(), get_filenames(), and render_sections(), and that
+ * DM-registered sections still expose their operator metadata unchanged.
+ *
+ * Run with: php tests/section-registry-substrate-readback-smoke.php
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = null ) {
+		unset( $domain );
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $key ) {
+		$key = strtolower( (string) $key );
+		return preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	}
+}
+
+if ( ! function_exists( 'sanitize_file_name' ) ) {
+	function sanitize_file_name( $filename ) {
+		return preg_replace( '/[^a-zA-Z0-9._\-]/', '', basename( (string) $filename ) );
+	}
+}
+
+$GLOBALS['datamachine_readback_actions'] = array();
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+		$GLOBALS['datamachine_readback_actions'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook, ...$args ): void {
+		$callbacks = $GLOBALS['datamachine_readback_actions'][ $hook ] ?? array();
+		ksort( $callbacks );
+		foreach ( $callbacks as $priority_callbacks ) {
+			foreach ( $priority_callbacks as $callback ) {
+				call_user_func_array( $callback[0], array_slice( $args, 0, $callback[1] ) );
+			}
+		}
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook, $value, ...$args ) {
+		unset( $hook, $args );
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( ...$args ) {
+		unset( $args );
+	}
+}
+
+if ( ! function_exists( 'current_filter' ) ) {
+	function current_filter() {
+		return 'plugins_loaded';
+	}
+}
+
+if ( ! function_exists( 'plugin_basename' ) ) {
+	function plugin_basename( $file ) {
+		return $file;
+	}
+}
+
+require_once __DIR__ . '/../vendor/wordpress/agents-api/agents-api.php';
+require_once __DIR__ . '/../inc/Engine/AI/MemoryFileRegistry.php';
+require_once __DIR__ . '/../inc/Engine/AI/SectionRegistry.php';
+
+use DataMachine\Engine\AI\MemoryFileRegistry;
+use DataMachine\Engine\AI\SectionRegistry;
+
+$failures = array();
+
+function readback_assert( bool $condition, string $message ): void {
+	global $failures;
+	if ( ! $condition ) {
+		$failures[] = $message;
+	}
+}
+
+MemoryFileRegistry::register(
+	'AGENTS.md',
+	10,
+	array(
+		'layer'      => MemoryFileRegistry::LAYER_SHARED,
+		'composable' => true,
+	)
+);
+
+// A DM-owned registration with full operator metadata.
+SectionRegistry::register(
+	'AGENTS.md',
+	'dm-owned',
+	20,
+	static function () {
+		return "## DM Owned\n";
+	},
+	array(
+		'label'       => 'DM Owned',
+		'description' => 'Registered through Data Machine.',
+		'owner'       => 'data-machine',
+		'freshness'   => 'static',
+		'conditions'  => 'always',
+	)
+);
+
+// A substrate-only registration, the way a plugin that depends on agents-api
+// but not on Data Machine registers guidance.
+WP_Agent_Context_Section_Registry::register(
+	'agents-md',
+	'substrate-only',
+	10,
+	static function ( array $context, array $section ) {
+		unset( $context, $section );
+		return "## Substrate Only\n";
+	},
+	array(
+		'label'       => 'Substrate Only',
+		'description' => 'Registered on the agents-api registry directly.',
+	)
+);
+
+// Inspection surface.
+$sections = SectionRegistry::get_sections( 'AGENTS.md' );
+readback_assert( array_keys( $sections ) === array( 'substrate-only', 'dm-owned' ), 'get_sections() returns both registrations in priority order.' );
+readback_assert( null !== SectionRegistry::get_section( 'AGENTS.md', 'substrate-only' ), 'get_section() resolves a substrate-only section.' );
+readback_assert( SectionRegistry::has_sections( 'AGENTS.md' ), 'has_sections() sees substrate registrations.' );
+readback_assert( array( 'AGENTS.md' ) === SectionRegistry::get_filenames(), 'get_filenames() maps context slugs back to registered filenames.' );
+
+// DM metadata survives the round-trip unchanged.
+$dm = $sections['dm-owned'];
+readback_assert( 'data-machine' === $dm['owner'], 'DM owner survives readback.' );
+readback_assert( 'static' === $dm['freshness'], 'DM freshness survives readback.' );
+readback_assert( 'always' === $dm['conditions'], 'DM conditions survive readback.' );
+readback_assert( 'plugins_loaded' === $dm['registered_at'], 'DM registered_at provenance survives readback.' );
+readback_assert( 'Closure' === $dm['source_callback'], 'DM source_callback provenance survives readback.' );
+readback_assert( 'AGENTS.md' === $dm['filename'], 'DM filename survives readback.' );
+
+// Substrate-only sections degrade to '-' for DM-specific columns rather than
+// being dropped or throwing on missing keys.
+$sub = $sections['substrate-only'];
+readback_assert( 'Substrate Only' === $sub['label'], 'Substrate label is preserved.' );
+readback_assert( '-' === $sub['owner'], 'Substrate owner defaults to "-".' );
+readback_assert( '-' === $sub['freshness'], 'Substrate freshness defaults to "-".' );
+readback_assert( '-' === $sub['conditions'], 'Substrate conditions default to "-".' );
+readback_assert( '-' === $sub['source_plugin'], 'Substrate source_plugin defaults to "-".' );
+readback_assert( 'AGENTS.md' === $sub['filename'], 'Substrate filename is inferred from the requested file.' );
+readback_assert( is_callable( $sub['callback'] ), 'Substrate callback is exposed for render_sections().' );
+
+// Rendering and composition agree on section count.
+$rendered = SectionRegistry::render_sections( 'AGENTS.md' );
+readback_assert( 2 === count( $rendered ), 'render_sections() renders both registrations.' );
+readback_assert( ! isset( $rendered['substrate-only']['callback'] ), 'render_sections() strips callbacks from the snapshot.' );
+
+$content = SectionRegistry::generate( 'AGENTS.md' );
+readback_assert( false !== strpos( $content, '## Substrate Only' ), 'generate() composes the substrate-only section.' );
+readback_assert( false !== strpos( $content, '## DM Owned' ), 'generate() composes the DM-owned section.' );
+readback_assert( strpos( $content, '## Substrate Only' ) < strpos( $content, '## DM Owned' ), 'generate() honors priority across both registries.' );
+readback_assert( count( $rendered ) === count( SectionRegistry::get_sections( 'AGENTS.md' ) ), 'Section count matches what was composed.' );
+
+// Deregistration removes from the single source of truth.
+SectionRegistry::deregister( 'AGENTS.md', 'dm-owned' );
+readback_assert( null === SectionRegistry::get_section( 'AGENTS.md', 'dm-owned' ), 'deregister() removes the section from readback.' );
+readback_assert( false === strpos( SectionRegistry::generate( 'AGENTS.md' ), '## DM Owned' ), 'deregister() removes the section from composition.' );
+
+// Reset clears everything.
+SectionRegistry::reset();
+readback_assert( ! SectionRegistry::has_sections( 'AGENTS.md' ), 'reset() clears the substrate registry.' );
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, "FAILURES:\n- " . implode( "\n- ", $failures ) . "\n" );
+	exit( 1 );
+}
+
+echo "section-registry-substrate-readback-smoke: OK\n";


### PR DESCRIPTION
Closes #3486

## Problem

`\DataMachine\Engine\AI\SectionRegistry` forwarded every `register()` to agents-api's `WP_Agent_Context_Section_Registry` and composed `AGENTS.md` from it, but `get_sections()` / `get_section()` / `has_sections()` / `get_filenames()` read a private `self::$sections` shadow array.

A section registered directly on the substrate (the correct move for a plugin that depends on agents-api but not on Data Machine — see Automattic/wp-codebox#2501) was composed into the file but invisible to `wp datamachine memory sections` / `memory explain` and undercounted in the `ComposableFileGenerator` regen log.

## Change

- Delete the shadow array. `register()` now only forwards to the substrate; all DM-specific operator metadata (`owner`, `freshness`, `conditions`, `source_*`, `registered_at`, `site_*`, `filename`) was already packed into `meta`.
- `get_sections()` reads back from `WP_Agent_Context_Section_Registry::get_sections( context_slug )` and maps each section through a new `from_context_section()` that restores the DM shape, defaulting DM-specific columns to `'-'` for substrate-only registrations.
- `has_sections()` / `get_filenames()` derive from the substrate; `get_filenames()` maps context slugs back to filenames via `MemoryFileRegistry::get_filenames()`.
- `deregister()` / `reset()` no longer touch a local copy.
- `datamachine_sections` fires without the snapshot argument — no consumer on the network read it (verified: all four registrants take zero args).

## Verification

```
php tests/section-registry-substrate-readback-smoke.php   # new — OK
php tests/agents-api-memory-contract-adoption-smoke.php   # OK
php tests/agents-md-multisite-composition-smoke.php       # OK
php tests/agents-md-section-ownership-smoke.php           # OK
phpcs --standard=WordPress inc/Engine/AI/SectionRegistry.php   # clean
```

The new smoke registers one section through DM and one directly on `WP_Agent_Context_Section_Registry`, then asserts both appear in `get_sections()` in priority order, DM metadata survives the round-trip unchanged, substrate-only columns default to `-`, `render_sections()`/`generate()` counts agree, and `deregister()`/`reset()` clear the single source of truth.

## AI disclosure

Authored by Extra Chill Bot (Claude) from the live extrachill.com session; reviewed diff and test output before opening.