### PR TITLE
fix(scheduling): lock flow schedule reconcile before boot(), not after

### DIFF
--- a/inc/Abilities/Flow/ReconcileFlowSchedulesAbility.php
+++ b/inc/Abilities/Flow/ReconcileFlowSchedulesAbility.php
@@ -44,6 +44,8 @@ class ReconcileFlowSchedulesAbility {
 						'properties' => array(
 							'success'     => array( 'type' => 'boolean' ),
 							'applied'     => array( 'type' => 'boolean' ),
+							'skipped'     => array( 'type' => 'boolean' ),
+							'reason'      => array( 'type' => 'string' ),
 							'covered'     => array( 'type' => 'integer' ),
 							'missing'     => array( 'type' => 'integer' ),
 							'removed'     => array( 'type' => 'integer' ),

--- a/inc/Api/Flows/FlowScheduleReconciliationLock.php
+++ b/inc/Api/Flows/FlowScheduleReconciliationLock.php
@@ -2,17 +2,38 @@
 /**
  * Atomic per-site flow schedule reconciliation lock.
  *
- * Compare-and-set option lock: no add_option()/delete_option() cache-vs-DB
- * split. Every mutation is a conditional `$wpdb->query()` against the exact
- * expected serialized value, paired with an explicit `wp_cache_delete()` so
- * a stale object-cache entry can never survive a successful write and block
- * the lock forever (see Extra-Chill/data-machine#3492 for the failure mode
- * this is designed to avoid: an object-cache-only lock entry with no DB row
- * makes add_option() always fail and delete_option() never clear the cache).
+ * Compare-and-set option lock that never trusts the persistent object
+ * cache for the lock row itself. Every read this class needs to make a
+ * locking decision goes straight to `wp_options` via `$wpdb`; every
+ * mutation is a conditional `$wpdb->query()` against the exact DB-read
+ * value, followed by an unconditional `wp_cache_delete()`.
+ *
+ * This is deliberately stricter than a plain add_option()/get_option()
+ * compare-and-set. `add_option()` checks the object cache before it checks
+ * the database, and `get_option()` serves the cached value when present.
+ * If a killed request leaves this lock cached in Redis with no backing row
+ * in `wp_options` (a normal outcome of a request dying mid-write, and the
+ * exact failure mode observed on the underlying agents-api registry lock,
+ * `agents_routine_reconcile_lock`, during the Extra-Chill/data-machine#3492
+ * incident):
+ *
+ *  - `add_option()` always fails (cache hit), so the "fast path" acquire
+ *    never succeeds again on this site;
+ *  - `get_option()` keeps returning the cached payload as if it were live,
+ *    so the staleness check sees an apparently-fresh lock for up to
+ *    STALE_AFTER seconds even though nothing actually holds it;
+ *  - once the cached value is finally old enough to be treated as stale,
+ *    a compare-and-set UPDATE against it matches zero rows (there is no
+ *    row to update), so acquisition fails forever — the lock is
+ *    permanently stuck until an operator manually flushes the cache key.
+ *
+ * Reading and comparing against `wp_options` directly (never the cache)
+ * closes that hole: the database, not Redis, is the only source of truth
+ * for whether the lock row exists and what it currently says.
  *
  * Guards {@see \DataMachine\Engine\Scheduling\FlowRoutines::reconcile()}
- * before it calls `boot()`, so lock contention costs one option read instead
- * of a full ~700-routine registration pass.
+ * before it calls `boot()`, so lock contention costs one direct DB read
+ * instead of a full ~700-routine registration pass.
  *
  * @package DataMachine\Api\Flows
  */
@@ -38,16 +59,33 @@ class FlowScheduleReconciliationLock {
 			'acquired_at' => time(),
 		);
 
-		if ( add_option( self::OPTION_NAME, $payload, '', false ) ) {
-			return $token;
+		$row = self::read_db_row();
+
+		if ( null === $row ) {
+			// No backing row. The object cache may still hold a stale
+			// payload from a killed request — clear it before inserting so
+			// a later get_option() elsewhere can't resurrect a phantom lock
+			// with no row behind it.
+			wp_cache_delete( self::OPTION_NAME, 'options' );
+
+			if ( self::insert_new( $payload ) ) {
+				return $token;
+			}
+
+			// Someone else's INSERT won the race between our read and our
+			// insert attempt. Re-read and fall through to evaluate their lock
+			// instead of assuming failure.
+			$row = self::read_db_row();
+			if ( null === $row ) {
+				return new \WP_Error( 'flow_schedule_reconciliation_locked', 'Another flow schedule reconciliation acquired the lock first.' );
+			}
 		}
 
-		$current = get_option( self::OPTION_NAME, array() );
-		if ( is_array( $current ) && (int) ( $current['acquired_at'] ?? 0 ) > time() - self::STALE_AFTER ) {
+		if ( is_array( $row['value'] ) && (int) ( $row['value']['acquired_at'] ?? 0 ) > time() - self::STALE_AFTER ) {
 			return new \WP_Error( 'flow_schedule_reconciliation_locked', 'Another flow schedule reconciliation is already running.' );
 		}
 
-		if ( self::compare_and_swap( $current, $payload ) ) {
+		if ( self::compare_and_swap( $row['raw'], $payload ) ) {
 			return $token;
 		}
 
@@ -61,29 +99,29 @@ class FlowScheduleReconciliationLock {
 	 * @return bool True when this owner released the lock.
 	 */
 	public static function release( string $token ): bool {
-		$current = get_option( self::OPTION_NAME, array() );
-		if ( ! is_array( $current ) || ! hash_equals( (string) ( $current['token'] ?? '' ), $token ) ) {
+		$row = self::read_db_row();
+		if ( null === $row || ! is_array( $row['value'] ) || ! hash_equals( (string) ( $row['value']['token'] ?? '' ), $token ) ) {
 			return false;
 		}
 
 		global $wpdb;
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Conditional delete provides token-safe lock release.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Conditional delete against the DB-read value provides token-safe lock release.
 		$deleted = $wpdb->query(
 			$wpdb->prepare(
 				'DELETE FROM %i WHERE option_name = %s AND option_value = %s',
 				$wpdb->options,
 				self::OPTION_NAME,
-				maybe_serialize( $current )
+				$row['raw']
 			)
 		);
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 
-		if ( 1 === $deleted ) {
-			wp_cache_delete( self::OPTION_NAME, 'options' );
-			return true;
-		}
+		// Clear the cache unconditionally: even a 0-row DELETE means someone
+		// else already mutated the row out from under us, and either way a
+		// stale cached copy must never survive this call.
+		wp_cache_delete( self::OPTION_NAME, 'options' );
 
-		return false;
+		return 1 === $deleted;
 	}
 
 	/**
@@ -93,42 +131,97 @@ class FlowScheduleReconciliationLock {
 	 * @return bool True when the exact owned lease was refreshed.
 	 */
 	public static function refresh( string $token ): bool {
-		$current = get_option( self::OPTION_NAME, array() );
-		if ( ! is_array( $current ) || ! hash_equals( (string) ( $current['token'] ?? '' ), $token ) ) {
+		$row = self::read_db_row();
+		if ( null === $row || ! is_array( $row['value'] ) || ! hash_equals( (string) ( $row['value']['token'] ?? '' ), $token ) ) {
 			return false;
 		}
 
-		$replacement                = $current;
-		$replacement['acquired_at'] = max( time(), (int) ( $current['acquired_at'] ?? 0 ) + 1 );
-		return self::compare_and_swap( $current, $replacement );
+		$replacement                = $row['value'];
+		$replacement['acquired_at'] = max( time(), (int) ( $row['value']['acquired_at'] ?? 0 ) + 1 );
+
+		return self::compare_and_swap( $row['raw'], $replacement );
 	}
 
 	/**
-	 * Atomically replace the exact expected payload.
+	 * Read the lock row straight from `wp_options`, bypassing the object cache.
 	 *
-	 * @param mixed                $expected    Current expected lock payload.
-	 * @param array<string, mixed> $replacement New lock payload.
+	 * @return array{raw: string, value: mixed}|null Null when no row exists.
+	 */
+	private static function read_db_row(): ?array {
+		global $wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Locking decisions must never be based on the cached option value.
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT option_value FROM %i WHERE option_name = %s',
+				$wpdb->options,
+				self::OPTION_NAME
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( ! is_array( $row ) || ! array_key_exists( 'option_value', $row ) ) {
+			return null;
+		}
+
+		return array(
+			'raw'   => (string) $row['option_value'],
+			'value' => maybe_unserialize( $row['option_value'] ),
+		);
+	}
+
+	/**
+	 * Insert the lock row only if no row exists yet (`INSERT IGNORE` on the
+	 * unique `option_name` key), never through `add_option()`.
+	 *
+	 * @param array<string, mixed> $payload New lock payload.
+	 * @return bool True when this call created the row.
+	 */
+	private static function insert_new( array $payload ): bool {
+		global $wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- INSERT IGNORE on the unique option_name key resolves concurrent first-acquire races.
+		$inserted = $wpdb->query(
+			$wpdb->prepare(
+				'INSERT IGNORE INTO %i (option_name, option_value, autoload) VALUES (%s, %s, %s)',
+				$wpdb->options,
+				self::OPTION_NAME,
+				maybe_serialize( $payload ),
+				'off'
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+
+		wp_cache_delete( self::OPTION_NAME, 'options' );
+
+		return 1 === $inserted;
+	}
+
+	/**
+	 * Atomically replace the exact expected raw (already-serialized) value.
+	 *
+	 * @param string                $expected_raw Raw `option_value` read directly from the DB.
+	 * @param array<string, mixed>  $replacement  New lock payload.
 	 * @return bool True when the expected owner was replaced.
 	 */
-	private static function compare_and_swap( $expected, array $replacement ): bool {
+	private static function compare_and_swap( string $expected_raw, array $replacement ): bool {
 		global $wpdb;
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Conditional update provides atomic stale-lock takeover.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Conditional update against the DB-read value provides atomic stale-lock takeover.
 		$updated = $wpdb->query(
 			$wpdb->prepare(
 				'UPDATE %i SET option_value = %s WHERE option_name = %s AND option_value = %s',
 				$wpdb->options,
 				maybe_serialize( $replacement ),
 				self::OPTION_NAME,
-				maybe_serialize( $expected )
+				$expected_raw
 			)
 		);
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 
-		if ( 1 === $updated ) {
-			wp_cache_delete( self::OPTION_NAME, 'options' );
-			return true;
-		}
+		// Clear the cache unconditionally: a 0-row UPDATE means another
+		// caller already replaced the row, and a resurrected stale cache
+		// entry must never be allowed to survive either outcome.
+		wp_cache_delete( self::OPTION_NAME, 'options' );
 
-		return false;
+		return 1 === $updated;
 	}
 }

--- a/inc/Api/Flows/FlowScheduleReconciliationLock.php
+++ b/inc/Api/Flows/FlowScheduleReconciliationLock.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Atomic per-site flow schedule reconciliation lock.
+ *
+ * Compare-and-set option lock: no add_option()/delete_option() cache-vs-DB
+ * split. Every mutation is a conditional `$wpdb->query()` against the exact
+ * expected serialized value, paired with an explicit `wp_cache_delete()` so
+ * a stale object-cache entry can never survive a successful write and block
+ * the lock forever (see Extra-Chill/data-machine#3492 for the failure mode
+ * this is designed to avoid: an object-cache-only lock entry with no DB row
+ * makes add_option() always fail and delete_option() never clear the cache).
+ *
+ * Guards {@see \DataMachine\Engine\Scheduling\FlowRoutines::reconcile()}
+ * before it calls `boot()`, so lock contention costs one option read instead
+ * of a full ~700-routine registration pass.
+ *
+ * @package DataMachine\Api\Flows
+ */
+
+namespace DataMachine\Api\Flows;
+
+defined( 'ABSPATH' ) || exit;
+
+class FlowScheduleReconciliationLock {
+
+	private const OPTION_NAME = 'datamachine_flow_schedule_reconciliation_lock';
+	private const STALE_AFTER = 1800;
+
+	/**
+	 * Acquire the reconcile lock, atomically replacing a stale owner when needed.
+	 *
+	 * @return string|\WP_Error Lock token or an error when another reconcile is active.
+	 */
+	public static function acquire() {
+		$token   = function_exists( 'wp_generate_uuid4' ) ? wp_generate_uuid4() : uniqid( 'dm-flow-reconcile-', true );
+		$payload = array(
+			'token'       => $token,
+			'acquired_at' => time(),
+		);
+
+		if ( add_option( self::OPTION_NAME, $payload, '', false ) ) {
+			return $token;
+		}
+
+		$current = get_option( self::OPTION_NAME, array() );
+		if ( is_array( $current ) && (int) ( $current['acquired_at'] ?? 0 ) > time() - self::STALE_AFTER ) {
+			return new \WP_Error( 'flow_schedule_reconciliation_locked', 'Another flow schedule reconciliation is already running.' );
+		}
+
+		if ( self::compare_and_swap( $current, $payload ) ) {
+			return $token;
+		}
+
+		return new \WP_Error( 'flow_schedule_reconciliation_locked', 'Another flow schedule reconciliation acquired the stale lock first.' );
+	}
+
+	/**
+	 * Release only the lock owned by the supplied token.
+	 *
+	 * @param string $token Lock token returned by acquire().
+	 * @return bool True when this owner released the lock.
+	 */
+	public static function release( string $token ): bool {
+		$current = get_option( self::OPTION_NAME, array() );
+		if ( ! is_array( $current ) || ! hash_equals( (string) ( $current['token'] ?? '' ), $token ) ) {
+			return false;
+		}
+
+		global $wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Conditional delete provides token-safe lock release.
+		$deleted = $wpdb->query(
+			$wpdb->prepare(
+				'DELETE FROM %i WHERE option_name = %s AND option_value = %s',
+				$wpdb->options,
+				self::OPTION_NAME,
+				maybe_serialize( $current )
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( 1 === $deleted ) {
+			wp_cache_delete( self::OPTION_NAME, 'options' );
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Atomically refresh a lock lease owned by the supplied token.
+	 *
+	 * @param string $token Active lock token.
+	 * @return bool True when the exact owned lease was refreshed.
+	 */
+	public static function refresh( string $token ): bool {
+		$current = get_option( self::OPTION_NAME, array() );
+		if ( ! is_array( $current ) || ! hash_equals( (string) ( $current['token'] ?? '' ), $token ) ) {
+			return false;
+		}
+
+		$replacement                = $current;
+		$replacement['acquired_at'] = max( time(), (int) ( $current['acquired_at'] ?? 0 ) + 1 );
+		return self::compare_and_swap( $current, $replacement );
+	}
+
+	/**
+	 * Atomically replace the exact expected payload.
+	 *
+	 * @param mixed                $expected    Current expected lock payload.
+	 * @param array<string, mixed> $replacement New lock payload.
+	 * @return bool True when the expected owner was replaced.
+	 */
+	private static function compare_and_swap( $expected, array $replacement ): bool {
+		global $wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Conditional update provides atomic stale-lock takeover.
+		$updated = $wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i SET option_value = %s WHERE option_name = %s AND option_value = %s',
+				$wpdb->options,
+				maybe_serialize( $replacement ),
+				self::OPTION_NAME,
+				maybe_serialize( $expected )
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( 1 === $updated ) {
+			wp_cache_delete( self::OPTION_NAME, 'options' );
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/inc/Cli/Commands/Flows/FlowsCommand.php
+++ b/inc/Cli/Commands/Flows/FlowsCommand.php
@@ -574,6 +574,11 @@ class FlowsCommand extends BaseCommand {
 			WP_CLI::halt( 1 );
 		}
 
+		if ( ! empty( $result['skipped'] ) ) {
+			WP_CLI::log( 'Skipped: another flow schedule reconciliation is already running. Try again shortly.' );
+			return;
+		}
+
 		WP_CLI::log( ! empty( $result['applied'] ) ? 'Mode: apply' : 'Mode: dry-run' );
 		WP_CLI::log(
 			sprintf(

--- a/inc/Engine/Scheduling/FlowRoutines.php
+++ b/inc/Engine/Scheduling/FlowRoutines.php
@@ -28,6 +28,7 @@ namespace DataMachine\Engine\Scheduling;
 
 use AgentsAPI\AI\Routines\WP_Agent_Routine;
 use AgentsAPI\AI\Routines\WP_Agent_Routine_Registry;
+use DataMachine\Api\Flows\FlowScheduleReconciliationLock;
 use DataMachine\Core\ActionScheduler\GroupRegistrar;
 use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Engine\Tasks\RecurringScheduleRegistry;
@@ -449,6 +450,16 @@ final class FlowRoutines {
 	 * Runs on `init` of every full-runtime request. Registration is cheap:
 	 * the hash-gated backend stops unchanged routines from reaching Action
 	 * Scheduler. Also performs the one-shot legacy-action migration.
+	 *
+	 * The whole body runs inside a try/finally so a single routine that
+	 * throws (e.g. a Redis exception from `update_option()` inside the
+	 * Action Scheduler bridge) never skips {@see HashGatedRoutineBackend::persist()}.
+	 * A lost persist() would make the next boot() see no fingerprint for
+	 * every routine registered so far this request and re-schedule all of
+	 * them again — the self-sustaining failure mode in
+	 * Extra-Chill/data-machine#3492. Per-routine registration is further
+	 * isolated with its own try/catch so one bad routine does not stop the
+	 * rest of the set from registering.
 	 */
 	public static function boot(): void {
 		if ( ! self::available() ) {
@@ -459,67 +470,91 @@ final class FlowRoutines {
 		self::install_backend();
 		self::install_permission_filter();
 
-		$flows_db = new Flows();
-		foreach ( $flows_db->get_flow_schedules() as $row ) {
-			$flow_id    = (int) ( $row['flow_id'] ?? 0 );
-			$scheduling = $row['scheduling_config'] ?? array();
-			if ( ! is_array( $scheduling ) ) {
-				$scheduling = json_decode( (string) $scheduling, true ) ?? array();
+		try {
+			$flows_db = new Flows();
+			foreach ( $flows_db->get_flow_schedules() as $row ) {
+				$flow_id    = (int) ( $row['flow_id'] ?? 0 );
+				$scheduling = $row['scheduling_config'] ?? array();
+				if ( ! is_array( $scheduling ) ) {
+					$scheduling = json_decode( (string) $scheduling, true ) ?? array();
+				}
+
+				if ( $flow_id <= 0 ) {
+					continue;
+				}
+
+				$flow_name = is_string( $row['flow_name'] ?? null ) ? (string) $row['flow_name'] : '';
+				$args      = self::flow_routine_args( $flow_id, $scheduling, $flow_name );
+				if ( null === $args ) {
+					continue;
+				}
+
+				self::register_routine_logged(
+					self::routine_id( $flow_id ),
+					$args,
+					array( 'flow_id' => $flow_id )
+				);
 			}
 
-			if ( $flow_id <= 0 ) {
-				continue;
+			foreach ( RecurringScheduleRegistry::all() as $schedule ) {
+				$schedule_id = (string) ( $schedule['schedule_id'] ?? '' );
+				if ( '' === $schedule_id ) {
+					continue;
+				}
+
+				if ( ! self::system_schedule_active( $schedule ) ) {
+					self::unregister_routine( self::system_routine_id( $schedule_id ) );
+					continue;
+				}
+
+				$args = self::system_routine_args( $schedule );
+				if ( null === $args ) {
+					continue;
+				}
+
+				self::register_routine_logged(
+					self::system_routine_id( $schedule_id ),
+					$args,
+					array( 'schedule_id' => $schedule_id )
+				);
 			}
 
-			$flow_name = is_string( $row['flow_name'] ?? null ) ? (string) $row['flow_name'] : '';
-			$args      = self::flow_routine_args( $flow_id, $scheduling, $flow_name );
-			if ( null === $args ) {
-				continue;
-			}
-
-			self::register_routine_logged(
-				self::routine_id( $flow_id ),
-				$args,
-				array( 'flow_id' => $flow_id )
-			);
+			self::maybe_migrate();
+		} finally {
+			HashGatedRoutineBackend::persist();
 		}
-
-		foreach ( RecurringScheduleRegistry::all() as $schedule ) {
-			$schedule_id = (string) ( $schedule['schedule_id'] ?? '' );
-			if ( '' === $schedule_id ) {
-				continue;
-			}
-
-			if ( ! self::system_schedule_active( $schedule ) ) {
-				self::unregister_routine( self::system_routine_id( $schedule_id ) );
-				continue;
-			}
-
-			$args = self::system_routine_args( $schedule );
-			if ( null === $args ) {
-				continue;
-			}
-
-			self::register_routine_logged(
-				self::system_routine_id( $schedule_id ),
-				$args,
-				array( 'schedule_id' => $schedule_id )
-			);
-		}
-
-		self::maybe_migrate();
-		HashGatedRoutineBackend::persist();
 	}
 
 	/**
-	 * Register one routine and log any registration error.
+	 * Register one routine and log any registration error or thrown exception.
+	 *
+	 * Never lets a thrown exception escape: one routine's registration
+	 * failure must not abort the rest of the boot loop or skip the trailing
+	 * `persist()` call.
 	 *
 	 * @param string               $routine_id  Routine id.
 	 * @param array<string, mixed> $args        Registry args.
 	 * @param array<string, mixed> $log_context Extra identifiers for the error log.
 	 */
 	private static function register_routine_logged( string $routine_id, array $args, array $log_context ): void {
-		$registered = WP_Agent_Routine_Registry::register( $routine_id, $args );
+		try {
+			$registered = WP_Agent_Routine_Registry::register( $routine_id, $args );
+		} catch ( \Throwable $error ) {
+			do_action(
+				'datamachine_log',
+				'error',
+				'Routine registration threw',
+				array_merge(
+					$log_context,
+					array(
+						'routine_id' => $routine_id,
+						'error'      => $error->getMessage(),
+					)
+				)
+			);
+			return;
+		}
+
 		if ( ! is_wp_error( $registered ) ) {
 			return;
 		}
@@ -546,8 +581,20 @@ final class FlowRoutines {
 	 * the reconcile algorithm runs — an empty registry would classify every
 	 * pending routine action as an orphan.
 	 *
+	 * A DM-owned reconcile guard ({@see FlowScheduleReconciliationLock}) is
+	 * acquired BEFORE `boot()` runs. Under contention this makes a losing
+	 * caller's cost one option read: it never re-registers the full routine
+	 * set. Extra-Chill/data-machine#3492 was caused by the opposite order —
+	 * `boot()` ran first and only the (much cheaper) registry-level reconcile
+	 * step was guarded, so every concurrent request paid the full boot()
+	 * cost before finding out someone else already held the lock.
+	 *
 	 * @param bool $apply Repair missing coverage when true; dry-run otherwise.
-	 * @return array<string, mixed> Reconciliation report.
+	 * @return array<string, mixed> Reconciliation report. A caller that lost
+	 *                              the lock race gets back `skipped => true`
+	 *                              with `success => true` — lock contention is
+	 *                              not a failure, it means another reconcile is
+	 *                              already in flight.
 	 */
 	public static function reconcile( bool $apply = false ): array {
 		if ( ! self::available() ) {
@@ -562,14 +609,32 @@ final class FlowRoutines {
 			);
 		}
 
-		self::boot();
+		$lock_token = FlowScheduleReconciliationLock::acquire();
+		if ( is_wp_error( $lock_token ) ) {
+			return array(
+				'success' => true,
+				'applied' => $apply,
+				'skipped' => true,
+				'reason'  => 'locked',
+				'covered' => 0,
+				'missing' => 0,
+				'removed' => 0,
+				'errors'  => array(),
+			);
+		}
 
-		HashGatedRoutineBackend::set_verification_mode( true );
 		try {
-			$report = WP_Agent_Routine_Registry::reconcile( array( 'dry_run' => ! $apply ) );
+			self::boot();
+
+			HashGatedRoutineBackend::set_verification_mode( true );
+			try {
+				$report = WP_Agent_Routine_Registry::reconcile( array( 'dry_run' => ! $apply ) );
+			} finally {
+				HashGatedRoutineBackend::set_verification_mode( false );
+				HashGatedRoutineBackend::persist();
+			}
 		} finally {
-			HashGatedRoutineBackend::set_verification_mode( false );
-			HashGatedRoutineBackend::persist();
+			FlowScheduleReconciliationLock::release( $lock_token );
 		}
 
 		$enqueued = $report['enqueued'];

--- a/inc/setup/flow-schedules.php
+++ b/inc/setup/flow-schedules.php
@@ -2,14 +2,37 @@
 /**
  * Data Machine flow schedule reconciliation lifecycle.
  *
- * Activation and deploy-time migrations only mark the current site. The repair
- * runs after init so the routines adapter has re-declared the flow registry
- * and Action Scheduler datastore reads and writes are safe.
+ * Activation and deploy-time migrations only mark the current site. The
+ * actual reconcile runs out of the request path, inside a single Action
+ * Scheduler async action, so a page view never pays the cost of a full
+ * routine registration pass.
+ *
+ * Extra-Chill/data-machine#3492: the previous version ran
+ * `FlowRoutines::reconcile(true)` inline on `init` of every web request
+ * while the marker was set. With 60 concurrent php-fpm workers all racing
+ * for the registry's reconcile lock, 59 of them re-registered ~700 routines
+ * through `boot()` before discovering the lock was already held, and lock
+ * contention was misclassified as failure — so the marker was retained and
+ * every subsequent request paid the same cost again. `FlowRoutines::reconcile()`
+ * now takes a DM-owned lock before `boot()` runs, so a losing caller's cost is
+ * one option read; this file additionally moves the whole reconcile call off
+ * the request path and treats lock contention as a silent no-op rather than a
+ * failure worth retrying on every request.
  *
  * @package DataMachine
  */
 
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Action Scheduler hook the deferred reconcile runs under.
+ */
+const DATAMACHINE_FLOW_SCHEDULE_RECONCILE_HOOK = 'datamachine_run_deferred_flow_schedule_reconciliation';
+
+/**
+ * Transient suppressing re-enqueue after a genuine reconcile failure.
+ */
+const DATAMACHINE_FLOW_SCHEDULE_RECONCILE_BACKOFF = 'datamachine_flow_schedule_reconciliation_backoff';
 
 /**
  * Persist a per-site marker requesting flow schedule reconciliation.
@@ -28,11 +51,13 @@ function datamachine_mark_flow_schedule_reconciliation(): void {
 }
 
 /**
- * Repair marked flow schedules once the routines adapter is available.
+ * Enqueue the deferred reconcile off the request path, once.
  *
- * The marker is retained after failures so a later request can retry.
- * FlowRoutines::reconcile() re-declares the registry before reconciling,
- * so repairs classify against a fully populated routine set.
+ * Runs on `init` while the marker is set. This function itself never calls
+ * `FlowRoutines::reconcile()` — it only ensures exactly one Action Scheduler
+ * async action is pending to do that work. Enqueuing is a cheap
+ * `as_has_scheduled_action()` read plus (at most) one insert, regardless of
+ * how many concurrent requests hit `init` while the marker is live.
  *
  * @return void
  */
@@ -45,7 +70,57 @@ function datamachine_reconcile_marked_flow_schedules(): void {
 		return;
 	}
 
+	if ( get_transient( DATAMACHINE_FLOW_SCHEDULE_RECONCILE_BACKOFF ) ) {
+		return;
+	}
+
+	if ( ! function_exists( 'as_enqueue_async_action' ) ) {
+		return;
+	}
+
+	$group = \DataMachine\Core\ActionScheduler\GroupRegistrar::GROUP;
+
+	if ( function_exists( 'as_has_scheduled_action' )
+		&& as_has_scheduled_action( DATAMACHINE_FLOW_SCHEDULE_RECONCILE_HOOK, array(), $group )
+	) {
+		return;
+	}
+
+	as_enqueue_async_action( DATAMACHINE_FLOW_SCHEDULE_RECONCILE_HOOK, array(), $group );
+}
+
+/**
+ * Run the deferred flow schedule reconcile.
+ *
+ * This is the Action Scheduler worker callback for
+ * {@see DATAMACHINE_FLOW_SCHEDULE_RECONCILE_HOOK}. It runs off the web
+ * request path so its cost — a full `FlowRoutines::boot()` pass plus the
+ * registry reconcile algorithm — never lands on a page view.
+ *
+ * A `skipped` result (the DM reconcile lock was held by someone else) is a
+ * silent no-op: it is not an error, the marker is left alone, and the
+ * holder of the lock is responsible for either finishing the repair or
+ * leaving the marker for the next enqueue to retry. A genuine failure
+ * retains the marker and sets a short backoff transient so a persistently
+ * failing reconcile does not re-enqueue on every subsequent request.
+ *
+ * @return void
+ */
+function datamachine_run_deferred_flow_schedule_reconciliation(): void {
+	if ( ! get_option( 'datamachine_flow_schedule_reconciliation_pending', false ) ) {
+		return;
+	}
+
+	if ( ! \DataMachine\Engine\Scheduling\FlowRoutines::available() ) {
+		return;
+	}
+
 	$result = \DataMachine\Engine\Scheduling\FlowRoutines::reconcile( true );
+
+	if ( ! empty( $result['skipped'] ) ) {
+		return;
+	}
+
 	if ( empty( $result['success'] ) ) {
 		do_action(
 			'datamachine_log',
@@ -53,6 +128,7 @@ function datamachine_reconcile_marked_flow_schedules(): void {
 			'Deferred flow schedule reconciliation failed; marker retained',
 			array( 'result' => $result )
 		);
+		set_transient( DATAMACHINE_FLOW_SCHEDULE_RECONCILE_BACKOFF, true, 5 * MINUTE_IN_SECONDS );
 		return;
 	}
 
@@ -70,3 +146,4 @@ function datamachine_reconcile_marked_flow_schedules(): void {
 }
 
 add_action( 'init', 'datamachine_reconcile_marked_flow_schedules', 10 );
+add_action( DATAMACHINE_FLOW_SCHEDULE_RECONCILE_HOOK, 'datamachine_run_deferred_flow_schedule_reconciliation' );

--- a/tests/flow-routines-reconcile-lock-before-boot-smoke.php
+++ b/tests/flow-routines-reconcile-lock-before-boot-smoke.php
@@ -128,6 +128,7 @@ namespace DataMachine\Engine\Scheduling {
 namespace {
 
 	define( 'ABSPATH', __DIR__ );
+	define( 'ARRAY_A', 'ARRAY_A' );
 
 	class WP_Error {
 		public function __construct( private string $code = '', private string $message = '' ) {}
@@ -145,7 +146,15 @@ namespace {
 		return $thing instanceof WP_Error;
 	}
 
+	// The object cache and `wp_options` are modeled as two INDEPENDENT
+	// stores, exactly like a real Redis-backed object cache sitting in
+	// front of MySQL. FlowScheduleReconciliationLock must never trust the
+	// cache store for a locking decision — see the "ghost cache entry"
+	// scenario below, which reproduces the Extra-Chill/data-machine#3492
+	// failure mode where a killed request left a cache entry with no
+	// backing DB row.
 	$GLOBALS['datamachine_smoke_options'] = array();
+	$GLOBALS['datamachine_smoke_db']      = array();
 
 	function get_option( string $name, $default = false ) {
 		return $GLOBALS['datamachine_smoke_options'][ $name ] ?? $default;
@@ -175,8 +184,22 @@ namespace {
 		return is_array( $value ) || is_object( $value ) ? serialize( $value ) : (string) $value;
 	}
 
+	function maybe_unserialize( $value ) {
+		if ( ! is_string( $value ) ) {
+			return $value;
+		}
+		$unserialized = @unserialize( $value );
+		return ( false !== $unserialized || 'b:0;' === $value ) ? $unserialized : $value;
+	}
+
+	$GLOBALS['datamachine_smoke_cache_delete_calls'] = array();
+
 	function wp_cache_delete( string $key, string $group ): bool {
-		unset( $key, $group );
+		$GLOBALS['datamachine_smoke_cache_delete_calls'][] = array( $key, $group );
+		// A real persistent object cache actually removes the entry —
+		// model that so tests can prove a ghost cache entry doesn't
+		// survive the class's own defensive wp_cache_delete() calls.
+		unset( $GLOBALS['datamachine_smoke_options'][ $key ] );
 		return true;
 	}
 
@@ -212,25 +235,54 @@ namespace {
 			return array( $query, $args );
 		}
 
+		/**
+		 * Every locking decision reads straight from the `datamachine_smoke_db`
+		 * store — never `datamachine_smoke_options` (the cache).
+		 */
+		public function get_row( array $prepared, $output = null ) {
+			unset( $output );
+			list( $query, $args ) = $prepared;
+			if ( ! str_starts_with( $query, 'SELECT' ) ) {
+				return null;
+			}
+
+			list( , $option_name ) = $args;
+			if ( ! array_key_exists( $option_name, $GLOBALS['datamachine_smoke_db'] ) ) {
+				return null;
+			}
+
+			return array( 'option_value' => $GLOBALS['datamachine_smoke_db'][ $option_name ] );
+		}
+
 		public function query( array $prepared ): int {
 			list( $query, $args ) = $prepared;
-			if ( str_starts_with( $query, 'UPDATE' ) ) {
-				list( , $replacement, $option_name, $expected ) = $args;
-				$current                                        = $GLOBALS['datamachine_smoke_options'][ $option_name ] ?? null;
-				if ( maybe_serialize( $current ) !== $expected ) {
+
+			if ( str_starts_with( $query, 'INSERT IGNORE' ) ) {
+				list( , $option_name, $value ) = $args;
+				if ( array_key_exists( $option_name, $GLOBALS['datamachine_smoke_db'] ) ) {
 					return 0;
 				}
-				$GLOBALS['datamachine_smoke_options'][ $option_name ] = unserialize( $replacement );
+				$GLOBALS['datamachine_smoke_db'][ $option_name ] = $value;
+				return 1;
+			}
+
+			if ( str_starts_with( $query, 'UPDATE' ) ) {
+				list( , $replacement, $option_name, $expected_raw ) = $args;
+				$current_raw                                        = $GLOBALS['datamachine_smoke_db'][ $option_name ] ?? null;
+				if ( $current_raw !== $expected_raw ) {
+					return 0;
+				}
+				$GLOBALS['datamachine_smoke_db'][ $option_name ] = $replacement;
 				return 1;
 			}
 
 			if ( str_starts_with( $query, 'DELETE' ) ) {
-				list( , $option_name, $expected ) = $args;
-				$current                          = $GLOBALS['datamachine_smoke_options'][ $option_name ] ?? null;
-				if ( maybe_serialize( $current ) !== $expected ) {
+				list( , $option_name, $expected_raw ) = $args;
+				$current_raw                          = $GLOBALS['datamachine_smoke_db'][ $option_name ] ?? null;
+				if ( $current_raw !== $expected_raw ) {
 					return 0;
 				}
-				unset( $GLOBALS['datamachine_smoke_options'][ $option_name ] );
+				unset( $GLOBALS['datamachine_smoke_db'][ $option_name ] );
 				return 1;
 			}
 
@@ -263,16 +315,19 @@ namespace {
 	function datamachine_smoke_reset(): void {
 		WP_Agent_Routine_Registry::reset();
 		HashGatedRoutineBackend::reset_state();
-		RecurringScheduleRegistry::$throw_on_all = false;
-		$GLOBALS['datamachine_smoke_logs']       = array();
+		RecurringScheduleRegistry::$throw_on_all         = false;
+		$GLOBALS['datamachine_smoke_logs']               = array();
+		$GLOBALS['datamachine_smoke_db']                 = array();
+		$GLOBALS['datamachine_smoke_options']            = array( FlowRoutines::MIGRATED_OPTION => true );
+		$GLOBALS['datamachine_smoke_cache_delete_calls'] = array();
 	}
 
 	echo "=== flow-routines-reconcile-lock-before-boot-smoke ===\n";
 
-	// The one-shot legacy-action migration is out of scope for this smoke;
-	// mark it done so boot() doesn't reach for as_get_scheduled_actions()
-	// (Action Scheduler is not stubbed here).
-	$GLOBALS['datamachine_smoke_options'][ FlowRoutines::MIGRATED_OPTION ] = true;
+	// datamachine_smoke_reset() primes FlowRoutines::MIGRATED_OPTION in the
+	// cache store so boot() doesn't reach for as_get_scheduled_actions()
+	// (Action Scheduler is not stubbed here) — the one-shot legacy-action
+	// migration is out of scope for this smoke.
 
 	// --- (a) lock held elsewhere: reconcile() must skip without booting. ---
 	Flows::$schedules = array(
@@ -361,6 +416,57 @@ namespace {
 		'both flow routines from the first loop still registered before the second loop threw'
 	);
 	datamachine_smoke_assert( 1 === HashGatedRoutineBackend::$persist_calls, 'boot() persists via its top-level finally even when it ultimately rethrows' );
+
+	// --- Cache/DB split: a ghost cache entry with no backing DB row must never block acquisition. ---
+	//
+	// Reproduces the Extra-Chill/data-machine#3492 recovery-time failure
+	// mode observed on the underlying agents-api registry lock: a killed
+	// request leaves the lock cached (Redis) with no row in `wp_options`.
+	// A lock built on add_option()/get_option() would see the cached
+	// payload, treat it as live for up to STALE_AFTER seconds, and then
+	// fail its compare-and-set forever (there is no DB row to match against).
+	datamachine_smoke_reset();
+	$lock_option = 'datamachine_flow_schedule_reconciliation_lock';
+
+	datamachine_smoke_assert( ! array_key_exists( $lock_option, $GLOBALS['datamachine_smoke_db'] ), 'setup: no DB row backs the lock' );
+
+	// A "fresh" (not stale) cached payload from a request that died right
+	// after writing the cache but before (or without) ever writing the DB row.
+	$GLOBALS['datamachine_smoke_options'][ $lock_option ] = array(
+		'token'       => 'ghost-owner-token',
+		'acquired_at' => time(),
+	);
+
+	$acquired = FlowScheduleReconciliationLock::acquire();
+
+	datamachine_smoke_assert( is_string( $acquired ), 'a ghost cache entry with no DB row never blocks acquire() — the DB, not the cache, is authoritative' );
+	datamachine_smoke_assert( $acquired !== 'ghost-owner-token', 'the new owner gets its own token, independent of the ghost cache payload' );
+	datamachine_smoke_assert( array_key_exists( $lock_option, $GLOBALS['datamachine_smoke_db'] ), 'acquire() actually wrote a backing DB row' );
+	datamachine_smoke_assert(
+		! array_key_exists( $lock_option, $GLOBALS['datamachine_smoke_options'] ),
+		'the ghost cache entry was cleared, not left to mislead the next reader'
+	);
+	datamachine_smoke_assert(
+		! empty( $GLOBALS['datamachine_smoke_cache_delete_calls'] ),
+		'acquiring against a cache-only ghost entry defensively calls wp_cache_delete()'
+	);
+	datamachine_smoke_assert( FlowScheduleReconciliationLock::release( $acquired ), 'teardown: release the lock acquired over the ghost cache entry' );
+
+	// --- Two acquires race against an empty DB: exactly one wins. ---
+	datamachine_smoke_reset();
+	datamachine_smoke_assert( array() === $GLOBALS['datamachine_smoke_db'], 'setup: the DB starts with no lock row at all' );
+
+	$racer_a = FlowScheduleReconciliationLock::acquire();
+	$racer_b = FlowScheduleReconciliationLock::acquire();
+
+	datamachine_smoke_assert( is_string( $racer_a ), 'the first racer against an empty DB wins the lock' );
+	datamachine_smoke_assert( is_wp_error( $racer_b ), 'the second racer against the now-occupied DB loses' );
+	datamachine_smoke_assert(
+		'flow_schedule_reconciliation_locked' === $racer_b->get_error_code(),
+		'the losing racer gets the machine-readable lock error, not a crash or a silently-granted duplicate token'
+	);
+	datamachine_smoke_assert( 1 === count( $GLOBALS['datamachine_smoke_db'] ), 'exactly one lock row exists after the race — no duplicate rows, no torn state' );
+	datamachine_smoke_assert( FlowScheduleReconciliationLock::release( $racer_a ), 'teardown: release the winning racer\'s lock' );
 
 	echo "\nAll flow-routines-reconcile-lock-before-boot assertions passed.\n";
 }

--- a/tests/flow-routines-reconcile-lock-before-boot-smoke.php
+++ b/tests/flow-routines-reconcile-lock-before-boot-smoke.php
@@ -98,11 +98,9 @@ namespace DataMachine\Engine\Tasks {
 	}
 }
 
-namespace DataMachine\Core\ActionScheduler {
-	class GroupRegistrar {
-		public const GROUP = 'data-machine';
-	}
-}
+// GroupRegistrar is required from its real file below (not stubbed): it is
+// a plain constant holder plus DB-touching methods this smoke never calls,
+// and requiring it avoids hand-duplicating its GROUP slug literal here.
 
 // Spy replacing the real HashGatedRoutineBackend: same namespace as
 // FlowRoutines, so its unqualified `HashGatedRoutineBackend::persist()`
@@ -292,6 +290,7 @@ namespace {
 
 	$wpdb = new DatamachineSmokeWpdb();
 
+	require_once __DIR__ . '/../inc/Core/ActionScheduler/GroupRegistrar.php';
 	require_once __DIR__ . '/../inc/Api/Flows/FlowScheduleReconciliationLock.php';
 	require_once __DIR__ . '/../inc/Engine/Scheduling/FlowRoutines.php';
 

--- a/tests/flow-routines-reconcile-lock-before-boot-smoke.php
+++ b/tests/flow-routines-reconcile-lock-before-boot-smoke.php
@@ -1,0 +1,366 @@
+<?php
+/**
+ * Pure-PHP behavioral smoke for FlowRoutines::reconcile()'s lock-before-boot
+ * ordering and boot()'s persist-survives-a-throw guarantee.
+ *
+ * Regression coverage for Extra-Chill/data-machine#3492: a deploy-time
+ * reconcile marker caused `FlowRoutines::reconcile(true)` to run on every
+ * web request. Because `boot()` (a full ~700-routine registration pass) ran
+ * BEFORE the registry's own reconcile lock was taken, every concurrent
+ * request paid the full boot() cost before discovering someone else already
+ * held the lock. This smoke proves:
+ *
+ *  (a) with the DM reconcile guard held, reconcile() returns a `skipped`
+ *      result WITHOUT ever calling boot() (zero registry registration calls,
+ *      zero persist() calls) — and that normal operation resumes once the
+ *      guard is released.
+ *  (c) boot() calls HashGatedRoutineBackend::persist() even when a routine
+ *      registration throws, and even when something outside the per-routine
+ *      try/catch throws — a lost persist() is what made the real incident
+ *      self-sustaining (lost fingerprints reschedule everything again).
+ *
+ * Run with: php tests/flow-routines-reconcile-lock-before-boot-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace AgentsAPI\AI\Routines {
+	interface WP_Agent_Routine_Backend {}
+
+	class WP_Agent_Routine_Registry {
+		/** @var string[] */
+		public static array $register_calls = array();
+		/** @var string[] */
+		public static array $throw_for = array();
+
+		public static function register( string $id, array $args ) {
+			unset( $args );
+			self::$register_calls[] = $id;
+			if ( in_array( $id, self::$throw_for, true ) ) {
+				throw new \RuntimeException( "synthetic register throw for {$id}" );
+			}
+			return true;
+		}
+
+		public static function unregister( string $id ) {
+			unset( $id );
+			return true;
+		}
+
+		public static function find( string $id ) {
+			unset( $id );
+			return null;
+		}
+
+		public static function reconcile( array $opts = array() ): array {
+			unset( $opts );
+			return array(
+				'enqueued'  => array(),
+				'removed'   => array(),
+				'unchanged' => array(),
+				'errors'    => array(),
+			);
+		}
+
+		public static function reset(): void {
+			self::$register_calls = array();
+			self::$throw_for      = array();
+		}
+	}
+}
+
+namespace DataMachine\Core\Database\Flows {
+	class Flows {
+		/** @var array<int, array<string, mixed>> */
+		public static array $schedules = array();
+
+		public function get_flow_schedules(): array {
+			return self::$schedules;
+		}
+	}
+}
+
+namespace DataMachine\Engine\Tasks {
+	class RecurringScheduleRegistry {
+		public static bool $throw_on_all = false;
+
+		public static function all(): array {
+			if ( self::$throw_on_all ) {
+				throw new \RuntimeException( 'synthetic RecurringScheduleRegistry::all() throw' );
+			}
+			return array();
+		}
+
+		public static function isEnabled( array $schedule ): bool {
+			unset( $schedule );
+			return false;
+		}
+	}
+}
+
+namespace DataMachine\Core\ActionScheduler {
+	class GroupRegistrar {
+		public const GROUP = 'data-machine';
+	}
+}
+
+// Spy replacing the real HashGatedRoutineBackend: same namespace as
+// FlowRoutines, so its unqualified `HashGatedRoutineBackend::persist()`
+// calls resolve here instead of the real (unrequired) file.
+namespace DataMachine\Engine\Scheduling {
+	final class HashGatedRoutineBackend {
+		public static int $persist_calls = 0;
+
+		public static function persist(): void {
+			++self::$persist_calls;
+		}
+
+		public static function set_verification_mode( bool $mode ): void {
+			unset( $mode );
+		}
+
+		public static function reset_state(): void {
+			self::$persist_calls = 0;
+		}
+	}
+}
+
+namespace {
+
+	define( 'ABSPATH', __DIR__ );
+
+	class WP_Error {
+		public function __construct( private string $code = '', private string $message = '' ) {}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+	}
+
+	function is_wp_error( $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+
+	$GLOBALS['datamachine_smoke_options'] = array();
+
+	function get_option( string $name, $default = false ) {
+		return $GLOBALS['datamachine_smoke_options'][ $name ] ?? $default;
+	}
+
+	function update_option( string $name, $value, $autoload = null ): bool {
+		unset( $autoload );
+		$GLOBALS['datamachine_smoke_options'][ $name ] = $value;
+		return true;
+	}
+
+	function delete_option( string $name ): bool {
+		unset( $GLOBALS['datamachine_smoke_options'][ $name ] );
+		return true;
+	}
+
+	function add_option( string $name, $value, string $deprecated = '', bool $autoload = true ): bool {
+		unset( $deprecated, $autoload );
+		if ( array_key_exists( $name, $GLOBALS['datamachine_smoke_options'] ) ) {
+			return false;
+		}
+		$GLOBALS['datamachine_smoke_options'][ $name ] = $value;
+		return true;
+	}
+
+	function maybe_serialize( $value ): string {
+		return is_array( $value ) || is_object( $value ) ? serialize( $value ) : (string) $value;
+	}
+
+	function wp_cache_delete( string $key, string $group ): bool {
+		unset( $key, $group );
+		return true;
+	}
+
+	function wp_generate_uuid4(): string {
+		static $counter = 0;
+		return 'test-token-' . ++$counter;
+	}
+
+	function add_filter( string $tag, $callback, int $priority = 10, int $accepted_args = 1 ): bool {
+		unset( $tag, $callback, $priority, $accepted_args );
+		return true;
+	}
+
+	function apply_filters( string $tag, $value ) {
+		if ( 'datamachine_scheduler_intervals' === $tag ) {
+			return array( 'hourly' => array( 'seconds' => 3600 ) );
+		}
+		return $value;
+	}
+
+	$GLOBALS['datamachine_smoke_logs'] = array();
+
+	function do_action( string $tag, ...$args ): void {
+		if ( 'datamachine_log' === $tag ) {
+			$GLOBALS['datamachine_smoke_logs'][] = $args;
+		}
+	}
+
+	class DatamachineSmokeWpdb {
+		public string $options = 'wp_options';
+
+		public function prepare( string $query, ...$args ): array {
+			return array( $query, $args );
+		}
+
+		public function query( array $prepared ): int {
+			list( $query, $args ) = $prepared;
+			if ( str_starts_with( $query, 'UPDATE' ) ) {
+				list( , $replacement, $option_name, $expected ) = $args;
+				$current                                        = $GLOBALS['datamachine_smoke_options'][ $option_name ] ?? null;
+				if ( maybe_serialize( $current ) !== $expected ) {
+					return 0;
+				}
+				$GLOBALS['datamachine_smoke_options'][ $option_name ] = unserialize( $replacement );
+				return 1;
+			}
+
+			if ( str_starts_with( $query, 'DELETE' ) ) {
+				list( , $option_name, $expected ) = $args;
+				$current                          = $GLOBALS['datamachine_smoke_options'][ $option_name ] ?? null;
+				if ( maybe_serialize( $current ) !== $expected ) {
+					return 0;
+				}
+				unset( $GLOBALS['datamachine_smoke_options'][ $option_name ] );
+				return 1;
+			}
+
+			return 0;
+		}
+	}
+
+	$wpdb = new DatamachineSmokeWpdb();
+
+	require_once __DIR__ . '/../inc/Api/Flows/FlowScheduleReconciliationLock.php';
+	require_once __DIR__ . '/../inc/Engine/Scheduling/FlowRoutines.php';
+
+	use AgentsAPI\AI\Routines\WP_Agent_Routine_Registry;
+	use DataMachine\Api\Flows\FlowScheduleReconciliationLock;
+	use DataMachine\Core\Database\Flows\Flows;
+	use DataMachine\Engine\Scheduling\FlowRoutines;
+	use DataMachine\Engine\Scheduling\HashGatedRoutineBackend;
+	use DataMachine\Engine\Tasks\RecurringScheduleRegistry;
+
+	function datamachine_smoke_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+
+		echo "  [FAIL] {$message}\n";
+		exit( 1 );
+	}
+
+	function datamachine_smoke_reset(): void {
+		WP_Agent_Routine_Registry::reset();
+		HashGatedRoutineBackend::reset_state();
+		RecurringScheduleRegistry::$throw_on_all = false;
+		$GLOBALS['datamachine_smoke_logs']       = array();
+	}
+
+	echo "=== flow-routines-reconcile-lock-before-boot-smoke ===\n";
+
+	// The one-shot legacy-action migration is out of scope for this smoke;
+	// mark it done so boot() doesn't reach for as_get_scheduled_actions()
+	// (Action Scheduler is not stubbed here).
+	$GLOBALS['datamachine_smoke_options'][ FlowRoutines::MIGRATED_OPTION ] = true;
+
+	// --- (a) lock held elsewhere: reconcile() must skip without booting. ---
+	Flows::$schedules = array(
+		array(
+			'flow_id'           => 1,
+			'flow_name'         => 'Flow One',
+			'scheduling_config' => array(
+				'enabled'  => true,
+				'interval' => 'hourly',
+			),
+		),
+	);
+	datamachine_smoke_reset();
+
+	$other_owner = FlowScheduleReconciliationLock::acquire();
+	datamachine_smoke_assert( is_string( $other_owner ), 'setup: a concurrent caller holds the reconcile lock' );
+
+	$result = FlowRoutines::reconcile( true );
+
+	datamachine_smoke_assert( true === ( $result['success'] ?? null ), 'locked reconcile() reports success (contention is not a failure)' );
+	datamachine_smoke_assert( true === ( $result['skipped'] ?? null ), 'locked reconcile() reports skipped => true' );
+	datamachine_smoke_assert( 'locked' === ( $result['reason'] ?? null ), 'locked reconcile() reports a machine-readable reason' );
+	datamachine_smoke_assert( array() === WP_Agent_Routine_Registry::$register_calls, 'locked reconcile() never calls boot() — zero registry register() calls' );
+	datamachine_smoke_assert( 0 === HashGatedRoutineBackend::$persist_calls, 'locked reconcile() never calls persist()' );
+
+	datamachine_smoke_assert( FlowScheduleReconciliationLock::release( $other_owner ), 'teardown: release the concurrent lock' );
+
+	// --- Lock now free: reconcile() must proceed normally. ---
+	datamachine_smoke_reset();
+	$result = FlowRoutines::reconcile( true );
+
+	datamachine_smoke_assert( true === ( $result['success'] ?? null ), 'unlocked reconcile() succeeds' );
+	datamachine_smoke_assert( empty( $result['skipped'] ), 'unlocked reconcile() is not marked skipped' );
+	datamachine_smoke_assert( array( 'flow-1' ) === WP_Agent_Routine_Registry::$register_calls, 'unlocked reconcile() actually boots and registers the flow routine' );
+	datamachine_smoke_assert( 2 === HashGatedRoutineBackend::$persist_calls, 'unlocked reconcile() persists from both boot() and the registry-reconcile finally' );
+
+	// --- (c) a throwing registration must not skip persist(). ---
+	Flows::$schedules = array(
+		array(
+			'flow_id'           => 1,
+			'flow_name'         => 'Flow One',
+			'scheduling_config' => array(
+				'enabled'  => true,
+				'interval' => 'hourly',
+			),
+		),
+		array(
+			'flow_id'           => 2,
+			'flow_name'         => 'Flow Two',
+			'scheduling_config' => array(
+				'enabled'  => true,
+				'interval' => 'hourly',
+			),
+		),
+	);
+	datamachine_smoke_reset();
+	WP_Agent_Routine_Registry::$throw_for = array( 'flow-1' );
+
+	FlowRoutines::boot();
+
+	datamachine_smoke_assert(
+		array( 'flow-1', 'flow-2' ) === WP_Agent_Routine_Registry::$register_calls,
+		'boot() continues to the next routine after one registration throws'
+	);
+	datamachine_smoke_assert( 1 === HashGatedRoutineBackend::$persist_calls, 'boot() still persists once even though a registration threw' );
+	datamachine_smoke_assert( 1 === count( $GLOBALS['datamachine_smoke_logs'] ), 'the throw is logged once via datamachine_log' );
+	$logged_error = $GLOBALS['datamachine_smoke_logs'][0];
+	datamachine_smoke_assert( 'error' === ( $logged_error[0] ?? null ), 'the throw is logged at error level' );
+	datamachine_smoke_assert( 'flow-1' === ( $logged_error[2]['routine_id'] ?? null ), 'the log identifies the routine that threw' );
+
+	// --- boot()'s top-level finally must persist even on a throw outside the per-routine catch. ---
+	datamachine_smoke_reset();
+	RecurringScheduleRegistry::$throw_on_all = true;
+
+	$threw = false;
+	try {
+		FlowRoutines::boot();
+	} catch ( \Throwable $error ) {
+		$threw = true;
+		unset( $error );
+	}
+
+	datamachine_smoke_assert( $threw, 'an unexpected throw outside register_routine_logged() propagates out of boot()' );
+	datamachine_smoke_assert(
+		array( 'flow-1', 'flow-2' ) === WP_Agent_Routine_Registry::$register_calls,
+		'both flow routines from the first loop still registered before the second loop threw'
+	);
+	datamachine_smoke_assert( 1 === HashGatedRoutineBackend::$persist_calls, 'boot() persists via its top-level finally even when it ultimately rethrows' );
+
+	echo "\nAll flow-routines-reconcile-lock-before-boot assertions passed.\n";
+}

--- a/tests/flow-schedule-reconciliation-lock-smoke.php
+++ b/tests/flow-schedule-reconciliation-lock-smoke.php
@@ -2,14 +2,22 @@
 /**
  * Pure-PHP behavioral smoke for the reconciliation option lock.
  *
+ * The fake `$wpdb` models `wp_options` as the sole source of truth (a
+ * dedicated `$GLOBALS['datamachine_lock_db']` store, keyed by option name,
+ * holding the exact raw serialized string a real `option_value` column
+ * would hold). The class under test must never consult `add_option()` /
+ * `get_option()` — see tests/flow-routines-reconcile-lock-before-boot-smoke.php
+ * for coverage of the cache/DB split this is designed to defend against.
+ *
  * Run with: php tests/flow-schedule-reconciliation-lock-smoke.php
  *
  * @package DataMachine\Tests
  */
 
 define( 'ABSPATH', __DIR__ );
+define( 'ARRAY_A', 'ARRAY_A' );
 
-$GLOBALS['datamachine_lock_options'] = array();
+$GLOBALS['datamachine_lock_db'] = array();
 
 class WP_Error {
 	public function __construct( private string $code, private string $message ) {}
@@ -30,25 +38,50 @@ class DatamachineLockWpdb {
 		return array( $query, $args );
 	}
 
+	public function get_row( array $prepared, $output = ARRAY_A ) {
+		unset( $output );
+		list( $query, $args ) = $prepared;
+		if ( ! str_starts_with( $query, 'SELECT' ) ) {
+			return null;
+		}
+
+		list( , $option_name ) = $args;
+		if ( ! array_key_exists( $option_name, $GLOBALS['datamachine_lock_db'] ) ) {
+			return null;
+		}
+
+		return array( 'option_value' => $GLOBALS['datamachine_lock_db'][ $option_name ] );
+	}
+
 	public function query( array $prepared ): int {
 		list( $query, $args ) = $prepared;
-		if ( str_starts_with( $query, 'UPDATE' ) ) {
-			list( , $replacement, $option_name, $expected ) = $args;
-			$current = $GLOBALS['datamachine_lock_options'][ $option_name ] ?? null;
-			if ( maybe_serialize( $current ) !== $expected ) {
+
+		if ( str_starts_with( $query, 'INSERT IGNORE' ) ) {
+			list( , $option_name, $value ) = $args;
+			if ( array_key_exists( $option_name, $GLOBALS['datamachine_lock_db'] ) ) {
 				return 0;
 			}
-			$GLOBALS['datamachine_lock_options'][ $option_name ] = unserialize( $replacement );
+			$GLOBALS['datamachine_lock_db'][ $option_name ] = $value;
+			return 1;
+		}
+
+		if ( str_starts_with( $query, 'UPDATE' ) ) {
+			list( , $replacement, $option_name, $expected_raw ) = $args;
+			$current_raw                                        = $GLOBALS['datamachine_lock_db'][ $option_name ] ?? null;
+			if ( $current_raw !== $expected_raw ) {
+				return 0;
+			}
+			$GLOBALS['datamachine_lock_db'][ $option_name ] = $replacement;
 			return 1;
 		}
 
 		if ( str_starts_with( $query, 'DELETE' ) ) {
-			list( , $option_name, $expected ) = $args;
-			$current = $GLOBALS['datamachine_lock_options'][ $option_name ] ?? null;
-			if ( maybe_serialize( $current ) !== $expected ) {
+			list( , $option_name, $expected_raw ) = $args;
+			$current_raw                          = $GLOBALS['datamachine_lock_db'][ $option_name ] ?? null;
+			if ( $current_raw !== $expected_raw ) {
 				return 0;
 			}
-			unset( $GLOBALS['datamachine_lock_options'][ $option_name ] );
+			unset( $GLOBALS['datamachine_lock_db'][ $option_name ] );
 			return 1;
 		}
 
@@ -63,26 +96,33 @@ function wp_generate_uuid4(): string {
 	return 'test-token-' . ++$counter;
 }
 
-function add_option( string $name, $value, string $deprecated = '', bool $autoload = true ): bool {
-	unset( $deprecated, $autoload );
-	if ( array_key_exists( $name, $GLOBALS['datamachine_lock_options'] ) ) {
-		return false;
-	}
-	$GLOBALS['datamachine_lock_options'][ $name ] = $value;
-	return true;
-}
-
-function get_option( string $name, $default = false ) {
-	return $GLOBALS['datamachine_lock_options'][ $name ] ?? $default;
-}
-
 function maybe_serialize( $value ): string {
 	return is_array( $value ) || is_object( $value ) ? serialize( $value ) : (string) $value;
+}
+
+function maybe_unserialize( $value ) {
+	if ( ! is_string( $value ) ) {
+		return $value;
+	}
+	$unserialized = @unserialize( $value );
+	return ( false !== $unserialized || 'b:0;' === $value ) ? $unserialized : $value;
 }
 
 function wp_cache_delete( string $key, string $group ): bool {
 	unset( $key, $group );
 	return true;
+}
+
+/** Directly poke the fake DB row's decoded value, mirroring a real UPDATE outside this class. */
+function datamachine_lock_smoke_db_get( string $option_name ) {
+	if ( ! array_key_exists( $option_name, $GLOBALS['datamachine_lock_db'] ) ) {
+		return null;
+	}
+	return maybe_unserialize( $GLOBALS['datamachine_lock_db'][ $option_name ] );
+}
+
+function datamachine_lock_smoke_db_set( string $option_name, $value ): void {
+	$GLOBALS['datamachine_lock_db'][ $option_name ] = maybe_serialize( $value );
 }
 
 require_once __DIR__ . '/../inc/Api/Flows/FlowScheduleReconciliationLock.php';
@@ -109,22 +149,27 @@ datamachine_lock_assert( $blocked instanceof WP_Error, 'concurrent owner is reje
 datamachine_lock_assert( 'flow_schedule_reconciliation_locked' === $blocked->get_error_code(), 'lock rejection is machine-readable' );
 datamachine_lock_assert( FlowScheduleReconciliationLock::refresh( $first ), 'same-second heartbeat advances the lease monotonically' );
 datamachine_lock_assert( ! FlowScheduleReconciliationLock::refresh( 'wrong-token' ), 'non-owner cannot refresh the lease' );
-$GLOBALS['datamachine_lock_options']['datamachine_flow_schedule_reconciliation_lock']['acquired_at'] = time() - 1200;
+
+$option_name            = 'datamachine_flow_schedule_reconciliation_lock';
+$current                = datamachine_lock_smoke_db_get( $option_name );
+$current['acquired_at'] = time() - 1200;
+datamachine_lock_smoke_db_set( $option_name, $current );
 datamachine_lock_assert( FlowScheduleReconciliationLock::refresh( $first ), 'owner atomically refreshes the lease' );
 datamachine_lock_assert(
-	(int) $GLOBALS['datamachine_lock_options']['datamachine_flow_schedule_reconciliation_lock']['acquired_at'] > time() - 5,
+	(int) datamachine_lock_smoke_db_get( $option_name )['acquired_at'] > time() - 5,
 	'refreshed lease receives current timing'
 );
 
-$option_name = 'datamachine_flow_schedule_reconciliation_lock';
-$GLOBALS['datamachine_lock_options'][ $option_name ]['acquired_at'] = time() - 3600;
+$current                = datamachine_lock_smoke_db_get( $option_name );
+$current['acquired_at'] = time() - 3600;
+datamachine_lock_smoke_db_set( $option_name, $current );
 $replacement = FlowScheduleReconciliationLock::acquire();
 datamachine_lock_assert( is_string( $replacement ) && $replacement !== $first, 'stale owner is replaced with a new token' );
 datamachine_lock_assert( ! FlowScheduleReconciliationLock::release( $first ), 'stale owner cannot release replacement lock' );
 datamachine_lock_assert( FlowScheduleReconciliationLock::release( $replacement ), 'replacement owner releases its lock' );
-datamachine_lock_assert( ! array_key_exists( $option_name, $GLOBALS['datamachine_lock_options'] ), 'successful release deletes the lock option' );
+datamachine_lock_assert( ! array_key_exists( $option_name, $GLOBALS['datamachine_lock_db'] ), 'successful release deletes the lock row' );
 
-$GLOBALS['datamachine_lock_options'][ $option_name ] = 'malformed-stale-lock';
+datamachine_lock_smoke_db_set( $option_name, 'malformed-stale-lock' );
 $recovered = FlowScheduleReconciliationLock::acquire();
 datamachine_lock_assert( is_string( $recovered ), 'malformed stale lock is recovered atomically' );
 datamachine_lock_assert( FlowScheduleReconciliationLock::release( $recovered ), 'recovered lock remains token-safe' );

--- a/tests/flow-schedule-reconciliation-worker-smoke.php
+++ b/tests/flow-schedule-reconciliation-worker-smoke.php
@@ -54,11 +54,9 @@ namespace DataMachine\Engine\Scheduling {
 	}
 }
 
-namespace DataMachine\Core\ActionScheduler {
-	class GroupRegistrar {
-		public const GROUP = 'data-machine';
-	}
-}
+// GroupRegistrar is required from its real file below (not stubbed): it is
+// a plain constant holder plus DB-touching methods this smoke never calls,
+// and requiring it avoids hand-duplicating its GROUP slug literal here.
 
 namespace {
 
@@ -124,6 +122,7 @@ namespace {
 		return count( $GLOBALS['datamachine_smoke_as_actions'] );
 	}
 
+	require_once __DIR__ . '/../inc/Core/ActionScheduler/GroupRegistrar.php';
 	require_once __DIR__ . '/../inc/setup/flow-schedules.php';
 
 	use DataMachine\Engine\Scheduling\FlowRoutines;

--- a/tests/flow-schedule-reconciliation-worker-smoke.php
+++ b/tests/flow-schedule-reconciliation-worker-smoke.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * Pure-PHP behavioral smoke for the deploy-time flow schedule reconcile
+ * lifecycle in inc/setup/flow-schedules.php.
+ *
+ * Regression coverage for Extra-Chill/data-machine#3492: the `init` handler
+ * used to call `FlowRoutines::reconcile(true)` directly on every web
+ * request while the deploy marker was set, and treated lock contention as a
+ * failure worth retrying on every subsequent request. This smoke proves:
+ *
+ *  (b) the `init` handler never calls FlowRoutines::reconcile() itself — it
+ *      only enqueues a single Action Scheduler async action (deduplicated
+ *      against an already-pending one) — and the deferred worker treats a
+ *      `skipped` (locked) result as a silent no-op: the marker is left
+ *      alone and nothing is logged as an error.
+ *  (d) a genuine reconcile failure retains the marker and sets a short
+ *      backoff transient so a persistently failing reconcile does not
+ *      re-enqueue on every request.
+ *  (e) a genuine reconcile success clears the marker and logs completion.
+ *
+ * Run with: php tests/flow-schedule-reconciliation-worker-smoke.php
+ *
+ * @package DataMachine\Tests
+ */
+
+namespace DataMachine\Engine\Scheduling {
+	/**
+	 * Fully controllable stand-in for the real adapter: the worker smoke
+	 * only exercises inc/setup/flow-schedules.php, not FlowRoutines itself
+	 * (see tests/flow-routines-reconcile-lock-before-boot-smoke.php for
+	 * that coverage).
+	 */
+	class FlowRoutines {
+		public static bool $available = true;
+		/** @var array<string, mixed> */
+		public static array $result = array();
+		/** @var bool[] */
+		public static array $reconcile_calls = array();
+
+		public static function available(): bool {
+			return self::$available;
+		}
+
+		public static function reconcile( bool $apply = false ): array {
+			self::$reconcile_calls[] = $apply;
+			return self::$result;
+		}
+
+		public static function reset(): void {
+			self::$available       = true;
+			self::$result          = array();
+			self::$reconcile_calls = array();
+		}
+	}
+}
+
+namespace DataMachine\Core\ActionScheduler {
+	class GroupRegistrar {
+		public const GROUP = 'data-machine';
+	}
+}
+
+namespace {
+
+	define( 'ABSPATH', __DIR__ );
+	define( 'MINUTE_IN_SECONDS', 60 );
+
+	$GLOBALS['datamachine_smoke_options']    = array();
+	$GLOBALS['datamachine_smoke_transients'] = array();
+	$GLOBALS['datamachine_smoke_logs']       = array();
+	$GLOBALS['datamachine_smoke_as_actions'] = array();
+
+	function get_option( string $name, $default = false ) {
+		return $GLOBALS['datamachine_smoke_options'][ $name ] ?? $default;
+	}
+
+	function update_option( string $name, $value, $autoload = null ): bool {
+		unset( $autoload );
+		$GLOBALS['datamachine_smoke_options'][ $name ] = $value;
+		return true;
+	}
+
+	function delete_option( string $name ): bool {
+		unset( $GLOBALS['datamachine_smoke_options'][ $name ] );
+		return true;
+	}
+
+	function get_transient( string $name ) {
+		return $GLOBALS['datamachine_smoke_transients'][ $name ] ?? false;
+	}
+
+	function set_transient( string $name, $value, int $expiration ): bool {
+		unset( $expiration );
+		$GLOBALS['datamachine_smoke_transients'][ $name ] = $value;
+		return true;
+	}
+
+	function do_action( string $tag, ...$args ): void {
+		if ( 'datamachine_log' === $tag ) {
+			$GLOBALS['datamachine_smoke_logs'][] = $args;
+		}
+	}
+
+	function add_action( string $tag, $callback, int $priority = 10, int $accepted_args = 1 ): bool {
+		unset( $tag, $callback, $priority, $accepted_args );
+		return true;
+	}
+
+	function as_has_scheduled_action( string $hook, array $args = array(), string $group = '' ): bool {
+		foreach ( $GLOBALS['datamachine_smoke_as_actions'] as $action ) {
+			if ( $action['hook'] === $hook && $action['args'] === $args && $action['group'] === $group ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	function as_enqueue_async_action( string $hook, array $args = array(), string $group = '' ): int {
+		$GLOBALS['datamachine_smoke_as_actions'][] = array(
+			'hook'  => $hook,
+			'args'  => $args,
+			'group' => $group,
+		);
+		return count( $GLOBALS['datamachine_smoke_as_actions'] );
+	}
+
+	require_once __DIR__ . '/../inc/setup/flow-schedules.php';
+
+	use DataMachine\Engine\Scheduling\FlowRoutines;
+
+	function datamachine_smoke_assert( bool $condition, string $message ): void {
+		if ( $condition ) {
+			echo "  [PASS] {$message}\n";
+			return;
+		}
+
+		echo "  [FAIL] {$message}\n";
+		exit( 1 );
+	}
+
+	function datamachine_smoke_reset(): void {
+		FlowRoutines::reset();
+		$GLOBALS['datamachine_smoke_logs']       = array();
+		$GLOBALS['datamachine_smoke_as_actions'] = array();
+		$GLOBALS['datamachine_smoke_transients'] = array();
+	}
+
+	echo "=== flow-schedule-reconciliation-worker-smoke ===\n";
+
+	// --- No marker: the init handler is a complete no-op. ---
+	datamachine_smoke_reset();
+	datamachine_reconcile_marked_flow_schedules();
+	datamachine_smoke_assert( array() === $GLOBALS['datamachine_smoke_as_actions'], 'no marker: nothing is enqueued' );
+
+	// --- Marker set: the init handler enqueues once and never calls reconcile() itself. ---
+	datamachine_smoke_reset();
+	update_option( 'datamachine_flow_schedule_reconciliation_pending', array( 'marked_at' => time() ) );
+
+	datamachine_reconcile_marked_flow_schedules();
+
+	datamachine_smoke_assert( 1 === count( $GLOBALS['datamachine_smoke_as_actions'] ), 'marker set: the init handler enqueues exactly one Action Scheduler action' );
+	datamachine_smoke_assert(
+		DATAMACHINE_FLOW_SCHEDULE_RECONCILE_HOOK === $GLOBALS['datamachine_smoke_as_actions'][0]['hook'],
+		'the enqueued action targets the deferred reconcile hook'
+	);
+	datamachine_smoke_assert( array() === FlowRoutines::$reconcile_calls, 'the init handler never calls FlowRoutines::reconcile() directly — a page view never pays the boot() cost' );
+
+	// A second concurrent request must not enqueue a duplicate.
+	datamachine_reconcile_marked_flow_schedules();
+	datamachine_smoke_assert( 1 === count( $GLOBALS['datamachine_smoke_as_actions'] ), 'a concurrent request does not enqueue a duplicate action' );
+
+	// --- (b) the deferred worker treats a locked/skipped result as a silent no-op. ---
+	datamachine_smoke_reset();
+	update_option( 'datamachine_flow_schedule_reconciliation_pending', array( 'marked_at' => time() ) );
+	FlowRoutines::$result = array(
+		'success' => true,
+		'applied' => true,
+		'skipped' => true,
+		'reason'  => 'locked',
+		'covered' => 0,
+		'missing' => 0,
+		'removed' => 0,
+		'errors'  => array(),
+	);
+
+	datamachine_run_deferred_flow_schedule_reconciliation();
+
+	datamachine_smoke_assert(
+		false !== get_option( 'datamachine_flow_schedule_reconciliation_pending', false ),
+		'a locked/skipped result leaves the marker in place'
+	);
+	datamachine_smoke_assert( array() === $GLOBALS['datamachine_smoke_logs'], 'a locked/skipped result logs nothing — contention is not an error' );
+	datamachine_smoke_assert( false === get_transient( DATAMACHINE_FLOW_SCHEDULE_RECONCILE_BACKOFF ), 'a locked/skipped result does not arm the failure backoff' );
+
+	// The marker is still live and no backoff is armed, so the next request re-enqueues.
+	$GLOBALS['datamachine_smoke_as_actions'] = array();
+	datamachine_reconcile_marked_flow_schedules();
+	datamachine_smoke_assert( 1 === count( $GLOBALS['datamachine_smoke_as_actions'] ), 'after a skipped run, a later request retries by enqueuing again' );
+
+	// --- (d) a genuine failure retains the marker and arms a backoff. ---
+	datamachine_smoke_reset();
+	update_option( 'datamachine_flow_schedule_reconciliation_pending', array( 'marked_at' => time() ) );
+	FlowRoutines::$result = array(
+		'success' => false,
+		'applied' => true,
+		'covered' => 0,
+		'missing' => 3,
+		'removed' => 0,
+		'errors'  => array( '_substrate' => 'synthetic failure' ),
+	);
+
+	datamachine_run_deferred_flow_schedule_reconciliation();
+
+	datamachine_smoke_assert(
+		false !== get_option( 'datamachine_flow_schedule_reconciliation_pending', false ),
+		'a genuine failure retains the marker'
+	);
+	datamachine_smoke_assert( 1 === count( $GLOBALS['datamachine_smoke_logs'] ), 'a genuine failure is logged' );
+	datamachine_smoke_assert( 'error' === ( $GLOBALS['datamachine_smoke_logs'][0][0] ?? null ), 'a genuine failure is logged at error level' );
+	datamachine_smoke_assert( true === get_transient( DATAMACHINE_FLOW_SCHEDULE_RECONCILE_BACKOFF ), 'a genuine failure arms the backoff transient' );
+
+	// While the backoff is armed, the init handler must not re-enqueue even though the marker is still set.
+	$GLOBALS['datamachine_smoke_as_actions'] = array();
+	datamachine_reconcile_marked_flow_schedules();
+	datamachine_smoke_assert( array() === $GLOBALS['datamachine_smoke_as_actions'], 'while the backoff is armed, the init handler does not re-enqueue on every request' );
+
+	// --- (e) a genuine success clears the marker and logs completion. ---
+	datamachine_smoke_reset();
+	update_option( 'datamachine_flow_schedule_reconciliation_pending', array( 'marked_at' => time() ) );
+	FlowRoutines::$result = array(
+		'success' => true,
+		'applied' => true,
+		'covered' => 12,
+		'missing' => 0,
+		'removed' => 0,
+		'errors'  => array(),
+	);
+
+	datamachine_run_deferred_flow_schedule_reconciliation();
+
+	datamachine_smoke_assert( false === get_option( 'datamachine_flow_schedule_reconciliation_pending', false ), 'a genuine success clears the marker' );
+	datamachine_smoke_assert( 1 === count( $GLOBALS['datamachine_smoke_logs'] ), 'a genuine success is logged' );
+	datamachine_smoke_assert( 'info' === ( $GLOBALS['datamachine_smoke_logs'][0][0] ?? null ), 'a genuine success is logged at info level' );
+	datamachine_smoke_assert( false === get_transient( DATAMACHINE_FLOW_SCHEDULE_RECONCILE_BACKOFF ), 'a genuine success does not arm the backoff' );
+
+	echo "\nAll flow-schedule-reconciliation-worker assertions passed.\n";
+}


### PR DESCRIPTION
Closes #3492

## Summary

The v0.176.8 deploy took the whole Extra Chill network down for ~45 minutes because `FlowRoutines::reconcile()` called `self::boot()` (a full ~700-routine registration pass through the Agents API Action Scheduler bridge) **before** any lock was taken. Only the registry's own reconcile step was guarded, so every one of 60 concurrent php-fpm workers paid the full `boot()` cost before finding out the registry lock was already held — and lock contention was misclassified as failure, so the deploy marker was retained and every subsequent request repeated the same cost. Under that load a `RedisException` from `update_option()` inside the Action Scheduler bridge escaped `boot()` before `HashGatedRoutineBackend::persist()` ran, losing that request's fingerprints and making the next `boot()` reschedule everything again — self-sustaining until the DB pinned out.

## Changes

1. **Lock before boot.** Restored `FlowScheduleReconciliationLock` — a compare-and-set `$wpdb->query()` option lock with an explicit `wp_cache_delete()` (not `add_option()`/`delete_option()`, which can leave a stale object-cache-only entry that blocks forever — this was observed on the underlying agents-api registry lock during recovery). It was deleted by #3475's routines convergence, along with its production class but *not* its smoke test (`tests/flow-schedule-reconciliation-lock-smoke.php`), which has been silently broken (`require_once` a file that no longer existed) since that PR landed. `FlowRoutines::reconcile()` now acquires this lock **before** calling `boot()`. A losing caller returns immediately with `success => true, skipped => true, reason => 'locked'`, having done zero registry or Action Scheduler work.

2. **Lock contention is not failure.** `datamachine_reconcile_marked_flow_schedules()` (soon `datamachine_run_deferred_flow_schedule_reconciliation()`, see #3) treats a `skipped` result as a silent no-op: marker untouched, nothing logged. Only a genuine failure retains the marker, and it now arms a 5-minute backoff transient so a persistently failing reconcile doesn't re-enqueue on every request.

3. **Moved off the request path.** `init` no longer runs `reconcile(true)` inline — it only enqueues a single Action Scheduler async action (deduplicated with `as_has_scheduled_action()`), and the actual reconcile runs inside that action's callback. The WP-CLI path (`wp datamachine flows reconcile-schedules --apply`) still calls `FlowRoutines::reconcile()` synchronously, and now prints a clear message when it loses the lock race instead of reporting a misleading empty "success".

4. **`persist()` survives a throw.** `boot()`'s registration loops now run inside a `try/finally` so `HashGatedRoutineBackend::persist()` always runs, and each routine's registration has its own `try/catch` so one throwing registration (e.g. the Redis exception from the incident) logs and continues instead of silently losing every fingerprint recorded so far that request.

## Testing

Two new pure-PHP smoke tests (existing style — no PHPUnit/WP bootstrap):

- `tests/flow-routines-reconcile-lock-before-boot-smoke.php` — proves (a) a held lock makes `reconcile()` skip without ever calling `boot()` or `persist()`, and that normal operation resumes once released; (c) `boot()` persists once even when a registration throws (loop continues to the next routine), and persists via its top-level `finally` even when an unexpected throw outside the per-routine catch propagates out of `boot()`.
- `tests/flow-schedule-reconciliation-worker-smoke.php` — proves (b) the `init` handler never calls `FlowRoutines::reconcile()` itself (only enqueues, deduplicated against an already-pending action), a locked/skipped worker result is a silent no-op, (d) a genuine failure retains the marker and arms the backoff transient (and the `init` handler respects it), and (e) a genuine success clears the marker and logs completion.

Ran:
```
php tests/flow-routines-reconcile-lock-before-boot-smoke.php   # 19/19 pass
php tests/flow-schedule-reconciliation-worker-smoke.php        # 18/18 pass
php tests/flow-schedule-reconciliation-lock-smoke.php          # 13/13 pass (previously broken by #3475's dangling require)
php tests/setup-schema-runtime-smoke.php                       # pass, unaffected
```

`composer lint` (WordPress-Extra standard — this repo has no `phpcs.xml`, so I diffed against the pre-existing per-file baseline rather than a bare `phpcs` run against PSR2 defaults, which flags unrelated pre-existing style across the whole codebase): every touched production file is clean relative to its pre-existing baseline. The one alignment issue my own change introduced (`ReconcileFlowSchedulesAbility.php`'s new `skipped`/`reason` output-schema keys) was fixed with `phpcbf`.

## Not in scope / follow-ups

- The agents-api registry's own `agents_routine_reconcile_lock` still uses `add_option()`/`delete_option()` and has the same stale-object-cache failure mode this PR's lock is designed to avoid. That's an agents-api issue, filed separately per the network's layer-purity convention — not fixed here since it's owned by a different repo/layer.
- The ~300k leaked `agents_routine_action_generation_*` option rows observed during recovery are also an agents-api-side leak, out of scope for this DM-side fix.

## AI disclosure

This PR was authored by an AI coding agent (Extra Chill Bot / Claude) per repository convention.